### PR TITLE
chore: fix JavaScript lint errors (issue #9699)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
@@ -38,6 +38,26 @@ var rule;
 
 
 // FUNCTIONS //
+/**
+* Copies AST node location info.
+*
+* @private
+* @param {Object} loc - AST node location
+* @returns {Object} copied location info
+*/
+function copyLocationInfo( loc ) {
+	return {
+		'start': {
+			'line': loc.start.line,
+			'column': loc.start.column
+		},
+		'end': {
+			'line': loc.end.line,
+			'column': loc.end.column
+		}
+	};
+}
+
 
 /**
 * Rule to prevent indentation of Markdown heading content in JSDoc descriptions.
@@ -112,25 +132,7 @@ function main( context ) {
 		}
 	}
 
-	/**
-	* Copies AST node location info.
-	*
-	* @private
-	* @param {Object} loc - AST node location
-	* @returns {Object} copied location info
-	*/
-	function copyLocationInfo( loc ) {
-		return {
-			'start': {
-				'line': loc.start.line,
-				'column': loc.start.column
-			},
-			'end': {
-				'line': loc.end.line,
-				'column': loc.end.column
-			}
-		};
-	}
+	
 
 	/**
 	* Reports an error message.

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
@@ -38,6 +38,7 @@ var rule;
 
 
 // FUNCTIONS //
+
 /**
 * Copies AST node location info.
 *
@@ -57,7 +58,6 @@ function copyLocationInfo( loc ) {
 		}
 	};
 }
-
 
 /**
 * Rule to prevent indentation of Markdown heading content in JSDoc descriptions.
@@ -131,8 +131,6 @@ function main( context ) {
 			report( msg, loc );
 		}
 	}
-
-	
 
 	/**
 	* Reports an error message.


### PR DESCRIPTION
Resolves #9699 .

## Description

> What is the purpose of this pull request?

This pull request:

-  This pull request fixes a JavaScript linting error by moving the `copyLocationInfo` function to module scope, resolving a violation of the `stdlib/no-unnecessary-nested-functions` ESLint rule.

No functional behavior is changed; the update strictly improves code structure to satisfy linting requirements.


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   resolves #9699
## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
