### PR TITLE
bench: refactor to use string interpolation in `array/fixed-endian-float32`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.from.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.from.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var Float32Array = require( '@stdlib/array/float32' );
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Float32ArrayFE = require( './../lib' );
 
@@ -36,7 +37,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::typed_array:from', function benchmark( b ) {
+bench( format( '%s::typed_array:from', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -58,7 +59,7 @@ bench( pkg+'::typed_array:from', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array:from:len=5', function benchmark( b ) {
+bench( format( '%s::typed_array:from:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -80,7 +81,7 @@ bench( pkg+'::typed_array:from:len=5', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array,clbk:from:len=5', function benchmark( b ) {
+bench( format( '%s::typed_array,clbk:from:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -106,7 +107,7 @@ bench( pkg+'::typed_array,clbk:from:len=5', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array:from', function benchmark( b ) {
+bench( format( '%s::array:from', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -128,7 +129,7 @@ bench( pkg+'::array:from', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array:from:len=5', function benchmark( b ) {
+bench( format( '%s::array:from:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -150,7 +151,7 @@ bench( pkg+'::array:from:len=5', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array,clbk:from:len=5', function benchmark( b ) {
+bench( format( '%s::array,clbk:from:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -176,7 +177,7 @@ bench( pkg+'::array,clbk:from:len=5', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iterable:from', opts, function benchmark( b ) {
+bench( format( '%s::iterable:from', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -213,7 +214,7 @@ bench( pkg+'::iterable:from', opts, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iterable:from:len=5', opts, function benchmark( b ) {
+bench( format( '%s::iterable:from:len=5', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -259,7 +260,7 @@ bench( pkg+'::iterable:from:len=5', opts, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iterable,clbk:from:len=5', opts, function benchmark( b ) {
+bench( format( '%s::iterable,clbk:from:len=5', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.get.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.get.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Float32ArrayFE = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':get:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s:get:endianness=little-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -56,7 +57,7 @@ bench( pkg+':get:endianness=little-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':get:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s:get:endianness=big-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;

--- a/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.js
@@ -26,6 +26,7 @@ var Float32Array = require( '@stdlib/array/float32' );
 var isArrayBuffer = require( '@stdlib/assert/is-arraybuffer' );
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Float32ArrayFE = require( './../lib' );
 
@@ -66,7 +67,7 @@ function createIterable() {
 
 // MAIN //
 
-bench( pkg+'::instantiation,new:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,new:endianness=little-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var i;
 	b.tic();
@@ -84,7 +85,7 @@ bench( pkg+'::instantiation,new:endianness=little-endian', function benchmark( b
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,new:endianness=big-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var i;
 	b.tic();
@@ -102,7 +103,7 @@ bench( pkg+'::instantiation,new:endianness=big-endian', function benchmark( b ) 
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new:endianness=little-endian', pkg ), function benchmark( b ) {
 	var ctor;
 	var arr;
 	var i;
@@ -124,7 +125,7 @@ bench( pkg+'::instantiation,no_new:endianness=little-endian', function benchmark
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new:endianness=big-endian', pkg ), function benchmark( b ) {
 	var ctor;
 	var arr;
 	var i;
@@ -146,7 +147,7 @@ bench( pkg+'::instantiation,no_new:endianness=big-endian', function benchmark( b
 	b.end();
 });
 
-bench( pkg+'::instantiation,length:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,length:endianness=little-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var i;
 	b.tic();
@@ -164,7 +165,7 @@ bench( pkg+'::instantiation,length:endianness=little-endian', function benchmark
 	b.end();
 });
 
-bench( pkg+'::instantiation,length:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,length:endianness=big-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var i;
 	b.tic();
@@ -182,7 +183,7 @@ bench( pkg+'::instantiation,length:endianness=big-endian', function benchmark( b
 	b.end();
 });
 
-bench( pkg+'::instantiation,typed_array:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,typed_array:endianness=little-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -204,7 +205,7 @@ bench( pkg+'::instantiation,typed_array:endianness=little-endian', function benc
 	b.end();
 });
 
-bench( pkg+'::instantiation,typed_array:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,typed_array:endianness=big-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -226,7 +227,7 @@ bench( pkg+'::instantiation,typed_array:endianness=big-endian', function benchma
 	b.end();
 });
 
-bench( pkg+'::instantiation,array:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,array:endianness=little-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -248,7 +249,7 @@ bench( pkg+'::instantiation,array:endianness=little-endian', function benchmark(
 	b.end();
 });
 
-bench( pkg+'::instantiation,array:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,array:endianness=big-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -270,7 +271,7 @@ bench( pkg+'::instantiation,array:endianness=big-endian', function benchmark( b 
 	b.end();
 });
 
-bench( pkg+'::instantiation,iterable:endianness=little-endian', opts, function benchmark( b ) {
+bench( format( '%s::instantiation,iterable:endianness=little-endian', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -289,7 +290,7 @@ bench( pkg+'::instantiation,iterable:endianness=little-endian', opts, function b
 	b.end();
 });
 
-bench( pkg+'::instantiation,iterable:endianness=big-endian', opts, function benchmark( b ) {
+bench( format( '%s::instantiation,iterable:endianness=big-endian', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -308,7 +309,7 @@ bench( pkg+'::instantiation,iterable:endianness=big-endian', opts, function benc
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer:endianness=little-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -330,7 +331,7 @@ bench( pkg+'::instantiation,arraybuffer:endianness=little-endian', function benc
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer:endianness=big-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -352,7 +353,7 @@ bench( pkg+'::instantiation,arraybuffer:endianness=big-endian', function benchma
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset:endianness=little-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -374,7 +375,7 @@ bench( pkg+'::instantiation,arraybuffer,byte_offset:endianness=little-endian', f
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset:endianness=big-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -396,7 +397,7 @@ bench( pkg+'::instantiation,arraybuffer,byte_offset:endianness=big-endian', func
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset,length:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset,length:endianness=little-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -418,7 +419,7 @@ bench( pkg+'::instantiation,arraybuffer,byte_offset,length:endianness=little-end
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset,length:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset,length:endianness=big-endian', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -440,7 +441,7 @@ bench( pkg+'::instantiation,arraybuffer,byte_offset,length:endianness=big-endian
 	b.end();
 });
 
-bench( pkg+'::get:buffer', function benchmark( b ) {
+bench( format( '%s::get:buffer', pkg ), function benchmark( b ) {
 	var arr;
 	var v;
 	var i;
@@ -463,7 +464,7 @@ bench( pkg+'::get:buffer', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:byteLength', function benchmark( b ) {
+bench( format( '%s::get:byteLength', pkg ), function benchmark( b ) {
 	var arr;
 	var v;
 	var i;
@@ -486,7 +487,7 @@ bench( pkg+'::get:byteLength', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:byteOffset', function benchmark( b ) {
+bench( format( '%s::get:byteOffset', pkg ), function benchmark( b ) {
 	var arr;
 	var v;
 	var i;
@@ -509,7 +510,7 @@ bench( pkg+'::get:byteOffset', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:length', function benchmark( b ) {
+bench( format( '%s::get:length', pkg ), function benchmark( b ) {
 	var arr;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.of.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.of.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Float32ArrayFE = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':of', function benchmark( b ) {
+bench( format( '%s:of', pkg ), function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -46,7 +47,7 @@ bench( pkg+':of', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':len=5', function benchmark( b ) {
+bench( format( '%s:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.set.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.set.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Float32ArrayFE = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::number:set:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::number:set:endianness=little-endian', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var N;
@@ -57,7 +58,7 @@ bench( pkg+'::number:set:endianness=little-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::number:set:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::number:set:endianness=big-endian', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var N;
@@ -86,7 +87,7 @@ bench( pkg+'::number:set:endianness=big-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array:set:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::array:set:endianness=little-endian', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var N;
@@ -115,7 +116,7 @@ bench( pkg+'::array:set:endianness=little-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array:set:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::array:set:endianness=big-endian', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var N;
@@ -144,7 +145,7 @@ bench( pkg+'::array:set:endianness=big-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array:set:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::typed_array:set:endianness=little-endian', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var buf;
@@ -176,7 +177,7 @@ bench( pkg+'::typed_array:set:endianness=little-endian', function benchmark( b )
 	b.end();
 });
 
-bench( pkg+'::typed_array:set:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::typed_array:set:endianness=big-endian', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var buf;

--- a/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.set.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.set.length.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var randu = require( '@stdlib/random/array/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Float32ArrayFE = require( './../lib' );
 
@@ -103,7 +104,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':set:len='+len, f );
+		bench( format( '%s:set:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.to_string.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.to_string.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Float32ArrayFE = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':toString', function benchmark( b ) {
+bench( format( '%s:toString', pkg ), function benchmark( b ) {
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.to_string.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-float32/benchmark/benchmark.to_string.length.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Float32ArrayFE = require( './../lib' );
 
@@ -87,7 +88,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':toString:len='+len, f );
+		bench( format( '%s:toString:len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
Resolves a part of #8647 

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the JavaScript benchmark in `@stdlib/array/fixed-endian-float32` to use `@stdlib/string/format` for string interpolation instead of string concatenation when specifying the benchmark name
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
