### PR TITLE
bench: refactor to use string interpolation in `lapack/base/crot`

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/crot/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/crot/benchmark/benchmark.js
@@ -27,6 +27,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var crot = require( './../lib/crot.js' );
 
@@ -107,7 +108,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/lapack/base/crot/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/crot/benchmark/benchmark.ndarray.js
@@ -27,6 +27,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var crot = require( './../lib/ndarray.js' );
 
@@ -107,7 +108,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':ndarray:len='+len, f );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
Progresses #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-  Updates benchmark files for `lapack/base/crot` to use string interpolation in JavaScript benchmarks for the benchmark name.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
