### PR TITLE
docs: fix comments and returns description

### DIFF
--- a/lib/node_modules/@stdlib/complex/float64/base/add3/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/complex/float64/base/add3/docs/types/test.ts
@@ -185,7 +185,7 @@ import add3 = require( './index' );
 	add3.assign( 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, ( x: number ): number => x, 1, 0 ); // $ExpectError
 }
 
-// The compiler throws an error if the `assign` method is provided a sixth argument which is not a number...
+// The compiler throws an error if the `assign` method is provided an eighth argument which is not a number...
 {
 	const out = new Float64Array( 2 );
 
@@ -199,7 +199,7 @@ import add3 = require( './index' );
 	add3.assign( 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, out, ( x: number ): number => x, 0 ); // $ExpectError
 }
 
-// The compiler throws an error if the `assign` method is provided a seventh argument which is not a number...
+// The compiler throws an error if the `assign` method is provided a ninth argument which is not a number...
 {
 	const out = new Float64Array( 2 );
 

--- a/lib/node_modules/@stdlib/stats/strided/nanrange/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/strided/nanrange/lib/main.js
@@ -32,7 +32,7 @@ var ndarray = require( './ndarray.js' );
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NumericArray} x - input array
 * @param {integer} strideX - stride length
-* @returns {number} variance
+* @returns {number} range
 *
 * @example
 * var x = [ 1.0, -2.0, NaN, 2.0 ];


### PR DESCRIPTION

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   fix: correct argument position comments in `complex/float64/base/add3` and fix incorrect `@returns` description in `stats/strided/nanrange`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [X] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
