### PR TITLE
bench: refactor to use string interpolation in mathjs

### DIFF
--- a/docs/migration-guides/mathjs/benchmark/benchmark.subtract.js
+++ b/docs/migration-guides/mathjs/benchmark/benchmark.subtract.js
@@ -26,9 +26,9 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var filledBy = require( '@stdlib/array/filled-by' );
 var uniform = require( '@stdlib/random/base/uniform' ).factory;
 var base = require( '@stdlib/number/float64/base/sub' );
+var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
-var format = require( '@stdlib/string/format' );
 
 // VARIABLES //
 

--- a/docs/migration-guides/mathjs/benchmark/benchmark.subtract.js
+++ b/docs/migration-guides/mathjs/benchmark/benchmark.subtract.js
@@ -28,7 +28,7 @@ var uniform = require( '@stdlib/random/base/uniform' ).factory;
 var base = require( '@stdlib/number/float64/base/sub' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
-
+var format = require( '@stdlib/string/format' );
 
 // VARIABLES //
 
@@ -40,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::stdlib:number/float64/base/sub:value=number', opts, function benchmark( b ) {
+bench( format( '%s::stdlib:number/float64/base/sub:value=number' , pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var z;
@@ -68,7 +68,7 @@ bench( pkg+'::stdlib:number/float64/base/sub:value=number', opts, function bench
 
 // TODO: add math/ops/sub benchmarks
 
-bench( pkg+'::mathjs:subtract:value=number', opts, function benchmark( b ) {
+bench( format( '%s::mathjs:subtract:value=number' , pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var z;

--- a/docs/migration-guides/mathjs/benchmark/benchmark.subtract.js
+++ b/docs/migration-guides/mathjs/benchmark/benchmark.subtract.js
@@ -41,7 +41,7 @@ var opts = {
 
 // MAIN //
 
-bench( format( '%s::stdlib:number/float64/base/sub:value=number' , pkg ), opts, function benchmark( b ) {
+bench( format( '%s::stdlib:number/float64/base/sub:value=number', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var z;
@@ -69,7 +69,7 @@ bench( format( '%s::stdlib:number/float64/base/sub:value=number' , pkg ), opts, 
 
 // TODO: add math/ops/sub benchmarks
 
-bench( format( '%s::mathjs:subtract:value=number' , pkg ), opts, function benchmark( b ) {
+bench( format( '%s::mathjs:subtract:value=number', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var z;

--- a/docs/migration-guides/mathjs/benchmark/benchmark.subtract.js
+++ b/docs/migration-guides/mathjs/benchmark/benchmark.subtract.js
@@ -30,6 +30,7 @@ var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
 
+
 // VARIABLES //
 
 var mathjs = tryRequire( resolve( __dirname, '..', 'node_modules', 'mathjs' ) );


### PR DESCRIPTION
Resolves #{{a part of #8647}}.

## Description

> What is the purpose of this pull request?

  Refactors the JavaScript benchmarks in docs/migration-guides/mathjs/benchmark/benchmark.subtract.js to replace string   concatenation with @stdlib/string/format for benchmark names.
 Improves readability, consistency, and allows future linting of benchmark names.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   a part of #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> NOT applicable. no AI used.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
