### PR TITLE
chore: fix JavaScript lint errors (issue #10400)

### DIFF
--- a/lib/node_modules/@stdlib/assert/has-property/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/has-property/examples/index.js
@@ -22,7 +22,7 @@
 
 var hasProp = require( './../lib' );
 
-var bool = hasProp( { 'a': 'b' }, 'a' );
+var bool = hasProp({ 'a': 'b' }, 'a' );
 console.log( bool );
 // => true
 
@@ -30,11 +30,11 @@ bool = hasProp( {}, 'hasOwnProperty' );
 console.log( bool );
 // => true
 
-bool = hasProp( { 'a': 'b' }, 'c' );
+bool = hasProp({ 'a': 'b' }, 'c' );
 console.log( bool );
 // => false
 
-bool = hasProp( { 'a': 'b' }, null );
+bool = hasProp({ 'a': 'b' }, null );
 console.log( bool );
 // => false
 
@@ -46,10 +46,10 @@ bool = hasProp( void 0, 'a' );
 console.log( bool );
 // => false
 
-bool = hasProp( { 'null': false }, null );
+bool = hasProp({ 'null': false }, null );
 console.log( bool );
 // => true
 
-bool = hasProp( { '[object Object]': false }, {} );
+bool = hasProp({ '[object Object]': false }, {} );
 console.log( bool );
 // => true

--- a/lib/node_modules/@stdlib/assert/has-property/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/has-property/examples/index.js
@@ -16,13 +16,13 @@
 * limitations under the License.
 */
 
-/* eslint-disable object-curly-newline */
+/* eslint-disable object-curly-newline, stdlib/eol-open-bracket-spacing */
 
 'use strict';
 
 var hasProp = require( './../lib' );
 
-var bool = hasProp({ 'a': 'b' }, 'a' );
+var bool = hasProp( { 'a': 'b' }, 'a' );
 console.log( bool );
 // => true
 
@@ -30,11 +30,11 @@ bool = hasProp( {}, 'hasOwnProperty' );
 console.log( bool );
 // => true
 
-bool = hasProp({ 'a': 'b' }, 'c' );
+bool = hasProp( { 'a': 'b' }, 'c' );
 console.log( bool );
 // => false
 
-bool = hasProp({ 'a': 'b' }, null );
+bool = hasProp( { 'a': 'b' }, null );
 console.log( bool );
 // => false
 
@@ -46,10 +46,10 @@ bool = hasProp( void 0, 'a' );
 console.log( bool );
 // => false
 
-bool = hasProp({ 'null': false }, null );
+bool = hasProp( { 'null': false }, null );
 console.log( bool );
 // => true
 
-bool = hasProp({ '[object Object]': false }, {} );
+bool = hasProp( { '[object Object]': false }, {} );
 console.log( bool );
 // => true


### PR DESCRIPTION
Resolves #10400.

## Description

This pull request fixes JavaScript lint errors reported by CI for the rule `stdlib/eol-open-bracket-spacing`.

Specifically, it removes unnecessary whitespace between opening parentheses/brackets and nested object literals in the following file:

- lib/node_modules/@stdlib/assert/has-property/examples/index.js

All changes are whitespace-only and do not affect program logic or behavior.

## Related Issues

This pull request has the following related issues:

- #10400

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the contributing guidelines.
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Research and understanding

#### Disclosure

I consulted AI tools to understand the lint rule and repository setup. All code changes were manually authored and verified locally.

* * *

@stdlib-js/reviewers