### PR TITLE
chore: fix JavaScript lint errors (issue #9699)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
@@ -40,6 +40,26 @@ var rule;
 // FUNCTIONS //
 
 /**
+* Copies AST node location info.
+*
+* @private
+* @param {Object} loc - AST node location
+* @returns {Object} copied location info
+*/
+function copyLocationInfo( loc ) {
+	return {
+		'start': {
+			'line': loc.start.line,
+			'column': loc.start.column
+		},
+		'end': {
+			'line': loc.end.line,
+			'column': loc.end.column
+		}
+	};
+}
+
+/**
 * Rule to prevent indentation of Markdown heading content in JSDoc descriptions.
 *
 * @param {Object} context - ESLint context
@@ -110,26 +130,6 @@ function main( context ) {
 			loc.start.column = err.location.start.column + 1; // Note: we assume that 1 space separates `*` from JSDoc description content (e.g., `* ## Beep`)
 			report( msg, loc );
 		}
-	}
-
-	/**
-	* Copies AST node location info.
-	*
-	* @private
-	* @param {Object} loc - AST node location
-	* @returns {Object} copied location info
-	*/
-	function copyLocationInfo( loc ) {
-		return {
-			'start': {
-				'line': loc.start.line,
-				'column': loc.start.column
-			},
-			'end': {
-				'line': loc.end.line,
-				'column': loc.end.column
-			}
-		};
 	}
 
 	/**


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #9699.

## Description

> What is the purpose of this pull request?

This pull request fixes an ESLint violation (`stdlib/no-unnecessary-nested-functions`) by moving the helper function `copyLocationInfo` from a nested scope to module scope in the `jsdoc-no-heading-content-indent` ESLint rule implementation. The change preserves existing behavior while ensuring compliance with stdlib linting guidelines.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9699

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
