### PR TITLE
chore: fix jslint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-shortcut-reference-image/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-shortcut-reference-image/lib/main.js
@@ -40,6 +40,26 @@ var rule;
 // FUNCTIONS //
 
 /**
+* Copies AST node location info.
+*
+* @private
+* @param {Object} loc - AST node location
+* @returns {Object} copied location info
+*/
+function copyLocationInfo( loc ) {
+	return {
+		'start': {
+			'line': loc.start.line,
+			'column': loc.start.column
+		},
+		'end': {
+			'line': loc.end.line,
+			'column': loc.end.column
+		}
+	};
+}
+
+/**
 * Rule to prevent shortcut Markdown reference images from being used in JSDoc descriptions.
 *
 * @param {Object} context - ESLint context
@@ -110,26 +130,6 @@ function main( context ) {
 			loc.start.column = err.location.start.column + 1; // Note: we assume that 1 space separates `*` from JSDoc description content (e.g., `* ## Beep`)
 			report( msg, loc );
 		}
-	}
-
-	/**
-	* Copies AST node location info.
-	*
-	* @private
-	* @param {Object} loc - AST node location
-	* @returns {Object} copied location info
-	*/
-	function copyLocationInfo( loc ) {
-		return {
-			'start': {
-				'line': loc.start.line,
-				'column': loc.start.column
-			},
-			'end': {
-				'line': loc.end.line,
-				'column': loc.end.column
-			}
-		};
 	}
 
 	/**

--- a/lib/node_modules/@stdlib/datasets/cdc-nchs-us-infant-mortality-bw-1915-2013/scripts/build.js
+++ b/lib/node_modules/@stdlib/datasets/cdc-nchs-us-infant-mortality-bw-1915-2013/scripts/build.js
@@ -24,6 +24,7 @@ var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -66,7 +67,7 @@ function main() {
 	for ( i = 0; i < data.length; i++ ) {
 		d = data[ i ].split( ',' );
 		if ( d.length !== fields.length ) {
-			throw new Error( 'unexpected error. Number of row values ('+d.length+') does not match the expected number of fields ('+fields.length+').' );
+			throw new Error( format( 'unexpected error. Number of row values (%d) does not match the expected number of fields (%d).', d.length, fields.length ) );
 		}
 		for ( j = 1; j < d.length; j++ ) {
 			d[ j ] = parseFloat( d[ j ] );
@@ -86,7 +87,7 @@ function main() {
 		} else if ( d[ 0 ] === 'white' ) {
 			json.white.push( d[ 2 ] );
 		} else {
-			throw new Error( 'unexpected error. Unrecognized race: `'+d[2]+'`.' );
+			throw new Error( format( 'unexpected error. Unrecognized race: `%s`.', d[ 0 ] ) );
 		}
 	}
 	if ( json.black.length !== json.white.length ) {


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames
    status: passed
  - task: lint_editorconfig
    status: passed
  - task: lint_markdown
    status: na
  - task: lint_package_json
    status: na
  - task: lint_repl_help
    status: na
  - task: lint_javascript_src
    status: passed
  - task: lint_javascript_cli
    status: na
  - task: lint_javascript_examples
    status: na
  - task: lint_javascript_tests
    status: na
  - task: lint_javascript_benchmarks
    status: na
  - task: lint_python
    status: na
  - task: lint_r
    status: na
  - task: lint_c_src
    status: na
  - task: lint_c_examples
    status: na
  - task: lint_c_benchmarks
    status: na
  - task: lint_c_tests_fixtures
    status: na
  - task: lint_shell
    status: na
  - task: lint_typescript_declarations
    status: passed
  - task: lint_typescript_tests
    status: na
  - task: lint_license_headers
    status: passed
---

Resolves #10211.

## Description

This pull request fixes ESLint errors reported during CI.

Specifically:

- Replaced string concatenation in error messages with `@stdlib/string/format` in  
  `lib/node_modules/@stdlib/datasets/cdc-nchs-us-infant-mortality-bw-1915-2013/scripts/build.js`
  to satisfy the `stdlib/no-error-string-concat` rule.
- Moved the `copyLocationInfo` function to module scope in  
  `lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-shortcut-reference-image/lib/main.js`
  to satisfy the `stdlib/no-unnecessary-nested-functions` rule.

All lint checks now pass.

## Related Issues

- #10211

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
