### PR TITLE
refactor: add typed array support in DSV parser

### DIFF
--- a/lib/node_modules/@stdlib/utils/dsv/base/parse/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/dsv/base/parse/lib/main.js
@@ -366,8 +366,7 @@ setReadOnly( Parser.prototype, '_reset', function reset() {
 setReadOnly( Parser.prototype, '_setField', function set( value, idx ) {
 	var buf = this._rowBuffer;
 
-	// FIXME: as buffer may be provided from userland, use `set` accessor and consider using `@stdlib/utils/push` to allow support of dynamically resizing fixed length buffers
-	// Partially addressed: `@stdlib/utils/push` is now used to support TypedArrays, but `set` accessor still needs to be implemented.
+	// FIXME: as buffer may be provided from userland, use `set` accessor and consider using `@stdlib/utils/push` to allow support of dynamically resizing fixed length buffers. Partially addressed: `@stdlib/utils/push` is now used to support TypedArrays, but `set` accessor still needs to be implemented.
 
 	// Only expand the row buffer if we've run out of previously allocated memory...
 	if ( idx >= buf.length ) {

--- a/lib/node_modules/@stdlib/utils/dsv/base/parse/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/dsv/base/parse/lib/main.js
@@ -29,6 +29,7 @@ var Boolean = require( '@stdlib/boolean/ctor' );
 var format = require( '@stdlib/string/format' );
 var rescape = require( '@stdlib/utils/escape-regexp-string' );
 var replace = require( '@stdlib/string/base/replace' );
+var push = require( '@stdlib/utils/push' );
 var defaults = require( './defaults.js' );
 var state2enum = require( './states/state2enum.js' );
 var enum2state = require( './states/enum2state.json' );
@@ -365,12 +366,10 @@ setReadOnly( Parser.prototype, '_reset', function reset() {
 setReadOnly( Parser.prototype, '_setField', function set( value, idx ) {
 	var buf = this._rowBuffer;
 
-	// FIXME: as buffer may be provided from userland, use `set` accessor and consider using `@stdlib/utils/push` to allow support of dynamically resizing fixed length buffers
-
 	// Only expand the row buffer if we've run out of previously allocated memory...
 	if ( idx >= buf.length ) {
-		buf.push( value );
-		debug( 'Row buffer size increased. Length: %d.', buf.length );
+		this._rowBuffer = push( buf, value );
+		debug( 'Row buffer size increased. Length: %d.', this._rowBuffer.length );
 	} else {
 		// Reuse existing memory:
 		buf[ idx ] = value;

--- a/lib/node_modules/@stdlib/utils/dsv/base/parse/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/dsv/base/parse/lib/main.js
@@ -366,6 +366,9 @@ setReadOnly( Parser.prototype, '_reset', function reset() {
 setReadOnly( Parser.prototype, '_setField', function set( value, idx ) {
 	var buf = this._rowBuffer;
 
+	// FIXME: as buffer may be provided from userland, use `set` accessor and consider using `@stdlib/utils/push` to allow support of dynamically resizing fixed length buffers
+	// Partially addressed: `@stdlib/utils/push` is now used to support TypedArrays, but `set` accessor still needs to be implemented.
+
 	// Only expand the row buffer if we've run out of previously allocated memory...
 	if ( idx >= buf.length ) {
 		this._rowBuffer = push( buf, value );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

Fixes a crash in `@stdlib/utils/dsv/base/parse` when a TypedArray is provided as the `rowBuffer` option. The `_setField` method was calling `buf.push()` which throws a TypeError since TypedArrays do not have a `push` method. added the fix suggested in the existing FIXME comment by using `@stdlib/utils/push`, which supports arrays, typed arrays, and array-like objects.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   No related issue filed - this was discovered during code review of the codebase.

## Questions

> Any questions for reviewers of this pull request?

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md