### PR TITLE
docs: remove duplicate words in documentation and comments

### DIFF
--- a/lib/node_modules/@stdlib/repl/info/data/data.csv
+++ b/lib/node_modules/@stdlib/repl/info/data/data.csv
@@ -2564,7 +2564,7 @@ base.wrap,"\nbase.wrap( v:number, min:number, max:number )\n    Wraps a value to
 base.xlog1py,"\nbase.xlog1py( x:number, y:number )\n    Computes `x * ln(y+1)` so that the result is `0` if `x = 0`.\n"
 base.xlogy,"\nbase.xlogy( x:number, y:number )\n    Computes `x * ln(y)` so that the result is `0` if `x = 0`.\n"
 base.zeta,"\nbase.zeta( s:number )\n    Evaluates the Riemann zeta function as a function of a real variable `s`.\n"
-BERNDT_CPS_WAGES_1985,"\nBERNDT_CPS_WAGES_1985()\n    Returns a random sample of 534 workers from the Current Population Survey\n    (CPS) from 1985, including their wages and and other characteristics.\n"
+BERNDT_CPS_WAGES_1985,"\nBERNDT_CPS_WAGES_1985()\n    Returns a random sample of 534 workers from the Current Population Survey\n    (CPS) from 1985, including their wages and other characteristics.\n"
 bifurcate,"\nbifurcate( collection:Array|TypedArray|Object, [options:Object,] \n  filter:Array|TypedArray|Object )\n    Splits values into two groups.\n"
 bifurcateBy,"\nbifurcateBy( collection:Array|TypedArray|Object, [options:Object,] \n  predicate:Function )\n    Splits values into two groups according to a predicate function.\n"
 bifurcateByAsync,"\nbifurcateByAsync( collection:Array|TypedArray|Object, [options:Object,] \n  predicate:Function, done:Function )\n    Splits values into two groups according to a predicate function.\n"

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/mode/README.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 <section class="intro">
 
-The [mode][mode] for an [arcsine][arcsine-distribution] random variable with with minimum support `a` and maximum support `b` is
+The [mode][mode] for an [arcsine][arcsine-distribution] random variable with minimum support `a` and maximum support `b` is
 
 <!-- <equation class="equation" label="eq:arcsine_mode" align="center" raw="\operatorname{mode}\left( X \right) = \{ a, b \}" alt="Mode for an arcsine distribution."> -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/skewness/README.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 <section class="intro">
 
-The [skewness][skewness] for an [arcsine][arcsine-distribution] random variable with with minimum support `a` and maximum support `b` is
+The [skewness][skewness] for an [arcsine][arcsine-distribution] random variable with minimum support `a` and maximum support `b` is
 
 <!-- <equation class="equation" label="eq:arcsine_skewness" align="center" raw="\operatorname{skew}\left( X \right) = 0" alt="Skewness for an arcsine distribution."> -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/lib/main.js
@@ -56,7 +56,7 @@ function discreteUniformCDF( x ) {
 }
 
 /**
-* Evaluates the the natural logarithm of the cumulative distribution function (logCDF).
+* Evaluates the natural logarithm of the cumulative distribution function (logCDF).
 *
 * @private
 * @param {number} x - input value

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/lib/main.js
@@ -57,7 +57,7 @@ function uniformCDF( x ) {
 }
 
 /**
-* Evaluates the the natural logarithm of the cumulative distribution function (logCDF).
+* Evaluates the natural logarithm of the cumulative distribution function (logCDF).
 *
 * @private
 * @param {number} x - input value


### PR DESCRIPTION
## Description

This PR fixes duplicate word typos found in documentation and code comments across multiple files.

## Changes

Fixed the following duplicate words:
- **"the the"** → "the" in uniform and discrete-uniform distribution constructor comments
- **"with with"** → "with" in arcsine distribution README files  
- **"and and"** → "and" in REPL info data for BERNDT_CPS_WAGES_1985 dataset

## Files Modified

- `lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/lib/main.js`
- `lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/lib/main.js`
- `lib/node_modules/@stdlib/stats/base/dists/arcsine/skewness/README.md`
- `lib/node_modules/@stdlib/stats/base/dists/arcsine/mode/README.md`
- `lib/node_modules/@stdlib/repl/info/data/data.csv`

## AI Usage Disclosure

As per RFC [#9347](https://github.com/stdlib-js/stdlib/issues/9347), I used AI assistance  in this contribution like for searching more duplication of words and typos that i found in the  documentation: 

## Related Issues

None

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
-   [x] I have read and understood the Code of Conduct
-   [x] Searched for existing issues and pull requests
-   [x] The changes only affect documentation/comments (no functional code changes)
-   [x] Disclosed AI usage as per project guidelines