### PR TITLE
bench: use string interpolation in `blas/base/layout-resolve-enum`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/layout-resolve-enum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/layout-resolve-enum/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var str2enum = require( '@stdlib/blas/base/layout-str2enum' );
 var pkg = require( './../package.json' ).name;
@@ -29,7 +30,7 @@ var resolve = require( './../lib' );
 
 // MAIN //
 
-bench( pkg+'::string', function benchmark( b ) {
+bench( format( '%s::string', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -54,7 +55,7 @@ bench( pkg+'::string', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::integer', function benchmark( b ) {
+bench( format( '%s::integer', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed 
  ---
Progresses #8647.

## Description

> What is the purpose of this pull request?

This pull request updates the benchmark implementation for `blas/base/layout-resolve-enum` to use string interpolation.

This change improves benchmark message formatting and consistency with current stdlib benchmark conventions. No functional changes are introduced.

## Related Issues

> Does this pull request have any related issues?

This pull request progresses #8647.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

This change is limited to benchmark output formatting.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md