### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
 
@@ -32,20 +33,22 @@ var cdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = uniform( len, -100.0, 100.0 );
-	mu = uniform( len, -50.0, 50.0 );
-	sigma = uniform( len, EPS, 20.0 + EPS );
+	opts = {
+		'dtype': 'float64'
+	}
+	x = uniform( 100, -100.0, 100.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0 + EPS, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = cdf( x[ i % len ], mu[ i % len ], sigma[ i % len ]);
+		y = cdf( x[ i % x.length ], mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mycdf;
 	var sigma;
 	var mu;
@@ -69,7 +72,9 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	mycdf = cdf.factory( mu, sigma );
-	x = uniform( 100, -3.0, 3.0 );
+	x = uniform( 100, -3.0, 3.0, {
+		'dtype': 'float64'
+	});
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
@@ -61,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:factory', pkg ), function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var mycdf;
 	var sigma;
 	var mu;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	x = uniform( 100, -100.0, 100.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0 + EPS, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.native.js
@@ -41,20 +41,22 @@ var opts = {
 
 bench( pkg, opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = uniform( len, -100.0, 100.0 );
-	mu = uniform( len, -50.0, 50.0 );
-	sigma = uniform( len, EPS, 20.0 + EPS );
+	opts = {
+		'dtype': 'float64'
+	}
+	x = uniform( 100, -100.0, 100.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0 + EPS, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = cdf( x[ i % len ], mu[ i % len ], sigma[ i % len ]);
+		y = cdf( x[ i % x.length ], mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( pkg, opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	x = uniform( 100, -100.0, 100.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0 + EPS, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
@@ -21,26 +21,32 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Normal = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
+	var opts;
 	var mu;
 	var i;
 
+	opts = {
+		'dtype': 'float64'
+	}
+	mu = uniform( 100, EPS, 10.0, opts );
+	sigma = uniform( 100, EPS, 10.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu() * 10.0 ) + EPS;
-		sigma = ( randu() * 10.0 ) + EPS;
-		dist = new Normal( mu, sigma );
+		dist = new Normal( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( !( dist instanceof Normal ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -53,7 +59,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:mu', function benchmark( b ) {
+bench( format( '%s::get:mu', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
@@ -79,10 +85,11 @@ bench( pkg+'::get:mu', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set:mu', function benchmark( b ) {
+bench( format( '%s::set:mu', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -90,9 +97,13 @@ bench( pkg+'::set:mu', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
+		y = x[ i % x.length ];
 		dist.mu = y;
 		if ( dist.mu !== y ) {
 			b.fail( 'should return set value' );
@@ -106,7 +117,7 @@ bench( pkg+'::set:mu', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:sigma', function benchmark( b ) {
+bench( format( '%s::get:sigma', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
@@ -132,10 +143,11 @@ bench( pkg+'::get:sigma', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set:sigma', function benchmark( b ) {
+bench( format( '%s::set:sigma', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -143,9 +155,13 @@ bench( pkg+'::set:sigma', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
+		y = x[ i % x.length ];
 		dist.sigma = y;
 		if ( dist.sigma !== y ) {
 			b.fail( 'should return set value' );
@@ -159,10 +175,11 @@ bench( pkg+'::set:sigma', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':entropy', function benchmark( b ) {
+bench( format( '%s:entropy', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -170,9 +187,13 @@ bench( pkg+':entropy', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % x.length ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -186,10 +207,11 @@ bench( pkg+':entropy', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':kurtosis', function benchmark( b ) {
+bench( format( '%s:kurtosis', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -197,9 +219,13 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % x.length ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -213,10 +239,11 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':mean', function benchmark( b ) {
+bench( format( '%s:mean', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -224,9 +251,13 @@ bench( pkg+':mean', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % x.length ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -240,10 +271,11 @@ bench( pkg+':mean', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':median', function benchmark( b ) {
+bench( format( '%s:median', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -251,9 +283,13 @@ bench( pkg+':median', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % x.length ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -267,10 +303,11 @@ bench( pkg+':median', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':mode', function benchmark( b ) {
+bench( format( '%s:mode', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -278,9 +315,13 @@ bench( pkg+':mode', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS + 1.0, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + 1.0 + EPS;
+		dist.mu = x[ i % x.length ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -294,10 +335,11 @@ bench( pkg+':mode', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':skewness', function benchmark( b ) {
+bench( format( '%s:skewness', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -305,9 +347,13 @@ bench( pkg+':skewness', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % x.length ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -321,10 +367,11 @@ bench( pkg+':skewness', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':variance', function benchmark( b ) {
+bench( format( '%s:variance', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -332,9 +379,13 @@ bench( pkg+':variance', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % x.length ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -348,10 +399,11 @@ bench( pkg+':variance', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':variance', function benchmark( b ) {
+bench( format( '%s:variance', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
+	var x;
 	var y;
 	var i;
 
@@ -359,9 +411,13 @@ bench( pkg+':variance', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, EPS, 100.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % x.length ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -375,7 +431,7 @@ bench( pkg+':variance', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':cdf', function benchmark( b ) {
+bench( format( '%s:cdf', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
@@ -387,10 +443,13 @@ bench( pkg+':cdf', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, -3.0, 3.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -403,7 +462,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':logpdf', function benchmark( b ) {
+bench( format( '%s:logpdf', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
@@ -415,10 +474,13 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, -3.0, 3.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -431,7 +493,7 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':mgf', function benchmark( b ) {
+bench( format( '%s:mgf', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
@@ -443,10 +505,13 @@ bench( pkg+':mgf', function benchmark( b ) {
 	sigma = 0.2;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, 0.0, 1.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -459,7 +524,7 @@ bench( pkg+':mgf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':pdf', function benchmark( b ) {
+bench( format( '%s:pdf', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
@@ -471,10 +536,13 @@ bench( pkg+':pdf', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, -3.0, 3.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -487,7 +555,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':quantile', function benchmark( b ) {
+bench( format( '%s:quantile', pkg ), function benchmark( b ) {
 	var sigma;
 	var dist;
 	var mu;
@@ -499,10 +567,13 @@ bench( pkg+':quantile', function benchmark( b ) {
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
 
+	x = uniform( 100, 0.0, 1.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
@@ -40,7 +40,7 @@ bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, EPS, 10.0, opts );
 	sigma = uniform( 100, EPS, 10.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var entropy = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = entropy( mu[ i % len ], sigma[ i % len ] );
+		y = entropy( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.js
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,23 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = entropy( mu[ i % len ], sigma[ i % len ] );
+		y = entropy( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var kurtosis = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = kurtosis( mu[ i % len ], sigma[ i % len ] );
+		y = kurtosis( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.js
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,23 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = kurtosis( mu[ i % len ], sigma[ i % len ] );
+		y = kurtosis( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	x = uniform( 100, -100.0, 100.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0 + EPS, opts );
@@ -72,6 +72,7 @@ bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	mylogcdf = logcdf.factory( mu, sigma );
+
 	x = uniform( 100, -3.0, 3.0, {
 		'dtype': 'float64'
 	});

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
@@ -61,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:factory', pkg ), function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var mylogcdf;
 	var sigma;
 	var mu;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var logcdf = require( './../lib' );
 
@@ -32,20 +33,22 @@ var logcdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = uniform( len, -100.0, 100.0 );
-	mu = uniform( len, -50.0, 50.0 );
-	sigma = uniform( len, EPS, 20.0 + EPS );
+	opts = {
+		'dtype': 'float64'
+	}
+	x = uniform( 100, -100.0, 100.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0 + EPS, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logcdf( x[ i % len ], mu[ i % len ], sigma[ i % len ]);
+		y = logcdf( x[ i % x.length ], mu[ i % mu.length ], sigma[ i % sigma.length ]);
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mylogcdf;
 	var sigma;
 	var mu;
@@ -69,7 +72,9 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	mylogcdf = logcdf.factory( mu, sigma );
-	x = uniform( 100, -3.0, 3.0 );
+	x = uniform( 100, -3.0, 3.0, {
+		'dtype': 'float64'
+	});
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.native.js
@@ -41,20 +41,22 @@ var opts = {
 
 bench( pkg, opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = uniform( len, -100.0, 100.0 );
-	mu = uniform( len, -50.0, 50.0 );
-	sigma = uniform( len, EPS, 20.0 + EPS );
+	opts = {
+		'dtype': 'float64'
+	}
+	x = uniform( 100, -100.0, 100.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0 + EPS, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logcdf( x[ i % len ], mu[ i % len ], sigma[ i % len ]);
+		y = logcdf( x[ i % x.length ], mu[ i % mu.length ], sigma[ i % sigma.length ]);
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( pkg, opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	x = uniform( 100, -100.0, 100.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0 + EPS, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.js
@@ -61,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:factory', pkg ), function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var mylogpdf;
 	var sigma;
 	var mu;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var logpdf = require( './../lib' );
 
@@ -32,20 +33,22 @@ var logpdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = uniform( len, -100.0, 100.0 );
-	mu = uniform( len, -50.0, 50.0 );
-	sigma = uniform( len, EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
+	}
+	x = uniform( 100, -100.0, 100.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logpdf( x[ i % len ], mu[ i % len ], sigma[ i % len ] );
+		y = logpdf( x[ i % x.length ], mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mylogpdf;
 	var sigma;
 	var mu;
@@ -69,7 +72,9 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	mylogpdf = logpdf.factory( mu, sigma );
-	x = uniform( 100, -3.0, 3.0 );
+	x = uniform( 100, -3.0, 3.0, {
+		'dtype': 'float64'
+	});
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.js
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	x = uniform( 100, -100.0, 100.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.native.js
@@ -22,8 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -42,25 +41,22 @@ var opts = {
 
 bench( pkg, opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( -100.0, 100.0 );
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	x = uniform( 100, -100.0, 100.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logpdf( x[ i % len ], mu[ i % len ], sigma[ i % len ]);
+		y = logpdf( x[ i % x.length ], mu[ i % mu.length ], sigma[ i % sigma.length ]);
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( pkg, opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	x = uniform( 100, -100.0, 100.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +32,20 @@ var mean = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
+	opts = {
+		'dtype': 'float64'
+	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = mean( mu, sigma );
+		y = mean( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.js
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.native.js
@@ -42,7 +42,7 @@ var opts = {
 
 bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,23 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
 	var len;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mean( mu[ i % len ], sigma[ i % len ] );
+		y = mean( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.js
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var median = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = median( mu[ i % len ], sigma[ i % len ] );
+		y = median( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,23 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = median( mu[ i % len ], sigma[ i % len ] );
+		y = median( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
@@ -61,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:factory', pkg ), function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var mymgf;
 	var sigma;
 	var mu;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var mgf = require( './../lib' );
 
@@ -33,25 +33,22 @@ var mgf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var t;
 	var y;
 	var i;
 
-	len = 100;
-	t = new Float64Array( len );
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		t[ i ] = uniform( 0.0, 1.0 );
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	t = uniform( 100, 0.0, 1.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mgf( t[ i%len ], mu[ i%len ], sigma[ i%len ] );
+		y = mgf( t[ i%t.length ], mu[ i%mu.length ], sigma[ i%sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -64,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mymgf;
 	var sigma;
 	var mu;
@@ -76,10 +73,14 @@ bench( pkg+':factory', function benchmark( b ) {
 	sigma = 1.5;
 	mymgf = mgf.factory( mu, sigma );
 
+	opts = {
+		'dtype': 'float64'
+	}
+	t = uniform( 100, 0.0, 1.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = uniform( 0.0, 1.0 );
-		y = mymgf( t );
+		y = mymgf( t[ i % t.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	t = uniform( 100, 0.0, 1.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
@@ -73,10 +73,9 @@ bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	sigma = 1.5;
 	mymgf = mgf.factory( mu, sigma );
 
-	opts = {
+	t = uniform( 100, 0.0, 1.0, {
 		'dtype': 'float64'
-	}
-	t = uniform( 100, 0.0, 1.0, opts );
+	});
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.native.js
@@ -50,7 +50,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	t = uniform( 100, 0.0, 1.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,27 +40,24 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var t;
 	var y;
 	var i;
 
-	len = 100;
-	t = new Float64Array( len );
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		t[ i ] = uniform( 0.0, 1.0 );
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	t = uniform( 100, 0.0, 1.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mgf( t[ i%len ], mu[ i%len ], sigma[ i%len ] );
+		y = mgf( t[ i%t.length ], mu[ i%mu.length ], sigma[ i%sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var mode = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mode( mu[ i % len ], sigma[ i % len ] );
+		y = mode( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,23 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mode( mu[ i % len ], sigma[ i % len ] );
+		y = mode( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
@@ -61,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:factory', pkg ), function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var mypdf;
 	var sigma;
 	var mu;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var pdf = require( './../lib' );
 
@@ -33,25 +33,22 @@ var pdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( -100.0, 100.0 );
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	x = uniform( 100, -100.0, 100.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = pdf( x[ i%len ], mu[ i%len ], sigma[ i%len ] );
+		y = pdf( x[ i%x.length ], mu[ i%mu.length ], sigma[ i%sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -64,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mypdf;
 	var sigma;
 	var mu;
@@ -76,10 +73,13 @@ bench( pkg+':factory', function benchmark( b ) {
 	sigma = 1.5;
 	mypdf = pdf.factory( mu, sigma );
 
+	x = uniform( 100, -3.0, 3.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = uniform( -3.0, 3.0 );
-		y = mypdf( x );
+		y = mypdf( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	x = uniform( 100, -100.0, 100.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,27 +40,24 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( -100.0, 100.0 );
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	x = uniform( 100, -100.0, 100.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = pdf( x[ i % len ], mu[ i % len ], sigma[ i % len ] );
+		y = pdf( x[ i % x.length ], mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.native.js
@@ -50,7 +50,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	x = uniform( 100, -100.0, 100.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
@@ -61,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:factory', pkg ), function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var myquantile;
 	var sigma;
 	var mu;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
 
@@ -33,25 +33,22 @@ var quantile = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var p;
 	var y;
 	var i;
 
-	len = 100;
-	p = new Float64Array( len );
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		p[ i ] = uniform( 0.0, 1.0 );
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	p = uniform( 100, 0.0, 1.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = quantile( p[ i%len ], mu[ i%len ], sigma[ i%len ] );
+		y = quantile( p[ i % p.length ], mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -64,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var myquantile;
 	var sigma;
 	var mu;
@@ -76,10 +73,13 @@ bench( pkg+':factory', function benchmark( b ) {
 	sigma = 1.5;
 	myquantile = quantile.factory( mu, sigma );
 
+	p = uniform( 100, 0.0, 1.0, {
+		'dtype': 'float64'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = uniform( 0.0, 1.0 );
-		y = myquantile( p );
+		y = myquantile( p[ i % p.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	p = uniform( 100, 0.0, 1.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.native.js
@@ -50,7 +50,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	p = uniform( 100, 0.0, 1.0, opts );
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,27 +40,24 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var p;
 	var y;
 	var i;
 
-	len = 100;
-	p = new Float64Array( len );
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		p[ i ] = uniform( 0.0, 1.0 );
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	p = uniform( 100, 0.0, 1.0, opts );
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = quantile( p[ i%len ], mu[ i % len ], sigma[ i % len ] );
+		y = quantile( p[ i % p.length ], mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.js
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var skewness = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = skewness( mu[ i % len ], sigma[ i % len ] );
+		y = skewness( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,23 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = skewness( mu[ i % len ], sigma[ i % len ] );
+		y = skewness( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.js
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var stdev = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = stdev( mu[ i % len ], sigma[ i % len ] );
+		y = stdev( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,23 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = stdev( mu[ i % len ], sigma[ i % len ] );
+		y = stdev( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.js
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var variance = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = variance( mu[ i % len ], sigma[ i % len ] );
+		y = variance( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.native.js
@@ -49,7 +49,7 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 
 	opts = {
 		'dtype': 'float64'
-	}
+	};
 	mu = uniform( 100, -50.0, 50.0, opts );
 	sigma = uniform( 100, EPS, 20.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,24 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var sigma;
-	var len;
+	var opts;
 	var mu;
 	var y;
 	var i;
 
-	len = 100;
-	mu = new Float64Array( len );
-	sigma = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = uniform( -50.0, 50.0 );
-		sigma[ i ] = uniform( EPS, 20.0 );
+	opts = {
+		'dtype': 'float64'
 	}
+	mu = uniform( 100, -50.0, 50.0, opts );
+	sigma = uniform( 100, EPS, 20.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = variance( mu[ i % len ], sigma[ i % len ] );
+		y = variance( mu[ i % mu.length ], sigma[ i % sigma.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `stats/base/dists/normal/` packages.
-   Replaces `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Refactors to use string interpolation.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
