### PR TITLE
bench: refactor to use string interpolation in `dstructs/circular-buffer`

### DIFF
--- a/lib/node_modules/@stdlib/dstructs/circular-buffer/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/dstructs/circular-buffer/benchmark/benchmark.js
@@ -118,7 +118,7 @@ bench( format( '%s::instantiation,no_new,buffer', pkg ), function benchmark( b )
 	b.end();
 });
 
-bench( format( '%s:count', pkg ),  function benchmark( b ) {
+bench( format( '%s:count', pkg ), function benchmark( b ) {
 	var buf;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/dstructs/circular-buffer/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/dstructs/circular-buffer/benchmark/benchmark.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var CircularBuffer = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation,new,size', function benchmark( b ) {
+bench( format( '%s::instantiation,new,size', pkg ), function benchmark( b ) {
 	var buf;
 	var i;
 
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation,new,size', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new,buffer', function benchmark( b ) {
+bench( format( '%s::instantiation,new,buffer', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,new,buffer', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new,size', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new,size', pkg ), function benchmark( b ) {
 	var circularBuffer;
 	var buf;
 	var i;
@@ -92,7 +93,7 @@ bench( pkg+'::instantiation,no_new,size', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new,buffer', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new,buffer', pkg ), function benchmark( b ) {
 	var circularBuffer;
 	var buf;
 	var arr;
@@ -117,7 +118,7 @@ bench( pkg+'::instantiation,no_new,buffer', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':count', function benchmark( b ) {
+bench( format( '%s:count', pkg ),  function benchmark( b ) {
 	var buf;
 	var v;
 	var i;
@@ -144,7 +145,7 @@ bench( pkg+':count', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':full', function benchmark( b ) {
+bench( format( '%s:full', pkg ), function benchmark( b ) {
 	var bool;
 	var buf;
 	var i;
@@ -171,7 +172,7 @@ bench( pkg+':full', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':iterator', function benchmark( b ) {
+bench( format( '%s:iterator', pkg ), function benchmark( b ) {
 	var iter;
 	var buf;
 	var i;
@@ -197,7 +198,7 @@ bench( pkg+':iterator', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':length', function benchmark( b ) {
+bench( format( '%s:length', pkg ), function benchmark( b ) {
 	var len;
 	var buf;
 	var i;
@@ -224,7 +225,7 @@ bench( pkg+':length', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':push', function benchmark( b ) {
+bench( format( '%s:push', pkg ), function benchmark( b ) {
 	var buf;
 	var v;
 	var i;
@@ -250,7 +251,7 @@ bench( pkg+':push', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toArray', function benchmark( b ) {
+bench( format( '%s:toArray', pkg ), function benchmark( b ) {
 	var arr;
 	var buf;
 	var i;
@@ -277,7 +278,7 @@ bench( pkg+':toArray', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON', function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var buf;
 	var o;
 	var i;


### PR DESCRIPTION
Ref: #8647 

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the JavaScript benchmark in `@stdlib/dstructs/circular-buffer/` to `@stdlib/string/format` for string interpolation instead of string concatenation when specifying the benchmark name.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
