### PR TITLE
chore: fix JavaScript lint errors (issue #10378)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/slice-dimension-to/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/slice-dimension-to/benchmark/benchmark.js
@@ -69,11 +69,11 @@ bench( pkg+'::1d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2 ], { 'dtype': 'generic' } )
+		empty( [ 2 ], { 'dtype': 'float64' }),
+		empty( [ 2 ], { 'dtype': 'float32' }),
+		empty( [ 2 ], { 'dtype': 'int32' }),
+		empty( [ 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -134,11 +134,11 @@ bench( pkg+'::1d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2 ], { 'dtype': 'generic' } )
+		empty( [ 2 ], { 'dtype': 'float64' }),
+		empty( [ 2 ], { 'dtype': 'float32' }),
+		empty( [ 2 ], { 'dtype': 'int32' }),
+		empty( [ 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -199,11 +199,11 @@ bench( pkg+'::2d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -264,11 +264,11 @@ bench( pkg+'::2d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -329,11 +329,11 @@ bench( pkg+'::3d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -394,11 +394,11 @@ bench( pkg+'::3d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -459,11 +459,11 @@ bench( pkg+'::4d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -524,11 +524,11 @@ bench( pkg+'::4d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -589,11 +589,11 @@ bench( pkg+'::5d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -654,11 +654,11 @@ bench( pkg+'::5d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */


### PR DESCRIPTION
Resolves #10378.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes 50 JavaScript `stdlib/line-closing-bracket-spacing` linting errors within [lib/node_modules/@stdlib/ndarray/base/slice-dimension-to/benchmark/benchmark.js](cci:7://file:///Users/kamalrautela/Desktop/stdlib/lib/node_modules/@stdlib/ndarray/base/slice-dimension-to/benchmark/benchmark.js:0:0-0:0) where unintended spaces were included before closing object brackets on single lines.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #10378

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I consulted an AI agent to help identify and automatically fix the basic formatting failures dictated by the stdlib eslint rules, which were then manually verified and submitted. 

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

