### PR TITLE
bench: refactor to use string interpolation in `stats/base/dists/planck`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/cdf/benchmark/benchmark.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // MAIN //
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mycdf;
 	var opts;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/cdf/benchmark/benchmark.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/cdf/benchmark/benchmark.native.js
@@ -26,8 +26,8 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var pkg = require( './../package.json' ).name;
 var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/cdf/benchmark/benchmark.native.js
@@ -27,6 +27,7 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -39,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
 	var opts;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/entropy/benchmark/benchmark.native.js
@@ -25,8 +25,8 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var pkg = require( './../package.json' ).name;
 var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/entropy/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
 	var opts;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/benchmark/benchmark.native.js
@@ -25,8 +25,8 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var pkg = require( './../package.json' ).name;
 var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
 	var opts;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logcdf/benchmark/benchmark.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logcdf = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // MAIN //
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mylogcdf;
 	var opts;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logcdf/benchmark/benchmark.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var logcdf = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logcdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logcdf/benchmark/benchmark.native.js
@@ -26,8 +26,8 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var pkg = require( './../package.json' ).name;
 var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logcdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logcdf/benchmark/benchmark.native.js
@@ -27,6 +27,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -39,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg + '::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
 	var opts;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/benchmark/benchmark.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpmf = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // MAIN //
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mylogpmf;
 	var opts;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/benchmark/benchmark.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var logpmf = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/benchmark/benchmark.native.js
@@ -26,8 +26,8 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var pkg = require( './../package.json' ).name;
 var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/logpmf/benchmark/benchmark.native.js
@@ -27,6 +27,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -39,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
 	var opts;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/mean/benchmark/benchmark.native.js
@@ -25,8 +25,8 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var pkg = require( './../package.json' ).name;
 var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/mean/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
 	var opts;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
@@ -25,8 +25,8 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var pkg = require( './../package.json' ).name;
 var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
 	var opts;
 	var y;


### PR DESCRIPTION
Resolves a part of  #8647 

## Description

> What is the purpose of this pull request?

This pull request:

-   - Refactors Planck distribution JavaScript benchmarks to use string interpolation via `@stdlib/string/format` instead of string concatenation when constructing benchmark names.


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
