### PR TITLE
docs: improve doctests for complex number instances in math/base/special/cflipsign

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cflipsign/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsign/README.md
@@ -46,17 +46,8 @@ Returns a double-precision complex floating-point number with the same magnitude
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
-
 var v = cflipsign( new Complex128( -4.2, 5.5 ), -1.0 );
-// returns <Complex128>
-
-var re = real( v );
-// returns 4.2
-
-var im = imag( v );
-// returns -5.5
+// returns <Complex128>[ 4.2, -5.5 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cflipsign/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsign/docs/repl.txt
@@ -19,12 +19,8 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( -4.2, 5.5 ), -9.0 )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    4.2
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    -5.5
-
+    
+    <Complex128>[ 4.2, -5.5 ]
     See Also
     --------
 

--- a/lib/node_modules/@stdlib/math/base/special/cflipsign/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsign/docs/repl.txt
@@ -19,7 +19,6 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( -4.2, 5.5 ), -9.0 )
-    
     <Complex128>[ 4.2, -5.5 ]
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/cflipsign/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsign/docs/types/index.d.ts
@@ -31,17 +31,9 @@ import { Complex128 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cflipsign( new Complex128( -4.2, 5.5 ), -55.0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 4.2
-*
-* var im = imag( v );
-* // returns -5.5
+* // returns <Complex128>[ 4.2, -5.5 ]
 */
 declare function cflipsign( z: Complex128, y: number ): Complex128;
 

--- a/lib/node_modules/@stdlib/math/base/special/cflipsign/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsign/lib/index.js
@@ -25,18 +25,10 @@
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var cflipsign = require( '@stdlib/math/base/special/cflipsign' );
 *
 * var v = cflipsign( new Complex128( -4.2, 5.5 ), -55.0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 4.2
-*
-* var im = imag( v );
-* // returns -5.5
+* // returns <Complex128>[ 4.2, -5.5 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/cflipsign/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsign/lib/main.js
@@ -37,17 +37,9 @@ var imag = require( '@stdlib/complex/float64/imag' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cflipsign( new Complex128( -4.2, 5.5 ), -55.0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 4.2
-*
-* var im = imag( v );
-* // returns -5.5
+* // returns <Complex128>[ 4.2, -5.5 ]
 */
 function cflipsign( z, y ) {
 	var re = real( z );

--- a/lib/node_modules/@stdlib/math/base/special/cflipsign/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsign/lib/native.js
@@ -36,17 +36,9 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cflipsign( new Complex128( -4.2, 5.5 ), -55.0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 4.2
-*
-* var im = imag( v );
-* // returns -5.5
+* // returns <Complex128>[ 4.2, -5.5 ]
 */
 function cflipsign( z, y ) {
 	var v = addon( z, y );


### PR DESCRIPTION
Progresses part of #8641 

## Description

> What is the purpose of this pull request?

This pull request:

-   updates documentation examples for math/base/special/cflipsign to use complex number instance notation (e.g.,  returns <Complex128>[ 4.2, -5.5 ]) instead of decomposing values using realf and imagf, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8641 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
