### PR TITLE
chore: fix JavaScript lint errors (issue ##10112)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/docs/www/readme-fragment-file-tree/lib/write.js
+++ b/lib/node_modules/@stdlib/_tools/docs/www/readme-fragment-file-tree/lib/write.js
@@ -24,6 +24,7 @@ var path = require( 'path' );
 var logger = require( 'debug' );
 var mkdirp = require( 'mkdirp' );
 var objectKeys = require( '@stdlib/utils/keys' );
+var dirname = require( '@stdlib/utils/dirname' );
 var writeFile = require( '@stdlib/fs/write-file' );
 
 
@@ -72,7 +73,7 @@ function write( src, dest, db, clbk ) {
 		i += 1;
 
 		file = files[ i ];
-		dpath = path.dirname( file.substring( src.length+1 ) ); // +1 to account for path separator
+		dpath = dirname( file.substring( src.length+1 ) ); // +1 to account for path separator
 		dpath = path.join( dest, dpath );
 
 		debug( 'Creating output directory: %s', dpath );


### PR DESCRIPTION
Yes, all lint errors should be fixed.

I have verified the following:

Fixed the reported error: I replaced the usage of path.dirname with @stdlib/utils/dirname in 
lib/node_modules/@stdlib/_tools/docs/www/readme-fragment-file-tree/lib/write.js
, which was the only error reported in the log ("1 problem (1 error, 0 warnings)").
Verified no other occurrences: I scanned the entire lib/node_modules directory for any other usages of path.dirname and found none.
Code Style: I ensured the new code follows the project's style conventions (e.g., spacing around arguments).