### PR TITLE
fix: resolve JavaScript lint errors (no-error-string-concat, no-new-array)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/ahavercos-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/ahavercos-by/test/test.ndarray.js
@@ -73,7 +73,7 @@ tape( 'the function computes the inverse half-value versed cosine via a callback
 	ahavercosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = Array.from( { 'length': 5 } ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -81,7 +81,7 @@ tape( 'the function computes the inverse half-value versed cosine via a callback
 	ahavercosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = Array.from( { 'length': 5 } ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 

--- a/lib/node_modules/@stdlib/utils/async/for-each-right/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/async/for-each-right/examples/index.js
@@ -20,6 +20,7 @@
 
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' );
+var format = require( '@stdlib/string/format' );
 var forEachRightAsync = require( './../lib' );
 
 var files = [
@@ -42,7 +43,7 @@ function read( file, next ) {
 
 	function onFile( error ) {
 		if ( error ) {
-			error = new Error( 'unable to read file: '+file );
+			error = new Error( format( 'unable to read file: %s', file ) );
 			return next( error );
 		}
 		console.log( 'Successfully read file: %s', file );


### PR DESCRIPTION
## Description

Fixes two JavaScript lint errors caught in the automated lint workflow (issue #10556).

### Changes

**1. `lib/node_modules/@stdlib/utils/async/for-each-right/examples/index.js`**

- Replaced string concatenation in error message with `@stdlib/string/format`
- Fixes: `stdlib/no-error-string-concat` lint error at line 45

**2. `lib/node_modules/@stdlib/math/strided/special/ahavercos-by/test/test.ndarray.js`**

- Replaced `new Array( 5 )` constructor calls with `Array.from( { 'length': 5 } )`
- Fixes: `stdlib/no-new-array` lint errors at lines 76 and 84

### Checklist

- [x] Code follows stdlib conventions
- [x] Fixes lint errors referenced in #10556
- [x] No functional changes — behavior is preserved

Closes #10556