### PR TITLE
chore: fix JavaScript lint errors (issue #10621)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-table-cell-padding/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-table-cell-padding/lib/main.js
@@ -41,6 +41,26 @@ var rule;
 // FUNCTIONS //
 
 /**
+* Copies AST node location info.
+*
+* @private
+* @param {Object} loc - AST node location
+* @returns {Object} copied location info
+*/
+function copyLocationInfo( loc ) {
+	return {
+		'start': {
+			'line': loc.start.line,
+			'column': loc.start.column
+		},
+		'end': {
+			'line': loc.end.line,
+			'column': loc.end.column
+		}
+	};
+}
+
+/**
 * Rule to require Markdown table cells in JSDoc descriptions to be correctly padded.
 *
 * @param {Object} context - ESLint context
@@ -113,26 +133,6 @@ function main( context ) {
 			loc.start.column = err.location.start.column + 1; // Note: we assume that 1 space separates `*` from JSDoc description content (e.g., `* ## Beep`)
 			report( msg, loc );
 		}
-	}
-
-	/**
-	* Copies AST node location info.
-	*
-	* @private
-	* @param {Object} loc - AST node location
-	* @returns {Object} copied location info
-	*/
-	function copyLocationInfo( loc ) {
-		return {
-			'start': {
-				'line': loc.start.line,
-				'column': loc.start.column
-			},
-			'end': {
-				'line': loc.end.line,
-				'column': loc.end.column
-			}
-		};
 	}
 
 	/**

--- a/lib/node_modules/@stdlib/blas/base/dgemv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/test/test.ndarray.js
@@ -44,7 +44,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rap = require( './fixtures/row_major_complex_access_pattern.json' );
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );


### PR DESCRIPTION
Resolves #10621 .

## Description

> What is the purpose of this pull request?

This pull request:

-  `jsdoc-table-cell-padding/lib/main.js`: Moved `copyLocationInfo` to module scope to comply with `stdlib/no-unnecessary-nested-functions`.
-  `dgemv/test/test.ndarray.js`: Removed extra empty lines between require statements to comply with `stdlib/no-empty-lines-between-requires`.
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #10621 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
