### PR TITLE
bench: refactor to use string interpolation in `ndarray/base/slice-dimension-to`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/slice-dimension-to/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/slice-dimension-to/benchmark/benchmark.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
 var baseEmpty = require( '@stdlib/ndarray/base/empty' );
 var empty = require( '@stdlib/ndarray/empty' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var sliceDimensionTo = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::1d,base', function benchmark( b ) {
+bench( format( '%s::1d,base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -60,7 +61,7 @@ bench( pkg+'::1d,base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::1d,non-base', function benchmark( b ) {
+bench( format( '%s::1d,non-base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -95,7 +96,7 @@ bench( pkg+'::1d,non-base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::1d,base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::1d,base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -125,7 +126,7 @@ bench( pkg+'::1d,base,out-of-bounds', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::1d,non-base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::1d,non-base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -160,7 +161,7 @@ bench( pkg+'::1d,non-base,out-of-bounds', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::2d,base', function benchmark( b ) {
+bench( format( '%s::2d,base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -190,7 +191,7 @@ bench( pkg+'::2d,base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::2d,non-base', function benchmark( b ) {
+bench( format( '%s::2d,non-base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -225,7 +226,7 @@ bench( pkg+'::2d,non-base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::2d,base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::2d,base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -255,7 +256,7 @@ bench( pkg+'::2d,base,out-of-bounds', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::2d,non-base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::2d,non-base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -290,7 +291,7 @@ bench( pkg+'::2d,non-base,out-of-bounds', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::3d,base', function benchmark( b ) {
+bench( format( '%s::3d,base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -320,7 +321,7 @@ bench( pkg+'::3d,base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::3d,non-base', function benchmark( b ) {
+bench( format( '%s::3d,non-base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -355,7 +356,7 @@ bench( pkg+'::3d,non-base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::3d,base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::3d,base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -385,7 +386,7 @@ bench( pkg+'::3d,base,out-of-bounds', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::3d,non-base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::3d,non-base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -420,7 +421,7 @@ bench( pkg+'::3d,non-base,out-of-bounds', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::4d,base', function benchmark( b ) {
+bench( format( '%s::4d,base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -450,7 +451,7 @@ bench( pkg+'::4d,base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::4d,non-base', function benchmark( b ) {
+bench( format( '%s::4d,non-base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -485,7 +486,7 @@ bench( pkg+'::4d,non-base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::4d,base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::4d,base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -515,7 +516,7 @@ bench( pkg+'::4d,base,out-of-bounds', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::4d,non-base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::4d,non-base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -550,7 +551,7 @@ bench( pkg+'::4d,non-base,out-of-bounds', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::5d,base', function benchmark( b ) {
+bench( format( '%s::5d,base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -580,7 +581,7 @@ bench( pkg+'::5d,base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::5d,non-base', function benchmark( b ) {
+bench( format( '%s::5d,non-base', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -615,7 +616,7 @@ bench( pkg+'::5d,non-base', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::5d,base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::5d,base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;
@@ -645,7 +646,7 @@ bench( pkg+'::5d,base,out-of-bounds', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::5d,non-base,out-of-bounds', function benchmark( b ) {
+bench( format( '%s::5d,non-base,out-of-bounds', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var s;


### PR DESCRIPTION
## Summary
- Replace string concatenation (`pkg+'::...'`) with `@stdlib/string/format` for benchmark descriptions in `ndarray/base/slice-dimension-to`
- Add `var format = require( '@stdlib/string/format' );` to the module requires
- Converts all 20 `bench()` calls to use `format( '%s::...', pkg )`

## Motivation
Resolves the lint warnings from issue #10378 for this file. This follows the same pattern as recent commits (e.g., `array/zeros-like`, `array/zero-to-like`, `array/zero-to`).

## Checklist
- [x] No unnecessary formatting changes
- [x] Only addresses the actual lint issue (string concatenation → `format()`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)