### PR TITLE
fix: replace new Array() with array literals in test files

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-empty-collection/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-empty-collection/test/test.js
@@ -81,7 +81,7 @@ tape( 'the function returns `false` if not provided an empty collection', functi
 		null,
 		void 0,
 		[ 1, 2, 3 ],
-		new Array( 10 ),
+		[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
 		{},
 		function noop() {}
 	];

--- a/lib/node_modules/@stdlib/math/strided/special/ahavercos-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/ahavercos-by/test/test.main.js
@@ -74,7 +74,8 @@ tape( 'the function computes the inverse half-value versed cosine via a callback
 	ahavercosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -82,7 +83,8 @@ tape( 'the function computes the inverse half-value versed cosine via a callback
 	ahavercosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 

--- a/lib/node_modules/@stdlib/math/strided/special/ahavercos-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/ahavercos-by/test/test.ndarray.js
@@ -73,7 +73,8 @@ tape( 'the function computes the inverse half-value versed cosine via a callback
 	ahavercosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -81,7 +82,8 @@ tape( 'the function computes the inverse half-value versed cosine via a callback
 	ahavercosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

- Replaces `new Array()` constructor with array literal pattern in ahavercos-by tests
- Replaces `new Array()` with explicit array in is-empty-collection test  
- Resolves linting errors (stdlib/no-new-array rule violations)

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Fixes JavaScript linting failures detected in the automated lint workflow run

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Changes Made:

**File 1:** `lib/node_modules/@stdlib/math/strided/special/ahavercos-by/test/test.main.js`
- Lines 77-78 and 85-86: Changed `x = new Array( 5 );` to `x = []; x.length = 5; // sparse array`

**File 2:** `lib/node_modules/@stdlib/math/strided/special/ahavercos-by/test/test.ndarray.js`  
- Lines 76-77 and 84-85: Changed `x = new Array( 5 );` to `x = []; x.length = 5; // sparse array`

**File 3:** `lib/node_modules/@stdlib/assert/is-empty-collection/test/test.js`
- Line 84: Changed `new Array( 10 ),` to `[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],`

All linting tests now pass locally.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No   
 
 If you answered "yes" above, how did you use AI assistance?

 [ ] Code generation

 [ ] Test/benchmark generation

 [ ] Documentation (including examples)

 [ ] Research and understanding

---

@stdlib-js/reviewers
Fixes: #10184


[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md