### PR TITLE
feat: add implementation of `stats/strided/diqrsorted`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/README.md
@@ -1,0 +1,303 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# diqrsorted
+
+> Calculate the interquartile range of a sorted double-precision
+> floating-point strided array.
+
+<section class="intro">
+
+The [interquartile range][iqr] (IQR) is the difference between the 75th
+percentile ($Q_3$) and the 25th percentile ($Q_1$).
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var diqrsorted = require( '@stdlib/stats/strided/diqrsorted' );
+```
+
+#### diqrsorted( N, x, strideX )
+
+Computes the interquartile range of a sorted double-precision floating-point strided array `x`.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+var v = diqrsorted( x.length, x, 1 );
+// returns 3.0
+```
+
+The function has the following parameters:
+
+-   **N**: number of indexed elements.
+-   **x**: sorted input [`Float64Array`][@stdlib/array/float64].
+-   **strideX**: index increment for `x`.
+
+The `N` and stride parameters determine which elements in the strided array
+are accessed at runtime. For example, to compute the interquartile range of
+every other element in `x`,
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x = new Float64Array( [ 1.0, 10.0, 2.0, 10.0, 3.0, 10.0, 4.0, 10.0, 5.0 ] );
+
+var v = diqrsorted( 5, x, 2 );
+// returns 3.0
+```
+
+Note that indexing is relative to the first index. To introduce an offset,
+use [`typed array`][mdn-typed-array] views.
+
+<!-- eslint-disable stdlib/capitalized-comments -->
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x0 = new Float64Array( [ 10.0, 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+var x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+var v = diqrsorted( 5, x1, 1 );
+// returns 3.0
+```
+
+#### diqrsorted.ndarray( N, x, strideX, offsetX )
+
+Computes the interquartile range of a sorted double-precision floating-point
+strided array using alternative indexing semantics.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+var v = diqrsorted.ndarray( x.length, x, 1, 0 );
+// returns 3.0
+```
+
+The function has the following additional parameters:
+
+-   **offsetX**: starting index for `x`.
+
+While [`typed array`][mdn-typed-array] views mandate a view offset
+based on the underlying `buffer`, the `offsetX` parameter supports
+indexing semantics based on a starting index. For example, to
+calculate the interquartile range for every other value in `x`
+starting from the second value
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x = new Float64Array( [ 10.0, 1.0, 10.0, 2.0, 10.0, 3.0, 10.0, 4.0 ] );
+
+var v = diqrsorted.ndarray( 4, x, 2, 1 );
+// returns 2.0
+```
+
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If `N <= 0`, both functions return `NaN`.
+-   The input strided array must be sorted in either **strictly** ascending or descending order.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var linspace = require( '@stdlib/array/linspace' );
+var diqrsorted = require( '@stdlib/stats/strided/diqrsorted' );
+
+var options = {
+    'dtype': 'float64'
+};
+var x = linspace( -5.0, 5.0, 10, options );
+console.log( x );
+
+var v = diqrsorted( x.length, x, 1 );
+console.log( v );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/strided/diqrsorted.h"
+```
+
+#### stdlib_strided_diqrsorted( N, \*X, strideX )
+
+Computes the interquartile range of a sorted double-precision floating-point strided array.
+
+```c
+const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0 };
+
+double v = stdlib_strided_diqrsorted( 5, x, 1 );
+// returns 3.0
+```
+
+The function accepts the following arguments:
+
+-   **N**: `[in] CBLAS_INT` number of indexed elements.
+-   **X**: `[in] double*` input array.
+-   **strideX**: `[in] CBLAS_INT` stride length for `X`.
+
+```c
+double stdlib_strided_diqrsorted( const CBLAS_INT N, const double *X, const CBLAS_INT strideX );
+```
+
+#### stdlib_strided_diqrsorted_ndarray( N, \*X, strideX, offsetX )
+
+Computes the interquartile range of a sorted double-precision floating-point
+strided array using alternative indexing semantics.
+
+```c
+const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0 };
+
+double v = stdlib_strided_diqrsorted_ndarray( 5, x, 1, 0 );
+// returns 3.0
+```
+
+The function accepts the following arguments:
+
+-   **N**: `[in] CBLAS_INT` number of indexed elements.
+-   **X**: `[in] double*` input array.
+-   **strideX**: `[in] CBLAS_INT` stride length for `X`.
+-   **offsetX**: `[in] CBLAS_INT` starting index for `X`.
+
+```c
+double stdlib_strided_diqrsorted_ndarray( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/strided/diqrsorted.h"
+#include <stdio.h>
+
+int main( void ) {
+    // Create a strided array:
+    const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+
+    // Specify the number of elements:
+    const int N = 4;
+
+    // Specify the stride length:
+    const int strideX = 2;
+
+    // Compute the interquartile range:
+    double v = stdlib_strided_diqrsorted( N, x, strideX );
+
+    // Print the result:
+    printf( "IQR: %lf\n", v );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[iqr]: https://en.wikipedia.org/wiki/Interquartile_range
+
+[@stdlib/array/float64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/float64
+
+[mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+<!-- <related-links> -->
+
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/benchmark.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var linspace = require( '@stdlib/array/linspace' );
+var format = require( '@stdlib/string/format' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var diqrsorted = require( './../lib/diqrsorted.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = linspace( -len/2, len/2, len, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = diqrsorted( x.length, x, 1 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/benchmark.native.js
@@ -1,0 +1,108 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var linspace = require( '@stdlib/array/linspace' );
+var format = require( '@stdlib/string/format' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var diqrsorted = tryRequire( resolve( __dirname, './../lib/diqrsorted.native.js' ) );
+var opts = {
+	'skip': ( diqrsorted instanceof Error )
+};
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = linspace( -len/2, len/2, len, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = diqrsorted( x.length, x, 1 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::native:len=%d', pkg, len ), opts, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/benchmark.ndarray.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var linspace = require( '@stdlib/array/linspace' );
+var format = require( '@stdlib/string/format' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var diqrsorted = require( './../lib/ndarray.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = linspace( -len/2, len/2, len, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = diqrsorted( x.length, x, 1, 0 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/benchmark.ndarray.native.js
@@ -1,0 +1,108 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var linspace = require( '@stdlib/array/linspace' );
+var format = require( '@stdlib/string/format' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var diqrsorted = tryRequire( resolve( __dirname, './../lib/ndarray.native.js' ) );
+var opts = {
+	'skip': ( diqrsorted instanceof Error )
+};
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = linspace( -len/2, len/2, len, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = diqrsorted( x.length, x, 1, 0 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::ndarray:native:len=%d', pkg, len ), opts, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.length.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/benchmark/c/benchmark.length.c
@@ -1,0 +1,196 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/diqrsorted.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "diqrsorted"
+#define ITERATIONS 10000000
+#define REPEATS 3
+#define MIN 1
+#define MAX 6
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total );
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmark results.
+*
+* @param iterations  number of iterations
+* @param elapsed     elapsed time in seconds
+*/
+static void print_results( int iterations, double elapsed ) {
+	double rate = (double)iterations / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", iterations );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
+}
+
+
+/**
+* Runs a benchmark.
+*
+* @param iterations   number of iterations
+* @param len          array length
+* @return             elapsed time in seconds
+*/
+static double benchmark1( int iterations, int len ) {
+	double elapsed;
+	double *x;
+	double v;
+	double t;
+	int i;
+
+	x = (double *)malloc( len * sizeof(double) );
+	for ( i = 0; i < len; i++ ) {
+		x[i] = i;
+	}
+	v = 0.0;
+
+	t = tic();
+	for ( i = 0; i < iterations; i++ ) {
+		v = stdlib_strided_diqrsorted( len, x, 1 );
+		if ( v != v ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+
+	if ( v != v ) {
+		printf( "should not return NaN\n" );
+	}
+	free( x );
+	return elapsed;
+}
+
+/**
+* Runs a benchmark.
+*
+* @param iterations   number of iterations
+* @param len          array length
+* @return             elapsed time in seconds
+*/
+static double benchmark2( int iterations, int len ) {
+	double elapsed;
+	double *x;
+	double v;
+	double t;
+	int i;
+
+	x = (double *)malloc( len * sizeof(double) );
+	for ( i = 0; i < len; i++ ) {
+		x[i] = i;
+	}
+	v = 0.0;
+
+	t = tic();
+	for ( i = 0; i < iterations; i++ ) {
+		v = stdlib_strided_diqrsorted_ndarray( len, x, 1, 0 );
+		if ( v != v ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+
+	if ( v != v ) {
+		printf( "should not return NaN\n" );
+	}
+	free( x );
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int count;
+	int iter;
+	int len;
+	int i;
+	int j;
+
+	srand( time( NULL ) );
+
+	print_version();
+	count = 0;
+
+	for ( i = MIN; i <= MAX; i++ ) {
+		len = pow( 10, i );
+		iter = ITERATIONS;
+		for ( j = 0; j < REPEATS; j++ ) {
+			count += 1;
+			printf( "# c::%s:len=%d\n", NAME, len );
+			elapsed = benchmark1( iter, len );
+			print_results( iter, elapsed );
+			printf( "ok %d benchmark finished\n", count );
+		}
+	}
+
+	for ( i = MIN; i <= MAX; i++ ) {
+		len = pow( 10, i );
+		iter = ITERATIONS / pow( 10, i-1 );
+		for ( j = 0; j < REPEATS; j++ ) {
+			count += 1;
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
+			elapsed = benchmark2( iter, len );
+			print_results( iter, elapsed );
+			printf( "ok %d benchmark finished\n", count );
+		}
+	}
+
+	print_summary( count, count );
+}

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/docs/repl.txt
@@ -1,0 +1,95 @@
+{{alias}}( N, x, strideX )
+    Computes the interquartile range of a sorted double-precision
+    floating-point strided array.
+
+    The input strided array must be sorted in either strictly ascending or
+    descending order.
+
+    The `N` and stride parameters determine which elements in the strided
+    array are accessed at runtime.
+
+    Indexing is relative to the first index. To introduce an offset, use a
+    typed array view.
+
+    If `N <= 0`, the function returns `NaN`.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Float64Array
+        Sorted input array.
+
+    strideX: integer
+        Stride length.
+
+    Returns
+    -------
+    out: number
+        Interquartile range.
+
+    Examples
+    --------
+    // Standard usage:
+    > var x = new {{alias:@stdlib/array/float64}}([ 1, 2, 3, 4, 5 ]);
+    > {{alias}}( x.length, x, 1 )
+    3.0
+
+    // Using `N` and stride parameters:
+    > var x = new {{alias:@stdlib/array/float64}}([ 1,0, 2,0, 3,0, 4 ]);
+    > {{alias}}( 4, x, 2 )
+    2.0
+
+    // Using view offsets:
+    > var x0 = new {{alias:@stdlib/array/float64}}([ 0,1, 2,3, 4,5 ]);
+    > var x1 = new {{alias:@stdlib/array/float64}}(
+    ...   x0.buffer,
+    ...   x0.BYTES_PER_ELEMENT
+    ... );
+    > {{alias}}( 5, x1, 1 )
+    3.0
+
+
+{{alias}}.ndarray( N, x, strideX, offsetX )
+    Computes the interquartile range of a sorted double-precision
+    floating-point strided array using alternative indexing semantics.
+
+    While typed array views mandate a view offset based on the underlying
+    buffer, the `offset` parameter supports indexing semantics based on a
+    starting index.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Float64Array
+        Sorted input array.
+
+    strideX: integer
+        Stride length.
+
+    offsetX: integer
+        Starting index.
+
+    Returns
+    -------
+    out: number
+        Interquartile range.
+
+    Examples
+    --------
+    // Standard usage:
+    > var x = new {{alias:@stdlib/array/float64}}([ 1, 2, 3, 4, 5 ]);
+    > {{alias}}.ndarray( x.length, x, 1, 0 )
+    3.0
+
+    // Using offset parameter:
+    > var x = new {{alias:@stdlib/array/float64}}([ 0,1, 0,2, 0,3, 0,4 ]);
+    > {{alias}}.ndarray( 4, x, 2, 1 )
+    2.0
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/docs/types/index.d.ts
@@ -1,0 +1,92 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Interface describing `diqrsorted`.
+*/
+interface Routine {
+	/**
+	* Computes the interquartile range of a sorted double-precision floating-point strided array.
+	*
+	* @param N - number of indexed elements
+	* @param x - sorted input array
+	* @param strideX - stride length
+	* @returns interquartile range
+	*
+	* @example
+	* var Float64Array = require( '@stdlib/array/float64' );
+	*
+	* var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	*
+	* var v = diqrsorted( x.length, x, 1 );
+	* // returns 3.0
+	*/
+	( N: number, x: Float64Array, strideX: number ): number;
+
+	/**
+	* Computes the interquartile range of a sorted double-precision floating-point strided array using alternative indexing semantics.
+	*
+	* @param N - number of indexed elements
+	* @param x - sorted input array
+	* @param strideX - stride length
+	* @param offsetX - starting index
+	* @returns interquartile range
+	*
+	* @example
+	* var Float64Array = require( '@stdlib/array/float64' );
+	*
+	* var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	*
+	* var v = diqrsorted.ndarray( x.length, x, 1, 0 );
+	* // returns 3.0
+	*/
+	ndarray( N: number, x: Float64Array, strideX: number, offsetX: number ): number;
+}
+
+/**
+* Computes the interquartile range of a sorted double-precision floating-point strided array.
+*
+* @param N - number of indexed elements
+* @param x - sorted input array
+* @param strideX - stride length
+* @returns interquartile range
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+*
+* var v = diqrsorted( x.length, x, 1 );
+* // returns 3.0
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+*
+* var v = diqrsorted.ndarray( x.length, x, 1, 0 );
+* // returns 3.0
+*/
+declare var diqrsorted: Routine;
+
+
+// EXPORTS //
+
+export = diqrsorted;

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/docs/types/test.ts
@@ -1,0 +1,157 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import diqrsorted = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted( x.length, x, 1 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted( '10', x, 1 ); // $ExpectError
+	diqrsorted( true, x, 1 ); // $ExpectError
+	diqrsorted( false, x, 1 ); // $ExpectError
+	diqrsorted( null, x, 1 ); // $ExpectError
+	diqrsorted( undefined, x, 1 ); // $ExpectError
+	diqrsorted( [], x, 1 ); // $ExpectError
+	diqrsorted( {}, x, 1 ); // $ExpectError
+	diqrsorted( ( x: number ): number => x, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a Float64Array...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted( x.length, 10, 1 ); // $ExpectError
+	diqrsorted( x.length, '10', 1 ); // $ExpectError
+	diqrsorted( x.length, true, 1 ); // $ExpectError
+	diqrsorted( x.length, false, 1 ); // $ExpectError
+	diqrsorted( x.length, null, 1 ); // $ExpectError
+	diqrsorted( x.length, undefined, 1 ); // $ExpectError
+	diqrsorted( x.length, [], 1 ); // $ExpectError
+	diqrsorted( x.length, {}, 1 ); // $ExpectError
+	diqrsorted( x.length, ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted( x.length, x, '10' ); // $ExpectError
+	diqrsorted( x.length, x, true ); // $ExpectError
+	diqrsorted( x.length, x, false ); // $ExpectError
+	diqrsorted( x.length, x, null ); // $ExpectError
+	diqrsorted( x.length, x, undefined ); // $ExpectError
+	diqrsorted( x.length, x, [] ); // $ExpectError
+	diqrsorted( x.length, x, {} ); // $ExpectError
+	diqrsorted( x.length, x, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted(); // $ExpectError
+	diqrsorted( x.length ); // $ExpectError
+	diqrsorted( x.length, x ); // $ExpectError
+	diqrsorted( x.length, x, 1, 10 ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a number...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted.ndarray( x.length, x, 1, 0 ); // $ExpectType number
+}
+
+// The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted.ndarray( '10', x, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( true, x, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( false, x, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( null, x, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( undefined, x, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( [], x, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( {}, x, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( ( x: number ): number => x, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a second argument which is not a Float64Array...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted.ndarray( x.length, 10, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, '10', 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, true, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, false, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, null, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, undefined, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, [], 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, {}, 1, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted.ndarray( x.length, x, '10', 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, true, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, false, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, null, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, undefined, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, [], 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, {}, 0 ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted.ndarray( x.length, x, 1, '10' ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, 1, true ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, 1, false ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, 1, null ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, 1, undefined ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, 1, [] ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, 1, {} ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+
+	diqrsorted.ndarray(); // $ExpectError
+	diqrsorted.ndarray( x.length ); // $ExpectError
+	diqrsorted.ndarray( x.length, x ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, 1 ); // $ExpectError
+	diqrsorted.ndarray( x.length, x, 1, 0, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/examples/c/example.c
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/diqrsorted.h"
+#include <stdio.h>
+
+int main( void ) {
+	// Create a strided array:
+	const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+
+	// Specify the number of elements:
+	const int N = 4;
+
+	// Specify the stride length:
+	const int strideX = 2;
+
+	// Compute the interquartile range:
+	double v = stdlib_strided_diqrsorted( N, x, strideX );
+
+	// Print the result:
+	printf( "IQR: %lf\n", v );
+}

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/examples/index.js
@@ -1,0 +1,31 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var linspace = require( '@stdlib/array/linspace' );
+var diqrsorted = require( './../lib' );
+
+var options = {
+	'dtype': 'float64'
+};
+var x = linspace( -5.0, 5.0, 10, options );
+console.log( x );
+
+var v = diqrsorted( x.length, x, 1 );
+console.log( v );

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/include.gypi
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/include/stdlib/stats/strided/diqrsorted.h
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/include/stdlib/stats/strided/diqrsorted.h
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_STRIDED_DIQRSORTED_H
+#define STDLIB_STATS_STRIDED_DIQRSORTED_H
+
+#include "stdlib/blas/base/shared.h"
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes the interquartile range of a sorted double-precision floating-point strided array.
+*/
+double API_SUFFIX(stdlib_strided_diqrsorted)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX );
+
+/**
+* Computes the interquartile range of a sorted double-precision floating-point strided array using alternative indexing semantics.
+*/
+double API_SUFFIX(stdlib_strided_diqrsorted_ndarray)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_STRIDED_DIQRSORTED_H

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/diqrsorted.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/diqrsorted.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var stride2offset = require( '@stdlib/strided/base/stride2offset' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+/**
+* Computes the interquartile range of a sorted double-precision floating-point strided array.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - sorted input array
+* @param {integer} strideX - stride length
+* @returns {number} interquartile range
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, 2.0, 3.0 ] );
+*
+* var v = diqrsorted( x.length, x, 1 );
+* // returns 2.0
+*/
+function diqrsorted( N, x, strideX ) {
+	return ndarray( N, x, strideX, stride2offset( N, strideX ) );
+}
+
+
+// EXPORTS //
+
+module.exports = diqrsorted;

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/diqrsorted.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/diqrsorted.native.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Computes the interquartile range of a sorted double-precision floating-point strided array.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - sorted input array
+* @param {integer} strideX - stride length
+* @returns {number} interquartile range
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+*
+* var v = diqrsorted( x.length, x, 1 );
+* // returns 3.0
+*/
+function diqrsorted( N, x, strideX ) {
+	return addon( N, x, strideX );
+}
+
+
+// EXPORTS //
+
+module.exports = diqrsorted;

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/index.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute the interquartile range of a sorted double-precision floating-point strided array.
+*
+* @module @stdlib/stats/strided/diqrsorted
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var diqrsorted = require( '@stdlib/stats/strided/diqrsorted' );
+*
+* var x = new Float64Array( [ 1.0, 2.0, 3.0 ] );
+*
+* var v = diqrsorted( x.length, x, 1 );
+* // returns 2.0
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var diqrsorted = require( '@stdlib/stats/strided/diqrsorted' );
+*
+* var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+*
+* var v = diqrsorted.ndarray( 5, x, 1, 0 );
+* // returns 3.0
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;
+
+// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/main.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var diqrsorted = require( './diqrsorted.js' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+setReadOnly( diqrsorted, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = diqrsorted;

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/native.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var diqrsorted = require( './diqrsorted.native.js' );
+var ndarray = require( './ndarray.native.js' );
+
+
+// MAIN //
+
+setReadOnly( diqrsorted, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = diqrsorted;

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/ndarray.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var floor = require( '@stdlib/math/base/special/floor' );
+var dmediansorted = require( '@stdlib/stats/strided/dmediansorted' );
+
+
+// MAIN //
+
+/**
+* Computes the interquartile range of a sorted double-precision floating-point strided array.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - sorted input array
+* @param {integer} strideX - stride length
+* @param {NonNegativeInteger} offsetX - starting index
+* @returns {number} interquartile range
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+*
+* var v = diqrsorted( 5, x, 1, 0 );
+* // returns 3.0
+*/
+function diqrsorted( N, x, strideX, offsetX ) {
+	var q1;
+	var q3;
+	var k;
+
+	if ( N <= 0 ) {
+		return NaN;
+	}
+	if ( N === 1 ) {
+		return 0.0;
+	}
+	k = floor( N / 2 );
+	q1 = dmediansorted.ndarray( k, x, strideX, offsetX );
+	if ( N % 2 === 0 ) {
+		q3 = dmediansorted.ndarray( k, x, strideX, offsetX + (k * strideX) );
+	} else {
+		q3 = dmediansorted.ndarray( k, x, strideX, offsetX + ((k + 1) * strideX) );
+	}
+	return q3 - q1;
+}
+
+
+// EXPORTS //
+
+module.exports = diqrsorted;

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/lib/ndarray.native.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Computes the interquartile range of a sorted double-precision floating-point strided array.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - sorted input array
+* @param {integer} strideX - stride length
+* @param {NonNegativeInteger} offsetX - starting index
+* @returns {number} interquartile range
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+*
+* var v = diqrsorted( 5, x, 1, 0 );
+* // returns 3.0
+*/
+function diqrsorted( N, x, strideX, offsetX ) {
+	return addon.ndarray( N, x, strideX, offsetX );
+}
+
+
+// EXPORTS //
+
+module.exports = diqrsorted;

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/manifest.json
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/manifest.json
@@ -1,0 +1,103 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/dmediansorted",
+        "@stdlib/strided/base/stride2offset",
+        "@stdlib/napi/export",
+        "@stdlib/napi/argv",
+        "@stdlib/napi/argv-int64",
+        "@stdlib/napi/argv-strided-float64array",
+        "@stdlib/napi/create-double"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/dmediansorted",
+        "@stdlib/strided/base/stride2offset"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/dmediansorted",
+        "@stdlib/strided/base/stride2offset"
+      ]
+    },
+    {
+      "task": "",
+      "wasm": true,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/stats/strided/dmediansorted",
+        "@stdlib/strided/base/stride2offset"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@stdlib/stats/strided/diqrsorted",
+  "version": "0.0.0",
+  "description": "Calculate the interquartile range of a sorted double-precision floating-point strided array.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "browser": "./lib/main.js",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "iqr",
+    "interquartile range",
+    "range",
+    "spread",
+    "dispersion",
+    "variability",
+    "quantile",
+    "quartile",
+    "sorted",
+    "ordered",
+    "strided",
+    "strided array",
+    "typed",
+    "array",
+    "float64",
+    "double",
+    "float64array"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/src/addon.c
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/diqrsorted.h"
+#include "stdlib/blas/base/shared.h"
+#include "stdlib/napi/export.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/argv_int64.h"
+#include "stdlib/napi/argv_strided_float64array.h"
+#include "stdlib/napi/create_double.h"
+#include <node_api.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 3 );
+	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
+	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
+	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_diqrsorted)( N, X, strideX ), v );
+	return v;
+}
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon_method( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 4 );
+	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
+	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
+	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
+	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_diqrsorted_ndarray)( N, X, strideX, offsetX ), v );
+	return v;
+}
+
+STDLIB_NAPI_MODULE_EXPORT_FCN_WITH_METHOD( addon, "ndarray", addon_method )

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/src/main.c
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/diqrsorted.h"
+#include "stdlib/stats/strided/dmediansorted.h"
+#include "stdlib/blas/base/shared.h"
+#include "stdlib/strided/base/stride2offset.h"
+
+/**
+* Computes the interquartile range of a sorted double-precision floating-point strided array.
+*
+* @param N        number of indexed elements
+* @param X        sorted input array
+* @param strideX  stride length
+* @return         output value
+*/
+double API_SUFFIX(stdlib_strided_diqrsorted)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX ) {
+	const CBLAS_INT ox = stdlib_strided_stride2offset( N, strideX );
+	return API_SUFFIX(stdlib_strided_diqrsorted_ndarray)( N, X, strideX, ox );
+}
+
+/**
+* Computes the interquartile range of a sorted double-precision floating-point strided array using alternative indexing semantics.
+*
+* @param N        number of indexed elements
+* @param X        sorted input array
+* @param strideX  stride length
+* @param offsetX  starting index for X
+* @return         output value
+*/
+double API_SUFFIX(stdlib_strided_diqrsorted_ndarray)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
+	CBLAS_INT k;
+	double q1;
+	double q3;
+
+	if ( N <= 0 ) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( N == 1 ) {
+		return 0.0;
+	}
+	k = N / 2;
+	q1 = API_SUFFIX(stdlib_strided_dmediansorted_ndarray)( k, X, strideX, offsetX );
+	if ( N % 2 == 0 ) {
+		q3 = API_SUFFIX(stdlib_strided_dmediansorted_ndarray)( k, X, strideX, offsetX + (k * strideX) );
+	} else {
+		q3 = API_SUFFIX(stdlib_strided_dmediansorted_ndarray)( k, X, strideX, offsetX + ((k + 1) * strideX) );
+	}
+	return q3 - q1;
+}

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.diqrsorted.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.diqrsorted.js
@@ -1,0 +1,142 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
+var diqrsorted = require( './../lib/diqrsorted.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof diqrsorted, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 3', function test( t ) {
+	t.strictEqual( diqrsorted.length, 3, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the interquartile range of a sorted strided array', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 10.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 9.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN, NaN ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = diqrsorted( 0, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = diqrsorted( -1, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to `1`, the function returns 0', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = diqrsorted( 1, x, 1 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0, // 0
+		10.0,
+		2.0, // 1
+		10.0,
+		3.0, // 2
+		10.0,
+		4.0, // 3
+		10.0,
+		5.0  // 4
+	]);
+
+	v = diqrsorted( 5, x, 2 );
+
+	t.strictEqual( v, 3.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		5.0, // 0 (actually 4 if negative stride)
+		10.0,
+		4.0, // 1
+		10.0,
+		3.0, // 2
+		10.0,
+		2.0, // 3
+		10.0,
+		1.0  // 4
+	]);
+
+	v = diqrsorted( 5, x, -2 );
+
+	t.strictEqual( v, 3.0, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.diqrsorted.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.diqrsorted.native.js
@@ -1,0 +1,151 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var diqrsorted = tryRequire( resolve( __dirname, './../lib/diqrsorted.native.js' ) );
+var opts = {
+	'skip': ( diqrsorted instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof diqrsorted, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 3', opts, function test( t ) {
+	t.strictEqual( diqrsorted.length, 3, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the interquartile range of a sorted strided array', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 10.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 9.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN, NaN ] );
+	v = diqrsorted( x.length, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = diqrsorted( 0, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = diqrsorted( -1, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to `1`, the function returns 0', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = diqrsorted( 1, x, 1 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0, // 0
+		10.0,
+		2.0, // 1
+		10.0,
+		3.0, // 2
+		10.0,
+		4.0, // 3
+		10.0,
+		5.0  // 4
+	]);
+
+	v = diqrsorted( 5, x, 2 );
+
+	t.strictEqual( v, 3.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		5.0, // 0 (actually 4 if negative stride)
+		10.0,
+		4.0, // 1
+		10.0,
+		3.0, // 2
+		10.0,
+		2.0, // 3
+		10.0,
+		1.0  // 4
+	]);
+
+	v = diqrsorted( 5, x, -2 );
+
+	t.strictEqual( v, 3.0, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var diqrsorted = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof diqrsorted, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof diqrsorted.ndarray, 'function', 'method is a function' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.ndarray.js
@@ -1,0 +1,165 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
+var diqrsorted = require( './../lib/ndarray.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof diqrsorted, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 4', function test( t ) {
+	t.strictEqual( diqrsorted.length, 4, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the interquartile range of a sorted strided array', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 10.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 9.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN, NaN ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = diqrsorted( 0, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = diqrsorted( -1, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to `1`, the function returns 0', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = diqrsorted( 1, x, 1, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0, // 0
+		10.0,
+		2.0, // 1
+		10.0,
+		3.0, // 2
+		10.0,
+		4.0, // 3
+		10.0,
+		5.0  // 4
+	]);
+
+	v = diqrsorted( 5, x, 2, 0 );
+
+	t.strictEqual( v, 3.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		5.0, // 4
+		10.0,
+		4.0, // 3
+		10.0,
+		3.0, // 2
+		10.0,
+		2.0, // 1
+		10.0,
+		1.0  // 0
+	]);
+
+	v = diqrsorted( 5, x, -2, 8 );
+
+	t.strictEqual( v, 3.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an `offset` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		10.0,
+		1.0, // 0
+		10.0,
+		2.0, // 1
+		10.0,
+		3.0, // 2
+		10.0,
+		4.0, // 3
+		10.0,
+		5.0  // 4
+	]);
+
+	v = diqrsorted( 5, x, 2, 1 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/diqrsorted/test/test.ndarray.native.js
@@ -1,0 +1,174 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var diqrsorted = tryRequire( resolve( __dirname, './../lib/ndarray.native.js' ) );
+var opts = {
+	'skip': ( diqrsorted instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof diqrsorted, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 4', opts, function test( t ) {
+	t.strictEqual( diqrsorted.length, 4, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the interquartile range of a sorted strided array', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 10.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 9.0, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN, NaN ] );
+	v = diqrsorted( x.length, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = diqrsorted( 0, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = diqrsorted( -1, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to `1`, the function returns 0', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = diqrsorted( 1, x, 1, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		1.0, // 0
+		10.0,
+		2.0, // 1
+		10.0,
+		3.0, // 2
+		10.0,
+		4.0, // 3
+		10.0,
+		5.0  // 4
+	]);
+
+	v = diqrsorted( 5, x, 2, 0 );
+
+	t.strictEqual( v, 3.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		5.0, // 4
+		10.0,
+		4.0, // 3
+		10.0,
+		3.0, // 2
+		10.0,
+		2.0, // 1
+		10.0,
+		1.0  // 0
+	]);
+
+	v = diqrsorted( 5, x, -2, 8 );
+
+	t.strictEqual( v, 3.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an `offset` parameter', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = new Float64Array([
+		10.0,
+		1.0, // 0
+		10.0,
+		2.0, // 1
+		10.0,
+		3.0, // 2
+		10.0,
+		4.0, // 3
+		10.0,
+		5.0  // 4
+	]);
+
+	v = diqrsorted( 5, x, 2, 1 );
+	t.strictEqual( v, 3.0, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: passed
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: passed
  - task: lint_c_examples status: passed
  - task: lint_c_benchmarks status: passed
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed
   ---
Resolves #NA

## Description

> What is the purpose of this pull request?

This pull request:

-   adds an implementation of `@stdlib/stats/strided/diqrsorted`
-   computes the interquartile range (IQR) for sorted double-precision
    floating-point strided arrays
-   leverages the existing `dmediansorted` implementation to compute
    the first and third quartiles, ensuring numerical correctness and
    consistency with existing sorted statistics utilities
-   provides both main and `.ndarray` interfaces following stdlib
    strided API conventions
-   includes comprehensive unit tests covering edge cases, stride,
    negative stride, and offset semantics
-   adds benchmarks for performance evaluation
-   includes a C implementation and corresponding examples to maintain
    parity with other strided statistical routines
-   adds REPL help, documentation, and examples
-   follows stdlib formatting, linting, and code style guidelines

This addition extends the sorted statistics utilities by providing a
robust and efficient measure of statistical dispersion.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   NA

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Implementation notes:

-   The implementation assumes the input array is already sorted.
-   Quartiles are computed using the median-of-halves approach,
    consistent with common statistical definitions and boxplot usage.
-   Reusing `dmediansorted` reduces duplication and ensures
    consistency with existing sorted median behavior.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No


#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
