### PR TITLE
Fix lint error: unexpected empty line between require statements

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.dsyr2.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.dsyr2.js
@@ -21,14 +21,12 @@
 'use strict';
 
 // MODULES //
-
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var dsyr2 = require( './../lib/dsyr2.js' );
 
 
 // FIXTURES //
-
 var ru = require( './fixtures/row_major_u.json' );
 var rl = require( './fixtures/row_major_l.json' );
 var rx0 = require( './fixtures/row_major_x0.json' );


### PR DESCRIPTION
## Summary

Fixes ESLint error in `lib/node_modules/@stdlib/blas/base/dsyr2/test/test.dsyr2.js` by removing the empty lines between comment section headers (`// MODULES //` and `// FIXTURES //`) and the first require statements.

## Changes

- Removed empty line after `// MODULES //` 
- Removed empty line after `// FIXTURES //`

The ESLint rule `no-multiple-empty-lines` was triggering because there was an empty line between the comment section headers and the first require statements.

Addresses issue #10285.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

If this PR is helpful, tips appreciated via Lightning: max@klabo.world
