### PR TITLE
feat: add implementation of `stats/strided/dmad`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dmad/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/README.md
@@ -1,0 +1,304 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# dmad
+
+> Calculate the [mean absolute deviation][mean-absolute-deviation] of a double-precision floating-point strided array.
+
+<section class="intro">
+
+The [mean absolute deviation][mean-absolute-deviation] is defined as
+
+<!-- <equation class="equation" label="eq:mean_absolute_deviation" align="center" raw="\text{MAD} = \frac{1}{n} \sum_{i=0}^{n-1} |x_i - \mu|" alt="Equation for the mean absolute deviation."> -->
+
+```math
+\text{MAD} = \frac{1}{n} \sum_{i=0}^{n-1} |x_i - \mu|
+```
+
+<!-- </equation> -->
+
+where `μ` is the [arithmetic mean][arithmetic-mean].
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var dmad = require( '@stdlib/stats/strided/dmad' );
+```
+
+#### dmad( N, x, strideX )
+
+Computes the [mean absolute deviation][mean-absolute-deviation] of a double-precision floating-point strided array.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+
+var v = dmad( x.length, x, 1 );
+// returns ~1.5556
+```
+
+The function has the following parameters:
+
+-   **N**: number of indexed elements.
+-   **x**: input [`Float64Array`][@stdlib/array/float64].
+-   **strideX**: stride length for `x`.
+
+The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to compute the [mean absolute deviation][mean-absolute-deviation] of every other element in `x`,
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x = new Float64Array( [ 1.0, 2.0, 2.0, -7.0, -2.0, 3.0, 4.0, 2.0 ] );
+
+var v = dmad( 4, x, 2 );
+// returns 1.75
+```
+
+Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
+
+<!-- eslint-disable stdlib/capitalized-comments -->
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x0 = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ] );
+var x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+var v = dmad( 4, x1, 2 );
+// returns 1.75
+```
+
+#### dmad.ndarray( N, x, strideX, offsetX )
+
+Computes the [mean absolute deviation][mean-absolute-deviation] of a double-precision floating-point strided array using alternative indexing semantics.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+
+var v = dmad.ndarray( x.length, x, 1, 0 );
+// returns ~1.5556
+```
+
+The function has the following additional parameters:
+
+-   **offsetX**: starting index for `x`.
+
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameter supports indexing semantics based on a starting index. For example, to calculate the [mean absolute deviation][mean-absolute-deviation] for every other element in `x` starting from the second element
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ] );
+
+var v = dmad.ndarray( 4, x, 2, 1 );
+// returns 1.75
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If `N <= 0`, both functions return `NaN`.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var dmad = require( '@stdlib/stats/strided/dmad' );
+
+var x = discreteUniform( 10, -50, 50, {
+    'dtype': 'float64'
+});
+console.log( x );
+
+var v = dmad( x.length, x, 1 );
+console.log( v );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/strided/dmad.h"
+```
+
+#### stdlib_strided_dmad( N, \*X, strideX )
+
+Computes the [mean absolute deviation][mean-absolute-deviation] of a double-precision floating-point strided array.
+
+```c
+const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+
+double v = stdlib_strided_dmad( 4, x, 2 );
+// returns 2.0
+```
+
+The function accepts the following arguments:
+
+-   **N**: `[in] CBLAS_INT` number of indexed elements.
+-   **X**: `[in] double*` input array.
+-   **strideX**: `[in] CBLAS_INT` stride length for `X`.
+
+```c
+double stdlib_strided_dmad( const CBLAS_INT N, const double *X, const CBLAS_INT strideX );
+```
+
+#### stdlib_strided_dmad_ndarray( N, \*X, strideX, offsetX )
+
+Computes the [mean absolute deviation][mean-absolute-deviation] of a double-precision floating-point strided array using alternative indexing semantics.
+
+```c
+const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+
+double v = stdlib_strided_dmad_ndarray( 4, x, 2, 0 );
+// returns 2.0
+```
+
+The function accepts the following arguments:
+
+-   **N**: `[in] CBLAS_INT` number of indexed elements.
+-   **X**: `[in] double*` input array.
+-   **strideX**: `[in] CBLAS_INT` stride length for `X`.
+-   **offsetX**: `[in] CBLAS_INT` starting index for `X`.
+
+```c
+double stdlib_strided_dmad_ndarray( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/strided/dmad.h"
+#include <stdio.h>
+
+int main( void ) {
+    // Create a strided array:
+    const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+
+    // Specify the number of elements:
+    const int N = 4;
+
+    // Specify the stride length:
+    const int strideX = 2;
+
+    // Compute the mean absolute deviation:
+    double v = stdlib_strided_dmad( N, x, strideX );
+
+    // Print the result:
+    printf( "mad: %lf\n", v );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mean-absolute-deviation]: https://en.wikipedia.org/wiki/Average_absolute_deviation
+
+[arithmetic-mean]: https://en.wikipedia.org/wiki/Arithmetic_mean
+
+[@stdlib/array/float64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/float64
+
+[mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var dmad = require( './../lib/dmad.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = uniform( len, -10.0, 10.0, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = dmad( x.length, x, 1 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.native.js
@@ -1,0 +1,109 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var dmad = tryRequire( resolve( __dirname, './../lib/dmad.native.js' ) );
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = uniform( len, -10.0, 10.0, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = dmad( x.length, x, 1 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	if ( dmad instanceof Error ) {
+		console.log( 'skipping...' );
+		return;
+	}
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::native:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.native.js
@@ -33,6 +33,9 @@ var pkg = require( './../package.json' ).name;
 // VARIABLES //
 
 var dmad = tryRequire( resolve( __dirname, './../lib/dmad.native.js' ) );
+var opts = {
+	'skip': ( dmad instanceof Error )
+};
 var options = {
 	'dtype': 'float64'
 };
@@ -92,17 +95,13 @@ function main() {
 	var f;
 	var i;
 
-	if ( dmad instanceof Error ) {
-		console.log( 'skipping...' );
-		return;
-	}
 	min = 1; // 10^min
 	max = 6; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s::native:len=%d', pkg, len ), f );
+		bench( format( '%s::native:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.ndarray.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var dmad = require( './../lib/ndarray.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = uniform( len, -10.0, 10.0, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = dmad( x.length, x, 1, 0 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::ndarray:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.ndarray.native.js
@@ -1,0 +1,109 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var dmad = tryRequire( resolve( __dirname, './../lib/ndarray.native.js' ) );
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = uniform( len, -10.0, 10.0, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = dmad( x.length, x, 1, 0 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	if ( dmad instanceof Error ) {
+		console.log( 'skipping...' );
+		return;
+	}
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::ndarray:native:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/benchmark.ndarray.native.js
@@ -33,6 +33,9 @@ var pkg = require( './../package.json' ).name;
 // VARIABLES //
 
 var dmad = tryRequire( resolve( __dirname, './../lib/ndarray.native.js' ) );
+var opts = {
+	'skip': ( dmad instanceof Error )
+};
 var options = {
 	'dtype': 'float64'
 };
@@ -92,17 +95,13 @@ function main() {
 	var f;
 	var i;
 
-	if ( dmad instanceof Error ) {
-		console.log( 'skipping...' );
-		return;
-	}
 	min = 1; // 10^min
 	max = 6; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s::ndarray:native:len=%d', pkg, len ), f );
+		bench( format( '%s::ndarray:native:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.length.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/c/benchmark.length.c
@@ -1,0 +1,153 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/dmad.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "dmad"
+#define ITERATIONS 1000000
+#define REPEATS 3
+#define MIN 1
+#define MAX 6
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param iterations  number of iterations
+* @param elapsed     elapsed time in seconds
+*/
+static void print_results( int iterations, double elapsed ) {
+	double rate = (double)iterations / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", iterations );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static double rand_double( void ) {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @param iterations   number of iterations
+* @param len          array length
+* @return             elapsed time in seconds
+*/
+static double benchmark( int iterations, int len ) {
+	double elapsed;
+	double *x;
+	double v;
+	double t;
+	int i;
+
+	x = (double *) malloc( len * sizeof( double ) );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
+	}
+	v = 0.0;
+	t = tic();
+	for ( i = 0; i < iterations; i++ ) {
+		v = stdlib_strided_dmad( len, x, 1 );
+		if ( v != v ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( v != v ) {
+		printf( "should not return NaN\n" );
+	}
+	free( x );
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int count;
+	int iter;
+	int len;
+	int i;
+	int j;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	count = 0;
+	for ( i = MIN; i <= MAX; i++ ) {
+		len = pow( 10, i );
+		iter = ITERATIONS / pow( 10, i-1 );
+		for ( j = 0; j < REPEATS; j++ ) {
+			count += 1;
+			printf( "# c::%s:len=%d\n", NAME, len );
+			elapsed = benchmark( iter, len );
+			print_results( iter, elapsed );
+			printf( "ok %d benchmark finished\n", count );
+		}
+	}
+	print_summary( count, count );
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/benchmark/c/benchmark.length.c
@@ -94,20 +94,20 @@ static double rand_double( void ) {
 * @param len          array length
 * @return             elapsed time in seconds
 */
-static double benchmark( int iterations, int len ) {
+static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	double *x;
+	double x[ len ];
 	double v;
 	double t;
 	int i;
 
-	x = (double *) malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 	}
 	v = 0.0;
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
 		v = stdlib_strided_dmad( len, x, 1 );
 		if ( v != v ) {
 			printf( "should not return NaN\n" );
@@ -118,7 +118,40 @@ static double benchmark( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
-	free( x );
+	return elapsed;
+}
+
+/**
+* Runs a benchmark.
+*
+* @param iterations   number of iterations
+* @param len          array length
+* @return             elapsed time in seconds
+*/
+static double benchmark2( int iterations, int len ) {
+	double elapsed;
+	double x[ len ];
+	double v;
+	double t;
+	int i;
+
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
+	}
+	v = 0.0;
+	t = tic();
+	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
+		v = stdlib_strided_dmad_ndarray( len, x, 1, 0 );
+		if ( v != v ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( v != v ) {
+		printf( "should not return NaN\n" );
+	}
 	return elapsed;
 }
 
@@ -144,7 +177,18 @@ int main( void ) {
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
 			printf( "# c::%s:len=%d\n", NAME, len );
-			elapsed = benchmark( iter, len );
+			elapsed = benchmark1( iter, len );
+			print_results( iter, elapsed );
+			printf( "ok %d benchmark finished\n", count );
+		}
+	}
+	for ( i = MIN; i <= MAX; i++ ) {
+		len = pow( 10, i );
+		iter = ITERATIONS / pow( 10, i-1 );
+		for ( j = 0; j < REPEATS; j++ ) {
+			count += 1;
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
+			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
 		}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/docs/repl.txt
@@ -1,0 +1,90 @@
+
+{{alias}}( N, x, strideX )
+    Computes the mean absolute deviation of a double-precision floating-point
+    strided array.
+
+    The `N` and stride parameters determine which elements in the strided array
+    are accessed at runtime.
+
+    Indexing is relative to the first index. To introduce an offset, use a typed
+    array view.
+
+    If `N <= 0`, the function returns `NaN`.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Float64Array
+        Input array.
+
+    strideX: integer
+        Stride length.
+
+    Returns
+    -------
+    out: number
+        The mean absolute deviation.
+
+    Examples
+    --------
+    // Standard Usage:
+    > var x = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 2.0 ] );
+    > {{alias}}( x.length, x, 1 )
+    ~1.5556
+
+    // Using `N` and stride parameters:
+    > x = new {{alias:@stdlib/array/float64}}( [ -2.0, 1.0, 1.0, -5.0, 2.0, -1.0 ] );
+    > {{alias}}( 3, x, 2 )
+    ~1.5556
+
+    // Using view offsets:
+    > var x0 = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 3.0, 2.0, 5.0, -1.0 ] );
+    > var x1 = new {{alias:@stdlib/array/float64}}( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
+    > {{alias}}( 3, x1, 2 )
+    ~1.5556
+
+
+{{alias}}.ndarray( N, x, strideX, offsetX )
+    Computes the mean absolute deviation of a double-precision floating-point
+    strided array using alternative indexing semantics.
+
+    While typed array views mandate a view offset based on the underlying
+    buffer, the `offset` parameter supports indexing semantics based on a
+    starting index.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Float64Array
+        Input array.
+
+    strideX: integer
+        Stride length.
+
+    offsetX: integer
+        Starting index.
+
+    Returns
+    -------
+    out: number
+        The mean absolute deviation.
+
+    Examples
+    --------
+    // Standard Usage:
+    > var x = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 2.0 ] );
+    > {{alias}}.ndarray( x.length, x, 1, 0 )
+    ~1.5556
+
+    // Using offset parameter:
+    > var x = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 3.0, 2.0, 5.0, -1.0 ] );
+    > {{alias}}.ndarray( 3, x, 2, 1 )
+    ~1.5556
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/stats/strided/dmad/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/docs/repl.txt
@@ -51,8 +51,8 @@
     strided array using alternative indexing semantics.
 
     While typed array views mandate a view offset based on the underlying
-    buffer, the `offset` parameter supports indexing semantics based on a
-    starting index.
+    buffer, the offset parameter supports indexing semantics based on a starting
+    index.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/stats/strided/dmad/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/docs/types/index.d.ts
@@ -1,0 +1,92 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Interface describing `dmad`.
+*/
+interface Routine {
+	/**
+	* Computes the mean absolute deviation of a double-precision floating-point strided array.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - stride length
+	* @returns mean absolute deviation
+	*
+	* @example
+	* var Float64Array = require( '@stdlib/array/float64' );
+	*
+	* var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+	*
+	* var v = dmad( x.length, x, 1 );
+	* // returns ~1.5556
+	*/
+	( N: number, x: Float64Array, strideX: number ): number;
+
+	/**
+	* Computes the mean absolute deviation of a double-precision floating-point strided array using alternative indexing semantics.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - stride length
+	* @param offsetX - starting index
+	* @returns mean absolute deviation
+	*
+	* @example
+	* var Float64Array = require( '@stdlib/array/float64' );
+	*
+	* var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+	*
+	* var v = dmad.ndarray( x.length, x, 1, 0 );
+	* // returns ~1.5556
+	*/
+	ndarray( N: number, x: Float64Array, strideX: number, offsetX: number ): number;
+}
+
+/**
+* Computes the mean absolute deviation of a double-precision floating-point strided array.
+*
+* @param N - number of indexed elements
+* @param x - input array
+* @param strideX - stride length
+* @returns mean absolute deviation
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+*
+* var v = dmad( x.length, x, 1 );
+* // returns ~1.5556
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+*
+* var v = dmad.ndarray( x.length, x, 1, 0 );
+* // returns ~1.5556
+*/
+declare var dmad: Routine;
+
+
+// EXPORTS //
+
+export = dmad;

--- a/lib/node_modules/@stdlib/stats/strided/dmad/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/docs/types/test.ts
@@ -1,0 +1,118 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import dmad = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	const x = new Float64Array( 10 );
+
+	dmad( x.length, x, 1 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	dmad( '10', x, 1 ); // $ExpectError
+	dmad( true, x, 1 ); // $ExpectError
+	dmad( false, x, 1 ); // $ExpectError
+	dmad( null, x, 1 ); // $ExpectError
+	dmad( undefined, x, 1 ); // $ExpectError
+	dmad( [], x, 1 ); // $ExpectError
+	dmad( {}, x, 1 ); // $ExpectError
+	dmad( ( x: number ): number => x, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a Float64Array...
+{
+	const x = new Float64Array( 10 );
+
+	dmad( x.length, 10, 1 ); // $ExpectError
+	dmad( x.length, '10', 1 ); // $ExpectError
+	dmad( x.length, true, 1 ); // $ExpectError
+	dmad( x.length, false, 1 ); // $ExpectError
+	dmad( x.length, null, 1 ); // $ExpectError
+	dmad( x.length, undefined, 1 ); // $ExpectError
+	dmad( x.length, [], 1 ); // $ExpectError
+	dmad( x.length, {}, 1 ); // $ExpectError
+	dmad( x.length, ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	dmad( x.length, x, '10' ); // $ExpectError
+	dmad( x.length, x, true ); // $ExpectError
+	dmad( x.length, x, false ); // $ExpectError
+	dmad( x.length, x, null ); // $ExpectError
+	dmad( x.length, x, undefined ); // $ExpectError
+	dmad( x.length, x, [] ); // $ExpectError
+	dmad( x.length, x, {} ); // $ExpectError
+	dmad( x.length, x, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+
+	dmad(); // $ExpectError
+	dmad( x.length ); // $ExpectError
+	dmad( x.length, x ); // $ExpectError
+	dmad( x.length, x, 1, 10 ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a number...
+{
+	const x = new Float64Array( 10 );
+
+	dmad.ndarray( x.length, x, 1, 0 ); // $ExpectType number
+}
+
+// The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	dmad.ndarray( '10', x, 1, 0 ); // $ExpectError
+	dmad.ndarray( true, x, 1, 0 ); // $ExpectError
+	dmad.ndarray( false, x, 1, 0 ); // $ExpectError
+	dmad.ndarray( null, x, 1, 0 ); // $ExpectError
+	dmad.ndarray( undefined, x, 1, 0 ); // $ExpectError
+	dmad.ndarray( [], x, 1, 0 ); // $ExpectError
+	dmad.ndarray( {}, x, 1, 0 ); // $ExpectError
+	dmad.ndarray( ( x: number ): number => x, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a second argument which is not a Float64Array...
+{
+	const x = new Float64Array( 10 );
+
+	dmad.ndarray( x.length, 10, 1, 0 ); // $ExpectError
+	dmad.ndarray( x.length, '10', 1, 0 ); // $ExpectError
+	dmad.ndarray( x.length, true, 1, 0 ); // $ExpectError
+	dmad.ndarray( x.length, false, 1, 0 ); // $ExpectError
+	dmad.ndarray( x.length, null, 1, 0 ); // $ExpectError
+	dmad.ndarray( x.length, undefined, 1, 0 ); // $ExpectError
+	dmad.ndarray( x.length, [], 1, 0 ); // $ExpectError
+	dmad.ndarray( x.length, {}, 1, 0 ); // $ExpectError
+	dmad.ndarray( x.length, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/docs/types/test.ts
@@ -116,3 +116,42 @@ import dmad = require( './index' );
 	dmad.ndarray( x.length, {}, 1, 0 ); // $ExpectError
 	dmad.ndarray( x.length, ( x: number ): number => x, 1, 0 ); // $ExpectError
 }
+
+// The compiler throws an error if the `ndarray` method is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	dmad.ndarray( x.length, x, '10', 0 ); // $ExpectError
+	dmad.ndarray( x.length, x, true, 0 ); // $ExpectError
+	dmad.ndarray( x.length, x, false, 0 ); // $ExpectError
+	dmad.ndarray( x.length, x, null, 0 ); // $ExpectError
+	dmad.ndarray( x.length, x, undefined, 0 ); // $ExpectError
+	dmad.ndarray( x.length, x, [], 0 ); // $ExpectError
+	dmad.ndarray( x.length, x, {}, 0 ); // $ExpectError
+	dmad.ndarray( x.length, x, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	dmad.ndarray( x.length, x, 1, '10' ); // $ExpectError
+	dmad.ndarray( x.length, x, 1, true ); // $ExpectError
+	dmad.ndarray( x.length, x, 1, false ); // $ExpectError
+	dmad.ndarray( x.length, x, 1, null ); // $ExpectError
+	dmad.ndarray( x.length, x, 1, undefined ); // $ExpectError
+	dmad.ndarray( x.length, x, 1, [] ); // $ExpectError
+	dmad.ndarray( x.length, x, 1, {} ); // $ExpectError
+	dmad.ndarray( x.length, x, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+
+	dmad.ndarray(); // $ExpectError
+	dmad.ndarray( x.length ); // $ExpectError
+	dmad.ndarray( x.length, x ); // $ExpectError
+	dmad.ndarray( x.length, x, 1 ); // $ExpectError
+	dmad.ndarray( x.length, x, 1, 0, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/strided/dmad/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/examples/c/example.c
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/dmad.h"
+#include <stdio.h>
+
+int main( void ) {
+	// Create a strided array:
+	const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+
+	// Specify the number of elements:
+	const int N = 4;
+
+	// Specify the stride length:
+	const int strideX = 2;
+
+	// Compute the mean absolute deviation:
+	double v = stdlib_strided_dmad( N, x, strideX );
+
+	// Print the result:
+	printf( "mad: %lf\n", v );
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/examples/index.js
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var dmad = require( './../lib' );
+
+var x = discreteUniform( 10, -50, 50, {
+	'dtype': 'float64'
+});
+console.log( 'x:' );
+console.log( x );
+
+var v = dmad( x.length, x, 1 );
+console.log( 'MAD: %d', v );
+
+v = dmad.ndarray( x.length, x, 1, 0 );
+console.log( 'MAD (ndarray): %d', v );

--- a/lib/node_modules/@stdlib/stats/strided/dmad/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/examples/index.js
@@ -24,11 +24,7 @@ var dmad = require( './../lib' );
 var x = discreteUniform( 10, -50, 50, {
 	'dtype': 'float64'
 });
-console.log( 'x:' );
 console.log( x );
 
 var v = dmad( x.length, x, 1 );
-console.log( 'MAD: %d', v );
-
-v = dmad.ndarray( x.length, x, 1, 0 );
-console.log( 'MAD (ndarray): %d', v );
+console.log( v );

--- a/lib/node_modules/@stdlib/stats/strided/dmad/include.gypi
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/include/stdlib/stats/strided/dmad.h
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/include/stdlib/stats/strided/dmad.h
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_STRIDED_DMAD_H
+#define STDLIB_STATS_STRIDED_DMAD_H
+
+#include "stdlib/blas/base/shared.h"
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes the mean absolute deviation of a double-precision floating-point strided array.
+*/
+double API_SUFFIX(stdlib_strided_dmad)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX );
+
+/**
+* Computes the mean absolute deviation of a double-precision floating-point strided array using alternative indexing semantics.
+*/
+double API_SUFFIX(stdlib_strided_dmad_ndarray)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_STRIDED_DMAD_H

--- a/lib/node_modules/@stdlib/stats/strided/dmad/lib/dmad.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/lib/dmad.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var stride2offset = require( '@stdlib/strided/base/stride2offset' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+/**
+* Computes the mean absolute deviation of a double-precision floating-point strided array.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - input array
+* @param {integer} strideX - stride length
+* @returns {number} mean absolute deviation
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+*
+* var v = dmad( x.length, x, 1 );
+* // returns ~1.5556
+*/
+function dmad( N, x, strideX ) {
+	return ndarray( N, x, strideX, stride2offset( N, strideX ) );
+}
+
+
+// EXPORTS //
+
+module.exports = dmad;

--- a/lib/node_modules/@stdlib/stats/strided/dmad/lib/dmad.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/lib/dmad.native.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Computes the mean absolute deviation of a double-precision floating-point strided array.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - input array
+* @param {integer} strideX - stride length
+* @returns {number} mean absolute deviation
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+*
+* var v = dmad( x.length, x, 1 );
+* // returns ~1.5556
+*/
+function dmad( N, x, strideX ) {
+	return addon( N, x, strideX );
+}
+
+
+// EXPORTS //
+
+module.exports = dmad;

--- a/lib/node_modules/@stdlib/stats/strided/dmad/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/lib/index.js
@@ -1,0 +1,68 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute the mean absolute deviation of a double-precision floating-point strided array.
+*
+* @module @stdlib/stats/strided/dmad
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var dmad = require( '@stdlib/stats/strided/dmad' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+*
+* var v = dmad( x.length, x, 1 );
+* // returns ~1.5556
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var dmad = require( '@stdlib/stats/strided/dmad' );
+*
+* var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ] );
+*
+* var v = dmad.ndarray( 4, x, 2, 1 );
+* // returns 1.75
+*/
+
+// MODULES //
+
+var join = require( 'path' ).join;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isError = require( '@stdlib/assert/is-error' );
+var main = require( './main.js' );
+
+
+// MAIN //
+
+var dmad;
+var tmp = tryRequire( join( __dirname, './native.js' ) );
+if ( isError( tmp ) ) {
+	dmad = main;
+} else {
+	dmad = tmp;
+}
+
+
+// EXPORTS //
+
+module.exports = dmad;
+
+// exports: { "ndarray": "dmad.ndarray" }

--- a/lib/node_modules/@stdlib/stats/strided/dmad/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/lib/main.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var dmad = require( './dmad.js' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+setReadOnly( dmad, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = dmad;

--- a/lib/node_modules/@stdlib/stats/strided/dmad/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/lib/native.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var dmad = require( './dmad.native.js' );
+var ndarray = require( './ndarray.native.js' );
+
+
+// MAIN //
+
+setReadOnly( dmad, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = dmad;

--- a/lib/node_modules/@stdlib/stats/strided/dmad/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/lib/ndarray.js
@@ -1,0 +1,77 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var dmean = require( '@stdlib/stats/strided/dmean' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
+// MAIN //
+
+/**
+* Computes the mean absolute deviation of a double-precision floating-point strided array using alternative indexing semantics.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - input array
+* @param {integer} strideX - stride length
+* @param {NonNegativeInteger} offsetX - starting index
+* @returns {number} mean absolute deviation
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+*
+* var v = dmad( x.length, x, 1, 0 );
+* // returns ~1.5556
+*/
+function dmad( N, x, strideX, offsetX ) {
+	var sum;
+	var mu;
+	var ix;
+	var d;
+	var i;
+
+	if ( N <= 0 ) {
+		return NaN;
+	}
+	if ( N === 1 || strideX === 0 ) {
+		return 0.0;
+	}
+	mu = dmean.ndarray( N, x, strideX, offsetX );
+	if ( isnan( mu ) ) {
+		return NaN;
+	}
+	ix = offsetX;
+	sum = 0.0;
+	for ( i = 0; i < N; i++ ) {
+		d = x[ ix ] - mu;
+		sum += abs( d );
+		ix += strideX;
+	}
+	return sum / N;
+}
+
+
+// EXPORTS //
+
+module.exports = dmad;

--- a/lib/node_modules/@stdlib/stats/strided/dmad/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/lib/ndarray.js
@@ -22,7 +22,6 @@
 
 var dmean = require( '@stdlib/stats/strided/dmean' );
 var abs = require( '@stdlib/math/base/special/abs' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 
 
 // MAIN //
@@ -58,9 +57,7 @@ function dmad( N, x, strideX, offsetX ) {
 		return 0.0;
 	}
 	mu = dmean.ndarray( N, x, strideX, offsetX );
-	if ( isnan( mu ) ) {
-		return NaN;
-	}
+
 	ix = offsetX;
 	sum = 0.0;
 	for ( i = 0; i < N; i++ ) {

--- a/lib/node_modules/@stdlib/stats/strided/dmad/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/lib/ndarray.native.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Computes the mean absolute deviation of a double-precision floating-point strided array using alternative indexing semantics.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - input array
+* @param {integer} strideX - stride length
+* @param {NonNegativeInteger} offsetX - starting index
+* @returns {number} mean absolute deviation
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
+*
+* var v = dmad( x.length, x, 1, 0 );
+* // returns ~1.5556
+*/
+function dmad( N, x, strideX, offsetX ) {
+	return addon.ndarray( N, x, strideX, offsetX );
+}
+
+
+// EXPORTS //
+
+module.exports = dmad;

--- a/lib/node_modules/@stdlib/stats/strided/dmad/manifest.json
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/manifest.json
@@ -39,6 +39,7 @@
             "libpath": [],
             "dependencies": [
                 "@stdlib/blas/base/shared",
+                "@stdlib/strided/base/stride2offset",
                 "@stdlib/stats/strided/dmean",
                 "@stdlib/napi/export",
                 "@stdlib/napi/argv",
@@ -60,6 +61,7 @@
             "libpath": [],
             "dependencies": [
                 "@stdlib/blas/base/shared",
+                "@stdlib/strided/base/stride2offset",
                 "@stdlib/stats/strided/dmean"
             ]
         },
@@ -76,6 +78,7 @@
             "libpath": [],
             "dependencies": [
                 "@stdlib/blas/base/shared",
+                "@stdlib/strided/base/stride2offset",
                 "@stdlib/stats/strided/dmean"
             ]
         },
@@ -92,6 +95,7 @@
             "libpath": [],
             "dependencies": [
                 "@stdlib/blas/base/shared",
+                "@stdlib/strided/base/stride2offset",
                 "@stdlib/stats/strided/dmean"
             ]
         }

--- a/lib/node_modules/@stdlib/stats/strided/dmad/manifest.json
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/manifest.json
@@ -1,0 +1,99 @@
+{
+    "options": {
+        "task": "build",
+        "wasm": false
+    },
+    "fields": [
+        {
+            "field": "src",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "include",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "libraries",
+            "resolve": false,
+            "relative": false
+        },
+        {
+            "field": "libpath",
+            "resolve": true,
+            "relative": false
+        }
+    ],
+    "confs": [
+        {
+            "task": "build",
+            "wasm": false,
+            "src": [
+                "./src/main.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/blas/base/shared",
+                "@stdlib/stats/strided/dmean",
+                "@stdlib/napi/export",
+                "@stdlib/napi/argv",
+                "@stdlib/napi/argv-int64",
+                "@stdlib/napi/argv-strided-float64array",
+                "@stdlib/napi/create-double"
+            ]
+        },
+        {
+            "task": "benchmark",
+            "wasm": false,
+            "src": [
+                "./src/main.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/blas/base/shared",
+                "@stdlib/stats/strided/dmean"
+            ]
+        },
+        {
+            "task": "examples",
+            "wasm": false,
+            "src": [
+                "./src/main.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/blas/base/shared",
+                "@stdlib/stats/strided/dmean"
+            ]
+        },
+        {
+            "task": "",
+            "wasm": true,
+            "src": [
+                "./src/main.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/blas/base/shared",
+                "@stdlib/stats/strided/dmean"
+            ]
+        }
+    ]
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/manifest.json
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/manifest.json
@@ -45,7 +45,8 @@
                 "@stdlib/napi/argv",
                 "@stdlib/napi/argv-int64",
                 "@stdlib/napi/argv-strided-float64array",
-                "@stdlib/napi/create-double"
+                "@stdlib/napi/create-double",
+                "@stdlib/math/base/special/abs"
             ]
         },
         {
@@ -62,7 +63,8 @@
             "dependencies": [
                 "@stdlib/blas/base/shared",
                 "@stdlib/strided/base/stride2offset",
-                "@stdlib/stats/strided/dmean"
+                "@stdlib/stats/strided/dmean",
+                "@stdlib/math/base/special/abs"
             ]
         },
         {
@@ -79,7 +81,8 @@
             "dependencies": [
                 "@stdlib/blas/base/shared",
                 "@stdlib/strided/base/stride2offset",
-                "@stdlib/stats/strided/dmean"
+                "@stdlib/stats/strided/dmean",
+                "@stdlib/math/base/special/abs"
             ]
         },
         {
@@ -96,7 +99,8 @@
             "dependencies": [
                 "@stdlib/blas/base/shared",
                 "@stdlib/strided/base/stride2offset",
-                "@stdlib/stats/strided/dmean"
+                "@stdlib/stats/strided/dmean",
+                "@stdlib/math/base/special/abs"
             ]
         }
     ]

--- a/lib/node_modules/@stdlib/stats/strided/dmad/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/package.json
@@ -1,0 +1,76 @@
+{
+    "name": "@stdlib/stats/strided/dmad",
+    "version": "0.0.0",
+    "description": "Calculate the mean absolute deviation of a double-precision floating-point strided array.",
+    "license": "Apache-2.0",
+    "author": {
+        "name": "The Stdlib Authors",
+        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    },
+    "contributors": [
+        {
+            "name": "The Stdlib Authors",
+            "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+        }
+    ],
+    "main": "./lib",
+    "browser": "./lib/main.js",
+    "gypfile": true,
+    "directories": {
+        "benchmark": "./benchmark",
+        "doc": "./docs",
+        "example": "./examples",
+        "include": "./include",
+        "lib": "./lib",
+        "src": "./src",
+        "test": "./test"
+    },
+    "types": "./docs/types",
+    "scripts": {},
+    "homepage": "https://github.com/stdlib-js/stdlib",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/stdlib-js/stdlib.git"
+    },
+    "bugs": {
+        "url": "https://github.com/stdlib-js/stdlib/issues"
+    },
+    "dependencies": {},
+    "devDependencies": {},
+    "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+    },
+    "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+    ],
+    "keywords": [
+        "stdlib",
+        "stdmath",
+        "statistics",
+        "stats",
+        "mathematics",
+        "math",
+        "deviation",
+        "mad",
+        "mean absolute deviation",
+        "central tendency",
+        "variability",
+        "strided",
+        "strided array",
+        "typed",
+        "array",
+        "float64",
+        "double",
+        "float64array"
+    ],
+    "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/package.json
@@ -1,76 +1,76 @@
 {
-    "name": "@stdlib/stats/strided/dmad",
-    "version": "0.0.0",
-    "description": "Calculate the mean absolute deviation of a double-precision floating-point strided array.",
-    "license": "Apache-2.0",
-    "author": {
-        "name": "The Stdlib Authors",
-        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-    },
-    "contributors": [
-        {
-            "name": "The Stdlib Authors",
-            "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-        }
-    ],
-    "main": "./lib",
-    "browser": "./lib/main.js",
-    "gypfile": true,
-    "directories": {
-        "benchmark": "./benchmark",
-        "doc": "./docs",
-        "example": "./examples",
-        "include": "./include",
-        "lib": "./lib",
-        "src": "./src",
-        "test": "./test"
-    },
-    "types": "./docs/types",
-    "scripts": {},
-    "homepage": "https://github.com/stdlib-js/stdlib",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/stdlib-js/stdlib.git"
-    },
-    "bugs": {
-        "url": "https://github.com/stdlib-js/stdlib/issues"
-    },
-    "dependencies": {},
-    "devDependencies": {},
-    "engines": {
-        "node": ">=0.10.0",
-        "npm": ">2.7.0"
-    },
-    "os": [
-        "aix",
-        "darwin",
-        "freebsd",
-        "linux",
-        "macos",
-        "openbsd",
-        "sunos",
-        "win32",
-        "windows"
-    ],
-    "keywords": [
-        "stdlib",
-        "stdmath",
-        "statistics",
-        "stats",
-        "mathematics",
-        "math",
-        "deviation",
-        "mad",
-        "mean absolute deviation",
-        "central tendency",
-        "variability",
-        "strided",
-        "strided array",
-        "typed",
-        "array",
-        "float64",
-        "double",
-        "float64array"
-    ],
-    "__stdlib__": {}
+  "name": "@stdlib/stats/strided/dmad",
+  "version": "0.0.0",
+  "description": "Calculate the mean absolute deviation of a double-precision floating-point strided array.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "browser": "./lib/main.js",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "deviation",
+    "mad",
+    "mean absolute deviation",
+    "central tendency",
+    "variability",
+    "strided",
+    "strided array",
+    "typed",
+    "array",
+    "float64",
+    "double",
+    "float64array"
+  ],
+  "__stdlib__": {}
 }

--- a/lib/node_modules/@stdlib/stats/strided/dmad/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/strided/dmad/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/src/addon.c
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/dmad.h"
+#include "stdlib/napi/export.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/argv_int64.h"
+#include "stdlib/napi/argv_strided_float64array.h"
+#include "stdlib/napi/create_double.h"
+#include "stdlib/blas/base/shared.h"
+#include <node_api.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 3 );
+	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
+	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
+	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmad)( N, X, strideX ), v );
+	return v;
+}
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon_method( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 4 );
+	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
+	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
+	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
+	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmad_ndarray)( N, X, strideX, offsetX ), v );
+	return v;
+}
+
+STDLIB_NAPI_MODULE_EXPORT_FCN_WITH_METHOD( addon, "ndarray", addon_method )

--- a/lib/node_modules/@stdlib/stats/strided/dmad/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/src/main.c
@@ -20,7 +20,6 @@
 #include "stdlib/stats/strided/dmean.h"
 #include "stdlib/blas/base/shared.h"
 #include "stdlib/strided/base/stride2offset.h"
-#include <math.h>
 
 /**
 * Computes the mean absolute deviation of a double-precision floating-point strided array.

--- a/lib/node_modules/@stdlib/stats/strided/dmad/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/src/main.c
@@ -1,0 +1,75 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/dmad.h"
+#include "stdlib/stats/strided/dmean.h"
+#include "stdlib/blas/base/shared.h"
+#include "stdlib/strided/base/stride2offset.h"
+#include <math.h>
+
+/**
+* Computes the mean absolute deviation of a double-precision floating-point strided array.
+*
+* @param N        number of indexed elements
+* @param X        input array
+* @param strideX  stride length
+* @return         output value
+*/
+double API_SUFFIX(stdlib_strided_dmad)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX ) {
+	const CBLAS_INT ox = stdlib_strided_stride2offset( N, strideX );
+	return API_SUFFIX(stdlib_strided_dmad_ndarray)( N, X, strideX, ox );
+}
+
+/**
+* Computes the mean absolute deviation of a double-precision floating-point strided array using alternative indexing semantics.
+*
+* @param N        number of indexed elements
+* @param X        input array
+* @param strideX  stride length
+* @param offsetX  starting index for X
+* @return         output value
+*/
+double API_SUFFIX(stdlib_strided_dmad_ndarray)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
+	CBLAS_INT ix;
+	CBLAS_INT i;
+	double mu;
+	double sum;
+	double d;
+
+	if ( N <= 0 ) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( N == 1 || strideX == 0 ) {
+		return 0.0;
+	}
+	// Compute the mean:
+	mu = API_SUFFIX(stdlib_strided_dmean_ndarray)( N, X, strideX, offsetX );
+
+	ix = offsetX;
+	sum = 0.0;
+	for ( i = 0; i < N; i++ ) {
+		d = X[ ix ] - mu;
+		if ( d < 0.0 ) {
+			sum += -d;
+		} else {
+			sum += d;
+		}
+		ix += strideX;
+	}
+	return sum / (double)N;
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmad/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/stats/strided/dmean.h"
 #include "stdlib/blas/base/shared.h"
 #include "stdlib/strided/base/stride2offset.h"
+#include "stdlib/math/base/special/abs.h"
 
 /**
 * Computes the mean absolute deviation of a double-precision floating-point strided array.
@@ -63,11 +64,7 @@ double API_SUFFIX(stdlib_strided_dmad_ndarray)( const CBLAS_INT N, const double 
 	sum = 0.0;
 	for ( i = 0; i < N; i++ ) {
 		d = X[ ix ] - mu;
-		if ( d < 0.0 ) {
-			sum += -d;
-		} else {
-			sum += d;
-		}
+		sum += stdlib_base_abs( d );
 		ix += strideX;
 	}
 	return sum / (double)N;

--- a/lib/node_modules/@stdlib/stats/strided/dmad/test/test.dmad.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/test/test.dmad.js
@@ -1,0 +1,165 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
+var dmad = require( './../lib/dmad.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmad, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 3', function test( t ) {
+	t.strictEqual( dmad.length, 3, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the mean absolute deviation of a strided array', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ] );
+	v = dmad( x.length, x, 1 );
+	t.strictEqual( v, 2.5, 'returns expected value' );
+
+	x = new Float64Array( [ -4.0, -4.0 ] );
+	v = dmad( x.length, x, 1 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	v = dmad( x.length, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( 0, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = dmad( -1, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to `1`, the function returns 0.0', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( 1, x, 1 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0
+	]);
+
+	v = dmad( 4, x, 2 );
+
+	t.strictEqual( v, 1.75, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	]);
+
+	v = dmad( 4, x, -2 );
+
+	t.strictEqual( v, 1.75, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the function returns 0.0', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( x.length, x, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports view offsets', function test( t ) {
+	var x0;
+	var x1;
+	var v;
+
+	x0 = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0,  // 3
+		6.0
+	]);
+
+	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT * 1 ); // start at 2nd element
+
+	v = dmad( 4, x1, 2 );
+	t.strictEqual( v, 1.75, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/dmad/test/test.dmad.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/test/test.dmad.native.js
@@ -1,0 +1,174 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var path = require( 'path' );
+var tape = require( 'tape' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
+
+
+// VARIABLES //
+
+var dmad = tryRequire( path.join( __dirname, './../lib/dmad.native.js' ) );
+var opts = {
+	'skip': ( dmad instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmad, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 3', opts, function test( t ) {
+	t.strictEqual( dmad.length, 3, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the mean absolute deviation of a strided array', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ] );
+	v = dmad( x.length, x, 1 );
+	t.strictEqual( v, 2.5, 'returns expected value' );
+
+	x = new Float64Array( [ -4.0, -4.0 ] );
+	v = dmad( x.length, x, 1 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	v = dmad( x.length, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( 0, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = dmad( -1, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to `1`, the function returns 0.0', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( 1, x, 1 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0
+	]);
+
+	v = dmad( 4, x, 2 );
+
+	t.strictEqual( v, 1.75, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	]);
+
+	v = dmad( 4, x, -2 );
+
+	t.strictEqual( v, 1.75, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the function returns 0.0', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( x.length, x, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports view offsets', opts, function test( t ) {
+	var x0;
+	var x1;
+	var v;
+
+	x0 = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0,  // 3
+		6.0
+	]);
+
+	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT * 1 ); // start at 2nd element
+
+	v = dmad( 4, x1, 2 );
+	t.strictEqual( v, 1.75, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/dmad/test/test.dmad.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/test/test.dmad.native.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var path = require( 'path' );
+var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
@@ -29,7 +29,7 @@ var Float64Array = require( '@stdlib/array/float64' );
 
 // VARIABLES //
 
-var dmad = tryRequire( path.join( __dirname, './../lib/dmad.native.js' ) );
+var dmad = tryRequire( resolve( __dirname, './../lib/dmad.native.js' ) );
 var opts = {
 	'skip': ( dmad instanceof Error )
 };
@@ -46,6 +46,88 @@ tape( 'main export is a function', opts, function test( t ) {
 tape( 'the function has an arity of 3', opts, function test( t ) {
 	t.strictEqual( dmad.length, 3, 'has expected arity' );
 	t.end();
+});
+
+tape( 'the function throws an error if provided a first argument which is not a number', opts, function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			dmad( value, new Float64Array( 10 ), 1 );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a second argument which is not a Float64Array', opts, function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			dmad( 10, value, 1 );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a third argument which is not a number', opts, function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			dmad( 10, new Float64Array( 10 ), value );
+		};
+	}
 });
 
 tape( 'the function calculates the mean absolute deviation of a strided array', opts, function test( t ) {

--- a/lib/node_modules/@stdlib/stats/strided/dmad/test/test.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/test/test.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var dmad = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': IS_BROWSER
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmad, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof dmad.ndarray, 'function', 'method is a function' );
+	t.end();
+});
+
+tape( 'if a native implementation is available, the main export is the native implementation', opts, function test( t ) {
+	var dmad = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( dmad, mock, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return mock;
+	}
+
+	function mock() {
+		// Mock...
+	}
+});
+
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', opts, function test( t ) {
+	var dmad;
+	var main;
+
+	main = require( './../lib/dmad.js' );
+
+	dmad = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( dmad, main, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
+});

--- a/lib/node_modules/@stdlib/stats/strided/dmad/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/test/test.ndarray.js
@@ -1,0 +1,161 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
+var dmad = require( './../lib/ndarray.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmad, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 4', function test( t ) {
+	t.strictEqual( dmad.length, 4, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the mean absolute deviation of a strided array', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ] );
+	v = dmad( x.length, x, 1, 0 );
+	t.strictEqual( v, 2.5, 'returns expected value' );
+
+	x = new Float64Array( [ -4.0, -4.0 ] );
+	v = dmad( x.length, x, 1, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	v = dmad( x.length, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( 0, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = dmad( -1, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to `1`, the function returns 0.0', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( 1, x, 1, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0
+	]);
+
+	v = dmad( 4, x, 2, 0 );
+
+	t.strictEqual( v, 1.75, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	]);
+
+	v = dmad( 4, x, -2, 6 );
+
+	t.strictEqual( v, 1.75, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the function returns 0.0', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( x.length, x, 0, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports an `offset` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0   // 3
+	]);
+
+	v = dmad( 4, x, 2, 1 );
+	t.strictEqual( v, 1.75, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/dmad/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/test/test.ndarray.native.js
@@ -1,0 +1,170 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var path = require( 'path' );
+var tape = require( 'tape' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
+
+
+// VARIABLES //
+
+var dmad = tryRequire( path.join( __dirname, './../lib/ndarray.native.js' ) );
+var opts = {
+	'skip': ( dmad instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmad, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 4', opts, function test( t ) {
+	t.strictEqual( dmad.length, 4, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the mean absolute deviation of a strided array', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ] );
+	v = dmad( x.length, x, 1, 0 );
+	t.strictEqual( v, 2.5, 'returns expected value' );
+
+	x = new Float64Array( [ -4.0, -4.0 ] );
+	v = dmad( x.length, x, 1, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	v = dmad( x.length, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( 0, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = dmad( -1, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to `1`, the function returns 0.0', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( 1, x, 1, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0
+	]);
+
+	v = dmad( 4, x, 2, 0 );
+
+	t.strictEqual( v, 1.75, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	]);
+
+	v = dmad( 4, x, -2, 6 );
+
+	t.strictEqual( v, 1.75, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the function returns 0.0', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
+
+	v = dmad( x.length, x, 0, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports an `offset` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0   // 3
+	]);
+
+	v = dmad( 4, x, 2, 1 );
+	t.strictEqual( v, 1.75, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/dmad/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmad/test/test.ndarray.native.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var path = require( 'path' );
+var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
@@ -29,7 +29,7 @@ var Float64Array = require( '@stdlib/array/float64' );
 
 // VARIABLES //
 
-var dmad = tryRequire( path.join( __dirname, './../lib/ndarray.native.js' ) );
+var dmad = tryRequire( resolve( __dirname, './../lib/ndarray.native.js' ) );
 var opts = {
 	'skip': ( dmad instanceof Error )
 };


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: passed
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: passed
  - task: lint_c_examples status: passed
  - task: lint_c_benchmarks status: passed
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed 
  ---
Resolves #N/A.

## Description

> What is the purpose of this pull request?

This pull request adds a new statistical routine, **`stats/strided/dmad`**, which computes the mean absolute deviation (MAD) from the mean for double-precision floating-point strided arrays.

The implementation supports standard strided access as well as alternative indexing semantics using an explicit offset. It correctly handles negative strides, typed array views, and edge cases such as `N <= 0`, `N === 1`, `strideX === 0`, and `NaN` values.

In addition to the JavaScript implementation, this pull request includes a corresponding C implementation, along with benchmarks, unit tests, TypeScript declarations, and usage examples, ensuring feature completeness and consistency with existing stdlib APIs.

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The mean absolute deviation is computed with respect to the arithmetic mean (not the median), and all examples and doctests reflect this definition.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
