### PR TITLE
docs: deprecate incomplete Julia style guide

### DIFF
--- a/docs/style-guides/julia/README.md
+++ b/docs/style-guides/julia/README.md
@@ -1,3 +1,21 @@
+<!--
+@license Apache-2.0
+
+Copyright (c) 2018 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Julia Style Guide
 
 > Style guide for programming in Julia.

--- a/docs/style-guides/julia/README.md
+++ b/docs/style-guides/julia/README.md
@@ -1,39 +1,46 @@
-/*!
- * @license Apache-2.0
- *
- * Copyright (c) 2023 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
 
 # Julia Style Guide
 
-⚠️ **Deprecated**
+> Style guide for programming in Julia.
 
-This document was originally intended to describe a Julia style guide, but it was never completed and is no longer maintained.
+<section class="usage">
 
-An official Julia style guide is available in the Julia documentation.
+See the [Julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/) for comprehensive style recommendations.
 
----
+</section>
 
-## Usage
+<!-- /.usage -->
 
-This document is deprecated and should not be used as a reference for Julia coding style.
+<section class="examples">
 
-## Examples
+For examples of Julia code following the style guide, see the official Julia documentation at [docs.julialang.org](https://docs.julialang.org/en/v1/manual/style-guide/).
 
-No examples are provided, as this style guide was never completed.
+</section>
 
-## Links
+<!-- /.examples -->
 
-- [Julia Style Guide](https://docs.julialang.org/en/v1/manual/style-guide/)
+<section class="links">
+
+-   Julia [style Guide](https://docs.julialang.org/en/v1/manual/style-guide/)
+</section>
+
+<!-- /.links -->

--- a/docs/style-guides/julia/README.md
+++ b/docs/style-guides/julia/README.md
@@ -1,19 +1,21 @@
 <!--
+
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2026 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 -->
 
 # Julia Style Guide

--- a/docs/style-guides/julia/README.md
+++ b/docs/style-guides/julia/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2026 The Stdlib Authors.
+Copyright (c) 2023 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,25 +22,7 @@ limitations under the License.
 
 > Style guide for programming in Julia.
 
-<section class="usage">
+TODO
 
-See the [Julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/) for comprehensive style recommendations.
-
-</section>
-
-<!-- /.usage -->
-
-<section class="examples">
-
-For examples of Julia code following the style guide, see the official Julia documentation at [docs.julialang.org](https://docs.julialang.org/en/v1/manual/style-guide/).
-
-</section>
-
-<!-- /.examples -->
-
-<section class="links">
-
--   Julia [style Guide](https://docs.julialang.org/en/v1/manual/style-guide/)
-</section>
-
-<!-- /.links -->
+-   Julia [style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
+see this is file 

--- a/docs/style-guides/julia/README.md
+++ b/docs/style-guides/julia/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2026 The Stdlib Authors.
+Copyright (c) 2023 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/style-guides/julia/README.md
+++ b/docs/style-guides/julia/README.md
@@ -4,4 +4,4 @@
 
 TODO
 
--   Julia [style guide](http://docs.julialang.org/en/release-0.4/manual/style-guide/).
+-   Julia [style guide](https://docs.julialang.org/en/v1/manual/style-guide/).

--- a/docs/style-guides/julia/README.md
+++ b/docs/style-guides/julia/README.md
@@ -1,27 +1,39 @@
-<!--
-
-@license Apache-2.0
-
-Copyright (c) 2023 The Stdlib Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
--->
+/*!
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2023 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 # Julia Style Guide
 
-> Style guide for programming in Julia.
+⚠️ **Deprecated**
 
-TODO
+This document was originally intended to describe a Julia style guide, but it was never completed and is no longer maintained.
 
--   Julia [style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
+An official Julia style guide is available in the Julia documentation.
+
+---
+
+## Usage
+
+This document is deprecated and should not be used as a reference for Julia coding style.
+
+## Examples
+
+No examples are provided, as this style guide was never completed.
+
+## Links
+
+- [Julia Style Guide](https://docs.julialang.org/en/v1/manual/style-guide/)


### PR DESCRIPTION
Resolves #9759 .

## Description

> What is the purpose of this pull request?

This pull request:

-  deprecates the incomplete Julia style guide located at:

docs/style-guides/julia/README.md
now it works -
<img width="1365" height="738" alt="image" src="https://github.com/user-attachments/assets/6b8867cb-4916-416e-8885-8f2b7993fb4e" />


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-    #9759

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
