### PR TITLE
bench: refactor to use string interpolation in `number/float16/base`

### DIFF
--- a/lib/node_modules/@stdlib/number/float16/base/from-word/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/float16/base/from-word/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var word;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/number/float16/base/signbit/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/float16/base/signbit/benchmark/benchmark.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var toFloat16 = require( '@stdlib/number/float64/base/to-float16' );
+var format = require( '@stdlib/string/format' );
 var map = require( '@stdlib/array/base/map' );
 var naryFunction = require( '@stdlib/utils/nary-function' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/number/float16/base/significand/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/float16/base/significand/benchmark/benchmark.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var toFloat16 = require( '@stdlib/number/float64/base/to-float16' );
+var format = require( '@stdlib/string/format' );
 var map = require( '@stdlib/array/base/map' );
 var naryFunction = require( '@stdlib/utils/nary-function' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/number/float16/base/to-float32/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/float16/base/to-float32/benchmark/benchmark.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var map = require( '@stdlib/array/base/map' );
+var format = require( '@stdlib/string/format' );
 var naryFunction = require( '@stdlib/utils/nary-function' );
 var float64ToFloat16 = require( '@stdlib/number/float64/base/to-float16' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/number/float16/base/to-float64/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/float16/base/to-float64/benchmark/benchmark.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var map = require( '@stdlib/array/base/map' );
+var format = require( '@stdlib/string/format' );
 var naryFunction = require( '@stdlib/utils/nary-function' );
 var float64ToFloat16 = require( '@stdlib/number/float64/base/to-float16' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/number/float16/base/to-word/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/float16/base/to-word/benchmark/benchmark.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var toFloat16 = require( '@stdlib/number/float64/base/to-float16' );
+var format = require( '@stdlib/string/format' );
 var map = require( '@stdlib/array/base/map' );
 var naryFunction = require( '@stdlib/utils/nary-function' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var i;


### PR DESCRIPTION
Resolves #none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors to use string interpolation in `number/float16/base*`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{{TODO: add related issue number}}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
