### PR TITLE
fix: prevent deadlock on single-core systems and with empty arrays in `utils/parallel`

### DIFF
--- a/lib/node_modules/@stdlib/utils/parallel/lib/defaults.js
+++ b/lib/node_modules/@stdlib/utils/parallel/lib/defaults.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var numCPUs = require( '@stdlib/os/num-cpus' );
+var max = require( '@stdlib/math/base/special/fast/max' );
 
 
 // MAIN //
@@ -36,12 +37,17 @@ var numCPUs = require( '@stdlib/os/num-cpus' );
 * // returns {...}
 */
 function defaults() {
+	var n;
+
+	// Ensure at least 1 worker and 1 concurrent script to prevent deadlock on single-core systems:
+	n = max( 1, numCPUs - 1 );
+
 	return {
 		// Number of workers:
-		'workers': numCPUs - 1,
+		'workers': n,
 
 		// Number of scripts to execute concurrently:
-		'concurrency': numCPUs - 1,
+		'concurrency': n,
 
 		// Executable file/command:
 		'cmd': 'node',

--- a/lib/node_modules/@stdlib/utils/parallel/lib/defaults.js
+++ b/lib/node_modules/@stdlib/utils/parallel/lib/defaults.js
@@ -39,7 +39,7 @@ var max = require( '@stdlib/math/base/special/fast/max' );
 function defaults() {
 	var n;
 
-	// Ensure at least 1 worker and 1 concurrent script to prevent deadlock on single-core systems:
+	// Accommodate single-core systems by ensuring at least 1 worker and 1 concurrent script:
 	n = max( 1, numCPUs - 1 );
 
 	return {

--- a/lib/node_modules/@stdlib/utils/parallel/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/parallel/lib/main.js
@@ -94,20 +94,13 @@ function parallel() {
 	if ( !isFunction( clbk ) ) {
 		throw new TypeError( format( 'invalid argument. Callback argument must be a function. Value: `%s`.', clbk ) );
 	}
-	// Prevent the number of concurrent scripts exceeding the number of actual scripts to run.
+	// Prevent the number of concurrent scripts exceeding the number of actual scripts to run:
 	if ( opts.concurrency > files.length ) {
-		opts.concurrency = files.length;
+		opts.concurrency = files.length || 1;
 	}
-	// Prevent the number of workers exceeding the number of concurrent scripts (excess capacity), as some workers would never be allocated scripts to run and always be idle.
+	// Prevent the number of workers exceeding the number of concurrent scripts (excess capacity), as some workers would never be allocated scripts to run and always be idle:
 	if ( opts.workers > opts.concurrency ) {
 		opts.workers = opts.concurrency;
-	}
-	// Ensure at least 1 worker and 1 concurrent script to prevent deadlock (even with empty arrays or single-core systems):
-	if ( opts.workers < 1 ) {
-		opts.workers = 1;
-	}
-	if ( opts.concurrency < 1 ) {
-		opts.concurrency = 1;
 	}
 	// Resolve any relative paths to absolute paths...
 	dir = cwd();

--- a/lib/node_modules/@stdlib/utils/parallel/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/parallel/lib/main.js
@@ -102,6 +102,13 @@ function parallel() {
 	if ( opts.workers > opts.concurrency ) {
 		opts.workers = opts.concurrency;
 	}
+	// Ensure at least 1 worker and 1 concurrent script to prevent deadlock (even with empty arrays or single-core systems):
+	if ( opts.workers < 1 ) {
+		opts.workers = 1;
+	}
+	if ( opts.concurrency < 1 ) {
+		opts.concurrency = 1;
+	}
 	// Resolve any relative paths to absolute paths...
 	dir = cwd();
 	for ( i = 0; i < files.length; i++ ) {

--- a/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
+++ b/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
@@ -305,7 +305,7 @@ tape( 'if the number of workers is greater than the concurrency, the function se
 	}
 });
 
-tape( 'the function ensures at least 1 worker and 1 concurrent script on single-core systems', function test( t ) {
+tape( 'the function ensures at least one worker and a concurrency greater than or equal to unity', function test( t ) {
 	var parallel;
 
 	parallel = proxyquire( './../lib/main.js', {

--- a/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
+++ b/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
@@ -305,6 +305,100 @@ tape( 'if the number of workers is greater than the concurrency, the function se
 	}
 });
 
+tape( 'the function ensures at least 1 worker and 1 concurrent script on single-core systems', function test( t ) {
+	var parallel;
+
+	parallel = proxyquire( './../lib/main.js', {
+		'./node': exec,
+		'./defaults.js': mockDefaults
+	});
+
+	parallel( files(), done );
+
+	function mockDefaults() {
+		return {
+			'workers': 1,
+			'concurrency': 1,
+			'cmd': 'node',
+			'ordered': false,
+			'uid': null,
+			'gid': null,
+			'encoding': 'buffer',
+			'maxBuffer': 200 * 1024 * 1024
+		};
+	}
+
+	function done( error ) {
+		if ( error ) {
+			t.ok( false, error.message );
+		} else {
+			t.ok( true, 'executes successfully on single-core systems' );
+		}
+		t.end();
+	}
+
+	function exec( files, opts, clbk ) {
+		t.strictEqual( opts.workers, 1, 'has at least 1 worker' );
+		t.strictEqual( opts.concurrency, 1, 'has at least 1 concurrency' );
+		clbk();
+	}
+});
+
+tape( 'the function ensures at least 1 worker when called with an empty array', function test( t ) {
+	var parallel;
+
+	parallel = proxyquire( './../lib/main.js', {
+		'./node': exec
+	});
+
+	parallel( [], done );
+
+	function done( error ) {
+		if ( error ) {
+			t.ok( false, error.message );
+		} else {
+			t.ok( true, 'executes successfully with empty array' );
+		}
+		t.end();
+	}
+
+	function exec( files, opts, clbk ) {
+		t.strictEqual( opts.workers, 1, 'has at least 1 worker' );
+		t.strictEqual( opts.concurrency, 1, 'has at least 1 concurrency' );
+		clbk();
+	}
+});
+
+tape( 'the function ensures at least 1 worker when explicitly set to 0', function test( t ) {
+	var parallel;
+	var opts;
+
+	parallel = proxyquire( './../lib/main.js', {
+		'./node': exec
+	});
+	opts = {
+		'workers': 0,
+		'concurrency': 0
+	};
+
+	parallel( files(), opts, done );
+
+	function done( error ) {
+		if ( error ) {
+			t.ok( false, error.message );
+		} else {
+			t.ok( true, 'executes successfully when workers explicitly set to 0' );
+		}
+		t.end();
+	}
+
+	function exec( files, opts, clbk ) {
+		t.strictEqual( opts.workers, 1, 'overrides 0 workers to 1' );
+		t.strictEqual( opts.concurrency, 1, 'overrides 0 concurrency to 1' );
+		clbk();
+	}
+});
+
 tape( 'the function runs scripts in parallel', function test( t ) {
 	parallel( files(), done );
 	function done( error ) {

--- a/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
+++ b/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
@@ -344,36 +344,6 @@ tape( 'the function ensures at least 1 worker and 1 concurrent script on single-
 	}
 });
 
-tape( 'the function ensures at least 1 worker when explicitly set to 0', function test( t ) {
-	var parallel;
-	var opts;
-
-	parallel = proxyquire( './../lib/main.js', {
-		'./node': exec
-	});
-	opts = {
-		'workers': 0,
-		'concurrency': 0
-	};
-
-	parallel( files(), opts, done );
-
-	function done( error ) {
-		if ( error ) {
-			t.ok( false, error.message );
-		} else {
-			t.ok( true, 'executes successfully when workers explicitly set to 0' );
-		}
-		t.end();
-	}
-
-	function exec( files, opts, clbk ) {
-		t.strictEqual( opts.workers, 1, 'overrides 0 workers to 1' );
-		t.strictEqual( opts.concurrency, 1, 'overrides 0 concurrency to 1' );
-		clbk();
-	}
-});
-
 tape( 'the function runs scripts in parallel', function test( t ) {
 	parallel( files(), done );
 	function done( error ) {

--- a/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
+++ b/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
@@ -332,7 +332,7 @@ tape( 'the function ensures at least one worker and a concurrency greater than o
 		if ( error ) {
 			t.ok( false, error.message );
 		} else {
-			t.ok( true, 'executes successfully on single-core systems' );
+			t.ok( true, 'runs scripts successfully' );
 		}
 		t.end();
 	}

--- a/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
+++ b/lib/node_modules/@stdlib/utils/parallel/test/test.main.js
@@ -344,31 +344,6 @@ tape( 'the function ensures at least 1 worker and 1 concurrent script on single-
 	}
 });
 
-tape( 'the function ensures at least 1 worker when called with an empty array', function test( t ) {
-	var parallel;
-
-	parallel = proxyquire( './../lib/main.js', {
-		'./node': exec
-	});
-
-	parallel( [], done );
-
-	function done( error ) {
-		if ( error ) {
-			t.ok( false, error.message );
-		} else {
-			t.ok( true, 'executes successfully with empty array' );
-		}
-		t.end();
-	}
-
-	function exec( files, opts, clbk ) {
-		t.strictEqual( opts.workers, 1, 'has at least 1 worker' );
-		t.strictEqual( opts.concurrency, 1, 'has at least 1 concurrency' );
-		clbk();
-	}
-});
-
 tape( 'the function ensures at least 1 worker when explicitly set to 0', function test( t ) {
 	var parallel;
 	var opts;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

fixes a deadlock bug in `@stdlib/utils/parallel` where the function would hang indefinitely on single-core systems (`numCPUs = 1`) because defaults would set `workers = 0`. a deadlock bug when called with empty arrays (`parallel([])`) where clamping logic would reduce workers to 0.
fixes a deadlock bug when explicitly passing `{workers: 0, concurrency: 0}` options and updated `defaults.js` to use `@stdlib/math/base/special/fast/max` to ensure minimum of 1 worker/concurrency as suggested by maintainer ,adds safeguard in `main.js` to prevent workers/concurrency from dropping below 1 after clamping logic , tests covering all three edge cases.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   No related issue (discussed with maintainer @kgryte via direct message)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This fix was discussed with maintainer @kgryte who suggested using `@stdlib/math/base/special/fast/max` for the defaults.js fix. The safeguard in main.js was added to handle edge cases where clamping could still result in 0 workers even with the defaults fix.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure
> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *
@stdlib-js/reviewers
[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md