### PR TITLE
chore:  add missing `devDependencies` field

### DIFF
--- a/docs/migration-guides/tfjs/package.json
+++ b/docs/migration-guides/tfjs/package.json
@@ -29,6 +29,7 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
+  "devDependencies": {},
   "dependencies": {
     "@tensorflow/tfjs": "^4.20.0",
     "@tensorflow/tfjs-node": "^4.20.0"

--- a/docs/migration-guides/tfjs/package.json
+++ b/docs/migration-guides/tfjs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "stdlib-tfjs-benchmarks",
-  "private": true,
   "version": "0.0.0",
   "description": "Tensorflow.js benchmarks.",
   "license": "Apache-2.0",
@@ -16,7 +15,8 @@
   ],
   "main": "./package.json",
   "directories": {
-    "benchmark": "./benchmark"
+    "benchmark": "./benchmark",
+    "data": "./data"
   },
   "scripts": {
     "bench": "make benchmark"
@@ -29,11 +29,11 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "devDependencies": {},
   "dependencies": {
     "@tensorflow/tfjs": "^4.20.0",
     "@tensorflow/tfjs-node": "^4.20.0"
   },
+  "devDependencies": {},
   "engines": {},
   "os": [
     "aix",


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames
    status: passed
  - task: lint_editorconfig
    status: passed
  - task: lint_markdown
    status: na
  - task: lint_package_json
    status: passed
  - task: lint_repl_help
    status: na
  - task: lint_javascript_src
    status: na
  - task: lint_javascript_cli
    status: na
  - task: lint_javascript_examples
    status: na
  - task: lint_javascript_tests
    status: na
  - task: lint_javascript_benchmarks
    status: na
  - task: lint_python
    status: na
  - task: lint_r
    status: na
  - task: lint_c_src
    status: na
  - task: lint_c_examples
    status: na
  - task: lint_c_benchmarks
    status: na
  - task: lint_c_tests_fixtures
    status: na
  - task: lint_shell
    status: na
  - task: lint_typescript_declarations
    status: passed
  - task: lint_typescript_tests
    status: na
  - task: lint_license_headers
    status: passed
---

## Description

While investigating a separate issue, I ran `make lint-pkg-json` and found that the `lint_package_json` check was failing for one of the packages.

The failure was caused by a missing `devDependencies` field in `package.json`. According to the package.json schema enforced by the linting pipeline, `devDependencies` is a required field. As a result, the Ajv schema validator was flagging this omission as an error.

This pull request fixes the issue by adding the appropriate `devDependencies` field, bringing the package metadata back into compliance with the schema and allowing the lint step to pass.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [ ] Yes
- [x] No

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
