### PR TITLE
fix javascript lint errors(#10211)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-shortcut-reference-image/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-shortcut-reference-image/lib/main.js
@@ -20,12 +20,12 @@
 
 // MODULES //
 
-var parseJSDoc = require( 'doctrine' ).parse;
-var remark = require( 'remark' );
-var remarkLint = require( 'remark-lint' );
-var remarkPlugin = require( 'remark-lint-no-shortcut-reference-image' );
-var isObject = require( '@stdlib/assert/is-object' );
-var findJSDoc = require( '@stdlib/_tools/eslint/utils/find-jsdoc' );
+var parseJSDoc = require('doctrine').parse;
+var remark = require('remark');
+var remarkLint = require('remark-lint');
+var remarkPlugin = require('remark-lint-no-shortcut-reference-image');
+var isObject = require('@stdlib/assert/is-object');
+var findJSDoc = require('@stdlib/_tools/eslint/utils/find-jsdoc');
 
 
 // VARIABLES //
@@ -40,12 +40,32 @@ var rule;
 // FUNCTIONS //
 
 /**
+* Copies AST node location info.
+*
+* @private
+* @param {Object} loc - AST node location
+* @returns {Object} copied location info
+*/
+function copyLocationInfo(loc) {
+	return {
+		'start': {
+			'line': loc.start.line,
+			'column': loc.start.column
+		},
+		'end': {
+			'line': loc.end.line,
+			'column': loc.end.column
+		}
+	};
+}
+
+/**
 * Rule to prevent shortcut Markdown reference images from being used in JSDoc descriptions.
 *
 * @param {Object} context - ESLint context
 * @returns {Object} validators
 */
-function main( context ) {
+function main(context) {
 	var source;
 	var config;
 	var lint;
@@ -53,10 +73,10 @@ function main( context ) {
 	config = {
 		'plugins': [
 			remarkLint,
-			[ remarkPlugin, 'error' ]
+			[remarkPlugin, 'error']
 		]
 	};
-	lint = remark().use( config ).processSync; // eslint-disable-line node/no-sync
+	lint = remark().use(config).processSync; // eslint-disable-line node/no-sync
 	source = context.getSourceCode();
 
 	return {
@@ -72,18 +92,18 @@ function main( context ) {
 	* @private
 	* @param {ASTNode} node - AST node
 	*/
-	function validate( node ) {
+	function validate(node) {
 		var jsdoc;
 		var vfile;
 		var ast;
 
-		jsdoc = findJSDoc( source, node );
-		if ( isObject( jsdoc ) ) {
-			ast = parseJSDoc( jsdoc.value, DOPTS );
-			if ( ast.description ) {
-				vfile = lint( ast.description );
-				if ( vfile.messages.length ) {
-					reportErrors( vfile.messages, jsdoc.loc );
+		jsdoc = findJSDoc(source, node);
+		if (isObject(jsdoc)) {
+			ast = parseJSDoc(jsdoc.value, DOPTS);
+			if (ast.description) {
+				vfile = lint(ast.description);
+				if (vfile.messages.length) {
+					reportErrors(vfile.messages, jsdoc.loc);
 				}
 			}
 		}
@@ -96,41 +116,23 @@ function main( context ) {
 	* @param {ObjectArray} errors - Markdown lint errors
 	* @param {Object} location - JSDoc location information
 	*/
-	function reportErrors( errors, location ) {
+	function reportErrors(errors, location) {
 		var err;
 		var msg;
 		var loc;
 		var i;
 
-		for ( i = 0; i < errors.length; i++ ) {
-			err = errors[ i ];
+		for (i = 0; i < errors.length; i++) {
+			err = errors[i];
 			msg = err.message;
-			loc = copyLocationInfo( location );
+			loc = copyLocationInfo(location);
 			loc.start.line = err.location.start.line + 1; // Note: we assume `/**` is on its own line
 			loc.start.column = err.location.start.column + 1; // Note: we assume that 1 space separates `*` from JSDoc description content (e.g., `* ## Beep`)
-			report( msg, loc );
+			report(msg, loc);
 		}
 	}
 
-	/**
-	* Copies AST node location info.
-	*
-	* @private
-	* @param {Object} loc - AST node location
-	* @returns {Object} copied location info
-	*/
-	function copyLocationInfo( loc ) {
-		return {
-			'start': {
-				'line': loc.start.line,
-				'column': loc.start.column
-			},
-			'end': {
-				'line': loc.end.line,
-				'column': loc.end.column
-			}
-		};
-	}
+
 
 	/**
 	* Reports an error message.
@@ -139,7 +141,7 @@ function main( context ) {
 	* @param {string} msg - error message
 	* @param {Object} loc - error location info
 	*/
-	function report( msg, loc ) {
+	function report(msg, loc) {
 		context.report({
 			'node': null,
 			'message': msg,

--- a/lib/node_modules/@stdlib/datasets/cdc-nchs-us-infant-mortality-bw-1915-2013/scripts/build.js
+++ b/lib/node_modules/@stdlib/datasets/cdc-nchs-us-infant-mortality-bw-1915-2013/scripts/build.js
@@ -24,6 +24,7 @@ var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -66,7 +67,7 @@ function main() {
 	for ( i = 0; i < data.length; i++ ) {
 		d = data[ i ].split( ',' );
 		if ( d.length !== fields.length ) {
-			throw new Error( 'unexpected error. Number of row values ('+d.length+') does not match the expected number of fields ('+fields.length+').' );
+			throw new Error( format( 'unexpected error. Number of row values (%u) does not match the expected number of fields (%u).', d.length, fields.length ) );
 		}
 		for ( j = 1; j < d.length; j++ ) {
 			d[ j ] = parseFloat( d[ j ] );
@@ -86,7 +87,7 @@ function main() {
 		} else if ( d[ 0 ] === 'white' ) {
 			json.white.push( d[ 2 ] );
 		} else {
-			throw new Error( 'unexpected error. Unrecognized race: `'+d[2]+'`.' );
+			throw new Error( format( 'unexpected error. Unrecognized race: `%s`.', d[ 2 ] ) );
 		}
 	}
 	if ( json.black.length !== json.white.length ) {


### PR DESCRIPTION
Resolves #10211

## Description

> What is the purpose of this pull request?

This pull request:

1. `lib/node_modules/@stdlib/datasets/cdc-nchs-us-infant-mortality-bw-1915-2013/scripts/build.js`
- Error: `stdlib/no-error-string-concat`
- Fix: Use `@stdlib/string/format` for error messages.
             1. Add var format = `require( '@stdlib/string/format' );`
             2. Replace string concatenation in `throw new Error(...)`.
2. `lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-shortcut-reference-image/lib/main.js`
- Error: `stdlib/no-unnecessary-nested-functions`
- Fix: Move copyLocationInfo function from inside  main to the module scope (under `// FUNCTIONS //`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #10211

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
