### PR TITLE
chore: fix JavaScript lint errors (issue #8258)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/star-repo/lib/query.js
+++ b/lib/node_modules/@stdlib/_tools/github/star-repo/lib/query.js
@@ -62,6 +62,8 @@ function query( slug, options, clbk ) {
 	* @returns {void}
 	*/
 	function done( error, response ) {
+		var resetDate;
+		var resetISO;
 		var info;
 		if ( arguments.length === 1 ) {
 			debug( 'No available rate limit information.' );
@@ -73,7 +75,20 @@ function query( slug, options, clbk ) {
 		info = ratelimit( response.headers );
 		debug( 'Rate limit: %d', info.limit );
 		debug( 'Rate limit remaining: %d', info.remaining );
-		debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
+
+		// Guard against invalid or missing reset values which would throw a RangeError when calling toISOString:
+		resetISO = 'n/a';
+		if (
+			info &&
+			typeof info.reset === 'number' &&
+			isFinite( info.reset )
+		) {
+			resetDate = new Date( info.reset*1000 );
+			if ( !isNaN( resetDate.getTime() ) ) {
+				resetISO = resetDate.toISOString();
+			}
+		}
+		debug( 'Rate limit reset: %s', resetISO );
 
 		if ( error ) {
 			return clbk( error, info );


### PR DESCRIPTION
Resolves #8258 .

## Description

> What is the purpose of this pull request?

This pull request:

-  fixes a JavaScript linting failure caused by an unguarded call to `Date#toISOString()` in the GitHub star-repo tool. The code now safely validates the rate limit reset timestamp before converting it to an ISO string, preventing a `RangeError` during ESLint execution.


## Related Issues

>

This pull request has the following related issues:

-    #8258 
## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
