### PR TITLE
bench: refactor to use string interpolation in tools/snippets/benchmark

### DIFF
--- a/tools/snippets/benchmark/benchmark.native.js
+++ b/tools/snippets/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -36,7 +37,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var i;
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/tools/snippets/benchmark/benchmark.wasm.js
+++ b/tools/snippets/benchmark/benchmark.wasm.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var hasWebAssemblySupport = require( '@stdlib/assert/has-wasm-support' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var TODO = require( './../lib/wasm.js' );
 
@@ -35,7 +36,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::wasm', opts, function benchmark( b ) {
+bench( format( '%s::wasm', pkg ), opts, function benchmark( b ) {
 	var i;
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION
Resolves a part of #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR refactors JavaScript benchmark names to use `@stdlib/string/format` instead of string concatenation.


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
