### PR TITLE
feat: add `stats/array/nanmidrange-by`

### DIFF
--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/README.md
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/README.md
@@ -1,0 +1,152 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# nanmidrangeBy
+
+> Calculate the [midrange][midrange] of an array via a callback function, ignoring `NaN` values.
+
+<section class="intro">
+
+The [**midrange**][midrange] is defined as the arithmetic mean of the maximum and minimum values.
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var nanmidrangeBy = require( '@stdlib/stats/array/nanmidrange-by' );
+```
+
+#### nanmidrangeBy( x, clbk\[, thisArg] )
+
+Computes the [midrange][midrange] of an array via a callback function, ignoring `NaN` values.
+
+```javascript
+function accessor( v ) {
+    return v * 2.0;
+}
+
+var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, 0.0, -1.0, -3.0 ];
+
+var v = nanmidrangeBy( x, accessor );
+// returns -1.0
+```
+
+The function has the following parameters:
+
+-   **x**: input array.
+-   **clbk**: callback function.
+-   **thisArg**: execution context (_optional_).
+
+The invoked callback is provided three arguments:
+
+-   **value**: current array element.
+-   **index**: current array index.
+-   **array**: input array.
+
+To set the callback execution context, provide a `thisArg`.
+
+```javascript
+function accessor( v ) {
+    this.count += 1;
+    return v * 2.0;
+}
+
+var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, 0.0, -1.0, -3.0 ];
+
+var context = {
+    'count': 0
+};
+
+var v = nanmidrangeBy( x, accessor, context );
+// returns -1.0
+
+var cnt = context.count;
+// returns 9
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If provided an empty array, the function returns `NaN`.
+-   A provided callback function should return a numeric value.
+-   If a provided callback function does not return any value (or equivalently, explicitly returns `undefined`), the value is **ignored**.
+-   The function supports array-like objects having getter and setter accessors for array element access (e.g., [`@stdlib/array/base/accessor`][@stdlib/array/base/accessor]).
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var nanmidrangeBy = require( '@stdlib/stats/array/nanmidrange-by' );
+
+function accessor( v ) {
+    return v * 2.0;
+}
+
+var x = discreteUniform( 10, -50, 50, {
+    'dtype': 'float64'
+});
+x[ 2 ] = NaN;
+console.log( x );
+
+var v = nanmidrangeBy( x, accessor );
+console.log( v );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/array/base/accessor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/base/accessor
+
+[midrange]: https://en.wikipedia.org/wiki/Mid-range
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/README.md
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/README.md
@@ -24,7 +24,7 @@ limitations under the License.
 
 <section class="intro">
 
-The [**midrange**][midrange] is defined as the arithmetic mean of the maximum and minimum values.
+The [**midrange**][midrange] is defined as the arithmetic mean of the maximum and minimum values in a data set. The measure is the midpoint of the range and a measure of central tendency.
 
 </section>
 
@@ -47,7 +47,7 @@ function accessor( v ) {
     return v * 2.0;
 }
 
-var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, 0.0, -1.0, -3.0 ];
+var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, 0.0, -1.0, -3.0, NaN ];
 
 var v = nanmidrangeBy( x, accessor );
 // returns -1.0
@@ -73,7 +73,7 @@ function accessor( v ) {
     return v * 2.0;
 }
 
