### PR TITLE
chore: fix JavaScript lint errors (issue #9897)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/sgemv/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/test/test.ndarray.native.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable max-len */
+/* eslint-disable max-len, stdlib/no-empty-lines-between-requires */
 
 'use strict';
 
@@ -45,6 +45,7 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
+
 var rap = require( './fixtures/row_major_complex_access_pattern.json' );
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );

--- a/lib/node_modules/@stdlib/blas/base/sgemv/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/test/test.ndarray.native.js
@@ -27,6 +27,7 @@ var tape = require( 'tape' );
 var Float32Array = require( '@stdlib/array/float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
+
 // FIXTURES //
 
 var cap = require( './fixtures/column_major_complex_access_pattern.json' );
@@ -44,7 +45,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rap = require( './fixtures/row_major_complex_access_pattern.json' );
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );

--- a/lib/node_modules/@stdlib/blas/base/sgemv/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/test/test.ndarray.native.js
@@ -27,7 +27,6 @@ var tape = require( 'tape' );
 var Float32Array = require( '@stdlib/array/float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
-
 // FIXTURES //
 
 var cap = require( './fixtures/column_major_complex_access_pattern.json' );


### PR DESCRIPTION
Resolves #9897 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes JavaScript lint error by removing an empty line between `require` statements.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   resolves #9897

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
