### PR TITLE
Fix js lint errors

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/path/lib/render/utils/zip.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/path/lib/render/utils/zip.js
@@ -40,7 +40,8 @@ function zip( x, y ) {
 	if ( x.length !== y.length ) {
 		throw new Error( format( 'invalid arguments. Must provide equal length array-like objects. x length: `%u`. y length: `%u`.', x.length, y.length ) );
 	}
-	out = new Array( x.length );
+	out = []
+	out.length = x.length;
 	for ( i = 0; i < x.length; i++ ) {
 		out[ i ] = [ x[i], y[i] ];
 	}


### PR DESCRIPTION
Fixes #9867 

## Description

> What is the purpose of this pull request?

This pull request:

- Replaces usage of the `Array` constructor (`new Array(x.length)`) with explicit array allocation using an array literal and manual length assignment.
- Fixes a lint error reported by the `stdlib/no-new-array` ESLint rule.
- Preserves existing behavior and performance characteristics with no functional changes.

## Related Issues

> Does this pull request have any related issues?

This pull request has no associated issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

This change is a small refactor intended solely to resolve a lint failure and align the implementation with stdlib style guidelines.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

I consulted AI to understand the repository’s linting rules and contribution workflow. The code change itself was authored manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
