### PR TITLE
docs: simplify abs example by removing dtype

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/abs/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/abs/examples/index.js
@@ -22,8 +22,5 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var abs = require( './../lib' );
 
-var x = discreteUniform( 100, -100, 100, {
-	'dtype': 'float64'
-});
-
+var x = discreteUniform( 100, -100, 100 );
 logEachMap( 'abs(%d) = %d', x, abs );


### PR DESCRIPTION
## Description

This pull request simplifies the `abs` example by removing an explicit `float64` dtype from the `discreteUniform` call.

While reviewing the code and following the stdlib documentation, I observed that `discreteUniform` generates integer values by default. The explicit dtype is therefore unnecessary, and removing it avoids potential ambiguity between the integer format specifier used in the example output and the underlying data type, while keeping the example behavior unchanged.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
