### PR TITLE
fix(repl): update regexp_require examples to use valid paths (issue #8586)

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/regexp_require.js
+++ b/lib/node_modules/@stdlib/repl/lib/regexp_require.js
@@ -48,9 +48,9 @@ function createRegExp() {
 	*
 	* ## Examples
 	*
-	* -   `'require( \'./foo'`
-	* -   `'require( \'./foo/bar'`
-	* -   `'require( \'./foo/bar/'`
+	* -   `'require( \'./index'`
+	* -   `'require( \'./commands/help'`
+	* -   `'require( \'./commands/help/'`
 	* -   `'require( \'foo'`
 	* -   `'require( \'foo/bar'`
 	* -   `'require( \'foo/bar/'`


### PR DESCRIPTION
Fixes the ENOENT error when linting files by replacing invalid example paths in `regexp_require.js` with valid existing paths.

Ref: #8586

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)