### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/fs/read-wasm/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/read-wasm/lib/index.js
@@ -27,7 +27,7 @@
 * var join = require( 'path' ).join;
 * var readWASM = require( '@stdlib/fs/read-wasm' );
 *
-* var fpath = join( __dirname, 'foo.wasm' );
+* var fpath = join( __dirname, 'example.wasm' );
 * readWASM( fpath, onRead );
 *
 * function onRead( error, buf ) {
@@ -42,7 +42,7 @@
 * var instanceOf = require( '@stdlib/assert/instance-of' );
 * var readWASMSync = require( '@stdlib/fs/read-wasm' ).sync;
 *
-* var fpath = join( __dirname, 'foo.wasm' );
+* var fpath = join( __dirname, 'example.wasm' );
 * var out = readWASMSync( fpath );
 * if ( instanceOf( out, Error ) ) {
 *     throw out;

--- a/lib/node_modules/@stdlib/utils/async/inmap/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/utils/async/inmap/benchmark/benchmark.js
@@ -39,11 +39,11 @@ bench( pkg, function benchmark( b ) {
 			clbk( null, v*i );
 		}
 	}
-	arr = new Array( 100 );
-	len = arr.length;
-	for ( i = 0; i < len; i++ ) {
-		arr[ i ] = EPS;
+	arr = [];
+	for ( i = 0; i < 100; i++ ) {
+		arr.push( EPS );
 	}
+	len = arr.length;
 	i = 0;
 	b.tic();
 
@@ -79,11 +79,11 @@ bench( pkg+':series=true', function benchmark( b ) {
 	opts = {
 		'series': true
 	};
-	arr = new Array( 100 );
-	len = arr.length;
-	for ( i = 0; i < len; i++ ) {
-		arr[ i ] = EPS;
+	arr = [];
+	for ( i = 0; i < 100; i++ ) {
+		arr.push( EPS );
 	}
+	len = arr.length;
 	i = 0;
 	b.tic();
 
@@ -119,11 +119,11 @@ bench( pkg+':limit=3', function benchmark( b ) {
 	opts = {
 		'limit': 3
 	};
-	arr = new Array( 100 );
-	len = arr.length;
-	for ( i = 0; i < len; i++ ) {
-		arr[ i ] = EPS;
+	arr = [];
+	for ( i = 0; i < 100; i++ ) {
+		arr.push( EPS );
 	}
+	len = arr.length;
 	i = 0;
 	b.tic();
 


### PR DESCRIPTION
Resolves #9851 

Description
What is the purpose of this pull request?

This pull request:

- Fixes JavaScript ESLint errors related to the `stdlib/no-new-array` rule and resolves file reference issues detected in the automated linting workflow
- Replaces 3 instances of `new Array(100)` constructor with array literals `[]` and `.push()` method initialization in the async inmap benchmark file
- Updates JSDoc example file references from `foo.wasm` to `example.wasm` to prevent linting errors on non-existent files

Related Issues
Does this pull request have any related issues?
No

Questions
Any questions for reviewers of this pull request?

No.

Other
Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

Checklist
Please ensure the following tasks are completed before submitting this pull request.

   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

AI Assistance
When authoring the changes proposed in this PR, did you use any kind of AI assistance?

[ ] Yes
[x] No
