### PR TITLE
bench: refactor to use string interpolation in `blas/ext/base/dapx`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dapx/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapx/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dapx = require( './../lib/dapx.js' );
 
@@ -92,7 +93,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapx/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapx/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapx/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapx/benchmark/benchmark.ndarray.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dapx = require( './../lib/ndarray.js' );
 
@@ -92,7 +93,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':ndarray:len='+len, f );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapx/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapx/benchmark/benchmark.ndarray.native.js
@@ -26,6 +26,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapx/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapx/package.json
@@ -36,7 +36,9 @@
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "@stdlib/string/format": "^0.2.2"
+  },
   "engines": {
     "node": ">=0.10.0",
     "npm": ">2.7.0"

--- a/lib/node_modules/@stdlib/buffer/from-string/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/buffer/from-string/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var string2buffer = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':encoding=utf8', function benchmark( b ) {
+bench( format( '%s:encoding=utf8', pkg ), function benchmark( b ) {
 	var values;
 	var str;
 	var out;
@@ -90,7 +91,7 @@ bench( pkg+':encoding=utf8', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':encoding=hex', function benchmark( b ) {
+bench( format( '%s:encoding=hex', pkg ), function benchmark( b ) {
 	var values;
 	var str;
 	var out;

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/package.json
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",
@@ -31,7 +34,10 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@stdlib/math/base/assert/is-nonnegative-integer": "^0.2.2",
+    "@stdlib/stats/base/dists/gamma/pdf": "^0.2.2"
+  },
   "devDependencies": {},
   "engines": {
     "node": ">=0.10.0",


### PR DESCRIPTION
Ref #8647.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors the JavaScript benchmarks in `@stdlib/blas/ext/base/dapx` to use string interpolation via `@stdlib/string/format` instead of string concatenation for constructing benchmark names.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
