### PR TITLE
fix(random): remove duplicate export metadata causing ESM bundle failures

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
@@ -40,6 +40,26 @@ var rule;
 // FUNCTIONS //
 
 /**
+* Copies AST node location info.
+*
+* @private
+* @param {Object} loc - AST node location
+* @returns {Object} copied location info
+*/
+function copyLocationInfo( loc ) {
+	return {
+		'start': {
+			'line': loc.start.line,
+			'column': loc.start.column
+		},
+		'end': {
+			'line': loc.end.line,
+			'column': loc.end.column
+		}
+	};
+}
+
+/**
 * Rule to prevent indentation of Markdown heading content in JSDoc descriptions.
 *
 * @param {Object} context - ESLint context
@@ -110,26 +130,6 @@ function main( context ) {
 			loc.start.column = err.location.start.column + 1; // Note: we assume that 1 space separates `*` from JSDoc description content (e.g., `* ## Beep`)
 			report( msg, loc );
 		}
-	}
-
-	/**
-	* Copies AST node location info.
-	*
-	* @private
-	* @param {Object} loc - AST node location
-	* @returns {Object} copied location info
-	*/
-	function copyLocationInfo( loc ) {
-		return {
-			'start': {
-				'line': loc.start.line,
-				'column': loc.start.column
-			},
-			'end': {
-				'line': loc.end.line,
-				'column': loc.end.column
-			}
-		};
 	}
 
 	/**

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-heading-content-indent/lib/main.js
@@ -40,26 +40,6 @@ var rule;
 // FUNCTIONS //
 
 /**
-* Copies AST node location info.
-*
-* @private
-* @param {Object} loc - AST node location
-* @returns {Object} copied location info
-*/
-function copyLocationInfo( loc ) {
-	return {
-		'start': {
-			'line': loc.start.line,
-			'column': loc.start.column
-		},
-		'end': {
-			'line': loc.end.line,
-			'column': loc.end.column
-		}
-	};
-}
-
-/**
 * Rule to prevent indentation of Markdown heading content in JSDoc descriptions.
 *
 * @param {Object} context - ESLint context
@@ -130,6 +110,26 @@ function main( context ) {
 			loc.start.column = err.location.start.column + 1; // Note: we assume that 1 space separates `*` from JSDoc description content (e.g., `* ## Beep`)
 			report( msg, loc );
 		}
+	}
+
+	/**
+	* Copies AST node location info.
+	*
+	* @private
+	* @param {Object} loc - AST node location
+	* @returns {Object} copied location info
+	*/
+	function copyLocationInfo( loc ) {
+		return {
+			'start': {
+				'line': loc.start.line,
+				'column': loc.start.column
+			},
+			'end': {
+				'line': loc.end.line,
+				'column': loc.end.column
+			}
+		};
 	}
 
 	/**

--- a/lib/node_modules/@stdlib/random/strided/arcsine/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/arcsine/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/bernoulli/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/bernoulli/lib/index.js
@@ -60,4 +60,4 @@ setReadOnly( main, 'factory', factory );
 
 module.exports = main;
 
-// exports: { "factory": "main.factory", "ndarray": "main.ndarray" }
+// exports: { "factory": "main.factory" }

--- a/lib/node_modules/@stdlib/random/strided/beta/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/beta/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/betaprime/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/betaprime/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/chi/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/chi/lib/index.js
@@ -60,4 +60,4 @@ setReadOnly( main, 'factory', factory );
 
 module.exports = main;
 
-// exports: { "factory": "main.factory", "ndarray": "main.ndarray" }
+// exports: { "factory": "main.factory" }

--- a/lib/node_modules/@stdlib/random/strided/chisquare/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/chisquare/lib/index.js
@@ -60,4 +60,4 @@ setReadOnly( main, 'factory', factory );
 
 module.exports = main;
 
-// exports: { "factory": "main.factory", "ndarray": "main.ndarray" }
+// exports: { "factory": "main.factory" }

--- a/lib/node_modules/@stdlib/random/strided/cosine/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/cosine/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/discrete-uniform/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/discrete-uniform/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/exponential/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/exponential/lib/index.js
@@ -60,4 +60,4 @@ setReadOnly( main, 'factory', factory );
 
 module.exports = main;
 
-// exports: { "factory": "main.factory", "ndarray": "main.ndarray" }
+// exports: { "factory": "main.factory" }

--- a/lib/node_modules/@stdlib/random/strided/gamma/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/gamma/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/geometric/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/geometric/lib/index.js
@@ -60,4 +60,4 @@ setReadOnly( main, 'factory', factory );
 
 module.exports = main;
 
-// exports: { "factory": "main.factory", "ndarray": "main.ndarray" }
+// exports: { "factory": "main.factory" }

--- a/lib/node_modules/@stdlib/random/strided/invgamma/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/invgamma/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/lognormal/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/lognormal/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
@@ -69,7 +69,6 @@ setReadOnly( main, 'ndarray', ndarray );
 setReadOnly( main, 'normalized', normalized );
 setReadOnly( normalized, 'ndarray', ndarrayNormalized );
 
-
 // EXPORTS //
 
 module.exports = main;

--- a/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
@@ -69,6 +69,8 @@ setReadOnly( main, 'ndarray', ndarray );
 setReadOnly( main, 'normalized', normalized );
 setReadOnly( normalized, 'ndarray', ndarrayNormalized );
 
+
 // EXPORTS //
+
 
 module.exports = main;

--- a/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
@@ -54,6 +54,7 @@
 * minstd.normalized( out.length, out, 1 );
 */
 
