### PR TITLE
chore: fix JavaScript lint errors (issue #10042)

### DIFF
--- a/lib/node_modules/@stdlib/object/deep-set/examples/index.js
+++ b/lib/node_modules/@stdlib/object/deep-set/examples/index.js
@@ -30,12 +30,12 @@ function set( val ) {
 	return val * 10.0;
 }
 
-data = new Array( 100 );
-for ( i = 0; i < data.length; i++ ) {
-	data[ i ] = {
+data = [];
+for ( i = 0; i < 100; i++ ) {
+	data.push({
 		'x': Date.now(),
 		'y': [ randu(), randu(), i ]
-	};
+	});
 }
 
 keys = [ 0, 'y', 2 ];


### PR DESCRIPTION
Replace new Array() with array literal and push() in lib/node_modules/@stdlib/object/deep-set/examples/index.js

Resolves #10042

## Description

> What is the purpose of this pull request?

This pull request fixes a lint error by replacing `new Array()` with array literal and `push()` in `lib/node_modules/@stdlib/object/deep-set/examples/index.js` to comply with stdlib's JavaScript linting rules.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #10042

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

The code was written by Kimi K2.5.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
