### PR TITLE
bench: refactor to use string interpolation in `array/empty-like`

### DIFF
--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
 var isArray = require( '@stdlib/assert/is-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=float64', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'float64' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -74,7 +75,7 @@ bench( pkg+':dtype=float64', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=float32', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'float32' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -96,7 +97,7 @@ bench( pkg+':dtype=float32', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=bool', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'bool' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -118,7 +119,7 @@ bench( pkg+':dtype=bool', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=complex128', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'complex128' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -140,7 +141,7 @@ bench( pkg+':dtype=complex128', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=complex64', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'complex64' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -162,7 +163,7 @@ bench( pkg+':dtype=complex64', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=int32', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'int32' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -184,7 +185,7 @@ bench( pkg+':dtype=int32', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=uint32', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'uint32' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -206,7 +207,7 @@ bench( pkg+':dtype=uint32', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=int16', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'int16' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -228,7 +229,7 @@ bench( pkg+':dtype=int16', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=uint16', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'uint16' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -250,7 +251,7 @@ bench( pkg+':dtype=uint16', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=int8', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'int8' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -272,7 +273,7 @@ bench( pkg+':dtype=int8', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=uint8', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'uint8' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -294,7 +295,7 @@ bench( pkg+':dtype=uint8', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=uint8c', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'uint8c' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;
@@ -316,7 +317,7 @@ bench( pkg+':dtype=uint8c', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=generic', function benchmark( b ) {
+bench( format( '%s:dtype=%s', pkg, 'generic' ), function benchmark( b ) {
 	var arr;
 	var x;
 	var i;

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.bool.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.bool.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=bool,len='+len, f );
+		bench( format( '%s:dtype=bool,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.complex128.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.complex128.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=complex128,len='+len, f );
+		bench( format( '%s:dtype=complex128,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.complex64.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.complex64.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=complex64,len='+len, f );
+		bench( format( '%s:dtype=complex64,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.float32.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.float32.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=float32,len='+len, f );
+		bench( format( '%s:dtype=float32,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.float64.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.float64.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=float64,len='+len, f );
+		bench( format( '%s:dtype=float64,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.generic.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.generic.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isArray = require( '@stdlib/assert/is-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=generic,len='+len, f );
+		bench( format( '%s:dtype=generic,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.int16.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.int16.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=int16,len='+len, f );
+		bench( format( '%s:dtype=int16,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.int32.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.int32.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=int32,len='+len, f );
+		bench( format( '%s:dtype=int32,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.int8.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.int8.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=int8,len='+len, f );
+		bench( format( '%s:dtype=int8,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.uint16.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.uint16.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=uint16,len='+len, f );
+		bench( format( '%s:dtype=uint16,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.uint32.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.uint32.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=uint32,len='+len, f );
+		bench( format( '%s:dtype=uint32,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.uint8.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.uint8.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=uint8,len='+len, f );
+		bench( format( '%s:dtype=uint8,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.uint8c.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.uint8c.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -88,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype=uint8c,len='+len, f );
+		bench( format( '%s:dtype=uint8c,len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
Resolves a part of #8647 

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the JavaScript benchmark in `@stdlib/array/empty-like` to use `@stdlib/string/format` for string interpolation instead of string concatenation when specifying the benchmark name
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
