### PR TITLE
bench: refactor to use string interpolation in `lapack/base/iladlc`

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/iladlc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/iladlc/benchmark/benchmark.js
@@ -25,6 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var zeros = require( '@stdlib/array/zeros' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iladlc = require( './../lib/iladlc.js' );
 
@@ -103,7 +104,7 @@ function main() {
 		for ( i = min; i <= max; i++ ) {
 			N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 			f = createBenchmark( ord, N );
-			bench( pkg+'::square_matrix:order='+ord+',size='+(N*N), f );
+			bench( format( '%s::square_matrix:order=%s,size=%d', pkg, ord, (N*N) ), f );
 		}
 	}
 }

--- a/lib/node_modules/@stdlib/lapack/base/iladlc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/iladlc/benchmark/benchmark.js
@@ -104,7 +104,7 @@ function main() {
 		for ( i = min; i <= max; i++ ) {
 			N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 			f = createBenchmark( ord, N );
-			bench( format( '%s::square_matrix:order=%s,size=%d', pkg, ord, (N*N) ), f );
+			bench( format( '%s::square_matrix:order=%s,size=%d', pkg, ord, N*N ), f );
 		}
 	}
 }

--- a/lib/node_modules/@stdlib/lapack/base/iladlc/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/iladlc/benchmark/benchmark.ndarray.js
@@ -26,6 +26,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var zeros = require( '@stdlib/array/zeros' );
 var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iladlc = require( './../lib/ndarray.js' );
 
@@ -114,7 +115,7 @@ function main() {
 		for ( i = min; i <= max; i++ ) {
 			N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 			f = createBenchmark( ord, N );
-			bench( pkg+'::square_matrix:ndarray:order='+ord+',size='+(N*N), f );
+			bench( format( '%s::square_matrix:ndarray:order=%s,size=%d', pkg, ord, (N*N) ), f );
 		}
 	}
 }

--- a/lib/node_modules/@stdlib/lapack/base/iladlc/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/iladlc/benchmark/benchmark.ndarray.js
@@ -115,7 +115,7 @@ function main() {
 		for ( i = min; i <= max; i++ ) {
 			N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 			f = createBenchmark( ord, N );
-			bench( format( '%s::square_matrix:ndarray:order=%s,size=%d', pkg, ord, (N*N) ), f );
+			bench( format( '%s::square_matrix:ndarray:order=%s,size=%d', pkg, ord, N*N ), f );
 		}
 	}
 }


### PR DESCRIPTION
Resolves a part of #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-  Updates benchmark files for `lapack/base/iladlc` to use string interpolation in JavaScript benchmarks for the benchmark name.
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
