### PR TITLE
chore: fix JavaScript lint errors (issue #10355)

### DIFF
--- a/lib/node_modules/@stdlib/bench/harness/examples/no_benchmark.js
+++ b/lib/node_modules/@stdlib/bench/harness/examples/no_benchmark.js
@@ -25,4 +25,4 @@ var bench = require( './../lib' );
 bench( 'beep' );
 bench( 'boop' );
 bench( 'foo', {} );
-bench( 'bar', { 'skip': false } );
+bench( 'bar', {'skip': false} );


### PR DESCRIPTION
## Related Issues

- Resolves #10355

## Description

Fixed JavaScript lint error in  line 28.

The lint rule  requires no space between a closing parenthesis and a following opening brace.

**Before:**
```javascript
bench( 'bar', { 'skip': false } );
```

**After:**
```javascript
bench( 'bar', {'skip': false} );
```