### PR TITLE
test: remove duplicate NaN test cases in normal mean

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/test/test.js
@@ -57,9 +57,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/test/test.js
@@ -59,9 +59,6 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/test/test.native.js
@@ -68,9 +68,6 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/test/test.js
@@ -57,9 +57,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', function test
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/test/test.native.js
@@ -68,9 +68,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', opts, functio
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mean/test/test.js
@@ -53,9 +53,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', function test
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mean/test/test.native.js
@@ -62,9 +62,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', opts, functio
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/test/test.js
@@ -59,9 +59,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/test/test.js
@@ -59,9 +59,6 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function 
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/test/test.native.js
@@ -68,9 +68,6 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', opts, fun
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/test/test.js
@@ -59,9 +59,6 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function 
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/test/test.native.js
@@ -68,9 +68,6 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', opts, fun
 	y = mean( 2.0, -1.0 );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 
-	y = mean( 2.0, -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
-
 	y = mean( 1.0, NINF );
 	t.strictEqual( isnan( y ), true, 'returns expected value' );
 


### PR DESCRIPTION
Resolves #9567 .

## Description

> What is the purpose of this pull request?

This pull request: removes exact duplicate test cases in the normal distribution mean tests (`test.js` and `test.native.js`) which did not provide additional coverage.
The duplicated assertions used identical inputs and expectations for a pure function, making them redundant. Removing them simplifies the test suite while preserving full coverage.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Closes #9567

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
