### PR TITLE
chore: fix JavaScript lint errors (issue #10184)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/avercos-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/avercos-by/test/test.main.js
@@ -20,22 +20,22 @@
 
 // MODULES //
 
-var tape = require( 'tape' );
-var avercos = require( '@stdlib/math/base/special/avercos' );
-var uniform = require( '@stdlib/random/base/uniform' ).factory;
-var Float64Array = require( '@stdlib/array/float64' );
-var avercosBy = require( './../lib/main.js' );
+var tape = require('tape');
+var avercos = require('@stdlib/math/base/special/avercos');
+var uniform = require('@stdlib/random/base/uniform').factory;
+var Float64Array = require('@stdlib/array/float64');
+var avercosBy = require('./../lib/main.js');
 
 
 // VARIABLES //
 
-var rand = uniform( -2.0, 0.0 );
+var rand = uniform(-2.0, 0.0);
 
 
 // FUNCTIONS //
 
-function accessor( v ) {
-	if ( v === void 0 ) {
+function accessor(v) {
+	if (v === void 0) {
 		return;
 	}
 	return v;
@@ -44,18 +44,18 @@ function accessor( v ) {
 
 // TESTS //
 
-tape( 'main export is a function', function test( t ) {
-	t.ok( true, __filename );
-	t.strictEqual( typeof avercosBy, 'function', 'main export is a function' );
+tape('main export is a function', function test(t) {
+	t.ok(true, __filename);
+	t.strictEqual(typeof avercosBy, 'function', 'main export is a function');
 	t.end();
 });
 
-tape( 'the function has an arity of 7', function test( t ) {
-	t.strictEqual( avercosBy.length, 7, 'arity of 7' );
+tape('the function has an arity of 7', function test(t) {
+	t.strictEqual(avercosBy.length, 7, 'arity of 7');
 	t.end();
 });
 
-tape( 'the function computes the inverse versed cosine via a callback function', function test( t ) {
+tape('the function computes the inverse versed cosine via a callback function', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -65,39 +65,43 @@ tape( 'the function computes the inverse versed cosine via a callback function',
 	y = [];
 
 	expected = [];
-	for ( i = 0; i < 10; i++ ) {
-		x.push( rand() );
-		y.push( 0.0 );
-		expected.push( avercos( x[ i ] ) );
+	for (i = 0; i < 10; i++) {
+		x.push(rand());
+		y.push(0.0);
+		expected.push(avercos(x[i]));
 	}
 
-	avercosBy( x.length, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'deep equal' );
+	avercosBy(x.length, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'deep equal');
 
-	// eslint-disable-next-line stdlib/no-new-array
-	x = new Array( 5 ); // sparse array
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	
+	x = [];
+	x.length = 5; // sparse array
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	expected = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	avercosBy( x.length, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'deep equal' );
 
-	// eslint-disable-next-line stdlib/no-new-array
-	x = new Array( 5 ); // sparse array
-	x[ 2 ] = rand();
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	avercosBy(x.length, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'deep equal');
+
+	
+	x = [];
+	x.length = 5; // sparse array
+	x[2] = rand();
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 
 	expected = y.slice();
-	expected[ 2 ] = avercos( x[ 2 ] );
+	expected[2] = avercos(x[2]);
 
-	avercosBy( x.length, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'deep equal' );
+
+	avercosBy(x.length, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'deep equal');
 
 	t.end();
 });
 
-tape( 'the function supports an `x` stride', function test( t ) {
+tape('the function supports an `x` stride', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -119,21 +123,21 @@ tape( 'the function supports an `x` stride', function test( t ) {
 	];
 	N = 3;
 
-	avercosBy( N, x, 2, y, 1, accessor );
+	avercosBy(N, x, 2, y, 1, accessor);
 
 	expected = [
-		avercos( x[ 0 ] ),
-		avercos( x[ 2 ] ),
-		avercos( x[ 4 ] ),
+		avercos(x[0]),
+		avercos(x[2]),
+		avercos(x[4]),
 		0.0,
 		0.0
 	];
 
-	t.deepEqual( y, expected, 'deep equal' );
+	t.deepEqual(y, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function supports a `y` stride', function test( t ) {
+tape('the function supports a `y` stride', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -155,54 +159,54 @@ tape( 'the function supports a `y` stride', function test( t ) {
 	];
 	N = 3;
 
-	avercosBy( N, x, 1, y, 2, accessor );
+	avercosBy(N, x, 1, y, 2, accessor);
 
 	expected = [
-		avercos( x[ 0 ] ),
+		avercos(x[0]),
 		0.0,
-		avercos( x[ 1 ] ),
+		avercos(x[1]),
 		0.0,
-		avercos( x[ 2 ] )
+		avercos(x[2])
 	];
 
-	t.deepEqual( y, expected, 'deep equal' );
+	t.deepEqual(y, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function returns a reference to the destination array', function test( t ) {
+tape('the function returns a reference to the destination array', function test(t) {
 	var out;
 	var x;
 	var y;
 
-	x = [ rand(), rand(), rand(), rand(), rand() ];
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	x = [rand(), rand(), rand(), rand(), rand()];
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	out = avercosBy( x.length, x, 1, y, 1, accessor );
+	out = avercosBy(x.length, x, 1, y, 1, accessor);
 
-	t.strictEqual( out, y, 'same reference' );
+	t.strictEqual(out, y, 'same reference');
 	t.end();
 });
 
-tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `y` unchanged', function test( t ) {
+tape('if provided an `N` parameter less than or equal to `0`, the function returns `y` unchanged', function test(t) {
 	var expected;
 	var x;
 	var y;
 
-	x = [ rand(), rand(), rand(), rand(), rand() ];
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	x = [rand(), rand(), rand(), rand(), rand()];
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	expected = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	avercosBy( -1, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'returns `y` unchanged' );
+	avercosBy(-1, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'returns `y` unchanged');
 
-	avercosBy( 0, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'returns `y` unchanged' );
+	avercosBy(0, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'returns `y` unchanged');
 
 	t.end();
 });
 
-tape( 'the function supports negative strides', function test( t ) {
+tape('the function supports negative strides', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -224,21 +228,21 @@ tape( 'the function supports negative strides', function test( t ) {
 	];
 	N = 3;
 
-	avercosBy( N, x, -2, y, -1, accessor );
+	avercosBy(N, x, -2, y, -1, accessor);
 
 	expected = [
-		avercos( x[ 0 ] ),
-		avercos( x[ 2 ] ),
-		avercos( x[ 4 ] ),
+		avercos(x[0]),
+		avercos(x[2]),
+		avercos(x[4]),
 		0.0,
 		0.0
 	];
 
-	t.deepEqual( y, expected, 'deep equal' );
+	t.deepEqual(y, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function supports complex access patterns', function test( t ) {
+tape('the function supports complex access patterns', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -262,22 +266,22 @@ tape( 'the function supports complex access patterns', function test( t ) {
 	];
 	N = 3;
 
-	avercosBy( N, x, 2, y, -1, accessor );
+	avercosBy(N, x, 2, y, -1, accessor);
 
 	expected = [
-		avercos( x[ 4 ] ),
-		avercos( x[ 2 ] ),
-		avercos( x[ 0 ] ),
+		avercos(x[4]),
+		avercos(x[2]),
+		avercos(x[0]),
 		0.0,
 		0.0,
 		0.0
 	];
 
-	t.deepEqual( y, expected, 'deep equal' );
+	t.deepEqual(y, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function supports view offsets', function test( t ) {
+tape('the function supports view offsets', function test(t) {
 	var expected;
 	var x0;
 	var y0;
@@ -304,41 +308,41 @@ tape( 'the function supports view offsets', function test( t ) {
 	]);
 
 	// Create offset views...
-	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // begin at 2nd element
-	y1 = new Float64Array( y0.buffer, y0.BYTES_PER_ELEMENT*3 ); // begin at the 4th element
+	x1 = new Float64Array(x0.buffer, x0.BYTES_PER_ELEMENT * 1); // begin at 2nd element
+	y1 = new Float64Array(y0.buffer, y0.BYTES_PER_ELEMENT * 3); // begin at the 4th element
 
 	N = 3;
 
-	avercosBy( N, x1, -2, y1, 1, accessor );
+	avercosBy(N, x1, -2, y1, 1, accessor);
 	expected = new Float64Array([
 		0.0,
 		0.0,
 		0.0,
-		avercos( x0[ 5 ] ),
-		avercos( x0[ 3 ] ),
-		avercos( x0[ 1 ] )
+		avercos(x0[5]),
+		avercos(x0[3]),
+		avercos(x0[1])
 	]);
 
-	t.deepEqual( y0, expected, 'deep equal' );
+	t.deepEqual(y0, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function supports providing a callback execution context', function test( t ) {
+tape('the function supports providing a callback execution context', function test(t) {
 	var ctx;
 	var x;
 	var y;
 
-	x = [ rand(), rand(), rand(), rand(), rand() ];
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	x = [rand(), rand(), rand(), rand(), rand()];
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 	ctx = {
 		'count': 0
 	};
-	avercosBy( x.length, x, 1, y, 1, accessor, ctx );
+	avercosBy(x.length, x, 1, y, 1, accessor, ctx);
 
-	t.strictEqual( ctx.count, x.length, 'returns expected value' );
+	t.strictEqual(ctx.count, x.length, 'returns expected value');
 	t.end();
 
-	function accessor( v ) {
+	function accessor(v) {
 		this.count += 1; // eslint-disable-line no-invalid-this
 		return v;
 	}


### PR DESCRIPTION
## Summary
Fixes JavaScript lint errors reported by the CI workflow.

## Changes
- Replaced disallowed `new Array()` usages with array literals and adjusted length to preserve sparse behavior.
- Removed unnecessary eslint disable comments.

## Related Issues
resolves #10184

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
