### PR TITLE
chore: add missing bench task config to `complex/float64/base/assert/is_equal`

### DIFF
--- a/lib/node_modules/@stdlib/complex/float64/base/assert/is-equal/manifest.json
+++ b/lib/node_modules/@stdlib/complex/float64/base/assert/is-equal/manifest.json
@@ -41,6 +41,21 @@
       ]
     },
     {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/complex/float64/ctor",
+        "@stdlib/complex/float64/reim"
+      ]
+    },
+    {
       "task": "examples",
       "src": [
         "./src/main.c"


### PR DESCRIPTION


---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed 
  ---

Resolves #N/A.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds missing benchmark configuration to `complex/float64/base/assert/is_equal`.
-   While working on another package, I encountered issues running C benchmarks due to the missing benchmark configuration in the manifest.
-   This change ensures benchmarks are properly recognized and executable.

## Related Issues

> Does this pull request have any related issues?

This pull request has no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

#### Disclosure

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

