### PR TITLE
bench: use string interpolation in `blas/base/dgemv`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dgemv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -98,7 +99,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( N );
-		bench( pkg+':size='+(N*N), f );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/dgemv/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -103,7 +104,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( N );
-		bench( pkg+'::native:size='+(N*N), opts, f );
+		bench( format( '%s::native:size=%d', pkg, N*N ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/dgemv/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/benchmark/benchmark.ndarray.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -98,7 +99,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( N );
-		bench( pkg+':ndarray:size='+(N*N), f );
+		bench( format( '%s:ndarray:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/dgemv/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/benchmark/benchmark.ndarray.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -103,7 +104,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( N );
-		bench( pkg+'::native:ndarray:size='+(N*N), opts, f );
+		bench( format( '%s::native:ndarray:size=%d', pkg, N*N ), opts, f );
 	}
 }
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed 
  ----
Resolves #N/A.

## Description

> What is the purpose of this pull request?

This pull request:

- uses string interpolation in benchmark output for `blas/base/dgemv` to improve readability and maintain consistency with project formatting conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request has no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

#### Disclosure

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
