### PR TITLE
bench: refactor to use dynamic memory allocation in dasumpw

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/c/benchmark.length.c
@@ -16,12 +16,12 @@
 * limitations under the License.
 */
 
-#include "stdlib/blas/ext/base/dasumpw.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
-#include <time.h>
 #include <sys/time.h>
+#include "stdlib/blas/ext/base/dasumpw.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 #define NAME "dasumpw"
 #define ITERATIONS 1000000
@@ -74,7 +74,7 @@ static void print_results( int iterations, double elapsed ) {
 static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
-	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
 }
 
 /**
@@ -96,10 +96,11 @@ static double rand_double( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
+	x = (double *)malloc( len * sizeof( double ) );
 
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
@@ -118,6 +119,7 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
@@ -130,10 +132,11 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
+	x = (double *)malloc( len * sizeof( double ) );
 
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
@@ -152,6 +155,7 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
@@ -173,7 +177,7 @@ int main( void ) {
 	count = 0;
 	for ( i = MIN; i <= MAX; i++ ) {
 		len = pow( 10, i );
-		iter = ITERATIONS / pow( 10, i-1 );
+		iter = ITERATIONS / pow( 10, i - 1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
 			printf( "# c::%s:len=%d\n", NAME, len );
@@ -184,7 +188,7 @@ int main( void ) {
 	}
 	for ( i = MIN; i <= MAX; i++ ) {
 		len = pow( 10, i );
-		iter = ITERATIONS / pow( 10, i-1 );
+		iter = ITERATIONS / pow( 10, i - 1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
 			printf( "# c::%s:ndarray:len=%d\n", NAME, len );

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/c/benchmark.length.c
@@ -74,7 +74,7 @@ static void print_results( int iterations, double elapsed ) {
 static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
-	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
 }
 
 /**
@@ -96,11 +96,13 @@ static double rand_double( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
-	double y[ len ];
+	double *x;
+	double *y;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
+	y = (double *)malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 		y[ i ] = 0.0;
@@ -118,6 +120,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 
@@ -130,11 +134,13 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
-	double y[ len ];
+	double *x;
+	double *y;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
+	y = (double *)malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 		y[ i ] = 0.0;
@@ -152,6 +158,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 


### PR DESCRIPTION
Ref: #8643

Resolves : a part of #8643

## Description

> What is the purpose of this pull request?

This pull request:

-  Refactors the C benchmark for "dasumpw" to use dynamic memory allocation as following 
double x[len];

with:

double *x;
x = (double *) malloc( len * sizeof( double ) );
...
free( x );}}

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8643

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
