### PR TITLE
docs: improve doctests for ndarray instances in `ndarray/flatten-from`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/flatten-from/README.md
+++ b/lib/node_modules/@stdlib/ndarray/flatten-from/README.md
@@ -42,16 +42,12 @@ Returns a copy of an input [ndarray][@stdlib/ndarray/ctor] where all dimensions 
 
 ```javascript
 var array = require( '@stdlib/ndarray/array' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 5.0, 6.0 ] ] ] );
 // returns <ndarray>
 
 var y = flattenFrom( x, 1 );
-// returns <ndarray>
-
-var arr = ndarray2array( y );
-// returns [ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
+// returns <ndarray>[ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
 ```
 
 The function accepts the following arguments:
@@ -77,7 +73,6 @@ By default, the input [ndarray][@stdlib/ndarray/ctor] is flattened in lexicograp
 
 ```javascript
 var array = require( '@stdlib/ndarray/array' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 5.0, 6.0 ] ] ] );
 // returns <ndarray>
@@ -85,10 +80,7 @@ var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 5.0, 6.0 ] ] ] );
 var y = flattenFrom( x, 0, {
     'order': 'column-major'
 });
-// returns <ndarray>
-
-var arr = ndarray2array( y );
-// returns [ 1.0, 3.0, 5.0, 2.0, 4.0, 6.0 ]
+// returns <ndarray>[ 1.0, 3.0, 5.0, 2.0, 4.0, 6.0 ]
 ```
 
 By default, the output ndarray [data type][@stdlib/ndarray/dtypes] is inferred from the input [ndarray][@stdlib/ndarray/ctor]. To return an ndarray with a different [data type][@stdlib/ndarray/dtypes], specify the `dtype` option.
