### PR TITLE
chore: fix JavaScript lint errors (issue stdlib-js#9833)

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/reduce/lib/limit.js
+++ b/lib/node_modules/@stdlib/utils/async/reduce/lib/limit.js
@@ -76,6 +76,29 @@ function limit( collection, acc, opts, fcn, done ) {
 			next(); // eslint-disable-line node/callback-return
 		}
 	}
+
+	/**
+	* Callback invoked once a provided function finishes processing a collection element.
+	*
+	* @private
+	* @param {*} [error] - error
+	* @param {*} [result] - accumulation result
+	* @returns {void}
+	*/
+	function cb( error, result ) {
+		if ( flg ) {
+			// Prevent further processing of collection elements:
+			return;
+		}
+		if ( error ) {
+			flg = true;
+			return clbk( error );
+		}
+		debug( 'Accumulator: %s', JSON.stringify( result ) );
+		acc = result;
+		clbk();
+	}
+
 	/**
 	* Callback to invoke a provided function for the next element in a collection.
 	*
@@ -90,27 +113,6 @@ function limit( collection, acc, opts, fcn, done ) {
 			fcn.call( opts.thisArg, acc, collection[ idx ], idx, cb );
 		} else {
 			fcn.call( opts.thisArg, acc, collection[ idx ], idx, collection, cb ); // eslint-disable-line max-len
-		}
-		/**
-		* Callback invoked once a provided function finishes processing a collection element.
-		*
-		* @private
-		* @param {*} [error] - error
-		* @param {*} [result] - accumulation result
-		* @returns {void}
-		*/
-		function cb( error, result ) {
-			if ( flg ) {
-				// Prevent further processing of collection elements:
-				return;
-			}
-			if ( error ) {
-				flg = true;
-				return clbk( error );
-			}
-			debug( 'Accumulator: %s', JSON.stringify( result ) );
-			acc = result;
-			clbk();
 		}
 	}
 


### PR DESCRIPTION
Resolves #9833 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes javascript linting errors in `lib\node_modules\@stdlib\utils\async\reduce\lib\limit.js`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9833 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
