### PR TITLE
bench: refactor to use string interpolation in `array/nans`

### DIFF
--- a/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var nans = require( './../lib' );
 
@@ -47,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=float64', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'float64' ), function benchmark( b ) {
 	var arr;
 	var i;
 	b.tic();
@@ -65,7 +66,7 @@ bench( pkg+':dtype=float64', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=float32', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'float32' ), function benchmark( b ) {
 	var arr;
 	var i;
 	b.tic();
@@ -83,7 +84,7 @@ bench( pkg+':dtype=float32', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=complex128', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'complex128' ), function benchmark( b ) {
 	var arr;
 	var i;
 	b.tic();
@@ -101,7 +102,7 @@ bench( pkg+':dtype=complex128', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=complex64', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'complex64' ), function benchmark( b ) {
 	var arr;
 	var i;
 	b.tic();
@@ -119,7 +120,7 @@ bench( pkg+':dtype=complex64', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=generic', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'generic' ), function benchmark( b ) {
 	var arr;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.complex128.js
+++ b/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.complex128.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var nans = require( './../lib' );
 
@@ -86,7 +87,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=complex128,len='+len, f );
+		bench( format( '%s:dtype=%s,len=%d', pkg, 'complex128', len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.complex64.js
+++ b/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.complex64.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var nans = require( './../lib' );
 
@@ -86,7 +87,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=complex64,len='+len, f );
+		bench( format( '%s:dtype=%s,len=%d', pkg, 'complex64', len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.float32.js
+++ b/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.float32.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var nans = require( './../lib' );
 
@@ -86,7 +87,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=float32,len='+len, f );
+		bench( format( '%s:dtype=%s,len=%d', pkg, 'float32', len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.float64.js
+++ b/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.float64.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var nans = require( './../lib' );
 
@@ -86,7 +87,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=float64,len='+len, f );
+		bench( format( '%s:dtype=%s,len=%d', pkg, 'float64', len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.generic.js
+++ b/lib/node_modules/@stdlib/array/nans/benchmark/benchmark.length.generic.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var nans = require( './../lib' );
 
@@ -86,7 +87,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=generic,len='+len, f );
+		bench( format( '%s:dtype=%s,len=%d', pkg, 'generic', len ), f );
 	}
 }
 


### PR DESCRIPTION
Resolves a part of #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the JavaScript benchmark in `@stdlib/array/nans` to use `@stdlib/string/format` for string interpolation instead of string concatenation when specifying the benchmark name

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