@@ -96,7 +88,6 @@ By default, the output ndarray [data type][@stdlib/ndarray/dtypes] is inferred f
 ```javascript
 var array = require( '@stdlib/ndarray/array' );
 var dtype = require( '@stdlib/ndarray/dtype' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 5.0, 6.0 ] ] ] );
 // returns <ndarray>
@@ -104,13 +95,10 @@ var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 5.0, 6.0 ] ] ] );
 var y = flattenFrom( x, 0, {
     'dtype': 'float32'
 });
-// returns <ndarray>
+// returns <ndarray>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ]
 
 var dt = String( dtype( y ) );
 // returns 'float32'
-
-var arr = ndarray2array( y );
-// returns [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/ndarray/flatten-from/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/flatten-from/docs/repl.txt
@@ -43,9 +43,8 @@
     Examples
     --------
     > var x = {{alias:@stdlib/ndarray/array}}( [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] );
-    > var y = {{alias}}( x, 0 );
-    > var arr = {{alias:@stdlib/ndarray/to-array}}( y )
-    [ 1.0, 2.0, 3.0, 4.0 ]
+    > var y = {{alias}}( x, 0 )
+    <ndarray>[ 1.0, 2.0, 3.0, 4.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/ndarray/flatten-from/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/flatten-from/docs/types/index.d.ts
@@ -71,7 +71,6 @@ type Options<U> = BaseOptions & {
 * @example
 * var array = require( '@stdlib/ndarray/array' );
 * var shape = require( '@stdlib/ndarray/shape' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 5.0, 6.0 ] ] ] );
 * // returns <ndarray>
@@ -80,13 +79,10 @@ type Options<U> = BaseOptions & {
 * // returns [ 3, 1, 2 ]
 *
 * var y = flattenFrom( x, 1 );
-* // returns <ndarray>
+* // returns <ndarray>[ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
 *
 * var shy = shape( y );
 * // returns [ 3, 2 ]
-*
-* var arr = ndarray2array( y );
-* // returns [ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
 */
 declare function flattenFrom<T extends ndarray>( x: T, dim: number, options?: BaseOptions ): T;
 
@@ -107,7 +103,6 @@ declare function flattenFrom<T extends ndarray>( x: T, dim: number, options?: Ba
 * @example
 * var array = require( '@stdlib/ndarray/array' );
 * var shape = require( '@stdlib/ndarray/shape' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 5.0, 6.0 ] ] ] );
 * // returns <ndarray>
@@ -116,13 +111,10 @@ declare function flattenFrom<T extends ndarray>( x: T, dim: number, options?: Ba
 * // returns [ 3, 1, 2 ]
 *
 * var y = flattenFrom( x, 1 );
-* // returns <ndarray>
+* // returns <ndarray>[ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
 *
 * var shy = shape( y );
 * // returns [ 3, 2 ]
-*
-* var arr = ndarray2array( y );
-* // returns [ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
 */
 declare function flattenFrom<T = unknown, U extends keyof DataTypeMap<T> = 'generic'>( x: typedndarray<T>, dim: number, options: Options<U> ): DataTypeMap<T>[U];
 

--- a/lib/node_modules/@stdlib/ndarray/flatten-from/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/flatten-from/lib/index.js
@@ -25,7 +25,6 @@
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 * var flattenFrom = require( '@stdlib/ndarray/flatten-from' );
 *
 * // Create an input ndarray:
@@ -34,10 +33,7 @@
 *
 * // Flatten the input ndarray:
 * var y = flattenFrom( x, 1 );
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
+* // returns <ndarray>[ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/ndarray/flatten-from/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/flatten-from/lib/main.js
@@ -64,20 +64,15 @@ var COL_MAJOR = 'column-major';
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 5.0, 6.0 ] ] ] );
 * // returns <ndarray>
 *
 * var y = flattenFrom( x, 1 );
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
+* // returns <ndarray>[ [ 1.0, 2.0 ], [ 3.0, 4.0 ], [ 5.0, 6.0 ] ]
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var x = array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], {
 *     'shape': [ 2, 3 ],
@@ -86,14 +81,10 @@ var COL_MAJOR = 'column-major';
 * // returns <ndarray>
 *
 * var y = flattenFrom( x, 0 );
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 1.0, 3.0, 5.0, 2.0, 4.0, 6.0 ]
+* // returns <ndarray>[ 1.0, 3.0, 5.0, 2.0, 4.0, 6.0 ]
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var x = array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], {
 *     'shape': [ 2, 3 ],
@@ -104,14 +95,10 @@ var COL_MAJOR = 'column-major';
 * var y = flattenFrom( x, 0, {
 *     'order': 'column-major'
 * });
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 1.0, 4.0, 2.0, 5.0, 3.0, 6.0 ]
+* // returns <ndarray>[ 1.0, 4.0, 2.0, 5.0, 3.0, 6.0 ]
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var x = array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], {
 *     'shape': [ 2, 3 ],
@@ -122,14 +109,10 @@ var COL_MAJOR = 'column-major';
 * var y = flattenFrom( x, 0, {
 *     'order': 'row-major'
 * });
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 1.0, 3.0, 5.0, 2.0, 4.0, 6.0 ]
+* // returns <ndarray>[ 1.0, 3.0, 5.0, 2.0, 4.0, 6.0 ]
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var x = array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], {
 *     'shape': [ 2, 3 ],
@@ -140,14 +123,10 @@ var COL_MAJOR = 'column-major';
 * var y = flattenFrom( x, 0, {
 *     'order': 'same'
 * });
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ]
+* // returns <ndarray>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ]
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var x = array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ], {
 *     'shape': [ 2, 3 ],
@@ -158,14 +137,10 @@ var COL_MAJOR = 'column-major';
 * var y = flattenFrom( x, 0, {
 *     'order': 'same'
 * });
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ]
+* // returns <ndarray>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ]
 *
 * @example
 * var ndarray = require( '@stdlib/ndarray/ctor' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var xbuf = [ 1.0, null, 2.0, null, 3.0, null, 4.0, null, 5.0, null, 6.0, null ];
 *
@@ -173,14 +148,10 @@ var COL_MAJOR = 'column-major';
 * // returns <ndarray>
 *
 * var y = flattenFrom( x, 0 );
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ]
+* // returns <ndarray>[ 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ]
 *
 * @example
 * var ndarray = require( '@stdlib/ndarray/ctor' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var xbuf = [ 1.0, null, 2.0, null, 3.0, null, 4.0, null, 5.0, null, 6.0, null ];
 *
@@ -189,14 +160,10 @@ var COL_MAJOR = 'column-major';
 * // returns <ndarray>
 *
 * var y = flattenFrom( x, 0 );
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ]
+* // returns <ndarray>[ 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ]
 *
 * @example
 * var ndarray = require( '@stdlib/ndarray/ctor' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var xbuf = [ 1.0, null, 2.0, null, 3.0, null, 4.0, null, 5.0, null, 6.0, null ];
 *
@@ -207,14 +174,10 @@ var COL_MAJOR = 'column-major';
 * var y = flattenFrom( x, 0, {
 *     'order': 'same'
 * });
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 6.0, 3.0, 5.0, 2.0, 4.0, 1.0 ]
+* // returns <ndarray>[ 6.0, 3.0, 5.0, 2.0, 4.0, 1.0 ]
 *
 * @example
 * var ndarray = require( '@stdlib/ndarray/ctor' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var xbuf = [ 1.0, null, 2.0, null, 3.0, null, 4.0, null, 5.0, null, 6.0, null ];
 *
@@ -225,14 +188,10 @@ var COL_MAJOR = 'column-major';
 * var y = flattenFrom( x, 0, {
 *     'order': 'any'
 * });
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ]
+* // returns <ndarray>[ 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ]
 *
 * @example
 * var ndarray = require( '@stdlib/ndarray/ctor' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var xbuf = [ 1.0, null, 2.0, null, 3.0, null, 4.0, null, 5.0, null, 6.0, null ];
 *
@@ -241,14 +200,10 @@ var COL_MAJOR = 'column-major';
 * // returns <ndarray>
 *
 * var y = flattenFrom( x, 0 );
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 6.0, 4.0, 2.0, 5.0, 3.0, 1.0 ]
+* // returns <ndarray>[ 6.0, 4.0, 2.0, 5.0, 3.0, 1.0 ]
 *
 * @example
 * var ndarray = require( '@stdlib/ndarray/ctor' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var xbuf = [ 1.0, null, 2.0, null, 3.0, null, 4.0, null, 5.0, null, 6.0, null ];
 *
@@ -259,14 +214,10 @@ var COL_MAJOR = 'column-major';
 * var y = flattenFrom( x, 0, {
 *     'order': 'same'
 * });
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 6.0, 4.0, 2.0, 5.0, 3.0, 1.0 ]
+* // returns <ndarray>[ 6.0, 4.0, 2.0, 5.0, 3.0, 1.0 ]
 *
 * @example
 * var ndarray = require( '@stdlib/ndarray/ctor' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 *
 * var xbuf = [ 1.0, null, 2.0, null, 3.0, null, 4.0, null, 5.0, null, 6.0, null ];
 *
@@ -277,10 +228,7 @@ var COL_MAJOR = 'column-major';
 * var y = flattenFrom( x, 0, {
 *     'order': 'any'
 * });
-* // returns <ndarray>
-*
-* var arr = ndarray2array( y );
-* // returns [ 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ]
+* // returns <ndarray>[ 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ]
 */
 function flattenFrom( x, dim, options ) {
 	var view;


### PR DESCRIPTION
Progresses #9329.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates the examples for `ndarray/flatten-from` package, by migrating to using ndarray instance notation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9329

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [X] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
