### PR TITLE
chore: fix JavaScript lint errors (issue #10447)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-maximum-line-length/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-maximum-line-length/lib/main.js
@@ -116,26 +116,6 @@ function main( context ) {
 	}
 
 	/**
-	* Copies AST node location info.
-	*
-	* @private
-	* @param {Object} loc - AST node location
-	* @returns {Object} copied location info
-	*/
-	function copyLocationInfo( loc ) {
-		return {
-			'start': {
-				'line': loc.start.line,
-				'column': loc.start.column
-			},
-			'end': {
-				'line': loc.end.line,
-				'column': loc.end.column
-			}
-		};
-	}
-
-	/**
 	* Reports an error message.
 	*
 	* @private
@@ -149,6 +129,26 @@ function main( context ) {
 			'loc': loc
 		});
 	}
+}
+
+/**
+* Copies AST node location info.
+*
+* @private
+* @param {Object} loc - AST node location
+* @returns {Object} copied location info
+*/
+function copyLocationInfo( loc ) { // <--- No extra spaces before "function"
+	return {
+		'start': {
+			'line': loc.start.line,
+			'column': loc.start.column
+		},
+		'end': {
+			'line': loc.end.line,
+			'column': loc.end.column
+		}
+	};
 }
 
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-maximum-line-length/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-maximum-line-length/lib/main.js
@@ -138,7 +138,7 @@ function main( context ) {
 * @param {Object} loc - AST node location
 * @returns {Object} copied location info
 */
-function copyLocationInfo( loc ) { // <--- No extra spaces before "function"
+function copyLocationInfo( loc ) {
 	return {
 		'start': {
 			'line': loc.start.line,

--- a/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-cov/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-cov/lib/main.js
@@ -89,10 +89,8 @@ function plugin( dir ) {
 	opts = {};
 	opts.cwd = dir;
 
-	args = new Array( 1 );
-
 	// Target:
-	args[ 0 ] = 'view-cov';
+	args = [ 'view-cov' ];
 
 	proc = spawn( 'make', args, opts );
 	proc.on( 'error', onError );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #10447.

## Description

> What is the purpose of this pull request?

This pull request:
- Fixes a `stdlib/no-new-array` linting error in `@stdlib/_tools/makie/plugins/makie-view-cov` by replacing the `Array` constructor with an array literal.
- Fixes a `stdlib/no-unnecessary-nested-functions` linting error in `@stdlib/_tools/eslint/rules/jsdoc-maximum-line-length` by moving the `copyLocationInfo` function to the module scope and adjusting indentation/spacing.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #10447

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The fixes were verified locally using the following commands:

npx eslint lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-cov/lib/main.js
npx eslint lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-maximum-line-length/lib/main.js

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I consulted Gemini to understand the specific stdlib linting rules and to ensure the function relocation followed the project's architectural patterns, but the final implementation was manually reviewed and verified locally via npx eslint.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
