### PR TITLE
fix: correct undefined variable typo in AWK scripts

### DIFF
--- a/tools/awk/stdev.awk
+++ b/tools/awk/stdev.awk
@@ -41,7 +41,7 @@ BEGIN {
 	N += 1
 	delta = $1 - mean
 	mean += delta / N
-	M2 += delta * ($1 - mu)
+	M2 += delta * ($1 - mean)
 }
 END {
 	if (N < 2) {

--- a/tools/awk/variance.awk
+++ b/tools/awk/variance.awk
@@ -41,7 +41,7 @@ BEGIN {
 	N += 1
 	delta = $1 - mean
 	mean += delta / N
-	M2 += delta * ($1 - mu)
+	M2 += delta * ($1 - mean)
 }
 END {
 	if (N < 2) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a bug in `tools/awk/variance.awk` and `tools/awk/stdev.awk` where an undefined variable `mu` was used instead of the correctly initialized variable `mean`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Both scripts implement Welford's method for computing variance/standard deviation. The variable `mean` is properly initialized and updated during iteration, but line 44 incorrectly referenced `mu`, which is never defined. AWK treats undefined variables as 0, causing incorrect calculations.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md