### PR TITLE
feat: add `stats/strided/dmskmean`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/README.md
@@ -1,0 +1,330 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+
+# dmskmean
+
+> Calculate the arithmetic mean of a double-precision floating-point strided array according to a mask.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var dmskmean = require( '@stdlib/stats/strided/dmskmean' );
+```
+
+#### dmskmean( N, x, strideX, mask, strideMask )
+
+Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+
+var x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+var mask = new Uint8Array( [ 0, 0, 1, 0 ] );
+
+var v = dmskmean( x.length, x, 1, mask, 1 );
+// returns 0.3333333333333333
+```
+
+The function has the following parameters:
+
+-   **N**: number of indexed elements.
+-   **x**: input [`Float64Array`][@stdlib/array/float64].
+-   **strideX**: stride length for `x`.
+-   **mask**: mask [`Uint8Array`][@stdlib/array/uint8]. If a `mask` array element is `0`, the corresponding element in `x` is considered valid and **included** in computation. If a `mask` array element is `1`, the corresponding element in `x` is considered invalid/missing and **excluded** from computation.
+-   **strideMask**: stride length for `mask`.
+
+The `N` and stride parameters determine which elements in the strided arrays are accessed at runtime. For example, to compute the arithmetic mean of every other element in `x`,
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+
+var x = new Float64Array( [ 1.0, 2.0, -7.0, -2.0, 4.0, 3.0, 5.0, 6.0 ] );
+var mask = new Uint8Array( [ 0, 0, 0, 0, 0, 0, 1, 1 ] );
+
+var v = dmskmean( 4, x, 2, mask, 2 );
+// returns -0.6666666666666663
+```
+
+Note that indexing is relative to the first index. To introduce offsets, use [`typed array`][mdn-typed-array] views.
+
+<!-- eslint-disable stdlib/capitalized-comments -->
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+
+var x0 = new Float64Array( [ 2.0, 1.0, -2.0, -2.0, 3.0, 4.0, 5.0, 6.0 ] );
+var x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+var mask0 = new Uint8Array( [ 0, 0, 0, 0, 0, 0, 1, 1 ] );
+var mask1 = new Uint8Array( mask0.buffer, mask0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+var v = dmskmean( 4, x1, 2, mask1, 2 );
+// returns 1.0
+```
+
+#### dmskmean.ndarray( N, x, strideX, offsetX, mask, strideMask, offsetMask )
+
+Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask and using alternative indexing semantics.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+
+var x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+var mask = new Uint8Array( [ 0, 0, 1, 0 ] );
+
+var v = dmskmean.ndarray( x.length, x, 1, 0, mask, 1, 0 );
+// returns 0.3333333333333333
+```
+
+The function has the following additional parameters:
+
+-   **offsetX**: starting index for `x`.
+-   **offsetMask**: starting index for `mask`.
+
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example, to calculate the arithmetic mean for every other element in `x` starting from the second element
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+
+var x = new Float64Array( [ 2.0, 1.0, -2.0, -2.0, 3.0, 4.0, 5.0, 6.0 ] );
+var mask = new Uint8Array( [ 0, 0, 0, 0, 0, 0, 1, 1 ] );
+
+var v = dmskmean.ndarray( 4, x, 2, 1, mask, 2, 1 );
+// returns 1.0
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If `N <= 0` or if all elements are masked, both functions return `NaN`.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var uniform = require( '@stdlib/random/array/uniform' );
+var bernoulli = require( '@stdlib/random/array/bernoulli' );
+var dmskmean = require( '@stdlib/stats/strided/dmskmean' );
+
+var x = uniform( 10, -50.0, 50.0, {
+    'dtype': 'float64'
+});
+console.log( x );
+
+var mask = bernoulli( x.length, 0.2, {
+    'dtype': 'uint8'
+});
+console.log( mask );
+
+var v = dmskmean( x.length, x, 1, mask, 1 );
+console.log( v );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/strided/dmskmean.h"
+```
+
+#### stdlib_strided_dmskmean( N, \*X, strideX, \*Mask, strideMask )
+
+Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+
+```c
+#include <stdint.h>
+
+const double x[] = { 1.0, -2.0, 2.0 };
+const uint8_t mask[] = { 0, 1, 0 };
+
+double v = stdlib_strided_dmskmean( 3, x, 1, mask, 1 );
+// returns 1.5
+```
+
+The function accepts the following arguments:
+
+-   **N**: `[in] CBLAS_INT` number of indexed elements.
+-   **X**: `[in] double*` input array.
+-   **strideX**: `[in] CBLAS_INT` stride length for `X`.
+-   **Mask**: `[in] uint8_t*` mask array. If a `Mask` array element is `0`, the corresponding element in `X` is considered valid and included in computation. If a `Mask` array element is `1`, the corresponding element in `X` is considered invalid/missing and excluded from computation.
+-   **strideMask**: `[in] CBLAS_INT` stride length for `Mask`.
+
+```c
+double stdlib_strided_dmskmean( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const uint8_t *Mask, const CBLAS_INT strideMask );
+```
+
+<!-- lint disable maximum-heading-length -->
+
+#### stdlib_strided_dmskmean_ndarray( N, \*X, strideX, offsetX, \*Mask, strideMask, offsetMask )
+
+Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask and using alternative indexing semantics.
+
+```c
+#include <stdint.h>
+
+const double x[] = { 1.0, -2.0, 2.0 };
+const uint8_t mask[] = { 0, 1, 0 };
+
+double v = stdlib_strided_dmskmean_ndarray( 3, x, 1, 0, mask, 1, 0 );
+// returns 1.5
+```
+
+The function accepts the following arguments:
+
+-   **N**: `[in] CBLAS_INT` number of indexed elements.
+-   **X**: `[in] double*` input array.
+-   **strideX**: `[in] CBLAS_INT` stride length for `X`.
+-   **offsetX**: `[in] CBLAS_INT` starting index for `X`.
+-   **Mask**: `[in] uint8_t*` mask array. If a `Mask` array element is `0`, the corresponding element in `X` is considered valid and included in computation. If a `Mask` array element is `1`, the corresponding element in `X` is considered invalid/missing and excluded from computation.
+-   **strideMask**: `[in] CBLAS_INT` stride length for `Mask`.
+-   **offsetMask**: `[in] CBLAS_INT` starting index for `Mask`.
+
+```c
+double stdlib_strided_dmskmean_ndarray( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX, const uint8_t *Mask, const CBLAS_INT strideMask, const CBLAS_INT offsetMask );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/strided/dmskmean.h"
+#include <stdint.h>
+#include <stdio.h>
+
+int main( void ) {
+    // Create a strided array:
+    const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
+
+    // Create a mask array:
+    const uint8_t mask[] = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 };
+
+    // Specify the number of elements:
+    const int N = 5;
+
+    // Specify the stride lengths:
+    const int strideX = 2;
+    const int strideMask = 2;
+
+    // Compute the arithmetic mean:
+    double v = stdlib_strided_dmskmean( N, x, strideX, mask, strideMask );
+
+    // Print the result:
+    printf( "mean: %lf\n", v );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/array/float64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/float64
+
+[@stdlib/array/uint8]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/uint8
+
+[mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/benchmark.js
@@ -1,0 +1,108 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var bernoulli = require( '@stdlib/random/array/bernoulli' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var dmskmean = require( './../lib/dmskmean.js' );
+
+
+// VARIABLES //
+
+var uniformOptions = {
+	'dtype': 'float64'
+};
+var bernoulliOptions = {
+	'dtype': 'uint8'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var mask = bernoulli( len, 0.2, bernoulliOptions );
+	var x = uniform( len, -10.0, 10.0, uniformOptions );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = dmskmean( x.length, x, 1, mask, 1 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:len=%u', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/benchmark.native.js
@@ -1,0 +1,113 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var bernoulli = require( '@stdlib/random/array/bernoulli' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var dmskmean = tryRequire( resolve( __dirname, './../lib/dmskmean.native.js' ) );
+var opts = {
+	'skip': ( dmskmean instanceof Error )
+};
+var uniformOptions = {
+	'dtype': 'float64'
+};
+var bernoulliOptions = {
+	'dtype': 'uint8'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var mask = bernoulli( len, 0.2, bernoulliOptions );
+	var x = uniform( len, -10.0, 10.0, uniformOptions );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = dmskmean( x.length, x, 1, mask, 1 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::native:len=%u', pkg, len ), opts, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/benchmark.ndarray.js
@@ -1,0 +1,108 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var bernoulli = require( '@stdlib/random/array/bernoulli' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var dmskmean = require( './../lib/ndarray.js' );
+
+
+// VARIABLES //
+
+var uniformOptions = {
+	'dtype': 'float64'
+};
+var bernoulliOptions = {
+	'dtype': 'uint8'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var mask = bernoulli( len, 0.2, bernoulliOptions );
+	var x = uniform( len, -10.0, 10.0, uniformOptions );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = dmskmean( x.length, x, 1, 0, mask, 1, 0 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:ndarray:len=%u', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/benchmark.ndarray.native.js
@@ -1,0 +1,113 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var bernoulli = require( '@stdlib/random/array/bernoulli' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var dmskmean = tryRequire( resolve( __dirname, './../lib/ndarray.native.js' ) );
+var opts = {
+	'skip': ( dmskmean instanceof Error )
+};
+var uniformOptions = {
+	'dtype': 'float64'
+};
+var bernoulliOptions = {
+	'dtype': 'uint8'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var mask = bernoulli( len, 0.2, bernoulliOptions );
+	var x = uniform( len, -10.0, 10.0, uniformOptions );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = dmskmean( x.length, x, 1, 0, mask, 1, 0 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::native:ndarray:len=%u', pkg, len ), opts, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.length.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/benchmark/c/benchmark.length.c
@@ -1,0 +1,197 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/dmskmean.h"
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "dmskmean"
+#define ITERATIONS 1000000
+#define REPEATS 3
+#define MIN 1
+#define MAX 6
+
+/**
+* Print TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Print TAP summary.
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total );
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Print benchmark results.
+*/
+static void print_results( int iterations, double elapsed ) {
+	double rate = (double)iterations / elapsed;
+
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", iterations );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Return current time (seconds).
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
+}
+
+/**
+* Generate random number in [0,1).
+*/
+static double rand_double( void ) {
+	return (double)rand() / ((double)RAND_MAX + 1.0);
+}
+
+/**
+* Benchmark: strided version
+*/
+static double benchmark1( int iterations, int len ) {
+	double elapsed;
+	double *x;
+	uint8_t *mask;
+	double v;
+	double t;
+	int i;
+
+	x = (double *) malloc( len * sizeof( double ) );
+	mask = (uint8_t *) malloc( len * sizeof( uint8_t ) );
+
+	for ( i = 0; i < len; i++ ) {
+		mask[i] = ( rand_double() < 0.2 ) ? 1 : 0;
+		x[i] = ( rand_double() * 20000.0 ) - 10000.0;
+	}
+
+	t = tic();
+
+	for ( i = 0; i < iterations; i++ ) {
+		v = stdlib_strided_dmskmean( len, x, 1, mask, 1 );
+		if ( v != v ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+
+	elapsed = tic() - t;
+
+	free( x );
+	free( mask );
+	return elapsed;
+}
+
+/**
+* Benchmark: ndarray version
+*/
+static double benchmark2( int iterations, int len ) {
+	double elapsed;
+	double *x;
+	uint8_t *mask;
+	double v;
+	double t;
+	int i;
+
+	x = (double *) malloc( len * sizeof( double ) );
+	mask = (uint8_t *) malloc( len * sizeof( uint8_t ) );
+
+	for ( i = 0; i < len; i++ ) {
+		mask[i] = ( rand_double() < 0.2 ) ? 1 : 0;
+		x[i] = ( rand_double() * 20000.0 ) - 10000.0;
+	}
+
+	t = tic();
+
+	for ( i = 0; i < iterations; i++ ) {
+		v = stdlib_strided_dmskmean_ndarray( len, x, 1, 0, mask, 1, 0 );
+		if ( v != v ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+
+	elapsed = tic() - t;
+
+	free( x );
+	free( mask );
+	return elapsed;
+}
+
+/**
+* Main execution.
+*/
+int main( void ) {
+	double elapsed;
+	int count = 0;
+	int iter;
+	int len;
+	int i, j;
+
+	srand( time( NULL ) );
+
+	print_version();
+
+	/* --- strided --- */
+	for ( i = MIN; i <= MAX; i++ ) {
+		len = pow( 10, i );
+		iter = ITERATIONS / pow( 10, i - 1 );
+
+		for ( j = 0; j < REPEATS; j++ ) {
+			count++;
+			printf( "# c::%s:len=%d\n", NAME, len );
+			elapsed = benchmark1( iter, len );
+			print_results( iter, elapsed );
+			printf( "ok %d benchmark finished\n", count );
+		}
+	}
+
+	/* --- ndarray --- */
+	for ( i = MIN; i <= MAX; i++ ) {
+		len = pow( 10, i );
+		iter = ITERATIONS / pow( 10, i - 1 );
+
+		for ( j = 0; j < REPEATS; j++ ) {
+			count++;
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
+			elapsed = benchmark2( iter, len );
+			print_results( iter, elapsed );
+			printf( "ok %d benchmark finished\n", count );
+		}
+	}
+
+	print_summary( count, count );
+	return 0;
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/docs/repl.txt
@@ -1,0 +1,115 @@
+{{alias}}( N, x, strideX, mask, strideMask )
+    Calculates the arithmetic mean of a double-precision floating-point strided
+    array according to a mask.
+
+    The `N` and stride parameters determine which elements in the strided arrays
+    are accessed at runtime.
+
+    Indexing is relative to the first index. To introduce offsets, use typed
+    array views.
+
+    If a `mask` array element is `0`, the corresponding element in `x` is
+    considered valid and included in computation.
+
+    If a `mask` array element is `1`, the corresponding element in `x` is
+    considered invalid/missing and excluded from computation.
+
+    If `N <= 0`, the function returns `NaN`.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Float64Array
+        Input array.
+
+    strideX: integer
+        Stride length for `x`.
+
+    mask: Uint8Array
+        Mask array.
+
+    strideMask: integer
+        Stride length for `mask`.
+
+    Returns
+    -------
+    out: number
+        Arithmetic mean.
+
+    Examples
+    --------
+    // Standard Usage:
+    > var x = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 4.0, 2.0 ] );
+    > var mask = new {{alias:@stdlib/array/uint8}}( [ 0, 0, 1, 0 ] );
+    > {{alias}}( x.length, x, 1, mask, 1 )
+    0.3333333333333333
+
+    // Using `N` and `stride` parameters:
+    > x = new {{alias:@stdlib/array/float64}}( [ -2.0, 1.0, 1.0, -5.0, 2.0, -1.0, 4.0 ] );
+    > mask = new {{alias:@stdlib/array/uint8}}( [ 0, 0, 0, 0, 0, 0, 1 ] );
+    > {{alias}}( 3, x, 2, mask, 2 )
+    0.3333333333333333
+
+    // Using view offsets:
+    > var x0 = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 3.0, 2.0, 5.0, -1.0, 4.0 ] );
+    > var x1 = new {{alias:@stdlib/array/float64}}( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
+    > var mask0 = new {{alias:@stdlib/array/uint8}}( [ 0, 0, 0, 0, 0, 0, 1 ] );
+    > var mask1 = new {{alias:@stdlib/array/uint8}}( mask0.buffer, mask0.BYTES_PER_ELEMENT*1 );
+    > {{alias}}( 3, x1, 2, mask1, 2 )
+    -0.3333333333333333
+
+
+{{alias}}.ndarray( N, x, strideX, offsetX, mask, strideMask, offsetMask )
+    Calculates the arithmetic mean of a double-precision floating-point strided
+    array according to a mask and using alternative indexing semantics.
+
+    While typed array views mandate a view offset based on the underlying
+    buffer, offset parameters support indexing semantics based on starting
+    indices.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Float64Array
+        Input array.
+
+    strideX: integer
+        Stride length for `x`.
+
+    offsetX: integer
+        Starting index for `x`.
+
+    mask: Uint8Array
+        Mask array.
+
+    strideMask: integer
+        Stride length for `mask`.
+
+    offsetMask: integer
+        Starting index for `mask`.
+
+    Returns
+    -------
+    out: number
+        Arithmetic mean.
+
+    Examples
+    --------
+    // Standard Usage:
+    > var x = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 2.0, 4.0 ] );
+    > var mask = new {{alias:@stdlib/array/uint8}}( [ 0, 0, 0, 1 ] );
+    > {{alias}}.ndarray( x.length, x, 1, 0, mask, 1, 0 )
+    0.3333333333333333
+
+    // Using offset parameter:
+    > x = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 3.0, 2.0, 5.0, -1.0, 4.0 ] );
+    > mask = new {{alias:@stdlib/array/uint8}}( [ 0, 0, 0, 0, 0, 0, 1 ] );
+    > {{alias}}.ndarray( 3, x, 2, 1, mask, 2, 1 )
+    -0.3333333333333333
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/docs/types/index.d.ts
@@ -1,0 +1,107 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Interface describing `dmskmean`.
+*/
+interface Routine {
+	/**
+	* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - `x` stride length
+	* @param mask - mask array
+	* @param strideMask - `mask` stride length
+	* @returns arithmetic mean
+	*
+	* @example
+	* var Float64Array = require( '@stdlib/array/float64' );
+	* var Uint8Array = require( '@stdlib/array/uint8' );
+	*
+	* var x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	* var mask = new Uint8Array( [ 0, 0, 1, 0 ] );
+	*
+	* var v = dmskmean( x.length, x, 1, mask, 1 );
+	* // returns 0.3333333333333333
+	*/
+	( N: number, x: Float64Array, strideX: number, mask: Uint8Array, strideMask: number ): number;
+
+	/**
+	* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask and using alternative indexing semantics.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - `x` stride length
+	* @param offsetX - `x` starting index
+	* @param mask - mask array
+	* @param strideMask - `mask` stride length
+	* @param offsetMask - `mask` starting index
+	* @returns arithmetic mean
+	*
+	* @example
+	* var Float64Array = require( '@stdlib/array/float64' );
+	* var Uint8Array = require( '@stdlib/array/uint8' );
+	*
+	* var x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	* var mask = new Uint8Array( [ 0, 0, 1, 0 ] );
+	*
+	* var v = dmskmean.ndarray( x.length, x, 1, 0, mask, 1, 0 );
+	* // returns 0.3333333333333333
+	*/
+	ndarray( N: number, x: Float64Array, strideX: number, offsetX: number, mask: Uint8Array, strideMask: number, offsetMask: number ): number;
+}
+
+/**
+* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+*
+* @param N - number of indexed elements
+* @param x - input array
+* @param strideX - `x` stride length
+* @param mask - mask array
+* @param strideMask - `mask` stride length
+* @returns arithmetic mean
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var Uint8Array = require( '@stdlib/array/uint8' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+* var mask = new Uint8Array( [ 0, 0, 1, 0 ] );
+*
+* var v = dmskmean( x.length, x, 1, mask, 1 );
+* // returns 0.3333333333333333
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var Uint8Array = require( '@stdlib/array/uint8' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+* var mask = new Uint8Array( [ 0, 0, 1, 0 ] );
+*
+* var v = dmskmean.ndarray( x.length, x, 1, 0, mask, 1, 0 );
+* // returns 0.3333333333333333
+*/
+declare var dmskmean: Routine;
+
+
+// EXPORTS //
+
+export = dmskmean;

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/docs/types/test.ts
@@ -1,0 +1,247 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import dmskmean = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean( x.length, x, 1, mask, 1 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean( '10', x, 1, mask, 1 ); // $ExpectError
+	dmskmean( true, x, 1, mask, 1 ); // $ExpectError
+	dmskmean( false, x, 1, mask, 1 ); // $ExpectError
+	dmskmean( null, x, 1, mask, 1 ); // $ExpectError
+	dmskmean( undefined, x, 1, mask, 1 ); // $ExpectError
+	dmskmean( [], x, 1, mask, 1 ); // $ExpectError
+	dmskmean( {}, x, 1, mask, 1 ); // $ExpectError
+	dmskmean( ( x: number ): number => x, x, 1, mask, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a Float64Array...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean( x.length, 10, 1, mask, 1 ); // $ExpectError
+	dmskmean( x.length, '10', 1, mask, 1 ); // $ExpectError
+	dmskmean( x.length, true, 1, mask, 1 ); // $ExpectError
+	dmskmean( x.length, false, 1, mask, 1 ); // $ExpectError
+	dmskmean( x.length, null, 1, mask, 1 ); // $ExpectError
+	dmskmean( x.length, undefined, 1, mask, 1 ); // $ExpectError
+	dmskmean( x.length, [], 1, mask, 1 ); // $ExpectError
+	dmskmean( x.length, {}, 1, mask, 1 ); // $ExpectError
+	dmskmean( x.length, ( x: number ): number => x, 1, mask, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean( x.length, x, '10', mask, 1 ); // $ExpectError
+	dmskmean( x.length, x, true, mask, 1 ); // $ExpectError
+	dmskmean( x.length, x, false, mask, 1 ); // $ExpectError
+	dmskmean( x.length, x, null, mask, 1 ); // $ExpectError
+	dmskmean( x.length, x, undefined, mask, 1 ); // $ExpectError
+	dmskmean( x.length, x, [], mask, 1 ); // $ExpectError
+	dmskmean( x.length, x, {}, mask, 1 ); // $ExpectError
+	dmskmean( x.length, x, ( x: number ): number => x, mask, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a Uint8Array...
+{
+	const x = new Float64Array( 10 );
+
+	dmskmean( x.length, x, 1, 10, 1 ); // $ExpectError
+	dmskmean( x.length, x, 1, '10', 1 ); // $ExpectError
+	dmskmean( x.length, x, 1, true, 1 ); // $ExpectError
+	dmskmean( x.length, x, 1, false, 1 ); // $ExpectError
+	dmskmean( x.length, x, 1, null, 1 ); // $ExpectError
+	dmskmean( x.length, x, 1, undefined, 1 ); // $ExpectError
+	dmskmean( x.length, x, 1, [], 1 ); // $ExpectError
+	dmskmean( x.length, x, 1, {}, 1 ); // $ExpectError
+	dmskmean( x.length, x, 1, ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean( x.length, x, 1, mask, '10' ); // $ExpectError
+	dmskmean( x.length, x, 1, mask, true ); // $ExpectError
+	dmskmean( x.length, x, 1, mask, false ); // $ExpectError
+	dmskmean( x.length, x, 1, mask, null ); // $ExpectError
+	dmskmean( x.length, x, 1, mask, undefined ); // $ExpectError
+	dmskmean( x.length, x, 1, mask, [] ); // $ExpectError
+	dmskmean( x.length, x, 1, mask, {} ); // $ExpectError
+	dmskmean( x.length, x, 1, mask, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean(); // $ExpectError
+	dmskmean( x.length ); // $ExpectError
+	dmskmean( x.length, x, 1 ); // $ExpectError
+	dmskmean( x.length, x, 1, mask ); // $ExpectError
+	dmskmean( x.length, x, 1, mask, 1, 10 ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, 0 ); // $ExpectType number
+}
+
+// The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean.ndarray( '10', x, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( true, x, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( false, x, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( null, x, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( undefined, x, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( [], x, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( {}, x, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( ( x: number ): number => x, x, 1, 0, mask, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a second argument which is not a Float64Array...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean.ndarray( x.length, 10, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, '10', 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, true, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, false, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, null, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, undefined, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, [], 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, {}, 1, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, ( x: number ): number => x, 1, 0, mask, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean.ndarray( x.length, x, '10', 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, true, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, false, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, null, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, undefined, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, [], 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, {}, 0, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, ( x: number ): number => x, 0, mask, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean.ndarray( x.length, x, 1, '10', mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, true, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, false, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, null, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, undefined, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, [], mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, {}, mask, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, ( x: number ): number => x, mask, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fifth argument which is not a Uint8Array...
+{
+	const x = new Float64Array( 10 );
+
+	dmskmean.ndarray( x.length, x, 1, 0, 10, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, '10', 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, true, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, false, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, null, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, undefined, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, [], 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, {}, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a sixth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean.ndarray( x.length, x, 1, 0, mask, '10', 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, true, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, false, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, null, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, undefined, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, [], 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, {}, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a seventh argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, '10' ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, true ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, false ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, null ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, undefined ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, [] ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, {} ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+	const mask = new Uint8Array( 10 );
+
+	dmskmean.ndarray(); // $ExpectError
+	dmskmean.ndarray( x.length ); // $ExpectError
+	dmskmean.ndarray( x.length, x ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1 ); // $ExpectError
+	dmskmean.ndarray( x.length, x, 1, 0, mask, 1, 0, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/examples/c/example.c
@@ -1,0 +1,42 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/dmskmean.h"
+#include <stdint.h>
+#include <stdio.h>
+
+int main( void ) {
+	// Create a strided array:
+	const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
+
+	// Create a mask array:
+	const uint8_t mask[] = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 };
+
+	// Specify the number of elements:
+	const int N = 5;
+
+	// Specify the stride lengths:
+	const int strideX = 2;
+	const int strideMask = 2;
+
+	// Compute the arithmetic mean:
+	double v = stdlib_strided_dmskmean( N, x, strideX, mask, strideMask );
+
+	// Print the result:
+	printf( "mean: %lf\n", v );
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/examples/index.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var uniform = require( '@stdlib/random/array/uniform' );
+var bernoulli = require( '@stdlib/random/array/bernoulli' );
+var dmskmean = require( './../lib' );
+
+var uniformOptions = {
+	'dtype': 'float64'
+};
+var bernoulliOptions = {
+	'dtype': 'uint8'
+};
+
+var x = uniform( 10, -50.0, 50.0, uniformOptions );
+var mask = bernoulli( x.length, 0.2, bernoulliOptions );
+console.log( x );
+console.log( mask );
+
+var v = dmskmean( x.length, x, 1, mask, 1 );
+console.log( v );

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/include.gypi
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/include/stdlib/stats/strided/dmskmean.h
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/include/stdlib/stats/strided/dmskmean.h
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_STRIDED_DMSKMEAN_H
+#define STDLIB_STATS_STRIDED_DMSKMEAN_H
+
+#include "stdlib/blas/base/shared.h"
+#include <stdint.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+*/
+double API_SUFFIX(stdlib_strided_dmskmean)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const uint8_t *Mask, const CBLAS_INT strideMask );
+
+/**
+* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask and using alternative indexing semantics.
+*/
+double API_SUFFIX(stdlib_strided_dmskmean_ndarray)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX, const uint8_t *Mask, const CBLAS_INT strideMask, const CBLAS_INT offsetMask );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_STRIDED_DMSKMEAN_H

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/dmskmean.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/dmskmean.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var stride2offset = require( '@stdlib/strided/base/stride2offset' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+/**
+* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - input array
+* @param {integer} strideX - `x` stride length
+* @param {Uint8Array} mask - mask array
+* @param {integer} strideMask - `mask` stride length
+* @returns {number} arithmetic mean
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var Uint8Array = require( '@stdlib/array/uint8' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+* var mask = new Uint8Array( [ 0, 0, 1, 0 ] );
+*
+* var v = dmskmean( x.length, x, 1, mask, 1 );
+* // returns 0.3333333333333333
+*/
+function dmskmean( N, x, strideX, mask, strideMask ) {
+	var ox = stride2offset( N, strideX );
+	var om = stride2offset( N, strideMask );
+	return ndarray( N, x, strideX, ox, mask, strideMask, om );
+}
+
+
+// EXPORTS //
+
+module.exports = dmskmean;

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/dmskmean.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/dmskmean.native.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - input array
+* @param {integer} strideX - `x` stride length
+* @param {Uint8Array} mask - mask array
+* @param {integer} strideMask - `mask` stride length
+* @returns {number} arithmetic mean
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var Uint8Array = require( '@stdlib/array/uint8' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+* var mask = new Uint8Array( [ 0, 0, 1, 0 ] );
+*
+* var v = dmskmean( x.length, x, 1, mask, 1 );
+* // returns 0.3333333333333333
+*/
+function dmskmean( N, x, strideX, mask, strideMask ) {
+	return addon( N, x, strideX, mask, strideMask );
+}
+
+
+// EXPORTS //
+
+module.exports = dmskmean;

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/index.js
@@ -1,0 +1,72 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Calculate the arithmetic mean of a double-precision floating-point strided array according to a mask.
+*
+* @module @stdlib/stats/strided/dmskmean
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var Uint8Array = require( '@stdlib/array/uint8' );
+* var dmskmean = require( '@stdlib/stats/strided/dmskmean' );
+*
+* var x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+* var mask = new Uint8Array( [ 0, 0, 1, 0 ] );
+*
+* var v = dmskmean( x.length, x, 1, mask, 1 );
+* // returns 0.3333333333333333
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var Uint8Array = require( '@stdlib/array/uint8' );
+* var dmskmean = require( '@stdlib/stats/strided/dmskmean' );
+*
+* var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+* var mask = new Uint8Array( [ 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 ] );
+*
+* var v = dmskmean.ndarray( 5, x, 2, 1, mask, 2, 1 );
+* // returns 1.25
+*/
+
+// MODULES //
+
+var join = require( 'path' ).join;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isError = require( '@stdlib/assert/is-error' );
+var main = require( './main.js' );
+
+
+// MAIN //
+
+var dmskmean;
+var tmp = tryRequire( join( __dirname, './native.js' ) );
+if ( isError( tmp ) ) {
+	dmskmean = main;
+} else {
+	dmskmean = tmp;
+}
+
+
+// EXPORTS //
+
+module.exports = dmskmean;
+
+// exports: { "ndarray": "dmskmean.ndarray" }

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/main.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var dmskmean = require( './dmskmean.js' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+setReadOnly( dmskmean, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = dmskmean;

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/native.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var dmskmean = require( './dmskmean.native.js' );
+var ndarray = require( './ndarray.native.js' );
+
+
+// MAIN //
+
+setReadOnly( dmskmean, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = dmskmean;

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/ndarray.js
@@ -1,0 +1,99 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
+// MAIN //
+
+/**
+* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - input array
+* @param {integer} strideX - `x` stride length
+* @param {NonNegativeInteger} offsetX - `x` starting index
+* @param {Uint8Array} mask - mask array
+* @param {integer} strideMask - `mask` stride length
+* @param {NonNegativeInteger} offsetMask - `mask` starting index
+* @returns {number} arithmetic mean
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var Uint8Array = require( '@stdlib/array/uint8' );
+*
+* var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+* var mask = new Uint8Array( [ 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 ] );
+*
+* var v = dmskmean( 5, x, 2, 1, mask, 2, 1 );
+* // returns 1.25
+*/
+function dmskmean( N, x, strideX, offsetX, mask, strideMask, offsetMask ) {
+	var sum;
+	var ix;
+	var im;
+	var mu;
+	var v;
+	var i;
+	var n;
+	var c;
+
+	if ( N <= 0 ) {
+		return NaN;
+	}
+	n = 0;
+	sum = 0.0;
+	ix = offsetX;
+	im = offsetMask;
+	for ( i = 0; i < N; i++ ) {
+		if ( mask[ im ] === 0 ) {
+			v = x[ ix ];
+			if ( isnan( v ) ) {
+				return v;
+			}
+			sum += v;
+			n += 1;
+		}
+		ix += strideX;
+		im += strideMask;
+	}
+	if ( n === 0 ) {
+		return NaN;
+	}
+	mu = sum / n;
+	c = 0.0;
+	ix = offsetX;
+	im = offsetMask;
+	for ( i = 0; i < N; i++ ) {
+		if ( mask[ im ] === 0 ) {
+			c += x[ ix ] - mu;
+		}
+		ix += strideX;
+		im += strideMask;
+	}
+	return mu + ( c / n );
+}
+
+
+// EXPORTS //
+
+module.exports = dmskmean;

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/lib/ndarray.native.js
@@ -1,0 +1,57 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Float64Array} x - input array
+* @param {integer} strideX - `x` stride length
+* @param {NonNegativeInteger} offsetX - `x` starting index
+* @param {Uint8Array} mask - mask array
+* @param {integer} strideMask - `mask` stride length
+* @param {NonNegativeInteger} offsetMask - `mask` starting index
+* @returns {number} arithmetic mean
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var Uint8Array = require( '@stdlib/array/uint8' );
+*
+* var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+* var mask = new Uint8Array( [ 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 ] );
+*
+* var v = dmskmean( 5, x, 2, 1, mask, 2, 1 );
+* // returns 1.25
+*/
+function dmskmean( N, x, strideX, offsetX, mask, strideMask, offsetMask ) {
+	return addon.ndarray( N, x, strideX, offsetX, mask, strideMask, offsetMask ); // eslint-disable-line max-len
+}
+
+
+// EXPORTS //
+
+module.exports = dmskmean;

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/manifest.json
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/manifest.json
@@ -1,0 +1,104 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/strided/base/stride2offset",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/napi/export",
+        "@stdlib/napi/argv",
+        "@stdlib/napi/argv-int64",
+        "@stdlib/napi/argv-strided-float64array",
+        "@stdlib/napi/argv-strided-uint8array",
+        "@stdlib/napi/create-double"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/strided/base/stride2offset",
+        "@stdlib/math/base/assert/is-nan"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/strided/base/stride2offset",
+        "@stdlib/math/base/assert/is-nan"
+      ]
+    },
+    {
+      "task": "",
+      "wasm": true,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/strided/base/stride2offset",
+        "@stdlib/math/base/assert/is-nan"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@stdlib/stats/strided/dmskmean",
+  "version": "0.0.0",
+  "description": "Calculate the arithmetic mean of a double-precision floating-point strided array according to a mask.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "browser": "./lib/main.js",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "average",
+    "avg",
+    "mean",
+    "arithmetic mean",
+    "central tendency",
+    "strided",
+    "strided array",
+    "masked",
+    "mask",
+    "masked array",
+    "typed",
+    "array",
+    "float64",
+    "double",
+    "float64array"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/src/addon.c
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/dmskmean.h"
+#include "stdlib/blas/base/shared.h"
+#include "stdlib/napi/export.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/argv_int64.h"
+#include "stdlib/napi/argv_strided_float64array.h"
+#include "stdlib/napi/argv_strided_uint8array.h"
+#include "stdlib/napi/create_double.h"
+#include <node_api.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 5 );
+	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
+	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
+	STDLIB_NAPI_ARGV_INT64( env, strideMask, argv, 4 );
+	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
+	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 3 );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmskmean)( N, X, strideX, Mask, strideMask ), v );
+	return v;
+}
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon_method( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 7 );
+	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
+	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
+	STDLIB_NAPI_ARGV_INT64( env, strideMask, argv, 5 );
+	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
+	STDLIB_NAPI_ARGV_INT64( env, offsetMask, argv, 6 );
+	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
+	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 4 );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmskmean_ndarray)( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
+	return v;
+}
+
+STDLIB_NAPI_MODULE_EXPORT_FCN_WITH_METHOD( addon, "ndarray", addon_method )

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/src/main.c
@@ -1,0 +1,97 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/strided/dmskmean.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/blas/base/shared.h"
+#include "stdlib/strided/base/stride2offset.h"
+#include <stdint.h>
+
+/**
+* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask.
+*
+* @param N           number of indexed elements
+* @param X           input array
+* @param strideX     X stride length
+* @param Mask        mask array
+* @param strideMask  Mask stride length
+* @return            output value
+*/
+double API_SUFFIX(stdlib_strided_dmskmean)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const uint8_t *Mask, const CBLAS_INT strideMask ) {
+	const CBLAS_INT ox = stdlib_strided_stride2offset( N, strideX );
+	const CBLAS_INT om = stdlib_strided_stride2offset( N, strideMask );
+	return API_SUFFIX(stdlib_strided_dmskmean_ndarray)( N, X, strideX, ox, Mask, strideMask, om );
+}
+
+/**
+* Calculates the arithmetic mean of a double-precision floating-point strided array according to a mask and using alternative indexing semantics.
+*
+* @param N           number of indexed elements
+* @param X           input array
+* @param strideX     X stride length
+* @param offsetX     starting index for X
+* @param Mask        mask array
+* @param strideMask  Mask stride length
+* @param offsetMask  starting index for Mask
+* @return            output value
+*/
+double API_SUFFIX(stdlib_strided_dmskmean_ndarray)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX, const uint8_t *Mask, const CBLAS_INT strideMask, const CBLAS_INT offsetMask ) {
+	CBLAS_INT ix;
+	CBLAS_INT im;
+	CBLAS_INT i;
+	CBLAS_INT n;
+	double sum;
+	double mu;
+	double c;
+	double v;
+
+	if ( N <= 0 ) {
+		return 0.0 / 0.0; // NaN
+	}
+	n = 0;
+	sum = 0.0;
+	ix = offsetX;
+	im = offsetMask;
+	for ( i = 0; i < N; i++ ) {
+		if ( Mask[ im ] == 0 ) {
+			v = X[ ix ];
+			if ( stdlib_base_is_nan( v ) ) {
+				return 0.0 / 0.0; // NaN
+			}
+			sum += v;
+			n += 1;
+		}
+		ix += strideX;
+		im += strideMask;
+	}
+	if ( n == 0 ) {
+		return 0.0 / 0.0; // NaN
+	}
+	mu = sum / (double)n;
+	c = 0.0;
+	ix = offsetX;
+	im = offsetMask;
+	for ( i = 0; i < N; i++ ) {
+		if ( Mask[ im ] == 0 ) {
+			c += X[ ix ] - mu;
+		}
+		ix += strideX;
+		im += strideMask;
+	}
+	return mu + ( c / (double)n );
+}

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.dmskmean.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.dmskmean.js
@@ -1,0 +1,201 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var dmskmean = require( './../lib/dmskmean.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmskmean, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 5', function test( t ) {
+	t.strictEqual( dmskmean.length, 5, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the arithmetic mean of a strided array according to a mask', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( v, 1.25, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 1, 1, 1, 1 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	m = new Uint8Array( [ 0, 0 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	m = new Uint8Array( [ 1, 0 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( v, 4.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to 0, the function returns NaN', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 0, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	v = dmskmean( -1, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to 1, the function returns the first element', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 1, x, 1, m, 1 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	m = new Uint8Array( [ 1, 0, 0, 0 ] );
+	v = dmskmean( 1, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a stride for the input array', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, 10.0, -2.0, 20.0, 4.0, 30.0, 2.0, 40.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, 2, m, 1 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative stride for the input array', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, 10.0, -2.0, 20.0, 4.0, 30.0, 2.0, 40.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, -2, m, 1 );
+	t.strictEqual( v, 2.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a stride for the mask array', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 9, 0, 9, 1, 9, 0, 9 ] );
+	v = dmskmean( 4, x, 1, m, 2 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative stride for the mask array', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 9, 1, 9, 0, 9, 0, 9 ] );
+	v = dmskmean( 4, x, 1, m, -2 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a stride parameter equal to 0, the function returns the first element', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( x.length, x, 0, m, 1 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	v = dmskmean( x.length, x, 1, m, 0 );
+	t.strictEqual( v, 1.25, 'returns expected value' );
+
+	m = new Uint8Array( [ 1, 0, 0, 0 ] );
+	v = dmskmean( x.length, x, 0, m, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports view offsets', function test( t ) {
+	var x0;
+	var x1;
+	var m0;
+	var m1;
+	var v;
+
+	x0 = new Float64Array( [ 10.0, 1.0, -2.0, 4.0, 2.0 ] );
+	m0 = new Uint8Array( [ 1, 0, 0, 1, 0 ] );
+
+	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
+	m1 = new Uint8Array( m0.buffer, m0.BYTES_PER_ELEMENT*1 );
+
+	v = dmskmean( 4, x1, 1, m1, 1 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.dmskmean.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.dmskmean.native.js
@@ -1,0 +1,210 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var dmskmean = tryRequire( resolve( __dirname, './../lib/dmskmean.native.js' ) );
+var opts = {
+	'skip': ( dmskmean instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmskmean, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 5', opts, function test( t ) {
+	t.strictEqual( dmskmean.length, 5, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the arithmetic mean of a strided array according to a mask', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( v, 1.25, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 1, 1, 1, 1 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	m = new Uint8Array( [ 0, 0 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	m = new Uint8Array( [ 1, 0 ] );
+	v = dmskmean( x.length, x, 1, m, 1 );
+	t.strictEqual( v, 4.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if the number of elements is less than or equal to 0, the function returns NaN', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 0, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	v = dmskmean( -1, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to 1, the function returns the first element', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 1, x, 1, m, 1 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	m = new Uint8Array( [ 1, 0, 0, 0 ] );
+	v = dmskmean( 1, x, 1, m, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a stride for the input array', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, 10.0, -2.0, 20.0, 4.0, 30.0, 2.0, 40.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, 2, m, 1 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative stride for the input array', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, 10.0, -2.0, 20.0, 4.0, 30.0, 2.0, 40.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, -2, m, 1 );
+	t.strictEqual( v, 2.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a stride for the mask array', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 9, 0, 9, 1, 9, 0, 9 ] );
+	v = dmskmean( 4, x, 1, m, 2 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative stride for the mask array', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 9, 1, 9, 0, 9, 0, 9 ] );
+	v = dmskmean( 4, x, 1, m, -2 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a stride parameter equal to 0, the function returns the first element', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( x.length, x, 0, m, 1 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	v = dmskmean( x.length, x, 1, m, 0 );
+	t.strictEqual( v, 1.25, 'returns expected value' );
+
+	m = new Uint8Array( [ 1, 0, 0, 0 ] );
+	v = dmskmean( x.length, x, 0, m, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports view offsets', opts, function test( t ) {
+	var x0;
+	var x1;
+	var m0;
+	var m1;
+	var v;
+
+	x0 = new Float64Array( [ 10.0, 1.0, -2.0, 4.0, 2.0 ] );
+	m0 = new Uint8Array( [ 1, 0, 0, 1, 0 ] );
+
+	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
+	m1 = new Uint8Array( m0.buffer, m0.BYTES_PER_ELEMENT*1 );
+
+	v = dmskmean( 4, x1, 1, m1, 1 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var dmskmean = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': IS_BROWSER
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmskmean, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof dmskmean.ndarray, 'function', 'method is a function' );
+	t.end();
+});
+
+tape( 'if a native implementation is available, the main export is the native implementation', opts, function test( t ) {
+	var dmskmean = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( dmskmean, mock, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return mock;
+	}
+
+	function mock() {
+		// Mock...
+	}
+});
+
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', opts, function test( t ) {
+	var dmskmean;
+	var main;
+
+	main = require( './../lib/main.js' );
+
+	dmskmean = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( dmskmean, main, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
+});

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.ndarray.js
@@ -1,0 +1,195 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var dmskmean = require( './../lib/ndarray.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmskmean, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 7', function test( t ) {
+	t.strictEqual( dmskmean.length, 7, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the arithmetic mean of a strided array according to a mask', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, 1, 0, m, 1, 0 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+	v = dmskmean( 4, x, 1, 0, m, 1, 0 );
+	t.strictEqual( v, 1.25, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 1, 1, 1, 1 ] );
+	v = dmskmean( 4, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	m = new Uint8Array( [ 0, 0 ] );
+	v = dmskmean( 2, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	m = new Uint8Array( [ 1, 0 ] );
+	v = dmskmean( 2, x, 1, 0, m, 1, 0 );
+	t.strictEqual( v, 4.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to 0, the function returns NaN', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 0, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	v = dmskmean( -1, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to 1, the function returns the first element', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 1, x, 1, 0, m, 1, 0 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	m = new Uint8Array( [ 1, 0, 0, 0 ] );
+	v = dmskmean( 1, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports an offset', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 10.0, 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 1, 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, 1, 1, m, 1, 1 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a stride for the input array', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, 10.0, -2.0, 20.0, 4.0, 30.0, 2.0, 40.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, 2, 0, m, 1, 0 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative stride for the input array', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, 10.0, -2.0, 20.0, 4.0, 30.0, 2.0, 40.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, -2, 6, m, 1, 0 );
+	t.strictEqual( v, 2.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a stride for the mask array', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 9, 0, 9, 1, 9, 0, 9 ] );
+	v = dmskmean( 4, x, 1, 0, m, 2, 0 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative stride for the mask array', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 9, 1, 9, 0, 9, 0, 9 ] );
+	v = dmskmean( 4, x, 1, 0, m, -2, 6 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a stride parameter equal to 0, the function returns the first element', function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 4, x, 0, 0, m, 1, 0 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	v = dmskmean( 4, x, 1, 0, m, 0, 0 );
+	t.strictEqual( v, 1.25, 'returns expected value' );
+
+	m = new Uint8Array( [ 1, 0, 0, 0 ] );
+	v = dmskmean( 4, x, 0, 0, m, 0, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmean/test/test.ndarray.native.js
@@ -1,0 +1,204 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var dmskmean = tryRequire( resolve( __dirname, './../lib/ndarray.native.js' ) );
+var opts = {
+	'skip': ( dmskmean instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dmskmean, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 7', opts, function test( t ) {
+	t.strictEqual( dmskmean.length, 7, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the arithmetic mean of a strided array according to a mask', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, 1, 0, m, 1, 0 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+	v = dmskmean( 4, x, 1, 0, m, 1, 0 );
+	t.strictEqual( v, 1.25, 'returns expected value' );
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 1, 1, 1, 1 ] );
+	v = dmskmean( 4, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	m = new Uint8Array( [ 0, 0 ] );
+	v = dmskmean( 2, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	x = new Float64Array( [ NaN, 4.0 ] );
+	m = new Uint8Array( [ 1, 0 ] );
+	v = dmskmean( 2, x, 1, 0, m, 1, 0 );
+	t.strictEqual( v, 4.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to 0, the function returns NaN', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 0, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	v = dmskmean( -1, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter equal to 1, the function returns the first element', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 1, x, 1, 0, m, 1, 0 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	m = new Uint8Array( [ 1, 0, 0, 0 ] );
+	v = dmskmean( 1, x, 1, 0, m, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports an offset', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 10.0, 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 1, 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, 1, 1, m, 1, 1 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a stride for the input array', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, 10.0, -2.0, 20.0, 4.0, 30.0, 2.0, 40.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, 2, 0, m, 1, 0 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative stride for the input array', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, 10.0, -2.0, 20.0, 4.0, 30.0, 2.0, 40.0 ] );
+	m = new Uint8Array( [ 0, 0, 1, 0 ] );
+	v = dmskmean( 4, x, -2, 6, m, 1, 0 );
+	t.strictEqual( v, 2.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a stride for the mask array', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 9, 0, 9, 1, 9, 0, 9 ] );
+	v = dmskmean( 4, x, 1, 0, m, 2, 0 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative stride for the mask array', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 9, 1, 9, 0, 9, 0, 9 ] );
+	v = dmskmean( 4, x, 1, 0, m, -2, 6 );
+	t.strictEqual( v, 0.3333333333333333, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a stride parameter equal to 0, the function returns the first element', opts, function test( t ) {
+	var x;
+	var m;
+	var v;
+
+	x = new Float64Array( [ 1.0, -2.0, 4.0, 2.0 ] );
+	m = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	v = dmskmean( 4, x, 0, 0, m, 1, 0 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	v = dmskmean( 4, x, 1, 0, m, 0, 0 );
+	t.strictEqual( v, 1.25, 'returns expected value' );
+
+	m = new Uint8Array( [ 1, 0, 0, 0 ] );
+	v = dmskmean( 4, x, 0, 0, m, 0, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: passed
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: passed
  - task: lint_c_examples status: passed
  - task: lint_c_benchmarks status: passed
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed 
  ---Resolves none.

## Description


This pull request adds the `@stdlib/stats/strided/dmskmean` package.

The package provides a strided masked mean function for double-precision arrays and includes the C implementation, JavaScript interface, ndarray variant, tests, benchmarks, and documentation.


## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md