### PR TITLE
chore: add support for `private` key in `_tools/package-json/standardize`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/package-json/standardize/lib/keys.json
+++ b/lib/node_modules/@stdlib/_tools/package-json/standardize/lib/keys.json
@@ -1,5 +1,6 @@
 [
   "name",
+  "private",
   "version",
   "description",
   "license",
@@ -27,6 +28,5 @@
   "engines",
   "os",
   "keywords",
-  "private",
   "__stdlib__"
 ]

--- a/lib/node_modules/@stdlib/_tools/package-json/standardize/lib/keys.json
+++ b/lib/node_modules/@stdlib/_tools/package-json/standardize/lib/keys.json
@@ -27,5 +27,6 @@
   "engines",
   "os",
   "keywords",
+  "private",
   "__stdlib__"
 ]


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames
    status: passed
  - task: lint_editorconfig
    status: passed
  - task: lint_markdown
    status: na
  - task: lint_package_json
    status: na
  - task: lint_repl_help
    status: na
  - task: lint_javascript_src
    status: na
  - task: lint_javascript_cli
    status: na
  - task: lint_javascript_examples
    status: na
  - task: lint_javascript_tests
    status: na
  - task: lint_javascript_benchmarks
    status: na
  - task: lint_python
    status: na
  - task: lint_r
    status: na
  - task: lint_c_src
    status: na
  - task: lint_c_examples
    status: na
  - task: lint_c_benchmarks
    status: na
  - task: lint_c_tests_fixtures
    status: na
  - task: lint_shell
    status: na
  - task: lint_typescript_declarations
    status: passed
  - task: lint_typescript_tests
    status: na
  - task: lint_license_headers
    status: passed
---


# Add missing "private" key to keys.json

## Description

> What is the purpose of this pull request?

This pull request:

- Adds the `private` key to the `keys.json` reference file, as it is currently the only top-level `package.json` key missing from the reference despite being used across the codebase.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Background

I scanned all `package.json` files in the repository to identify which top-level keys are currently in use and compared them against the reference `keys.json` file. The scan revealed that `private` is the only key currently in use that is missing from the reference.

After discussion with @kgryte on Zulip, it was confirmed that the `private` key is intentional and should be included in the reference. **It must  be there so that CI lint checks for certain
 package.json files do not fail.**

[#dev-questions > Regarding &#96;package.json&#96; linting.](https://stdlib.zulipchat.com/#narrow/channel/546735-dev-questions/topic/Regarding.20.60package.2Ejson.60.20linting.2E/with/568581819)

### Verification

The following shell script can be used to verify this finding by running it from the root of the project:
```sh
#!/usr/bin/env sh
set -e

if ! command -v jq >/dev/null 2>&1; then
    echo "Error: jq is required but not installed."
    exit 1
fi

# KEYS.JSON REFERENCE
REFERENCE_KEYS=$(cat <<'EOF'
name
version
description
license
licenses
author
maintainers
contributors
funding
bin
main
exports
browser
unpkg
gypfile
directories
types
scripts
homepage
repository
repositories
bugs
dependencies
optionalDependencies
devDependencies
engines
os
keywords
__stdlib__
EOF
)

FOUND_FILE=$(mktemp)
REF_FILE=$(mktemp)
trap 'rm -f "$FOUND_FILE" "$REF_FILE"' EXIT

find . -type f -name "package.json" \
    | while read -r file; do
        if jq -e 'type == "object"' "$file" >/dev/null 2>&1; then
            jq -r 'keys[]' "$file"
        fi
    done \
    | sort -u > "$FOUND_FILE"

printf "%s\n" "$REFERENCE_KEYS" | sort > "$REF_FILE"

echo "EXTRA (found but not in reference)"
comm -23 "$FOUND_FILE" "$REF_FILE"

echo
echo "MISSING (in reference but not found)"
comm -13 "$FOUND_FILE" "$REF_FILE"
```
<img width="525" height="123" alt="hfhfh" src="https://github.com/user-attachments/assets/0671de49-2b45-43a0-97c8-34c970c2f576" />

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md