### PR TITLE
chore: fix JavaScript lint errors (issue #9883)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/licenses/update-header-file-list/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/licenses/update-header-file-list/lib/main.js
@@ -100,7 +100,7 @@ function updateHeader( files, old, header, clbk ) {
 		for ( i = 0; i < keys.length; i++ ) {
 			v = old[ keys[i] ];
 			if ( !isString( v ) && !isRegExp( v ) ) {
-				throw new TypeError( format( 'invalid argument. A header object must map each filename extension to a license header string or regular expression. `%s: %s`. Value: `%s`.',  keys[i], v, JSON.stringify( old ) ) );
+				throw new TypeError( format( 'invalid argument. A header object must map each filename extension to a license header string or regular expression. `%s: %s`. Value: `%s`.', keys[i], v, JSON.stringify( old ) ) );
 			}
 		}
 	} else if ( !isString( old ) && !isRegExp( old ) ) {

--- a/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/resolve.sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/resolve.sync.js
@@ -50,6 +50,7 @@ function getPkgs( pkgs, basedir ) {
 	var len;
 	var out;
 	var dir;
+	var o;
 	var i;
 	var k;
 
@@ -57,7 +58,6 @@ function getPkgs( pkgs, basedir ) {
 	debug( 'Resolving %d packages...', len );
 
 	out = [];
-	out.length = len;
 	for ( i = 0; i < len; i++ ) {
 		pkg = pkgs[ i ];
 		k = i + 1;
@@ -66,11 +66,11 @@ function getPkgs( pkgs, basedir ) {
 		opts = {
 			'basedir': basedir
 		};
-		out[ i ] = {};
-		out[ i ].pkg = pkg;
+		o = {};
+		o.pkg = pkg;
 
 		main = resolve( pkg, opts );
-		out[ i ].id = main;
+		o.id = main;
 		debug( 'Resolved package: %s (%d of %d). Main: %s.', pkg, k, len, main );
 
 		debug( 'Resolving package directory for package: %s (%d of %d)...', pkg, k, len );
@@ -79,7 +79,7 @@ function getPkgs( pkgs, basedir ) {
 			debug( 'Encountered an error while resolving package directory: %s (%d of %d). Error: %s', pkg, k, len, dir.message );
 			return dir;
 		}
-		out[ i ].dir = dir;
+		o.dir = dir;
 		debug( 'Resolved package directory for package: %s (%d of %d). Dir: %s', pkg, k, len, dir );
 
 		data = readJSON( join( dir, 'package.json' ) );
@@ -87,7 +87,8 @@ function getPkgs( pkgs, basedir ) {
 			debug( 'Encountered an error while reading `package.json`: %s (%d of %d). Error: %s', pkg, k, len, data.message );
 			return data;
 		}
-		out[ i ].data = data;
+		o.data = data;
+		out.push( o );
 	}
 	debug( 'Resolved all packages.' );
 	return out;

--- a/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/resolve.sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/resolve.sync.js
@@ -56,7 +56,8 @@ function getPkgs( pkgs, basedir ) {
 	len = pkgs.length;
 	debug( 'Resolving %d packages...', len );
 
-	out = new Array( len );
+	var out = [];
+	out.length = len;
 	for ( i = 0; i < len; i++ ) {
 		pkg = pkgs[ i ];
 		k = i + 1;

--- a/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/resolve.sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/resolve.sync.js
@@ -56,7 +56,7 @@ function getPkgs( pkgs, basedir ) {
 	len = pkgs.length;
 	debug( 'Resolving %d packages...', len );
 
-	var out = [];
+	out = [];
 	out.length = len;
 	for ( i = 0; i < len; i++ ) {
 		pkg = pkgs[ i ];

--- a/lib/node_modules/@stdlib/buffer/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/buffer/ctor/lib/main.js
@@ -20,7 +20,7 @@
 
 // MAIN //
 
-var ctor = require( 'buffer' ).Buffer; // eslint-disable-line stdlib/require-globals
+var ctor = require( 'buffer' ).Buffer;
 
 
 // EXPORTS //


### PR DESCRIPTION
Resolves #9883 .

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes JavaScript lint issues reported by the JavaScript lint workflow.

## Changes
- Removed unused eslint-disable directive
- Replaced `new Array(len)` usage with array literal + length assignment
- Fixed `no-multi-spaces` formatting issue

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9883

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