-var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, 0.0, -1.0, -3.0 ];
+var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, 0.0, -1.0, -3.0, NaN ];
 
 var context = {
     'count': 0
@@ -83,7 +83,7 @@ var v = nanmidrangeBy( x, accessor, context );
 // returns -1.0
 
 var cnt = context.count;
-// returns 9
+// returns 10
 ```
 
 </section>
@@ -96,6 +96,7 @@ var cnt = context.count;
 
 -   If provided an empty array, the function returns `NaN`.
 -   A provided callback function should return a numeric value.
+-   If a provided callback function returns `NaN`, the value is **ignored**.
 -   If a provided callback function does not return any value (or equivalently, explicitly returns `undefined`), the value is **ignored**.
 -   The function supports array-like objects having getter and setter accessors for array element access (e.g., [`@stdlib/array/base/accessor`][@stdlib/array/base/accessor]).
 
@@ -110,17 +111,23 @@ var cnt = context.count;
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
 var nanmidrangeBy = require( '@stdlib/stats/array/nanmidrange-by' );
+
+function rand() {
+    if ( bernoulli( 0.8 ) < 1 ) {
+        return NaN;
+    }
+    return uniform( -50.0, 50.0 );
+}
 
 function accessor( v ) {
     return v * 2.0;
 }
 
-var x = discreteUniform( 10, -50, 50, {
-    'dtype': 'float64'
-});
-x[ 2 ] = NaN;
+var x = filledarrayBy( 10, 'float64', rand );
 console.log( x );
 
 var v = nanmidrangeBy( x, accessor );

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/benchmark/benchmark.js
@@ -1,0 +1,115 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nanmidrangeBy = require( './../lib' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'generic'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Accessor function.
+*
+* @private
+* @param {number} value - array element
+* @returns {number} accessed value
+*/
+function accessor( value ) {
+	return value * 2.0;
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = uniform( len, -10, 10, options );
+	x[ 0 ] = NaN; // Ensure at least one NaN
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = nanmidrangeBy( x, accessor );
+			if ( len > 1 && isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( len > 1 && isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/benchmark/benchmark.js
@@ -21,19 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var format = require( '@stdlib/string/format' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var nanmidrangeBy = require( './../lib' );
-
-
-// VARIABLES //
-
-var options = {
-	'dtype': 'generic'
-};
 
 
 // FUNCTIONS //
@@ -50,6 +45,19 @@ function accessor( value ) {
 }
 
 /**
+* Returns a random number.
+*
+* @private
+* @returns {number} random number
+*/
+function rand() {
+	if ( bernoulli( 0.8 ) < 1 ) {
+		return NaN;
+	}
+	return uniform( -10.0, 10.0 );
+}
+
+/**
 * Creates a benchmark function.
 *
 * @private
@@ -57,8 +65,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
-	x[ 0 ] = NaN; // Ensure at least one NaN
+	var x = filledarrayBy( len, 'generic', rand );
 	return benchmark;
 
 	/**
@@ -74,12 +81,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			v = nanmidrangeBy( x, accessor );
-			if ( len > 1 && isnan( v ) ) {
+			if ( isnan( v ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( len > 1 && isnan( v ) ) {
+		if ( isnan( v ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/repl.txt
@@ -13,6 +13,8 @@
 
     The callback function should return a numeric value.
 
+    If the callback function returns `NaN`, the value is ignored.
+
     If the callback function does not return any value (or equivalently,
     explicitly returns `undefined`), the value is ignored.
 

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/repl.txt
@@ -1,0 +1,44 @@
+
+{{alias}}( x, clbk[, thisArg] )
+    Computes the midrange of an array via a callback function,
+    ignoring NaN values.
+
+    If provided an empty array, the function returns `NaN`.
+
+    The callback function is provided three arguments:
+
+    - value: current array element.
+    - index: current array index.
+    - array: the input array.
+
+    The callback function should return a numeric value.
+
+    If the callback function does not return any value (or equivalently,
+    explicitly returns `undefined`), the value is ignored.
+
+    Parameters
+    ----------
+    x: Array|TypedArray
+        Input array.
+
+    clbk: Function
+        Callback function.
+
+    thisArg: any (optional)
+        Execution context.
+
+    Returns
+    -------
+    out: number
+        Midrange.
+
+    Examples
+    --------
+    > function accessor( v ) { return v * 2.0; };
+    > var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, -1.0, -3.0 ];
+    > {{alias}}( x, accessor )
+    -1.0
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( x, clbk[, thisArg] )
     Computes the midrange of an array via a callback function,
-    ignoring NaN values.
+    ignoring `NaN` values.
 
     If provided an empty array, the function returns `NaN`.
 

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/types/index.d.ts
@@ -1,0 +1,97 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Collection, AccessorArrayLike } from '@stdlib/types/array';
+
+/**
+* Input array.
+*/
+type InputArray<T> = Collection<T> | AccessorArrayLike<T>;
+
+/**
+* Returns an accessed value.
+*
+* @returns accessed value
+*/
+type Nullary<ThisArg> = ( this: ThisArg ) => number | void;
+
+/**
+* Returns an accessed value.
+*
+* @param value - current array element
+* @returns accessed value
+*/
+type Unary<T, ThisArg> = ( this: ThisArg, value: T ) => number | void;
+
+/**
+* Returns an accessed value.
+*
+* @param value - current array element
+* @param index - current array index
+* @returns accessed value
+*/
+type Binary<T, ThisArg> = ( this: ThisArg, value: T, index: number ) => number | void;
+
+/**
+* Returns an accessed value.
+*
+* @param value - current array element
+* @param index - current array index
+* @param array - input array
+* @returns accessed value
+*/
+type Ternary<T, U, ThisArg> = ( this: ThisArg, value: T, index: number, array: U ) => number | void;
+
+/**
+* Returns an accessed value.
+*
+* @param value - current array element
+* @param index - current array index
+* @param array - input array
+* @returns accessed value
+*/
+type Callback<T, U, ThisArg> = Nullary<ThisArg> | Unary<T, ThisArg> | Binary<T, ThisArg> | Ternary<T, U, ThisArg>;
+
+/**
+* Computes the midrange of an array via a callback function, ignoring `NaN` values.
+*
+* @param x - input array
+* @param clbk - callback
+* @param thisArg - execution context
+* @returns midrange
+*
+* @example
+* var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, 0.0, -1.0, -3.0 ];
+*
+* function accessor( v ) {
+*     return v * 2.0;
+* }
+*
+* var v = nanmidrangeBy( x, accessor );
+* // returns -1.0
+*/
+declare function nanmidrangeBy<T = unknown, U extends InputArray<T> = InputArray<T>, ThisArg = unknown>( x: U, clbk: Callback<T, U, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, ThisArg>> ): number;
+
+
+// EXPORTS //
+
+export = nanmidrangeBy;

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/docs/types/test.ts
@@ -1,0 +1,76 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import AccessorArray = require( '@stdlib/array/base/accessor' );
+import nanmidrangeBy = require( './index' );
+
+/**
+* Accessor function.
+*
+* @returns accessed value
+*/
+function accessor(): number {
+	return 5.0;
+}
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	const x = new Float64Array( 10 );
+
+	nanmidrangeBy( x, accessor ); // $ExpectType number
+	nanmidrangeBy( new AccessorArray( x ), accessor ); // $ExpectType number
+
+	nanmidrangeBy( x, accessor, {} ); // $ExpectType number
+	nanmidrangeBy( new AccessorArray( x ), accessor, {} ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an array-like object...
+{
+	nanmidrangeBy( 10, accessor ); // $ExpectError
+	nanmidrangeBy( true, accessor ); // $ExpectError
+	nanmidrangeBy( false, accessor ); // $ExpectError
+	nanmidrangeBy( null, accessor ); // $ExpectError
+	nanmidrangeBy( undefined, accessor ); // $ExpectError
+	nanmidrangeBy( {}, accessor ); // $ExpectError
+	nanmidrangeBy( ( x: number ): number => x, accessor ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a function...
+{
+	const x = new Float64Array( 10 );
+
+	nanmidrangeBy( x, '10' ); // $ExpectError
+	nanmidrangeBy( x, true ); // $ExpectError
+	nanmidrangeBy( x, false ); // $ExpectError
+	nanmidrangeBy( x, null ); // $ExpectError
+	nanmidrangeBy( x, undefined ); // $ExpectError
+	nanmidrangeBy( x, [] ); // $ExpectError
+	nanmidrangeBy( x, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+
+	nanmidrangeBy(); // $ExpectError
+	nanmidrangeBy( x ); // $ExpectError
+	nanmidrangeBy( x, accessor, {}, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/examples/index.js
@@ -18,18 +18,23 @@
 
 'use strict';
 
-var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
 var nanmidrangeBy = require( './../lib' );
+
+function rand() {
+	if ( bernoulli( 0.8 ) < 1 ) {
+		return NaN;
+	}
+	return uniform( -50.0, 50.0 );
+}
 
 function accessor( v ) {
 	return v * 2.0;
 }
 
-var x = discreteUniform( 10, -50, 50, {
-	'dtype': 'float64'
-});
-x[ 2 ] = NaN;
-x[ 5 ] = NaN;
+var x = filledarrayBy( 10, 'float64', rand );
 console.log( x );
 
 var v = nanmidrangeBy( x, accessor );

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var nanmidrangeBy = require( './../lib' );
+
+function accessor( v ) {
+	return v * 2.0;
+}
+
+var x = discreteUniform( 10, -50, 50, {
+	'dtype': 'float64'
+});
+x[ 2 ] = NaN;
+x[ 5 ] = NaN;
+console.log( x );
+
+var v = nanmidrangeBy( x, accessor );
+console.log( v );

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Calculate the midrange of an array via a callback function, ignoring `NaN` values.
+* Compute the midrange of an array via a callback function, ignoring `NaN` values.
 *
 * @module @stdlib/stats/array/nanmidrange-by
 *

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Calculate the midrange of an array via a callback function, ignoring NaN values.
+* Calculate the midrange of an array via a callback function, ignoring `NaN` values.
 *
 * @module @stdlib/stats/array/nanmidrange-by
 *
@@ -41,6 +41,6 @@
 var main = require( './main.js' );
 
 
-// MAIN //
+// EXPORTS //
 
 module.exports = main;

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Calculate the midrange of an array via a callback function, ignoring NaN values.
+*
+* @module @stdlib/stats/array/nanmidrange-by
+*
+* @example
+* var nanmidrangeBy = require( '@stdlib/stats/array/nanmidrange-by' );
+*
+* function accessor( v ) {
+*     return v * 2.0;
+* }
+*
+* var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, 0.0, -1.0, -3.0 ];
+*
+* var v = nanmidrangeBy( x, accessor );
+* // returns -1.0
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// MAIN //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/lib/main.js
@@ -1,0 +1,78 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isCollection = require( '@stdlib/assert/is-collection' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var strided = require( '@stdlib/stats/strided/nanmidrange-by' ).ndarray;
+var format = require( '@stdlib/string/format' );
+
+
+// MAIN //
+
+/**
+* Computes the midrange of an array via a callback function, ignoring `NaN` values.
+*
+* @param {Collection} x - input array
+* @param {Callback} clbk - callback
+* @param {*} [thisArg] - execution context
+* @throws {TypeError} first argument must be an array-like object
+* @throws {TypeError} second argument must be a function
+* @returns {number} midrange
+*
+* @example
+* var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, NaN, 0.0, -1.0, -3.0 ];
+*
+* function accessor( v ) {
+*     return v * 2.0;
+* }
+*
+* var v = nanmidrangeBy( x, accessor );
+* // returns -1.0
+*/
+function nanmidrangeBy( x, clbk, thisArg ) {
+	if ( !isCollection( x ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be an array-like object. Value: `%s`.', x ) );
+	}
+	if ( !isFunction( clbk ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must be a function. Value: `%s`.', clbk ) );
+	}
+	return strided( x.length, x, 1, 0, wrapper );
+
+	/**
+	* Invokes a provided callback.
+	*
+	* @private
+	* @param {*} value - current element
+	* @param {NonNegativeInteger} aidx - current array index
+	* @param {NonNegativeInteger} sidx - current strided index
+	* @param {Collection} arr - input array
+	* @returns {number} callback return value
+	*/
+	function wrapper( value, aidx, sidx, arr ) {
+		return clbk.call( thisArg, value, aidx, arr );
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = nanmidrangeBy;

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/package.json
@@ -62,12 +62,9 @@
     "midrange",
     "range",
     "extremes",
-    "dispersion",
     "domain",
     "extent",
-    "array",
-    "nan",
-    "ignore"
+    "array"
   ],
   "__stdlib__": {}
 }

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@stdlib/stats/array/nanmidrange-by",
+  "version": "0.0.0",
+  "description": "Calculate the midrange of an array via a callback function, ignoring NaN values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "maximum",
+    "max",
+    "minimum",
+    "min",
+    "midrange",
+    "range",
+    "extremes",
+    "dispersion",
+    "domain",
+    "extent",
+    "array",
+    "nan",
+    "ignore"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/test/test.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/test/test.js
@@ -114,7 +114,7 @@ tape( 'the function throws an error if provided a second argument which is not a
 	}
 });
 
-tape( 'the function calculates the midrange of an array via a callback function, ignoring NaN values', function test( t ) {
+tape( 'the function calculates the midrange of an array via a callback function', function test( t ) {
 	var x;
 	var v;
 
@@ -141,7 +141,7 @@ tape( 'the function calculates the midrange of an array via a callback function,
 	t.end();
 });
 
-tape( 'the function calculates the midrange of an array via a callback function (accessors), ignoring NaN values', function test( t ) {
+tape( 'the function calculates the midrange of an array via a callback function (accessors)', function test( t ) {
 	var x;
 	var v;
 
@@ -168,7 +168,7 @@ tape( 'the function calculates the midrange of an array via a callback function 
 	t.end();
 });
 
-tape( 'the function calculates the midrange of an array (array-like object), ignoring NaN values', function test( t ) {
+tape( 'the function calculates the midrange of an array via a callback function (array-like object)', function test( t ) {
 	var x;
 	var v;
 

--- a/lib/node_modules/@stdlib/stats/array/nanmidrange-by/test/test.js
+++ b/lib/node_modules/@stdlib/stats/array/nanmidrange-by/test/test.js
@@ -1,0 +1,292 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isSameArray = require( '@stdlib/assert/is-same-array' );
+var nanmidrangeBy = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Accessor function.
+*
+* @private
+* @param {number} v - value
+* @returns {(number|void)} result
+*/
+function accessor( v ) {
+	if ( v === void 0 ) {
+		return;
+	}
+	return v * 2.0;
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nanmidrangeBy, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 3', function test( t ) {
+	t.strictEqual( nanmidrangeBy.length, 3, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided a first argument which is not an array-like object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nanmidrangeBy( value, accessor );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a second argument which is not a function', function test( t ) {
+	var values;
+	var i;
+	var x;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ];
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		void 0,
+		true,
+		[],
+		{}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nanmidrangeBy( x, value );
+		};
+	}
+});
+
+tape( 'the function calculates the midrange of an array via a callback function, ignoring NaN values', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, NaN, -2.0, -4.0, 5.0, 0.0, NaN, 3.0 ];
+	v = nanmidrangeBy( x, accessor );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	x = [ -4.0, NaN, -5.0 ];
+	v = nanmidrangeBy( x, accessor );
+	t.strictEqual( v, -9.0, 'returns expected value' );
+
+	x = [ -0.0, NaN, 0.0, -0.0 ];
+	v = nanmidrangeBy( x, accessor );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
+
+	x = [ NaN ];
+	v = nanmidrangeBy( x, accessor );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	x = [ NaN, NaN ];
+	v = nanmidrangeBy( x, accessor );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function calculates the midrange of an array via a callback function (accessors), ignoring NaN values', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, NaN, -2.0, -4.0, 5.0, 0.0, NaN, 3.0 ];
+	v = nanmidrangeBy( toAccessorArray( x ), accessor );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	x = [ -4.0, NaN, -5.0 ];
+	v = nanmidrangeBy( toAccessorArray( x ), accessor );
+	t.strictEqual( v, -9.0, 'returns expected value' );
+
+	x = [ -0.0, NaN, 0.0, -0.0 ];
+	v = nanmidrangeBy( toAccessorArray( x ), accessor );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
+
+	x = [ NaN ];
+	v = nanmidrangeBy( toAccessorArray( x ), accessor );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	x = [ NaN, NaN ];
+	v = nanmidrangeBy( toAccessorArray( x ), accessor );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function calculates the midrange of an array (array-like object), ignoring NaN values', function test( t ) {
+	var x;
+	var v;
+
+	x = {
+		'length': 8,
+		'0': 1.0,
+		'1': NaN,
+		'2': -2.0,
+		'3': -4.0,
+		'4': 5.0,
+		'5': 0.0,
+		'6': NaN,
+		'7': 3.0
+	};
+	v = nanmidrangeBy( x, accessor );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a callback execution context', function test( t ) {
+	var expected;
+	var indices;
+	var values;
+	var arrays;
+	var ctx;
+	var x;
+
+	x = [ 1.0, NaN, 2.0, 3.0, 4.0, 5.0 ];
+	ctx = {
+		'count': 0
+	};
+	indices = [];
+	values = [];
+	arrays = [];
+	nanmidrangeBy( x, accessor, ctx );
+
+	t.strictEqual( ctx.count, x.length, 'returns expected value' );
+
+	expected = [ 0, 1, 2, 3, 4, 5 ];
+	t.deepEqual( indices, expected, 'returns expected value' );
+
+	expected = [ 1.0, NaN, 2.0, 3.0, 4.0, 5.0 ];
+	t.strictEqual( isSameArray( values, expected ), true, 'returns expected value' );
+
+	expected = [ x, x, x, x, x, x ];
+	t.deepEqual( arrays, expected, 'returns expected value' );
+	t.end();
+
+	function accessor( v, idx, arr ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		indices.push( idx );
+		values.push( v );
+		arrays.push( arr );
+		return v * 2.0;
+	}
+});
+
+tape( 'the function supports providing a callback execution context (accessors)', function test( t ) {
+	var expected;
+	var indices;
+	var values;
+	var arrays;
+	var ctx;
+	var ax;
+	var x;
+
+	x = [ 1.0, NaN, 2.0, 3.0, 4.0, 5.0 ];
+	ax = toAccessorArray( x );
+	ctx = {
+		'count': 0
+	};
+	indices = [];
+	values = [];
+	arrays = [];
+	nanmidrangeBy( ax, accessor, ctx );
+
+	t.strictEqual( ctx.count, x.length, 'returns expected value' );
+
+	expected = [ 0, 1, 2, 3, 4, 5 ];
+	t.deepEqual( indices, expected, 'returns expected value' );
+
+	expected = [ 1.0, NaN, 2.0, 3.0, 4.0, 5.0 ];
+	t.strictEqual( isSameArray( values, expected ), true, 'returns expected value' );
+
+	expected = [ ax, ax, ax, ax, ax, ax ];
+	t.deepEqual( arrays, expected, 'returns expected value' );
+	t.end();
+
+	function accessor( v, idx, arr ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		indices.push( idx );
+		values.push( v );
+		arrays.push( arr );
+		return v * 2.0;
+	}
+});
+
+tape( 'if provided an empty array, the function returns `NaN`', function test( t ) {
+	var v = nanmidrangeBy( [], accessor );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided an empty array, the function returns `NaN` (accessors)', function test( t ) {
+	var v = nanmidrangeBy( toAccessorArray( [] ), accessor );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided an array containing a single element, the function returns the result of applying a provided callback function to that element', function test( t ) {
+	var v = nanmidrangeBy( [ 1.0 ], accessor );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided an array containing a single element, the function returns the result of applying a provided callback function to that element (accessors)', function test( t ) {
+	var v = nanmidrangeBy( toAccessorArray( [ 1.0 ] ), accessor );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: passed
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed
---



## Description

This pull request adds the `stats/array/nanmidrange-by` .

## Related Issues

None.

## Questions

None.

## Other

No additional information.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
