### PR TITLE
bench: refactor to use dynamic memory allocation in `blas/base/sspr`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/sspr/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/sspr/benchmark/c/benchmark.length.c
@@ -88,11 +88,13 @@ static double tic( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	float AP[ len*(len+1)/2 ];
-	float x[ len ];
+	float *AP;
+	float *x;
 	double t;
 	int i;
 
+	AP = (float *) malloc( ( len*(len+1)/2 ) * sizeof( float ) );
+	x = (float *) malloc( len * sizeof( float ) );
 	stdlib_strided_sfill( len, 0.5f, x, 1 );
 	stdlib_strided_sfill( len*(len+1)/2, 1.0f, AP, 1 );
 	t = tic();
@@ -107,6 +109,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( AP[ 0 ] != AP[ 0 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( AP );
+	free( x );
 	return elapsed;
 }
 
@@ -119,11 +123,13 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	float AP[ len*(len+1)/2 ];
-	float x[ len ];
+	float *AP;
+	float *x;
 	double t;
 	int i;
 
+	AP = (float *) malloc( ( len*(len+1)/2 ) * sizeof( float ) );
+	x = (float *) malloc( len * sizeof( float ) );
 	stdlib_strided_sfill( len, 0.5f, x, 1 );
 	stdlib_strided_sfill( len*(len+1)/2, 1.0f, AP, 1 );
 	t = tic();
@@ -138,6 +144,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( AP[ 0 ] != AP[ 0 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( AP );
+	free( x );
 	return elapsed;
 }
 


### PR DESCRIPTION
Resolves a part of #8643.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates the benchmark files for `blas/base/sspr` to use dynamic memory allocation for large arrays in C benchmarks.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8643

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

NA

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
