### PR TITLE
chore: fix JavaScript lint errors (issue #10582)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/browser-compatible/lib/resolve.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/browser-compatible/lib/resolve.js
@@ -51,19 +51,19 @@ function getPkgs( pkgs, dir, clbk ) {
 	len = pkgs.length;
 	debug( 'Resolving %d packages...', len );
 
-	out = new Array( len );
+	out = [];
 	count = 0;
 	for ( i = 0; i < len; i++ ) {
 		debug( 'Resolving package: %s (%d of %d).', pkgs[ i ], i+1, len );
 		opts = {
 			'basedir': dir
 		};
-		out[ i ] = {
+		out.push({
 			'id': null,
 			'pkg': pkgs[ i ],
 			'dir': null,
 			'data': null
-		};
+		});
 		resolve( pkgs[ i ], opts, createClbk( i ) );
 	}
 	/**


### PR DESCRIPTION
Resolves #10582.

## Description

> What is the purpose of this pull request?

This pull request:

- **Fixes a linting error** in the `@stdlib/_tools/pkgs/browser-compatible` package where the `new Array()` constructor was being used.
- **Replaces the constructor** with an array literal `[]` to comply with the `stdlib/no-new-array` lint rule.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #10582

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
