### PR TITLE
chore: fix JavaScript lint errors (issue #9569)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/flipud/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/flipud/benchmark/benchmark.js
@@ -66,11 +66,11 @@ bench( pkg+'::1d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2 ], { 'dtype': 'generic' } )
+		empty([ 2 ], { 'dtype': 'float64' }),
+		empty([ 2 ], { 'dtype': 'float32' }),
+		empty([ 2 ], { 'dtype': 'int32' }),
+		empty([ 2 ], { 'dtype': 'complex128' }),
+		empty([ 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -126,11 +126,11 @@ bench( pkg+'::2d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2 ], { 'dtype': 'generic' } )
+		empty([ 2, 2 ], { 'dtype': 'float64' }),
+		empty([ 2, 2 ], { 'dtype': 'float32' }),
+		empty([ 2, 2 ], { 'dtype': 'int32' }),
+		empty([ 2, 2 ], { 'dtype': 'complex128' }),
+		empty([ 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -186,11 +186,11 @@ bench( pkg+'::3d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty([ 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty([ 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty([ 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty([ 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty([ 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -246,11 +246,11 @@ bench( pkg+'::4d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty([ 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty([ 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty([ 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty([ 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty([ 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -306,11 +306,11 @@ bench( pkg+'::5d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */

--- a/lib/node_modules/@stdlib/ndarray/base/flipud/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/flipud/benchmark/benchmark.js
@@ -63,17 +63,17 @@ bench( pkg+'::1d,non-base', function benchmark( b ) {
 	var v;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty([ 2 ], { 'dtype': 'float64' }),
-		empty([ 2 ], { 'dtype': 'float32' }),
-		empty([ 2 ], { 'dtype': 'int32' }),
-		empty([ 2 ], { 'dtype': 'complex128' }),
-		empty([ 2 ], { 'dtype': 'generic' })
+		empty( [ 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -123,17 +123,17 @@ bench( pkg+'::2d,non-base', function benchmark( b ) {
 	var v;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty([ 2, 2 ], { 'dtype': 'float64' }),
-		empty([ 2, 2 ], { 'dtype': 'float32' }),
-		empty([ 2, 2 ], { 'dtype': 'int32' }),
-		empty([ 2, 2 ], { 'dtype': 'complex128' }),
-		empty([ 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -183,17 +183,17 @@ bench( pkg+'::3d,non-base', function benchmark( b ) {
 	var v;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty([ 2, 2, 2 ], { 'dtype': 'float64' }),
-		empty([ 2, 2, 2 ], { 'dtype': 'float32' }),
-		empty([ 2, 2, 2 ], { 'dtype': 'int32' }),
-		empty([ 2, 2, 2 ], { 'dtype': 'complex128' }),
-		empty([ 2, 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -243,17 +243,17 @@ bench( pkg+'::4d,non-base', function benchmark( b ) {
 	var v;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty([ 2, 2, 2, 2 ], { 'dtype': 'float64' }),
-		empty([ 2, 2, 2, 2 ], { 'dtype': 'float32' }),
-		empty([ 2, 2, 2, 2 ], { 'dtype': 'int32' }),
-		empty([ 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
-		empty([ 2, 2, 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -303,17 +303,17 @@ bench( pkg+'::5d,non-base', function benchmark( b ) {
 	var v;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' }),
-		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' }),
-		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' }),
-		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
-		empty([ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION
Resolves #9569.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes JS lint error by removing extra spaces between brackates.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9569

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [X] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
