### PR TITLE
bench: refactor to use string interpolation in `array/base/fillednd-by`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/fillednd-by/benchmark/benchmark.size.2d.js
+++ b/lib/node_modules/@stdlib/array/base/fillednd-by/benchmark/benchmark.size.2d.js
@@ -26,6 +26,7 @@ var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var isArrayArray = require( '@stdlib/assert/is-array-array' );
 var constantFunction = require( '@stdlib/utils/constant-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var filledndBy = require( './../lib' );
 
@@ -93,7 +94,7 @@ function main() {
 		N = floor( sqrt( pow( 10, i ) ) );
 
 		f = createBenchmark( N );
-		bench( pkg+'::2d,equidimensional:size='+(N*N), f );
+		bench( format( '%s::2d,equidimensional:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/base/fillednd-by/benchmark/benchmark.size.3d.js
+++ b/lib/node_modules/@stdlib/array/base/fillednd-by/benchmark/benchmark.size.3d.js
@@ -26,6 +26,7 @@ var floor = require( '@stdlib/math/base/special/floor' );
 var cbrt = require( '@stdlib/math/base/special/cbrt' );
 var isArrayArray = require( '@stdlib/assert/is-array-array' );
 var constantFunction = require( '@stdlib/utils/constant-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var filledndBy = require( './../lib' );
 
@@ -93,7 +94,7 @@ function main() {
 		N = floor( cbrt( pow( 10, i ) ) );
 
 		f = createBenchmark( N );
-		bench( pkg+'::3d,equidimensional:size='+(N*N*N), f );
+		bench( format( '%s::3d,equidimensional:size=%d', pkg, N*N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/base/fillednd-by/benchmark/benchmark.size.4d.js
+++ b/lib/node_modules/@stdlib/array/base/fillednd-by/benchmark/benchmark.size.4d.js
@@ -25,6 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var isArrayArray = require( '@stdlib/assert/is-array-array' );
 var constantFunction = require( '@stdlib/utils/constant-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var filledndBy = require( './../lib' );
 
@@ -92,7 +93,7 @@ function main() {
 		N = floor( pow( pow( 10, i ), 1.0/4.0 ) );
 
 		f = createBenchmark( N );
-		bench( pkg+'::4d,equidimensional:size='+(N*N*N*N), f );
+		bench( format( '%s::4d,equidimensional:size=%d', pkg, N*N*N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/base/fillednd-by/benchmark/benchmark.size.5d.js
+++ b/lib/node_modules/@stdlib/array/base/fillednd-by/benchmark/benchmark.size.5d.js
@@ -25,6 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var isArrayArray = require( '@stdlib/assert/is-array-array' );
 var constantFunction = require( '@stdlib/utils/constant-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var filledndBy = require( './../lib' );
 
@@ -92,7 +93,7 @@ function main() {
 		N = floor( pow( pow( 10, i ), 1.0/5.0 ) );
 
 		f = createBenchmark( N );
-		bench( pkg+'::5d,equidimensional:size='+(N*N*N*N*N), f );
+		bench( format( '%s::5d,equidimensional:size=%d', pkg, N*N*N*N*N ), f );
 	}
 }
 


### PR DESCRIPTION
Progresses #8647 .

## Description

> What is the purpose of this pull request?

This pull request:

-  Refactor the javaScript benchmark in @stdlib/array/base/fillednd-by to use @stdlib/string/format for string interpolation instead of string concatenation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
