### PR TITLE
Fix main.js and index.js in to-string-tag

### DIFF
--- a/lib/node_modules/@stdlib/symbol/to-string-tag/lib/index.js
+++ b/lib/node_modules/@stdlib/symbol/to-string-tag/lib/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require( './main.js' );

--- a/lib/node_modules/@stdlib/symbol/to-string-tag/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/to-string-tag/lib/main.js
@@ -1,0 +1,30 @@
+/* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var hasSymbolSupport = require( '@stdlib/assert/has-symbol-support' );
+
+
+// MAIN //
+
+/**
+* Symbol.toStringTag.
+*
+* @name ToStringTagSymbol
+* @constant
+* @type {(symbol|null)}
+*/
+var ToStringTagSymbol = ( hasSymbolSupport() ) ? Symbol.toStringTag : null;
+
+
+// EXPORTS //
+
+module.exports = ToStringTagSymbol;


### PR DESCRIPTION

Resolves #8482

## Description

### What is the purpose of this pull request?

This pull request fixes `main.js` and `index.js` in `@stdlib/symbol/to-string-tag` so that the `Symbol.toStringTag` export works correctly.

Specifically, this PR:

- Ensures proper module exports
- Correctly handles environments with and without `Symbol` support
- Aligns behavior with expected stdlib conventions

---

## Related Issues

This pull request resolves the following issue:

- #8482

---

## Questions

Any questions for reviewers of this pull request?

No.

---

## Other

Any other information relevant to this pull request?

No.

---

## Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

---

## AI Assistance

When authoring the changes proposed in this PR, did you use any kind of AI assistance?

Yes

---

## Disclosure

If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

AI assistance was used for understanding expected module behavior and validating export patterns. All code changes were reviewed and finalized by the author.