### PR TITLE
bench: refactor to use string interpolation in `assert/deep-has-property` 

### DIFF
--- a/lib/node_modules/@stdlib/assert/deep-has-property/benchmark/benchmark.factory.js
+++ b/lib/node_modules/@stdlib/assert/deep-has-property/benchmark/benchmark.factory.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isFunction = require( '@stdlib/assert/is-function' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' ).factory;
 
 
 // MAIN //
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var path;
 	var has;
 	var i;
@@ -51,7 +52,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::options:factory', function benchmark( b ) {
+bench( format( '%s::options:factory', pkg ), function benchmark( b ) {
 	var opts;
 	var has;
 	var i;
@@ -76,7 +77,7 @@ bench( pkg+'::options:factory', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::delimited-string:factory', function benchmark( b ) {
+bench( format( '%s::delimited-string:factory', pkg ), function benchmark( b ) {
 	var bool;
 	var obj;
 	var has;
@@ -110,7 +111,7 @@ bench( pkg+'::delimited-string:factory', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::key-array:factory', function benchmark( b ) {
+bench( format( '%s::key-array:factory', pkg ), function benchmark( b ) {
 	var bool;
 	var path;
 	var obj;
@@ -146,7 +147,7 @@ bench( pkg+'::key-array:factory', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::custom-delimiter:factory', function benchmark( b ) {
+bench( format( '%s::custom-delimiter:factory', pkg ), function benchmark( b ) {
 	var bool;
 	var opts;
 	var obj;

--- a/lib/node_modules/@stdlib/assert/deep-has-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/deep-has-property/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var deepHasProp = require( './../lib' );
 
@@ -60,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::delimited-string', function benchmark( b ) {
+bench( format( '%s::delimited-string', pkg ), function benchmark( b ) {
 	var bool;
 	var obj;
 	var i;
@@ -91,7 +92,7 @@ bench( pkg+'::delimited-string', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::key-array', function benchmark( b ) {
+bench( format( '%s::key-array', pkg ), function benchmark( b ) {
 	var bool;
 	var path;
 	var obj;
@@ -125,7 +126,7 @@ bench( pkg+'::key-array', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::custom-delimiter', function benchmark( b ) {
+bench( format( '%s::custom-delimiter', pkg ), function benchmark( b ) {
 	var bool;
 	var opts;
 	var obj;


### PR DESCRIPTION
Ref: #8647 

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors the JavaScript benchmark in `@stdlib/assert/deep-has-property` to `@stdlib/string/format` for string interpolation instead of string concatenation when specifying the benchmark name.

### **Benchmark Results** 

- **Benchmark.js**
```
# @stdlib/assert/deep-has-property
  ---
  iterations: 1000000
  elapsed: 0.2598026
  rate: 3849076.1832252643
  ...
ok 1 benchmark finished
# @stdlib/assert/deep-has-property
  ---
  iterations: 1000000
  elapsed: 0.2186983
  rate: 4572509.251329343
  ...
ok 2 benchmark finished
# @stdlib/assert/deep-has-property
  ---
  iterations: 1000000
  elapsed: 0.2244518
  rate: 4455299.534242987
  ...
ok 3 benchmark finished
# @stdlib/assert/deep-has-property::delimited-string
  ---
  iterations: 1000000
  elapsed: 0.2149607
  rate: 4652013.135424289
  ...
ok 4 benchmark finished
# @stdlib/assert/deep-has-property::delimited-string
  ---
  iterations: 1000000
  elapsed: 0.2024252
  rate: 4940096.391160784
  ...
ok 5 benchmark finished
# @stdlib/assert/deep-has-property::delimited-string
  ---
  iterations: 1000000
  elapsed: 0.2205633
  rate: 4533845.839267004
  ...
ok 6 benchmark finished
# @stdlib/assert/deep-has-property::key-array
  ---
  iterations: 1000000
  elapsed: 0.0891274
  rate: 11219894.218837306
  ...
ok 7 benchmark finished
# @stdlib/assert/deep-has-property::key-array
  ---
  iterations: 1000000
  elapsed: 0.0976008
  rate: 10245817.657232318
  ...
ok 8 benchmark finished
# @stdlib/assert/deep-has-property::key-array
  ---
  iterations: 1000000
  elapsed: 0.1042708
  rate: 9590412.656275775
  ...
ok 9 benchmark finished
# @stdlib/assert/deep-has-property::custom-delimiter
  ---
  iterations: 1000000
  elapsed: 0.447702
  rate: 2233628.61903677
  ...
ok 10 benchmark finished
# @stdlib/assert/deep-has-property::custom-delimiter
  ---
  iterations: 1000000
  elapsed: 0.5704095
  rate: 1753126.4819397293
  ...
ok 11 benchmark finished
# @stdlib/assert/deep-has-property::custom-delimiter
  ---
  iterations: 1000000
  elapsed: 0.5409028
  rate: 1848760.9973547927
  ...
ok 12 benchmark finished
#
1..12
# total 12
# pass  12
#
# ok
```
- **Benchmark.factory.js**
```
TAP version 13
# @stdlib/assert/deep-has-property:factory
  ---
  iterations: 1000000
  elapsed: 0.2641184
  rate: 3786180.743181846
  ...
ok 1 benchmark finished
# @stdlib/assert/deep-has-property:factory
  ---
  iterations: 1000000
  elapsed: 0.2824093
  rate: 3540959.876321354
  ...
ok 2 benchmark finished
# @stdlib/assert/deep-has-property:factory
  ---
  iterations: 1000000
  elapsed: 0.2698279
  rate: 3706065.9776101727
  ...
ok 3 benchmark finished
# @stdlib/assert/deep-has-property::options:factory
  ---
  iterations: 1000000
  elapsed: 0.4455561
  rate: 2244386.2849145145
  ...
ok 4 benchmark finished
# @stdlib/assert/deep-has-property::options:factory
  ---
  iterations: 1000000
  elapsed: 0.4947418
  rate: 2021256.340175825
  ...
ok 5 benchmark finished
# @stdlib/assert/deep-has-property::options:factory
  ---
  iterations: 1000000
  elapsed: 0.5088488
  rate: 1965220.3169192893
  ...
ok 6 benchmark finished
# @stdlib/assert/deep-has-property::delimited-string:factory
  ---
  iterations: 10000000
  elapsed: 0.8631782
  rate: 11585093.321402231
  ...
ok 7 benchmark finished
# @stdlib/assert/deep-has-property::delimited-string:factory        
  ---
  iterations: 10000000
  elapsed: 0.8960259
  rate: 11160391.680642266
  ...
ok 8 benchmark finished
# @stdlib/assert/deep-has-property::delimited-string:factory
  ---
  iterations: 10000000
  elapsed: 0.8509118
  rate: 11752099.336264934
  ...
ok 9 benchmark finished
# @stdlib/assert/deep-has-property::key-array:factory
  ---
  iterations: 10000000
  elapsed: 0.8417801
  rate: 11879587.07980861
  ...
ok 10 benchmark finished
# @stdlib/assert/deep-has-property::key-array:factory
  ---
  iterations: 10000000
  elapsed: 0.8800286
  rate: 11363267.057456996
  ...
ok 11 benchmark finished
# @stdlib/assert/deep-has-property::key-array:factory
  ---
  iterations: 10000000
  elapsed: 0.8277823
  rate: 12080470.916085063
  ...
ok 12 benchmark finished
# @stdlib/assert/deep-has-property::custom-delimiter:factory        
  ---
  iterations: 1000000
  elapsed: 0.0888562
  rate: 11254138.709510423
  ...
ok 13 benchmark finished
# @stdlib/assert/deep-has-property::custom-delimiter:factory        
  ---
  iterations: 1000000
  elapsed: 0.1077929
  rate: 9277048.859433228
  ...
ok 14 benchmark finished
# @stdlib/assert/deep-has-property::custom-delimiter:factory
  ---
  iterations: 1000000
  elapsed: 0.1001058
  rate: 9989431.181809645
  ...
ok 15 benchmark finished
#
1..15
# total 15
# pass  15
#
# ok

```
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
