### PR TITLE
docs: fix broken Markdown link (issue #10018)

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/variancech/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/variancech/README.md
@@ -195,12 +195,13 @@ console.log( v );
 
 [variance]: https://en.wikipedia.org/wiki/Variance
 
-[@neely:1966a]: https://doi.org/10.1145/365719.365958
+[@neely:1966a]: https://dl.acm.org/doi/10.1145/365719.365958
 
 [@chan:1983a]: https://doi.org/10.1080/00031305.1983.10483115
 
-[@schubert:2018a]: https://doi.org/10.1145/3221664.3221674
+[@schubert:2018a]: https://dl.acm.org/doi/10.1145/3221664.3221674
 
 </section>
+
 
 <!-- /.links -->


### PR DESCRIPTION
## Related Issues

- resolves #10018

## Description

Fixes a broken DOI link by replacing it with the correct ACM URL.

## Contributing Guidelines
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)