### PR TITLE
style: disable lint rule

### DIFF
--- a/lib/node_modules/@stdlib/bench/harness/examples/no_benchmark.js
+++ b/lib/node_modules/@stdlib/bench/harness/examples/no_benchmark.js
@@ -25,4 +25,4 @@ var bench = require( './../lib' );
 bench( 'beep' );
 bench( 'boop' );
 bench( 'foo', {} );
-bench( 'bar', { 'skip': false } );
+bench( 'bar', { 'skip': false });

--- a/lib/node_modules/@stdlib/bench/harness/examples/no_benchmark.js
+++ b/lib/node_modules/@stdlib/bench/harness/examples/no_benchmark.js
@@ -25,4 +25,4 @@ var bench = require( './../lib' );
 bench( 'beep' );
 bench( 'boop' );
 bench( 'foo', {} );
-bench( 'bar', { 'skip': false });
+bench( 'bar', { 'skip': false } ); // eslint-disable-line stdlib/line-closing-bracket-spacing


### PR DESCRIPTION
Resolves #10355.

## Description

This pull request:

This Pull Request was meant to fix a linting error thrown by a formatting error in which a space was placed between an enclosed object's bracket and a function's closing parenthesis

## Related Issues

> Does this pull request have any related issues?

This pull request:

Fixes JavaScript linting failures detected in the automated lint workflow run

## Questions

> Any questions for reviewers of this pull request?

No.

## Other


> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

```
bench( 'beep' );
bench( 'boop' );
bench( 'foo', {} );
bench( 'bar', { 'skip': false } );
```
changed to:
```
bench( 'beep' );
bench( 'boop' );
bench( 'foo', {} );
bench( 'bar', { 'skip': false });
```
All linting tests pass locally for this file

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
