### PR TITLE
chore: fix missing closing section tag in README

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/README.md
@@ -140,10 +140,6 @@ logEachMap( 'x: %d, p: %0.4f, ln( P( X = x; p ) ): %0.4f', x, p, logpmf );
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="references">
-
 <!-- C interface documentation. -->
 
 * * *
@@ -235,8 +231,12 @@ int main( void ) {
 
 </section>
 
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
 
 </section>
+
 <!-- /.references -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/README.md
@@ -235,6 +235,8 @@ int main( void ) {
 
 </section>
 
+
+</section>
 <!-- /.references -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/README.md
@@ -231,6 +231,12 @@ int main( void ) {
 
 </section>
 
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">


### PR DESCRIPTION
This PR fixes a missing closing </section> tag in the README for the geometric logpmf distribution.
Ref #5714
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)