### PR TITLE
bench: use string interpolation in `blas/base/ggemv`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ggemv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemv/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -93,7 +94,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( N );
-		bench( pkg+':size='+(N*N), f );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ggemv/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemv/benchmark/benchmark.ndarray.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var format = require( '@stdlib/string/format' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -93,7 +94,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
 		f = createBenchmark( N );
-		bench( pkg+':ndarray:size='+(N*N), f );
+		bench( format( '%s:ndarray:size=%d', pkg, N*N ), f );
 	}
 }
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed
   ---
Progresses #8647.

## Description

> What is the purpose of this pull request?

This pull request updates the benchmark implementation for `blas/base/ggemv` to use string interpolation.

This change improves benchmark message formatting and consistency with current stdlib benchmark conventions. No functional changes are introduced.

## Related Issues

> Does this pull request have any related issues?

This pull request progresses #8647.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

This change is limited to benchmark output formatting.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md