### PR TITLE
bench: refactor to use string interpolation in `blas/ext/base/dapxsumpw`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.js
@@ -97,7 +97,6 @@ function main() {
 		len = pow( 10, i );
 		f = createBenchmark( len );
 		bench( format( '%s:len=%d', pkg, len ), f );
-
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dapxsumpw = require( './../lib/dapxsumpw.js' );
 
@@ -95,7 +96,8 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
+
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.native.js
@@ -100,7 +100,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::native:len='+len, opts, f );
+		bench( format( '%s::native:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var pkg = require( './../package.json' ).name;
 var dapxsumpw = require( './../lib/ndarray.js' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -95,7 +96,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':ndarray:len='+len, f );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dapxsumpw = require( './../lib/ndarray.js' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.native.js
@@ -27,6 +27,8 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
+
 
 
 // VARIABLES //
@@ -100,7 +102,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::native:ndarray:len='+len, opts, f );
+		bench( format( '%s::native:ndarray:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.native.js
@@ -26,9 +26,8 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var pkg = require( './../package.json' ).name;
 var format = require( '@stdlib/string/format' );
-
+var pkg = require( './../package.json' ).name;
 
 
 // VARIABLES //


### PR DESCRIPTION
Ref #8647.

## Description

### What is the purpose of this pull request?

This pull request:

- Refactors the JavaScript benchmarks in `@stdlib/blas/ext/base/dapxsumpw` to use string interpolation via `@stdlib/string/format` instead of string concatenation for constructing benchmark names.

## Related Issues

This pull request resolves a part of #8647.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
- [x] Updated JavaScript benchmarks to use `@stdlib/string/format`.
- [x] Verified benchmark names are preserved after refactoring.
