### PR TITLE
bench: refactor to use string interpolation in blas/ext/base/dnannsumkbn

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn/benchmark/benchmark.js
@@ -27,6 +27,7 @@ var filledarrayBy = require( '@stdlib/array/filled-by' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dnannsumkbn = require( './../lib/dnannsumkbn.js' );
 
@@ -105,7 +106,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn/benchmark/benchmark.native.js
@@ -29,6 +29,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -114,7 +115,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::native:len='+len, opts, f );
+		bench( format( '%s::native:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn/benchmark/benchmark.ndarray.js
@@ -27,6 +27,7 @@ var filledarrayBy = require( '@stdlib/array/filled-by' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dnannsumkbn = require( './../lib/ndarray.js' );
 
@@ -105,7 +106,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':ndarray:len='+len, f );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn/benchmark/benchmark.ndarray.native.js
@@ -29,6 +29,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -114,7 +115,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::native:ndarray:len='+len, opts, f );
+		bench( format( '%s::native:ndarray:len=%d', pkg, len ), opts, f );
 	}
 }
 


### PR DESCRIPTION
Ref #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the JavaScript benchmarks in `@stdlib/blas/ext/base/dnannsumkbn` to use string interpolation via `@stdlib/string/format` instead of string concatenation for constructing benchmark names.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