+
 // MODULES //
 
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
@@ -71,6 +72,5 @@ setReadOnly( normalized, 'ndarray', ndarrayNormalized );
 
 
 // EXPORTS //
-
 
 module.exports = main;

--- a/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
@@ -74,4 +74,3 @@ setReadOnly( normalized, 'ndarray', ndarrayNormalized );
 
 module.exports = main;
 
-// exports: { "ndarray": "main.ndarray", "normalized": "main.normalized" }

--- a/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/minstd-shuffle/lib/index.js
@@ -73,4 +73,3 @@ setReadOnly( normalized, 'ndarray', ndarrayNormalized );
 // EXPORTS //
 
 module.exports = main;
-

--- a/lib/node_modules/@stdlib/random/strided/minstd/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/minstd/lib/index.js
@@ -73,5 +73,3 @@ setReadOnly( normalized, 'ndarray', ndarrayNormalized );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray", "normalized": "main.normalized" }

--- a/lib/node_modules/@stdlib/random/strided/mt19937/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/mt19937/lib/index.js
@@ -74,4 +74,3 @@ setReadOnly( normalized, 'ndarray', ndarrayNormalized );
 
 module.exports = main;
 
-// exports: { "ndarray": "main.ndarray", "normalized": "main.normalized" }

--- a/lib/node_modules/@stdlib/random/strided/mt19937/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/mt19937/lib/index.js
@@ -73,4 +73,3 @@ setReadOnly( normalized, 'ndarray', ndarrayNormalized );
 // EXPORTS //
 
 module.exports = main;
-

--- a/lib/node_modules/@stdlib/random/strided/normal/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/normal/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/poisson/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/poisson/lib/index.js
@@ -60,4 +60,4 @@ setReadOnly( main, 'factory', factory );
 
 module.exports = main;
 
-// exports: { "factory": "main.factory", "ndarray": "main.ndarray" }
+// exports: { "factory": "main.factory" }

--- a/lib/node_modules/@stdlib/random/strided/randu/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/randu/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/rayleigh/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/rayleigh/lib/index.js
@@ -60,4 +60,4 @@ setReadOnly( main, 'factory', factory );
 
 module.exports = main;
 
-// exports: { "factory": "main.factory", "ndarray": "main.ndarray" }
+// exports: { "factory": "main.factory" }

--- a/lib/node_modules/@stdlib/random/strided/t/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/t/lib/index.js
@@ -60,4 +60,4 @@ setReadOnly( main, 'factory', factory );
 
 module.exports = main;
 
-// exports: { "factory": "main.factory", "ndarray": "main.ndarray" }
+// exports: { "factory": "main.factory" }

--- a/lib/node_modules/@stdlib/random/strided/uniform/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/uniform/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/index.js
@@ -59,5 +59,3 @@ setReadOnly( main, 'ndarray', ndarray );
 // EXPORTS //
 
 module.exports = main;
-
-// exports: { "ndarray": "main.ndarray" }


### PR DESCRIPTION
Resolves #8864 .

## Description

This PR fixes ESM bundle failures caused by duplicate `ndarray` exports.The `// exports:` metadata comment caused bundle-action to generate named exports which duplicated those inferred from `setReadOnly(...)` property definitions. Removing the redundant export metadata resolves the issue without changing the public API.



This pull request:

-  Fixes #8864

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8864 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
