### PR TITLE
bench: refactor to use string interpolation in `blas/ext/base/dindex-of`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var oneTo = require( '@stdlib/array/one-to' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dindexOf = require( './../lib/dindex_of.js' );
 
@@ -89,7 +90,7 @@ function main() {
 		len = pow( 10, i );
 
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of/benchmark/benchmark.native.js
@@ -26,6 +26,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var oneTo = require( '@stdlib/array/one-to' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -98,7 +99,7 @@ function main() {
 		len = pow( 10, i );
 
 		f = createBenchmark( len );
-		bench( pkg+'::native:len='+len, opts, f );
+		bench( format( '%s::native:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of/benchmark/benchmark.ndarray.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var oneTo = require( '@stdlib/array/one-to' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dindexOf = require( './../lib/ndarray.js' );
 
@@ -89,7 +90,7 @@ function main() {
 		len = pow( 10, i );
 
 		f = createBenchmark( len );
-		bench( pkg+':ndarray:len='+len, f );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of/benchmark/benchmark.ndarray.native.js
@@ -26,6 +26,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var oneTo = require( '@stdlib/array/one-to' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -98,7 +99,7 @@ function main() {
 		len = pow( 10, i );
 
 		f = createBenchmark( len );
-		bench( pkg+'::native:ndarray:len='+len, opts, f );
+		bench( format( '%s::native:ndarray:len=%d', pkg, len ), opts, f );
 	}
 }
 


### PR DESCRIPTION
Resolves a part of #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates benchmark files for `blas/ext/base/dindex-of` to use string interpolation in JavaScript benchmarks for the benchmark name.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

NA

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
