### PR TITLE
readme file fixed

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/variancech/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/variancech/README.md
@@ -199,7 +199,7 @@ console.log( v );
 
 [@chan:1983a]: https://doi.org/10.1080/00031305.1983.10483115
 
-[@schubert:2018a]: https://doi.org/10.1145/3221664.3221674
+[@schubert:2018a]: https://dl.acm.org/doi/10.1145/3221664.3221674
 
 </section>
 


### PR DESCRIPTION
# PR Summary: Fix Broken Markdown Link

## Issue
Resolves #10018

## What Changed
Fixed a broken DOI link in `lib/node_modules/@stdlib/stats/base/ndarray/variancech/README.md`

**Before:**
```markdown
[@schubert:2018a]: https://doi.org/10.1145/3221664.3221674
```

**After:**
```markdown
[@schubert:2018a]: https://dl.acm.org/doi/10.1145/3221664.3221674
```

## Why
The original DOI URL was returning a 404 error. Replaced it with the working ACM Digital Library URL following the same pattern used for other similar fixes in the codebase.

## Reference
Schubert, Erich, and Michael Gertz. 2018. "Numerically Stable Parallel Computation of (Co-)Variance." SSDBM '18.
