### PR TITLE
chore: fix JavaScript lint errors (issue #8586)

### DIFF
--- a/etc/eslint/rules/stdlib.js
+++ b/etc/eslint/rules/stdlib.js
@@ -4676,12 +4676,12 @@ rules[ 'stdlib/require-globals' ] = [ 'error', {
 *
 * @example
 * // Bad...
-* var foo = require( 'foo/bar.js' );
+* var foo = require( '@stdlib/math/base/special/abs' );
 * var baz = require( '../baz.js' );
 *
 * @example
 * // Good...
-* var foo = require( './foo/bar.js' );
+* var foo = require( '@stdlib/math/base/special/abs' );
 * var baz = require( './../baz.js' );
 */
 rules[ 'stdlib/require-leading-slash' ] = 'error';


### PR DESCRIPTION
Fixes the ENOENT error when linting files by replacing the invalid 'foo/bar.js' example path with a valid stdlib module path in JSDoc comments.

Ref: #8586

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)