### PR TITLE
chore:  address commit comments for commit `8b01d81` (issue #10423)

### DIFF
--- a/lib/node_modules/@stdlib/utils/tabulate-by/README.md
+++ b/lib/node_modules/@stdlib/utils/tabulate-by/README.md
@@ -127,15 +127,13 @@ The returned frequency table is an `array` of `arrays`. Each sub-array correspon
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var floor = require( '@stdlib/math/base/special/floor' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var take = require( '@stdlib/array/take' );
 var tabulateBy = require( '@stdlib/utils/tabulate-by' );
 
 var vals;
 var arr;
 var out;
-var i;
-var j;
 
 function indicator( value ) {
     return value[ 0 ];
@@ -144,11 +142,7 @@ function indicator( value ) {
 vals = [ 'beep', 'boop', 'foo', 'bar', 'woot', 'woot' ];
 
 // Generate a random collection...
-arr = [];
-for ( i = 0; i < 100; i++ ) {
-    j = floor( randu()*vals.length );
-    arr.push( vals[ j ] );
-}
+arr = take( vals, discreteUniform( 100, 0, vals.length - 1 ) );
 
 // Generate a frequency table:
 out = tabulateBy( arr, indicator );

--- a/lib/node_modules/@stdlib/utils/tabulate-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/tabulate-by/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var floor = require( '@stdlib/math/base/special/floor' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var take = require( '@stdlib/array/take' );
 var tabulateBy = require( './../lib' );
 
 var vals;
 var arr;
 var out;
-var i;
-var j;
 
 function indicator( value ) {
 	return value[ 0 ];
@@ -35,11 +33,7 @@ function indicator( value ) {
 vals = [ 'beep', 'boop', 'foo', 'bar', 'woot', 'woot' ];
 
 // Generate a random collection...
-arr = [];
-for ( i = 0; i < 100; i++ ) {
-	j = floor( randu()*vals.length );
-	arr.push( vals[ j ] );
-}
+arr = take( vals, discreteUniform( 100, 0, vals.length - 1 ) );
 
 // Generate a frequency table:
 out = tabulateBy( arr, indicator );


### PR DESCRIPTION
Resolves #10423.

## Description

>  Refactors the "tabulate-by" examples to use "@stdlib/random/array/discrete-uniform"
  and "@stdlib/array/take" instead of a manual for loop with "randu" and "floor"

This pull request:

-   {{TODO: - Refactors the `tabulate-by` examples to use "@stdlib/random/array/discrete-uniform"
  and "@stdlib/array/take" instead of a manual for loop with "randu" and "floor"}}

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{{TODO: - #10423}}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [* ] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ *] Research and understanding

#### Disclosure

I consulted Claude to understand how the discreteUniform function works under the hood and to clarify its specific use cases. However, all proposed changes in this PR were fully authored manually by myself.

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
