### PR TITLE
chore: fix JavaScript lint errors (issue #9825)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-www/lib/transformer.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-www/lib/transformer.js
@@ -44,6 +44,24 @@ function factory( opts ) {
 	return transformer;
 
 	/**
+	* Callback invoked upon finding a matching node.
+	*
+	* @private
+	* @param {Node} node - reference node
+	*/
+	function visitor( node ) {
+		debug( 'Found a definition: %s', node.identifier );
+		if ( RE_STDLIB.test( node.identifier ) ) {
+			debug( 'Found a package identifier.' );
+
+			debug( 'Current URL: %s', node.url );
+			node.url = opts.base + node.identifier;
+
+			debug( 'Resolved URL: %s', node.url );
+		}
+	}
+
+	/**
 	* Transforms a Markdown abstract syntax tree (AST).
 	*
 	* @private
@@ -53,24 +71,6 @@ function factory( opts ) {
 	function transformer( tree ) {
 		debug( 'Processing virtual file...' );
 		visit( tree, 'definition', visitor );
-
-		/**
-		* Callback invoked upon finding a matching node.
-		*
-		* @private
-		* @param {Node} node - reference node
-		*/
-		function visitor( node ) {
-			debug( 'Found a definition: %s', node.identifier );
-			if ( RE_STDLIB.test( node.identifier ) ) {
-				debug( 'Found a package identifier.' );
-
-				debug( 'Current URL: %s', node.url );
-				node.url = opts.base + node.identifier;
-
-				debug( 'Resolved URL: %s', node.url );
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames
    status: passed
  - task: lint_editorconfig
    status: passed
  - task: lint_markdown
    status: na
  - task: lint_package_json
    status: na
  - task: lint_repl_help
    status: na
  - task: lint_javascript_src
    status: passed
  - task: lint_javascript_cli
    status: na
  - task: lint_javascript_examples
    status: na
  - task: lint_javascript_tests
    status: na
  - task: lint_javascript_benchmarks
    status: na
  - task: lint_python
    status: na
  - task: lint_r
    status: na
  - task: lint_c_src
    status: na
  - task: lint_c_examples
    status: na
  - task: lint_c_benchmarks
    status: na
  - task: lint_c_tests_fixtures
    status: na
  - task: lint_shell
    status: na
  - task: lint_typescript_declarations
    status: passed
  - task: lint_typescript_tests
    status: na
  - task: lint_license_headers
    status: passed
---

Resolves #9825.

## Description

This pull request:

-   Fixes a JavaScript lint failure in `remark-stdlib-urls-www` by moving the `visitor` callback to outer function scope.
-   Addresses the `stdlib/no-unnecessary-nested-functions` ESLint rule violation in `lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-www/lib/transformer.js`.

## Related Issues

This pull request has the following related issues:

-   #9825

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

I used ChatGPT to understand the lint error and the project's contribution conventions; the code changes were applied manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
