### PR TITLE
fix(build): add path-with-spaces check and document ARM64 dev container support

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -30,7 +30,7 @@ limitations under the License.
 
 <section class="intro">
 
-This folder includes configuration for developing the project in a local container or using [GitHub Codespaces][github-codespaces].
+This folder includes configuration for developing the project in a local container or using [GitHub Codespaces][github-codespaces]. The dev container supports both x86_64 and ARM64 (Apple Silicon) architectures.
 
 </section>
 
@@ -43,6 +43,14 @@ This folder includes configuration for developing the project in a local contain
 </section>
 
 <!-- /.usage -->
+
+<!-- Section to include examples. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
 
 <!-- Section to include usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,15 @@ this_dir := $(patsubst %/,%,$(this_dir))
 # Define the root project directory:
 ROOT_DIR ?= $(this_dir)
 
+# Check for spaces in the project path.
+# GNU make and the installation process fail when the path contains spaces.
+# See CONTRIBUTING.md and docs/contributing/development.md for details.
+_empty :=
+_space := $(_empty) $(_empty)
+ifneq ($(findstring $(_space),$(ROOT_DIR)),)
+$(error The project directory path contains spaces. GNU make and the installation process will fail. Please clone the repository to a path without spaces (e.g., use stdlib_gsoc instead of stdlib gsoc). See CONTRIBUTING.md and docs/contributing/development.md for details.)
+endif
+
 # Define the top-level directory containing source files:
 SRC_DIR ?= $(ROOT_DIR)/lib/node_modules
 

--- a/docs/contributing/FAQ.md
+++ b/docs/contributing/FAQ.md
@@ -64,7 +64,7 @@ There are primarily two options for setting up your development environment to c
 1. [Manually setting up the development environment][manual-setup]
 2. [Setting up the dev container][devcontainer-setup]
 
-Note: The dev container does not yet support ARM64 architectures. For more information, or if you're interested in adding ARM64 support, you can visit this [issue][devcontainer-issue].
+Note: The dev container supports ARM64/Apple Silicon. The base Node.js development environment works on both x86_64 and ARM64 architectures. Some optional features (e.g., R, Julia) may have architecture-specific limitations. For issues or feedback, see this [issue][devcontainer-issue].
 
 <a name="install-cppcheck"></a>
 
@@ -381,6 +381,20 @@ For more `make` commands, refer to the [documentation][benchmark] on running ben
 - [Git Cheatsheet][git-guide]
 - [Other make commands][make-commands]
 
+<!-- FIXME: the following two empty sections are merely to satisfy the linter for `expected-html-sections` which cannot, atm, be turned off -->
+
+<section class="usage">
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
 <section class="links">
 
 [git]: http://git-scm.com/
@@ -401,7 +415,7 @@ For more `make` commands, refer to the [documentation][benchmark] on running ben
 
 [manual-setup]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md#step-0-github
 
-[devcontainer-setup]: https://github.com/stdlib-js/stdlib/blob/87cbd67623892f90ddeea94e1d4e01eeada417b5/docs/devcontainer_setup.md
+[devcontainer-setup]: https://github.com/stdlib-js/stdlib/blob/develop/docs/contributing/setting_up_a_devcontainer.md
 
 [devcontainer-issue]: https://github.com/stdlib-js/stdlib/issues/4934
 

--- a/docs/contributing/setting_up_a_devcontainer.md
+++ b/docs/contributing/setting_up_a_devcontainer.md
@@ -30,7 +30,7 @@ Dev containers are Docker containers that are specifically configured to provide
 
 The stdlib repository includes a preconfigured dev container, making it the easiest way to set up your development environment. It ensures proper linting, EditorConfig, and tooling are configured right from the start.
 
-**Note:** The dev container does not yet support ARM64 architectures. For more information, or if you're interested in adding ARM64 support, you can visit this [issue][devcontainer-issue].
+**Note:** The dev container supports ARM64/Apple Silicon. The base Node.js development environment works on both x86_64 and ARM64 architectures. Some optional features (e.g., R, Julia) may have architecture-specific limitations. For issues or feedback, see this [issue][devcontainer-issue].
 
 ### Prerequisites
 
@@ -112,6 +112,20 @@ If you see this when you open the terminal, then the dev container installation 
         <img width="480" src="./img/welcome_to_codespaces_terminal.png" alt="Terminal window with a welcome message by GitHub Codespaces after it was successfully installed.">
     <br>
 </div>
+
+<!-- FIXME: the following two empty sections are merely to satisfy the linter for `expected-html-sections` which cannot, atm, be turned off -->
+
+<section class="usage">
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
 
 <section class="links">
 


### PR DESCRIPTION
Resolves #4934.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds an early failure in the Makefile when the project directory path contains spaces, so contributors get a clear error instead of cryptic make failures. This aligns with the guidance in CONTRIBUTING.md and docs/contributing/development.md.
-   Updates documentation to state that the dev container supports ARM64/Apple Silicon. The base `mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm` image is multi-arch and works on both x86_64 and ARM64.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #4934

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The path check uses a simple `findstring` test for spaces in `ROOT_DIR` and runs at Makefile parse time, so it applies to all make targets. The error message directs users to move the repository to a path without spaces (e.g., `stdlib_gsoc` instead of `stdlib gsoc`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md