### PR TITLE
docs: improve doctests for ndarray instances in `blas/base/ndarray/ddot`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/ddot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ddot/README.md
@@ -92,7 +92,6 @@ The function has the following parameters:
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var ddot = require( '@stdlib/blas/base/ndarray/ddot' );
 
 var opts = {
@@ -101,11 +100,9 @@ var opts = {
 
 var xbuf = discreteUniform( 10, 0, 500, opts );
 var x = new ndarray( opts.dtype, xbuf, [ xbuf.length ], [ 1 ], 0, 'row-major' );
-console.log( ndarray2array( x ) );
 
 var ybuf = discreteUniform( 10, 0, 255, opts );
 var y = new ndarray( opts.dtype, ybuf, [ ybuf.length ], [ 1 ], 0, 'row-major' );
-console.log( ndarray2array( y ) );
 
 var out = ddot( [ x, y ] );
 console.log( out );

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ddot/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ddot/examples/index.js
@@ -20,7 +20,6 @@
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var ddot = require( './../lib' );
 
 var opts = {
@@ -29,11 +28,9 @@ var opts = {
 
 var xbuf = discreteUniform( 10, 0, 500, opts );
 var x = new ndarray( opts.dtype, xbuf, [ xbuf.length ], [ 1 ], 0, 'row-major' );
-console.log( ndarray2array( x ) );
 
 var ybuf = discreteUniform( 10, 0, 255, opts );
 var y = new ndarray( opts.dtype, ybuf, [ ybuf.length ], [ 1 ], 0, 'row-major' );
-console.log( ndarray2array( y ) );
 
 var out = ddot( [ x, y ] );
 console.log( out );


### PR DESCRIPTION
Resolves #{ a part of #9329}

## Description

> What is the purpose of this pull request?

This pull request:
  
Examples use ndarray instances directly
Outdated helper utilities like ndarray2array are no longer used
The examples match current stdlib ndarray usage patterns
Code shown in docs runs correctly with the current ndarray API


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{ a part of #9329}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
