### PR TITLE
chore: fix JavaScript lint errors (issue #10000)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.egg-info/
+.venv/
 
 # TeX #
 #######

--- a/lib/node_modules/@stdlib/_tools/makie/plugins/makie-install-node-addons/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/makie/plugins/makie-install-node-addons/lib/main.js
@@ -32,7 +32,7 @@ var spawn = require( 'child_process' ).spawn;
 * @param {Error} error - error object
 */
 function onError( error ) {
-	proc.exitCode = 1;
+	process.exitCode = 1;
 	console.error( 'Error: %s', error.message ); // eslint-disable-line no-console
 }
 
@@ -45,7 +45,7 @@ function onError( error ) {
 */
 function onFinish( code ) {
 	if ( code !== 0 ) {
-		proc.exitCode = code;
+		process.exitCode = code;
 		return console.error( 'Child process exited with code `'+code + '`.' ); // eslint-disable-line no-console
 	}
 }
@@ -57,7 +57,7 @@ function onFinish( code ) {
 * @param {Buffer} data - standard output
 */
 function stdout( data ) {
-	proc.stdout.write( data );
+	process.stdout.write( data );
 }
 
 /**
@@ -67,7 +67,7 @@ function stdout( data ) {
 * @param {Buffer} data - standard error
 */
 function stderr( data ) {
-	proc.stderr.write( data );
+	process.stderr.write( data );
 }
 
 


### PR DESCRIPTION
## Summary
- fix undefined `proc` references in makie install plugin
- use `process` for exitCode and stdio writes

## Related Issues
- resolves #10000

## Testing
- not run (lint change only)
