### PR TITLE
chore: fix JavaScript lint errors (issue #9825)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-www/lib/transformer.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-www/lib/transformer.js
@@ -33,30 +33,21 @@ var RE_STDLIB = /^@stdlib\//;
 // FUNCTIONS //
 
 /**
-* Returns a visitor function.
+* Callback invoked upon finding a matching node.
 *
 * @private
+* @param {Node} node - reference node
 * @param {Options} opts - transformer options
-* @param {string} opts.base - base path for internal URLs
-* @returns {Function} visitor function
 */
-function createVisitor( opts ) {
-	/**
-	* Callback invoked upon finding a matching node.
-	*
-	* @private
-	* @param {Node} node - reference node
-	*/
-	return function visitor( node ) {
-		debug( 'Found a definition: %s', node.identifier );
-		if ( RE_STDLIB.test( node.identifier ) ) {
-			debug( 'Found a package identifier.' );
+function visitor( node, opts ) {
+	debug( 'Found a definition: %s', node.identifier );
+	if ( RE_STDLIB.test( node.identifier ) ) {
+		debug( 'Found a package identifier.' );
 
-			debug( 'Current URL: %s', node.url );
-			node.url = opts.base + node.identifier;
-			debug( 'Resolved URL: %s', node.url );
-		}
-	};
+		debug( 'Current URL: %s', node.url );
+		node.url = opts.base + node.identifier;
+		debug( 'Resolved URL: %s', node.url );
+	}
 }
 
 
@@ -71,7 +62,6 @@ function createVisitor( opts ) {
 * @returns {Function} transformer function
 */
 function factory( opts ) {
-	var visitor = createVisitor( opts );
 	return transformer;
 
 	/**
@@ -82,7 +72,17 @@ function factory( opts ) {
 	*/
 	function transformer( tree ) {
 		debug( 'Processing virtual file...' );
-		visit( tree, 'definition', visitor );
+		visit( tree, 'definition', wrappedVisitor );
+	}
+
+	/**
+	* Visitor wrapper to provide options.
+	*
+	* @private
+	* @param {Node} node - reference node
+	*/
+	function wrappedVisitor( node ) {
+		visitor( node, opts );
 	}
 }
 

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-www/lib/transformer.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-www/lib/transformer.js
@@ -30,6 +30,36 @@ var debug = logger( 'remark-stdlib-urls-www:transformer' );
 var RE_STDLIB = /^@stdlib\//;
 
 
+// FUNCTIONS //
+
+/**
+* Returns a visitor function.
+*
+* @private
+* @param {Options} opts - transformer options
+* @param {string} opts.base - base path for internal URLs
+* @returns {Function} visitor function
+*/
+function createVisitor( opts ) {
+	/**
+	* Callback invoked upon finding a matching node.
+	*
+	* @private
+	* @param {Node} node - reference node
+	*/
+	return function visitor( node ) {
+		debug( 'Found a definition: %s', node.identifier );
+		if ( RE_STDLIB.test( node.identifier ) ) {
+			debug( 'Found a package identifier.' );
+
+			debug( 'Current URL: %s', node.url );
+			node.url = opts.base + node.identifier;
+			debug( 'Resolved URL: %s', node.url );
+		}
+	};
+}
+
+
 // MAIN //
 
 /**
@@ -41,6 +71,7 @@ var RE_STDLIB = /^@stdlib\//;
 * @returns {Function} transformer function
 */
 function factory( opts ) {
+	var visitor = createVisitor( opts );
 	return transformer;
 
 	/**
@@ -48,29 +79,10 @@ function factory( opts ) {
 	*
 	* @private
 	* @param {Node} tree - root AST node
-	* @param {File} file - virtual file
 	*/
 	function transformer( tree ) {
 		debug( 'Processing virtual file...' );
 		visit( tree, 'definition', visitor );
-
-		/**
-		* Callback invoked upon finding a matching node.
-		*
-		* @private
-		* @param {Node} node - reference node
-		*/
-		function visitor( node ) {
-			debug( 'Found a definition: %s', node.identifier );
-			if ( RE_STDLIB.test( node.identifier ) ) {
-				debug( 'Found a package identifier.' );
-
-				debug( 'Current URL: %s', node.url );
-				node.url = opts.base + node.identifier;
-
-				debug( 'Resolved URL: %s', node.url );
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
Resolves - #9825

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a JavaScript lint error caused by an unnecessary nested function in the
remark-stdlib-urls-www transformer.
- Moves `visitor` to outer scope via a factory function
- No functional changes
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9825

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
