### PR TITLE
bench: refactor to use string interpolation in `blas/base/sspr`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.js
@@ -98,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( len );
-		bench( format( '%s:size=%d', pkg, ( len * ( len + 1 ) / 2 ) ), f );
+		bench( format( '%s:size=%d', pkg, len * ( len + 1 ) / 2 ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.js
@@ -25,6 +25,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var sspr = require( './../lib/sspr.js' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( len );
-		bench( pkg+':size='+( len * ( len + 1 ) / 2 ), f );
+		bench( format( '%s:size=%d', pkg, ( len * ( len + 1 ) / 2 ) ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
+var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
 
@@ -102,7 +103,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( len );
-		bench( pkg+'::native:size='+( len * ( len + 1 ) / 2 ), opts, f );
+		bench( format( '%s::native:size=%d', pkg, ( len * ( len + 1 ) / 2 )), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.native.js
@@ -103,7 +103,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( len );
-		bench( format( '%s::native:size=%d', pkg, ( len * ( len + 1 ) / 2 )), opts, f );
+		bench( format( '%s::native:size=%d', pkg, len * ( len + 1 ) / 2 ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.ndarray.js
@@ -25,6 +25,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var sspr = require( './../lib/ndarray.js' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( len );
-		bench( pkg+':ndarray:size='+( len * ( len + 1 ) / 2 ), f );
+		bench( format( '%s:ndarray:size=%d', pkg, ( len * ( len + 1 ) / 2 ) ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.ndarray.js
@@ -98,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( len );
-		bench( format( '%s:ndarray:size=%d', pkg, ( len * ( len + 1 ) / 2 ) ), f );
+		bench( format( '%s:ndarray:size=%d', pkg, len * ( len + 1 ) / 2 ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.ndarray.native.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
+var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
 
@@ -102,7 +103,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( len );
-		bench( pkg+'::native:ndarray:size='+( len * ( len + 1 ) / 2 ), opts, f );
+		bench( format( '%s::native:ndarray:size=%d', pkg, ( len * ( len + 1 ) / 2 ) ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/benchmark/benchmark.ndarray.native.js
@@ -103,7 +103,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( len );
-		bench( format( '%s::native:ndarray:size=%d', pkg, ( len * ( len + 1 ) / 2 ) ), opts, f );
+		bench( format( '%s::native:ndarray:size=%d', pkg, len * ( len + 1 ) / 2 ), opts, f );
 	}
 }
 


### PR DESCRIPTION
Resolves a part of  #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-  Updates benchmark files for `blas/base/sspr` to use string interpolation in JavaScript benchmarks for the benchmark name.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

NA

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
