### PR TITLE
bench: use string interpolation in `stats/base/dists/chi`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mycdf;
 	var opts;
 	var k;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg + '::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var x;
 	var k;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/ctor/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -30,7 +31,7 @@ var Chi = require( './../lib' );
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var i;
@@ -56,7 +57,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:k', function benchmark( b ) {
+bench( format( '%s::get:k', pkg ), function benchmark( b ) {
 	var dist;
 	var y;
 	var i;
@@ -80,7 +81,7 @@ bench( pkg+'::get:k', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set:k', function benchmark( b ) {
+bench( format( '%s::set:k', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var y;
@@ -110,7 +111,7 @@ bench( pkg+'::set:k', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':entropy', function benchmark( b ) {
+bench( format( '%s:entropy', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -142,7 +143,7 @@ bench( pkg+':entropy', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':kurtosis', function benchmark( b ) {
+bench( format( '%s:kurtosis', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -174,7 +175,7 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':mean', function benchmark( b ) {
+bench( format( '%s:mean', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -206,7 +207,7 @@ bench( pkg+':mean', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':mode', function benchmark( b ) {
+bench( format( '%s:mode', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -238,7 +239,7 @@ bench( pkg+':mode', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':skewness', function benchmark( b ) {
+bench( format( '%s:skewness', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -270,7 +271,7 @@ bench( pkg+':skewness', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':stdev', function benchmark( b ) {
+bench( format( '%s:stdev', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -302,7 +303,7 @@ bench( pkg+':stdev', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':variance', function benchmark( b ) {
+bench( format( '%s:variance', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -334,7 +335,7 @@ bench( pkg+':variance', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':cdf', function benchmark( b ) {
+bench( format( '%s:cdf', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -365,7 +366,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':logpdf', function benchmark( b ) {
+bench( format( '%s:logpdf', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -396,7 +397,7 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':pdf', function benchmark( b ) {
+bench( format( '%s:pdf', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;
@@ -427,7 +428,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':quantile', function benchmark( b ) {
+bench( format( '%s:quantile', pkg ), function benchmark( b ) {
 	var dist;
 	var opts;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/entropy/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -39,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var k;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg + '::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var k;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mylogpdf;
 	var opts;
 	var k;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/logpdf/benchmark/benchmark.native.js
@@ -24,6 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -39,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var len;
 	var k;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/mean/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg + '::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var k;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/mode/benchmark/benchmark.native.js
@@ -24,6 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -39,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var k;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/pdf/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var mypdf;
 	var opts;
 	var k;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/quantile/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var myquantile;
 	var opts;
 	var k;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/skewness/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg + '::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var k;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/stdev/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -39,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var k;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/variance/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -39,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var k;
 	var y;


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames
    status: passed
  - task: lint_editorconfig
    status: passed
  - task: lint_markdown
    status: na
  - task: lint_package_json
    status: na
  - task: lint_repl_help
    status: na
  - task: lint_javascript_src
    status: na
  - task: lint_javascript_cli
    status: na
  - task: lint_javascript_examples
    status: na
  - task: lint_javascript_tests
    status: na
  - task: lint_javascript_benchmarks
    status: passed
  - task: lint_python
    status: na
  - task: lint_r
    status: na
  - task: lint_c_src
    status: na
  - task: lint_c_examples
    status: na
  - task: lint_c_benchmarks
    status: na
  - task: lint_c_tests_fixtures
    status: na
  - task: lint_shell
    status: na
  - task: lint_typescript_declarations
    status: passed
  - task: lint_typescript_tests
    status: na
  - task: lint_license_headers
    status: passed
---

Resolves NA

## Description

This pull request updates benchmarks in `stats/base/dists/chi` to use string interpolation, improving readability and consistency with existing benchmark conventions.

## Related Issues

- NA

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [ ] Yes
- [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
