### PR TITLE
bench: refactor to use string interpolation in `lapack/base/claswp`

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/claswp/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/claswp/benchmark/benchmark.js
@@ -27,6 +27,7 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var claswp = require( './../lib/claswp.js' );
 
@@ -120,7 +121,7 @@ function main() {
 			j = 1;
 			while ( j <= N ) {
 				f = createBenchmark( ord, N, j );
-				bench( pkg+'::square_matrix:order='+ord+',nrows='+j+',size='+(N*N), f );
+				bench( format( '%s::square_matrix:order=%s,nrows=%d,size=%d', pkg, ord, j, (N*N) ), f );
 				j *= 2;
 			}
 		}

--- a/lib/node_modules/@stdlib/lapack/base/claswp/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/claswp/benchmark/benchmark.js
@@ -121,7 +121,7 @@ function main() {
 			j = 1;
 			while ( j <= N ) {
 				f = createBenchmark( ord, N, j );
-				bench( format( '%s::square_matrix:order=%s,nrows=%d,size=%d', pkg, ord, j, (N*N) ), f );
+				bench( format( '%s::square_matrix:order=%s,nrows=%d,size=%d', pkg, ord, j, N*N ), f );
 				j *= 2;
 			}
 		}

--- a/lib/node_modules/@stdlib/lapack/base/claswp/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/claswp/benchmark/benchmark.ndarray.js
@@ -28,6 +28,7 @@ var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var claswp = require( './../lib/ndarray.js' );
 
@@ -130,7 +131,7 @@ function main() {
 			j = 1;
 			while ( j <= N ) {
 				f = createBenchmark( ord, N, j );
-				bench( pkg+'::square_matrix:ndarray:order='+ord+',nrows='+j+',size='+(N*N), f );
+				bench( format( '%s::square_matrix:ndarray:order=%s,nrows=%d,size=%d', pkg, ord, j, (N*N) ), f );
 				j *= 2;
 			}
 		}

--- a/lib/node_modules/@stdlib/lapack/base/claswp/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/claswp/benchmark/benchmark.ndarray.js
@@ -131,7 +131,7 @@ function main() {
 			j = 1;
 			while ( j <= N ) {
 				f = createBenchmark( ord, N, j );
-				bench( format( '%s::square_matrix:ndarray:order=%s,nrows=%d,size=%d', pkg, ord, j, (N*N) ), f );
+				bench( format( '%s::square_matrix:ndarray:order=%s,nrows=%d,size=%d', pkg, ord, j, N*N ), f );
 				j *= 2;
 			}
 		}


### PR DESCRIPTION
Resolves a part of #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates benchmark files for `lapack/base/claswp` to use string interpolation in JavaScript benchmarks for the benchmark name.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
