### PR TITLE
bench: refactor to use string interpolation in `buffer/from-arraybuffer`

### DIFF
--- a/lib/node_modules/@stdlib/buffer/from-arraybuffer/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/buffer/from-arraybuffer/benchmark/benchmark.length.js
@@ -25,6 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
 var ArrayBuffer = require( '@stdlib/array/buffer' );
 var Uint8Array = require( '@stdlib/array/uint8' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var arraybuffer2buffer = require( './../lib' );
 
@@ -95,7 +96,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
---
Progresses #8647.

## Description

> What is the purpose of this pull request?

This pull request:

Refactors the JavaScript benchmark in @stdlib/buffer/from-arraybuffer to @stdlib/string/format for string interpolation instead of string concatenation when specifying the benchmark name.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
