### PR TITLE
bench: use string interpolation in `stats/strided/dnanmax`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var uniform = require( '@stdlib/random/base/uniform' );
+var format = require( '@stdlib/string/format' );
 var bernoulli = require( '@stdlib/random/base/bernoulli' );
 var filledarrayBy = require( '@stdlib/array/filled-by' );
 var pkg = require( './../package.json' ).name;
@@ -103,7 +104,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.native.js
@@ -113,7 +113,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:native:len=%d', pkg, len ), opts, f );
+		bench( format( '%s::native:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var uniform = require( '@stdlib/random/base/uniform' );
+var format = require( '@stdlib/string/format' );
 var bernoulli = require( '@stdlib/random/base/bernoulli' );
 var filledarrayBy = require( '@stdlib/array/filled-by' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -112,7 +113,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::native:len='+len, opts, f );
+		bench( format( '%s:native:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.ndarray.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var uniform = require( '@stdlib/random/base/uniform' );
+var format = require( '@stdlib/string/format' );
 var bernoulli = require( '@stdlib/random/base/bernoulli' );
 var filledarrayBy = require( '@stdlib/array/filled-by' );
 var pkg = require( './../package.json' ).name;
@@ -103,7 +104,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':ndarray:len='+len, f );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dnanmax/benchmark/benchmark.ndarray.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var uniform = require( '@stdlib/random/base/uniform' );
+var format = require( '@stdlib/string/format' );
 var bernoulli = require( '@stdlib/random/base/bernoulli' );
 var filledarrayBy = require( '@stdlib/array/filled-by' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -112,7 +113,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::native:ndarray:len='+len, opts, f );
+		bench( format( '%s::native:ndarray:len=%d', pkg, len ), opts, f );
 	}
 }
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed 
  ---
Resolves none.

## Description

This pull request updates benchmarks in `@stdlib/stats/strided/dnanmax` to use string interpolation.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md