### PR TITLE
bench: refactor to use string interpolation in `stats/base/dists/levy/mean`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mean/benchmark/benchmark.native.js
@@ -22,6 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var uniform = require( '@stdlib/random/base/uniform' );
@@ -40,7 +41,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var len;
 	var mu;
 	var c;


### PR DESCRIPTION
Resolves a part of #8647.

## Description

This pull request refactors the JavaScript benchmark for `stats/base/dists/levy/mean` to use string interpolation via `@stdlib/string/format` instead of string concatenation when specifying the benchmark name.

The change preserves the original benchmark name while aligning the benchmark implementation with the guidelines outlined in the RFC.

## Related Issues

> Does this pull request have any related issues?

#8647

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

I consulted ChatGPT to understand the RFC requirements and stdlib contribution workflow, but the code changes themselves were authored manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
