### PR TITLE
chore: fix JavaScript lint errors (issue #10073)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/index.js
@@ -25,7 +25,6 @@
 *
 * @example
 * var remark = require( 'remark' );
-* var run = require( '@stdlib/_tools/remark/plugins/remark-run-javascript-examples' );
 *
 * var str = [
 *     '<section class="usage">',
@@ -59,15 +58,27 @@
 *     ''
 * ];
 *
-* remark().use( run ).process( str.join( '\n' ), done );
-* // => 'HELLO WORLD'
+* var run = require( '@stdlib/_tools/remark/plugins/remark-run-javascript-examples' );
 *
-* function done( error ) {
-*     if ( error ) {
-*         throw error;
-*     }
-* }
+* run;
+* // => function attacher( options ) {
+* //        var opts;
+* //        var err;
+* //
+* //        // Set default options:
+* //        opts = copy( defaults );
+* //
+* //        // NOTE: cannot use `arguments.length` check, as `options` may be explicitly passed as `undefined`
+* //        if ( options !== void 0 ) {
+* //                err = validate( opts, options );
+* //                if ( err ) {
+* //                        throw err;
+* //                }
+* //        }
+* //        return runner( opts );
+* // }
 */
+
 
 // MODULES //
 

--- a/lib/node_modules/@stdlib/math/strided/special/cbrt-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/cbrt-by/test/test.main.js
@@ -83,7 +83,7 @@ tape( 'the function computes the cube root of each indexed strided array element
 	cbrtBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = []
+	x = [];
 	x.length = 5; // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/cbrt-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/cbrt-by/test/test.main.js
@@ -74,7 +74,8 @@ tape( 'the function computes the cube root of each indexed strided array element
 	cbrtBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -82,7 +83,8 @@ tape( 'the function computes the cube root of each indexed strided array element
 	cbrtBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = []
+	x.length = 5; // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
Resolves #10073.

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes `stdlib/jsdoc-doctest` and `stdlib/jsdoc-main-export` lint failures by updating the JSDoc example in `@stdlib/_tools/remark/plugins/remark-run-javascript-examples` to display the main export in the expected doctest format and ensure the example follows the “main export require last” convention.
- Fixes `stdlib/no-new-array` lint failures in `@stdlib/math/strided/special/cbrt-by` tests by replacing disallowed `new Array()` usage with an array literal pattern while preserving sparse-array intent.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #10073

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

I consulted Microsoft Copilot to understand the reported ESLint rule failures and file structure. I implemented the changes manually in a GitHub Codespace and verified the affected files by running ESLint on the specific paths referenced in issue #10073.
<img width="1318" height="246" alt="Screenshot 2026-02-04 105439" src="https://github.com/user-attachments/assets/123dfd7d-7ff2-4cb4-9b6f-c4d23fa37ae6" />
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md