### PR TITLE
fix: remove empty line between require statements in `test.dsyr2.js`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.dsyr2.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.dsyr2.js
@@ -36,7 +36,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cx0 = require( './fixtures/column_major_x0.json' );


### PR DESCRIPTION
## Summary
- Removes unexpected empty line between `require` statements around line 39 in `lib/node_modules/@stdlib/blas/base/dsyr2/test/test.dsyr2.js`
- Fixes the `stdlib/no-empty-lines-between-requires` ESLint rule violation

Closes #10285

## Test plan
- Run lint checks to verify the `stdlib/no-empty-lines-between-requires` violation is resolved

---

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)