### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
 
@@ -33,25 +33,22 @@ var cdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-		lambda[ i ] = uniform( EPS, 100.0 );
-		k[ i ] = uniform( EPS, 100.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
+	lambda = uniform( 100, EPS, 100.0, opts );
+	k = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = cdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = cdf( x[ i % x.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -64,10 +61,10 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var lambda;
 	var mycdf;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
@@ -76,15 +73,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mycdf = cdf.factory( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mycdf( x[ i % len ] );
+		y = mycdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,27 +40,24 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-		lambda[ i ] = uniform( EPS, 100.0 );
-		k[ i ] = uniform( EPS, 100.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
+	lambda = uniform( 100, EPS, 100.0, opts );
+	k = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = cdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = cdf( x[ i % x.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/ctor/benchmark/benchmark.js
@@ -21,34 +21,32 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Weibull = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var i;
 	var k;
 
-	len = 100;
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( EPS, 10.0 );
-		k[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, EPS, 10.0, opts );
+	lambda = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist = new Weibull( k[ i % len ], lambda[ i % len ] );
+		dist = new Weibull( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( !( dist instanceof Weibull ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -61,7 +59,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:k', function benchmark( b ) {
+bench( format( '%s::get:k', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
 	var y;
@@ -87,10 +85,10 @@ bench( pkg+'::get:k', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set:k', function benchmark( b ) {
+bench( format( '%s::set:k', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var i;
 	var k;
@@ -98,16 +96,16 @@ bench( pkg+'::set:k', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	y = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		y[ i ] = uniform( EPS, 10.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	y = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = y[ i % len ];
-		if ( dist.k !== y[ i % len ] ) {
+		dist.k = y[ i % y.length ];
+		if ( dist.k !== y[ i % y.length ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -119,7 +117,7 @@ bench( pkg+'::set:k', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:lambda', function benchmark( b ) {
+bench( format( '%s::get:lambda', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
 	var y;
@@ -145,10 +143,10 @@ bench( pkg+'::get:lambda', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set:lambda', function benchmark( b ) {
+bench( format( '%s::set:lambda', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var i;
 	var k;
@@ -156,16 +154,16 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	y = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		y[ i ] = uniform( EPS, 10.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	y = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.lambda = y[ i % len ];
-		if ( dist.lambda !== y[ i % len ] ) {
+		dist.lambda = y[ i % y.length ];
+		if ( dist.lambda !== y[ i % y.length ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -177,10 +175,10 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':entropy', function benchmark( b ) {
+bench( format( '%s:entropy', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var x;
 	var i;
@@ -189,15 +187,15 @@ bench( pkg+':entropy', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 10.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = x[ i % len ];
+		dist.k = x[ i % x.length ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -211,10 +209,10 @@ bench( pkg+':entropy', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':kurtosis', function benchmark( b ) {
+bench( format( '%s:kurtosis', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var x;
 	var i;
@@ -223,15 +221,15 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS + 1.0, 11.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS+1.0, 11.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = x[ i % len ];
+		dist.k = x[ i % x.length ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -245,10 +243,10 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':mean', function benchmark( b ) {
+bench( format( '%s:mean', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var x;
 	var i;
@@ -257,15 +255,15 @@ bench( pkg+':mean', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 10.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = x[ i % len ];
+		dist.k = x[ i % x.length ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -279,10 +277,10 @@ bench( pkg+':mean', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':median', function benchmark( b ) {
+bench( format( '%s:median', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var x;
 	var i;
@@ -291,15 +289,15 @@ bench( pkg+':median', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 10.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = x[ i % len ];
+		dist.k = x[ i % x.length ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -313,10 +311,10 @@ bench( pkg+':median', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':mode', function benchmark( b ) {
+bench( format( '%s:mode', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var x;
 	var i;
@@ -325,15 +323,15 @@ bench( pkg+':mode', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS + 1.0, 11.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS+1.0, 11.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = x[ i % len ];
+		dist.k = x[ i % x.length ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -347,10 +345,10 @@ bench( pkg+':mode', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':skewness', function benchmark( b ) {
+bench( format( '%s:skewness', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var x;
 	var i;
@@ -359,15 +357,15 @@ bench( pkg+':skewness', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS + 1.0, 11.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS+1.0, 11.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = x[ i % len ];
+		dist.k = x[ i % x.length ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -381,10 +379,10 @@ bench( pkg+':skewness', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':stdev', function benchmark( b ) {
+bench( format( '%s:stdev', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var x;
 	var i;
@@ -393,15 +391,15 @@ bench( pkg+':stdev', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS + 1.0, 11.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS+1.0, 11.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = x[ i % len ];
+		dist.k = x[ i % x.length ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -415,10 +413,10 @@ bench( pkg+':stdev', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':variance', function benchmark( b ) {
+bench( format( '%s:variance', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var y;
 	var x;
 	var i;
@@ -427,15 +425,15 @@ bench( pkg+':variance', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS + 1.0, 11.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS+1.0, 11.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = x[ i % len ];
+		dist.k = x[ i % x.length ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -449,10 +447,10 @@ bench( pkg+':variance', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':cdf', function benchmark( b ) {
+bench( format( '%s:cdf', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
@@ -461,15 +459,15 @@ bench( pkg+':cdf', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( 0.0, 1.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, 0.0, 1.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = dist.cdf( x[ i % len ] );
+		y = dist.cdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -482,10 +480,10 @@ bench( pkg+':cdf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':logpdf', function benchmark( b ) {
+bench( format( '%s:logpdf', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
@@ -494,15 +492,15 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( 0.0, 1.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, 0.0, 1.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = dist.logpdf( x[ i % len ] );
+		y = dist.logpdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -515,10 +513,10 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':mgf', function benchmark( b ) {
+bench( format( '%s:mgf', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
@@ -527,15 +525,15 @@ bench( pkg+':mgf', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( 0.0, 1.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, 0.0, 1.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = dist.mgf( x[ i % len ] );
+		y = dist.mgf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -548,10 +546,10 @@ bench( pkg+':mgf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':pdf', function benchmark( b ) {
+bench( format( '%s:pdf', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
@@ -560,15 +558,15 @@ bench( pkg+':pdf', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( 0.0, 1.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, 0.0, 1.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = dist.pdf( x[ i % len ] );
+		y = dist.pdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -581,10 +579,10 @@ bench( pkg+':pdf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':quantile', function benchmark( b ) {
+bench( format( '%s:quantile', pkg ), function benchmark( b ) {
 	var lambda;
 	var dist;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
@@ -593,15 +591,15 @@ bench( pkg+':quantile', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( 0.0, 1.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, 0.0, 1.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = dist.quantile( x[ i % len ] );
+		y = dist.quantile( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/entropy/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var entropy = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( EPS, 10.0 );
-		k[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	lambda = uniform( 100, EPS, 10.0, opts );
+	k = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = entropy( k[ i % len ], lambda[ i % len ] );
+		y = entropy( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/entropy/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tryRequire = require( '@stdlib/utils/try-require' );
-var Float64Array = require( '@stdlib/array/float64' );
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,24 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	k = new Float64Array( len );
-	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		k[ i ] = uniform( EPS, 10.0 );
-		lambda[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, EPS, 10.0, opts );
+	lambda = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = entropy( k[ i % len ], lambda[ i % len ] );
+		y = entropy( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/kurtosis/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var kurtosis = require( './../lib' );
@@ -32,22 +31,20 @@ var kurtosis = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( 1.0, 11.0 );
-		k[ i ] = uniform( 1.0, 11.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	lambda = uniform( 100, 1.0, 11.0, opts );
+	k = uniform( 100, 1.0, 11.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = kurtosis( k[ i % len ], lambda[ i % len ] );
+		y = kurtosis( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/kurtosis/benchmark/benchmark.native.js
@@ -22,10 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tryRequire = require( '@stdlib/utils/try-require' );
-var Float64Array = require( '@stdlib/array/float64' );
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -39,24 +39,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	k = new Float64Array( len );
-	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		k[ i ] = uniform( 1.0, 10.0 );
-		lambda[ i ] = uniform( 1.0, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, 1.0, 10.0, opts );
+	lambda = uniform( 100, 1.0, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = kurtosis( k[ i % len ], lambda[ i % len ] );
+		y = kurtosis( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var logcdf = require( './../lib' );
 
@@ -33,25 +33,22 @@ var logcdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-		lambda[ i ] = uniform( EPS, 100.0 );
-		k[ i ] = uniform( EPS, 100.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
+	lambda = uniform( 100, EPS, 100.0, opts );
+	k = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logcdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = logcdf( x[ i % x.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -64,10 +61,10 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var mylogcdf;
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
@@ -76,15 +73,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mylogcdf = logcdf.factory( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mylogcdf( x[ i % len ] );
+		y = mylogcdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,27 +40,24 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-		lambda[ i ] = uniform( EPS, 100.0 );
-		k[ i ] = uniform( EPS, 100.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
+	lambda = uniform( 100, EPS, 100.0, opts );
+	k = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logcdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = logcdf( x[ i % x.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logpdf/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var logpdf = require( './../lib' );
 
@@ -33,25 +33,22 @@ var logpdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-		lambda[ i ] = uniform( EPS, 100.0 );
-		k[ i ] = uniform( EPS, 100.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
+	lambda = uniform( 100, EPS, 100.0, opts );
+	k = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logpdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = logpdf( x[ i % x.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -64,10 +61,10 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var mylogpdf;
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
@@ -76,15 +73,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mylogpdf = logpdf.factory( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mylogpdf( x[ i % len ] );
+		y = mylogpdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logpdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logpdf/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,27 +40,24 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-		lambda[ i ] = uniform( EPS, 100.0 );
-		k[ i ] = uniform( EPS, 100.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
+	lambda = uniform( 100, EPS, 100.0, opts );
+	k = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logpdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = logpdf( x[ i % x.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var mean = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	k = new Float64Array( len );
-	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( EPS, 10.0 );
-		k[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, EPS, 10.0, opts );
+	lambda = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mean( k[ i % len ], lambda[ i % len ] );
+		y = mean( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,24 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	k = new Float64Array( len );
-	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( EPS, 10.0 );
-		k[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, EPS, 10.0, opts );
+	lambda = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mean( k[ i % len ], lambda[ i % len ] );
+		y = mean( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/median/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var median = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( EPS, 10.0 );
-		k[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	lambda = uniform( 100, EPS, 10.0, opts );
+	k = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = median( k[ i % len ], lambda[ i % len ] );
+		y = median( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/median/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,24 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( EPS, 10.0 );
-		k[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	lambda = uniform( 100, EPS, 10.0, opts );
+	k = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = median( k[ i % len ], lambda[ i % len ] );
+		y = median( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mgf/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var mgf = require( './../lib' );
 
@@ -33,25 +33,22 @@ var mgf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var t;
 	var y;
 	var i;
 
-	len = 100;
-	t = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		t[ i ] = uniform( EPS, 2.0 );
-		lambda[ i ] = uniform( EPS, 1.0 );
-		k[ i ] = uniform( 1.0, 2.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	t = uniform( 100, EPS, 2.0, opts );
+	lambda = uniform( 100, EPS, 1.0, opts );
+	k = uniform( 100, 1.0, 2.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mgf( t[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = mgf( t[ i % t.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -64,10 +61,10 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var lambda;
 	var mymgf;
-	var len;
+	var opts;
 	var k;
 	var t;
 	var y;
@@ -76,15 +73,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mymgf = mgf.factory( k, lambda );
-	len = 100;
-	t = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		t[ i ] = uniform( EPS, 10.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	t = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mymgf( t[ i % len ] );
+		y = mymgf( t[ i % t.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mgf/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,27 +40,24 @@ var opts = {
 
 // MAIN //
 
-bench( pkg, opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var t;
 	var y;
 	var i;
 
-	len = 100;
-	k = new Float64Array( len );
-	t = new Float64Array( len );
-	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		t[ i ] = uniform( 0.0, 5.0 );
-		k[ i ] = uniform( EPS, 10.0 );
-		lambda[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	t = uniform( 100, 0.0, 5.0, opts );
+	lambda = uniform( 100, EPS, 10.0, opts );
+	k = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mgf( t[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = mgf( t[ i % t.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mode/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var mode = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( EPS, 10.0 );
-		k[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	lambda = uniform( 100, EPS, 10.0, opts );
+	k = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mode( k[ i % len ], lambda[ i % len ] );
+		y = mode( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mode/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,24 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	k = new Float64Array( len );
-	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		k[ i ] = uniform( EPS, 10.0 );
-		lambda[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, EPS, 10.0, opts );
+	lambda = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mode( k[ i % len ], lambda[ i % len ] );
+		y = mode( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var pdf = require( './../lib' );
 
@@ -33,25 +33,22 @@ var pdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-		lambda[ i ] = uniform( EPS, 100.0 );
-		k[ i ] = uniform( EPS, 100.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
+	lambda = uniform( 100, EPS, 100.0, opts );
+	k = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = pdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = pdf( x[ i % x.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -64,10 +61,10 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var lambda;
 	var mypdf;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
@@ -76,15 +73,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mypdf = pdf.factory( k, lambda );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mypdf( x[ i % len ] );
+		y = mypdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,27 +40,24 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 100.0 );
-		lambda[ i ] = uniform( EPS, 100.0 );
-		k[ i ] = uniform( EPS, 100.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 100.0, opts );
+	lambda = uniform( 100, EPS, 100.0, opts );
+	k = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = pdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = pdf( x[ i % x.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
 
@@ -33,25 +33,23 @@ var quantile = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var p;
 	var y;
 	var i;
 
+	opts = {
+		'dtype': 'float64'
+	};
 	len = 100;
-	p = new Float64Array( len );
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		p[ i ] = uniform( 0.0, 1.0 );
-		lambda[ i ] = uniform( EPS, 100.0 );
-		k[ i ] = uniform( EPS, 100.0 );
-	}
+	p = uniform( len, 0.0, 1.0, opts );
+	lambda = uniform( len, EPS, 100.0, opts );
+	k = uniform( len, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = quantile( p[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = quantile( p[ i % p.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -64,10 +62,10 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var myquantile;
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var p;
 	var y;
@@ -76,15 +74,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	k = 1.5;
 	lambda = 1.5;
 	myquantile = quantile.factory( k, lambda );
-	len = 100;
-	p = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		p[ i ] = uniform( 0.0, 1.0 );
-	}
+
+	opts = {
+		'dtype': 'float64'
+	};
+	p = uniform( 100, 0.0, 1.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = myquantile( p[ i % len ] );
+		y = myquantile( p[ i % p.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.js
@@ -42,10 +42,9 @@ bench( pkg, function benchmark( b ) {
 	opts = {
 		'dtype': 'float64'
 	};
-	len = 100;
-	p = uniform( len, 0.0, 1.0, opts );
-	lambda = uniform( len, EPS, 100.0, opts );
-	k = uniform( len, EPS, 100.0, opts );
+	p = uniform( 100, 0.0, 1.0, opts );
+	lambda = uniform( 100, EPS, 100.0, opts );
+	k = uniform( 100, EPS, 100.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.native.js
@@ -50,10 +50,9 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	opts = {
 		'dtype': 'float64'
 	};
-	len = 100;
-	p = uniform( len, 0.0, 1.0, opts );
-	k = uniform( len, 0.1, 5.0, opts );
-	lambda = uniform( len, 0.1, 5.0, opts );
+	p = uniform( 100, 0.0, 1.0, opts );
+	k = uniform( 100, 0.1, 5.0, opts );
+	lambda = uniform( 100, 0.1, 5.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.native.js
@@ -22,10 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -39,27 +39,25 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var p;
 	var k;
 	var y;
 	var i;
 
+	opts = {
+		'dtype': 'float64'
+	};
 	len = 100;
-	p = new Float64Array( len );
-	k = new Float64Array( len );
-	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		p[ i ] = uniform( 0.0, 1.0 );
-		k[ i ] = uniform( 0.1, 5.0 );
-		lambda[ i ] = uniform( 0.1, 5.0 );
-	}
+	p = uniform( len, 0.0, 1.0, opts );
+	k = uniform( len, 0.1, 5.0, opts );
+	lambda = uniform( len, 0.1, 5.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = quantile( p[ i % len ], k[ i % len ], lambda[ i % len ] );
+		y = quantile( p[ i % p.length ], k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/skewness/benchmark/benchmark.js
@@ -32,18 +32,20 @@ var skewness = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	lambda = uniform( len, EPS + 1.0, 10.0 );
-	k = uniform( len, EPS + 1.0, 10.0 );
+	opts = {
+		'dtype': 'float64'
+	};
+	lambda = uniform( 100, EPS + 1.0, 10.0, opts );
+	k = uniform( 100, EPS + 1.0, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = skewness( k[ i % len ], lambda[ i % len ] );
+		y = skewness( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/skewness/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var tryRequire = require( '@stdlib/utils/try-require' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -39,20 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	k = uniform( len, 1.0 + EPS, 10.0 );
-	lambda = uniform( len, 1.0 + EPS, 10.0 );
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, 1.0 + EPS, 10.0, opts );
+	lambda = uniform( 100, 1.0 + EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = skewness( k[ i % len ], lambda[ i % len ] );
+		y = skewness( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/benchmark/benchmark.js
@@ -32,18 +32,20 @@ var stdev = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	k = uniform( len, EPS, 10.0 );
-	lambda = uniform( len, EPS, 10.0 );
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, EPS, 10.0, opts );
+	lambda = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = stdev( k[ i % len ], lambda[ i % len ] );
+		y = stdev( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -39,20 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	k = uniform( len, EPS, 10.0 );
-	lambda = uniform( len, EPS, 10.0 );
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, EPS, 10.0, opts );
+	lambda = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = stdev( k[ i % len ], lambda[ i % len ] );
+		y = stdev( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/variance/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,22 +32,20 @@ var variance = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	lambda = new Float64Array( len );
-	k = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( EPS + 1.0, 11.0 );
-		k[ i ] = uniform( EPS + 1.0, 11.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, EPS + 1.0, 11.0, opts );
+	lambda = uniform( 100, EPS + 1.0, 11.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = variance( k[ i % len ], lambda[ i % len ] );
+		y = variance( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/variance/benchmark/benchmark.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tryRequire = require( '@stdlib/utils/try-require' );
-var Float64Array = require( '@stdlib/array/float64' );
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,24 +40,22 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var lambda;
-	var len;
+	var opts;
 	var k;
 	var y;
 	var i;
 
-	len = 100;
-	k = new Float64Array( len );
-	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		k[ i ] = uniform( 1.0 + EPS, 10.0 );
-		lambda[ i ] = uniform( 1.0 + EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	k = uniform( 100, EPS + 1.0, 10.0, opts );
+	lambda = uniform( 100, EPS + 1.0, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = variance( k[ i % len ], lambda[ i % len ] );
+		y = variance( k[ i % k.length ], lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `stats/base/dists/weibull/*` packages.
-   Replaces `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Refactors to use string interpolation.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
