### PR TITLE
chore: fix JavaScript lint errors (issue #10084)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/asinh-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/asinh-by/test/test.ndarray.js
@@ -73,7 +73,8 @@ tape( 'the function computes the hyperbolic arcsine via a callback function', fu
 	asinhBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = []
+	x.length=5; // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -81,7 +82,8 @@ tape( 'the function computes the hyperbolic arcsine via a callback function', fu
 	asinhBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = []
+	x.length=5; // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
Resolves #10084

This pull request fixes JavaScript lint errors by replacing disallowed `new Array(n)` usage with lint-compliant sparse array initialization while preserving existing test behavior.
