### PR TITLE
bench: refactor to use string interpolation in `buffer/from-string`

### DIFF
--- a/lib/node_modules/@stdlib/buffer/from-string/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/buffer/from-string/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var string2buffer = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':encoding=utf8', function benchmark( b ) {
+bench( format( '%s:encoding=utf8', pkg ), function benchmark( b ) {
 	var values;
 	var str;
 	var out;
@@ -90,7 +91,7 @@ bench( pkg+':encoding=utf8', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':encoding=hex', function benchmark( b ) {
+bench( format( '%s:encoding=hex', pkg ), function benchmark( b ) {
 	var values;
 	var str;
 	var out;


### PR DESCRIPTION
Ref #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors benchmark names in `@stdlib/buffer/from-string` to use string interpolation via `@stdlib/string/format` instead of string concatenation.

## Related Issues

> Does this pull request have any related issues?

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

