### PR TITLE
chore: fix JavaScript lint errors (issue #9867)

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/path/lib/render/utils/zip.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/path/lib/render/utils/zip.js
@@ -40,9 +40,9 @@ function zip( x, y ) {
 	if ( x.length !== y.length ) {
 		throw new Error( format( 'invalid arguments. Must provide equal length array-like objects. x length: `%u`. y length: `%u`.', x.length, y.length ) );
 	}
-	out = new Array( x.length );
+	out = [];
 	for ( i = 0; i < x.length; i++ ) {
-		out[ i ] = [ x[i], y[i] ];
+		out.push( [ x[i], y[i] ] );
 	}
 	return out;
 }


### PR DESCRIPTION
Resolves #9867 

## Description

This pull request replaces usage of the `new Array()` constructor with array literals and `push()` to comply with the `stdlib/no-new-array` ESLint rule.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-  [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

I consulted ChatGPT to understand the contribution workflow, but the proposed changes were authored manually.