### PR TITLE
chore: fix JavaScript lint errors (issue #6355)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/every/scripts/lib/callback_body.js
+++ b/lib/node_modules/@stdlib/ndarray/base/every/scripts/lib/callback_body.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Returns a callback body based on an output data type.
+*
+* @private
+* @param {string} ch1 - one-letter character abbreviation for output data type
+* @returns {string} callback body
+*/
+function callbackBody( ch1 ) {
+	if ( ch1 === 'c' ) {
+		return 'return ( stdlib_complex64_real( x ) == 0.0f && stdlib_complex64_imag( x ) == 0.0f );';
+	}
+	if ( ch1 === 'z' ) {
+		return 'return ( stdlib_complex128_real( x ) == 0.0 && stdlib_complex128_imag( x ) == 0.0 );';
+	}
+	if ( ch1 === 'x' ) {
+		return 'return x;';
+	}
+	if ( ch1 === 'd' ) {
+		return 'return x == 0.0;';
+	}
+	if ( ch1 === 'f' ) {
+		return 'return x == 0.0f;';
+	}
+	return 'return x == 0;';
+}
+
+
+// EXPORTS //
+
+module.exports = callbackBody;

--- a/lib/node_modules/@stdlib/ndarray/base/every/scripts/lib/signatures.js
+++ b/lib/node_modules/@stdlib/ndarray/base/every/scripts/lib/signatures.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var dtypeChar = require( '@stdlib/ndarray/base/dtype-char' );
+var safeCasts = require( '@stdlib/ndarray/safe-casts' );
+var filter = require( './filter.js' );
+var EXCLUDE_DTYPES = require( './exclude_dtypes.js' );
+
+
+// MAIN //
+
+/**
+* Generates a list of loop signatures from a list of data types.
+*
+* @private
+* @param {StringArray} dtypes - list of data types
+* @param {StringArray} specialLoops - list of special loop signatures
+* @returns {StringArray} list of loop signatures
+*/
+function signatures( dtypes, specialLoops ) {
+	var casts;
+	var out;
+	var ch1;
+	var ch2;
+	var t1;
+	var t2;
+	var N;
+	var s;
+	var i;
+	var j;
+
+	N = dtypes.length;
+	out = [];
+	for ( i = 0; i < N; i++ ) {
+		t1 = dtypes[ i ];
+		ch1 = dtypeChar( t1 );
+		s = ch1 + '_x';
+		out.push( s );
+
+		casts = safeCasts( t1 );
+		casts = filter( casts, EXCLUDE_DTYPES );
+
+		for ( j = 0; j < casts.length; j++ ) {
+			t2 = casts[ j ];
+			if ( t2 === t1 ) {
+				continue;
+			}
+			ch2 = dtypeChar( t2 );
+			out.push( s + '_as_' + ch2 + '_x' );
+		}
+	}
+	for ( i = 0; i < specialLoops.length; i++ ) {
+		out.push( specialLoops[ i ] );
+	}
+	return out.sort();
+}
+
+
+// EXPORTS //
+
+module.exports = signatures;

--- a/lib/node_modules/@stdlib/ndarray/base/every/scripts/lib/update_main_header.js
+++ b/lib/node_modules/@stdlib/ndarray/base/every/scripts/lib/update_main_header.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var readFile = require( '@stdlib/fs/read-file' ).sync;
+var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var substringBefore = require( '@stdlib/string/substring-before' );
+var substringAfter = require( '@stdlib/string/substring-after' );
+
+
+// MAIN //
+
+/**
+* Updates the main header file.
+*
+* @private
+* @param {string} mainHeaderPath - path to the main header file
+* @param {Object} fopts - file options
+* @param {StringArray} signatures - list of (sorted) loop signatures
+* @throws {Error} unexpected error
+*/
+function updateMainHeader( mainHeaderPath, fopts, signatures ) {
+	var file;
+	var list;
+	var err;
+	var sig;
+	var ch;
+	var i;
+
+	file = readFile( mainHeaderPath, fopts );
+	if ( file instanceof Error ) {
+		throw file;
+	}
+	list = [];
+	ch = signatures[ 0 ].charAt( 0 );
+	for ( i = 0; i < signatures.length; i++ ) {
+		sig = signatures[ i ];
+		if ( sig.charAt( 0 ) !== ch ) {
+			ch = sig.charAt( 0 );
+			list.push( '' );
+		}
+		list.push( '#include "every/predicate/' + sig + '.h"' );
+	}
+	file = [
+		substringBefore( file, '\n// BEGIN PREDICATE LOOPS' ),
+		'// BEGIN PREDICATE LOOPS',
+		list.join( '\n' ),
+		'// END PREDICATE LOOPS',
+		substringAfter( file, '// END PREDICATE LOOPS\n' )
+	].join( '\n' );
+
+	err = writeFile( mainHeaderPath, file, fopts );
+	if ( err ) {
+		throw err;
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = updateMainHeader;

--- a/lib/node_modules/@stdlib/ndarray/base/every/scripts/lib/update_manifest.js
+++ b/lib/node_modules/@stdlib/ndarray/base/every/scripts/lib/update_manifest.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var readJSON = require( '@stdlib/fs/read-json' ).sync;
+var writeFile = require( '@stdlib/fs/write-file' ).sync;
+
+
+// MAIN //
+
+/**
+* Updates the package manifest.
+*
+* @private
+* @param {string} manifestPath - path to manifest file
+* @param {Object} fopts - file options
+* @param {RegExp} reLoopFile - regular expression to test for a loop file
+* @param {StringArray} signatures - list of (sorted) loop signatures
+* @throws {Error} unexpected error
+*/
+function updateManifest( manifestPath, fopts, reLoopFile, signatures ) {
+	var file;
+	var list;
+	var tmp;
+	var err;
+	var l;
+	var i;
+	var j;
+
+	file = readJSON( manifestPath, fopts );
+	if ( file instanceof Error ) {
+		throw file;
+	}
+	list = [];
+	for ( i = 0; i < signatures.length; i++ ) {
+		list.push( './src/predicate/' + signatures[ i ] + '.c' );
+	}
+	for ( j = 0; j < file.confs.length; j++ ) {
+		l = list.slice();
+		tmp = file.confs[ j ].src;
+		for ( i = 0; i < tmp.length; i++ ) {
+			if ( reLoopFile.test( tmp[ i ] ) === false ) {
+				l.push( tmp[ i ] );
+			}
+		}
+		l.sort();
+		file.confs[ j ].src = l;
+	}
+	err = writeFile( manifestPath, JSON.stringify( file, null, 2 ) + '\n', fopts );
+	if ( err ) {
+		throw err;
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = updateManifest;

--- a/lib/node_modules/@stdlib/ndarray/base/every/scripts/predicate_loops.js
+++ b/lib/node_modules/@stdlib/ndarray/base/every/scripts/predicate_loops.js
@@ -25,27 +25,24 @@
 var path = require( 'path' );
 var logger = require( 'debug' );
 var readFile = require( '@stdlib/fs/read-file' ).sync;
-var readJSON = require( '@stdlib/fs/read-json' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var replace = require( '@stdlib/string/replace' );
-var substringBefore = require( '@stdlib/string/substring-before' );
-var substringAfter = require( '@stdlib/string/substring-after' );
 var uppercase = require( '@stdlib/string/uppercase' );
-var safeCasts = require( '@stdlib/ndarray/safe-casts' );
-var dtypeChar = require( '@stdlib/ndarray/base/dtype-char' );
 var dtype2c = require( '@stdlib/ndarray/base/dtype2c' );
 var char2dtype = require( '@stdlib/ndarray/base/char2dtype' );
 var bytesPerElement = require( '@stdlib/ndarray/base/bytes-per-element' );
 var currentYear = require( '@stdlib/time/current-year' );
 var format = require( '@stdlib/string/format' );
+var updateMainHeader = require( './lib/update_main_header.js' );
 var isComplexChar = require( './lib/is_complex_char.js' );
-var filter = require( './lib/filter.js' );
 var defineStrides = require( './lib/define_strides.js' );
 var defineShapes = require( './lib/define_shapes.js' );
 var defineByteArrays = require( './lib/define_byte_arrays.js' );
 var removeFilesByRegExp = require( './lib/remove_files.js' );
-var EXCLUDE_DTYPES = require( './lib/exclude_dtypes.js' );
 var DTYPES = require( './lib/dtypes.js' );
+var callbackBody = require( './lib/callback_body.js' );
+var signatures = require( './lib/signatures.js' );
+var updateManifest = require( './lib/update_manifest.js' );
 
 
 // VARIABLES //
@@ -123,88 +120,6 @@ var ORDER = 'row-major';
 
 
 // FUNCTIONS //
-
-/**
-* Returns a callback body based on an output data type.
-*
-* @private
-* @param {string} ch1 - one-letter character abbreviation for output data type
-* @returns {string} callback body
-*/
-function callbackBody( ch1 ) {
-	if ( ch1 === 'c' ) {
-		return 'return ( stdlib_complex64_real( x ) == 0.0f && stdlib_complex64_imag( x ) == 0.0f );';
-	}
-	if ( ch1 === 'z' ) {
-		return 'return ( stdlib_complex128_real( x ) == 0.0 && stdlib_complex128_imag( x ) == 0.0 );';
-	}
-	if ( ch1 === 'x' ) {
-		return 'return x;';
-	}
-	if ( ch1 === 'd' ) {
-		return 'return x == 0.0;';
-	}
-	if ( ch1 === 'f' ) {
-		return 'return x == 0.0f;';
-	}
-	return 'return x == 0;';
-}
-
-/**
-* Generates a list of loop signatures from a list of data types.
-*
-* @private
-* @param {StringArray} dtypes - list of data types
-* @returns {StringArray} list of loop signatures
-*/
-function signatures( dtypes ) {
-	var casts;
-	var out;
-	var ch1;
-	var ch2;
-	var t1;
-	var t2;
-	var N;
-	var s;
-	var i;
-	var j;
-
-	N = dtypes.length;
-
-	// Generate the list of signatures:
-	out = [];
-	for ( i = 0; i < N; i++ ) {
-		t1 = dtypes[ i ];
-
-		// Resolve single-letter dtype abbreviation:
-		ch1 = dtypeChar( t1 );
-
-		// Generate the input/output array signature:
-		s = ch1+'_x'; // e.g., d_x
-		out.push( s );
-
-		// Resolve the list of safe casts for the input dtype:
-		casts = safeCasts( t1 );
-
-		// Remove the excluded dtypes:
-		casts = filter( casts, EXCLUDE_DTYPES );
-
-		// Generate signatures for allowed casts:
-		for ( j = 0; j < casts.length; j++ ) {
-			t2 = casts[ j ];
-			if ( t2 === t1 ) {
-				continue;
-			}
-			ch2 = dtypeChar( t2 );
-			out.push( s+'_as_'+ch2+'_x' ); // e.g., `b_x_as_i_x`
-		}
-	}
-	// Append any special loops:
-	for ( i = 0; i < SPECIAL_LOOPS.length; i++ ) {
-		out.push( SPECIAL_LOOPS[ i ] );
-	}
-	return out.sort();
-}
 
 /**
 * Creates a header file for a provided loop signature.
@@ -505,94 +420,6 @@ function updateREADME( signatures ) {
 	}
 }
 
-/**
-* Updates the main header file.
-*
-* @private
-* @param {StringArray} signatures - list of (sorted) loop signatures
-* @throws {Error} unexpected error
-*/
-function updateMainHeader( signatures ) {
-	var file;
-	var list;
-	var err;
-	var sig;
-	var ch;
-	var i;
-
-	file = readFile( INCLUDE_MAIN, FOPTS );
-	if ( file instanceof Error ) {
-		throw file;
-	}
-	list = [];
-	ch = signatures[ 0 ].charAt( 0 );
-	for ( i = 0; i < signatures.length; i++ ) {
-		sig = signatures[ i ];
-		if ( sig.charAt( 0 ) !== ch ) {
-			ch = sig.charAt( 0 );
-			list.push( '' );
-		}
-		list.push( '#include "every/predicate/'+sig+'.h"' );
-	}
-	file = [
-		substringBefore( file, '\n// BEGIN PREDICATE LOOPS' ),
-		'// BEGIN PREDICATE LOOPS',
-		list.join( '\n' ),
-		'// END PREDICATE LOOPS',
-		substringAfter( file, '// END PREDICATE LOOPS\n' )
-	].join( '\n' );
-
-	err = writeFile( INCLUDE_MAIN, file, FOPTS );
-	if ( err ) {
-		throw err;
-	}
-}
-
-/**
-* Updates the package manifest.
-*
-* @private
-* @param {StringArray} signatures - list of (sorted) loop signatures
-* @throws {Error} unexpected error
-*/
-function updateManifest( signatures ) {
-	var file;
-	var list;
-	var tmp;
-	var err;
-	var l;
-	var i;
-	var j;
-
-	file = readJSON( MANIFEST, FOPTS );
-	if ( file instanceof Error ) {
-		throw file;
-	}
-	list = [];
-	for ( i = 0; i < signatures.length; i++ ) {
-		list.push( './src/predicate/'+signatures[ i ]+'.c' );
-	}
-	for ( j = 0; j < file.confs.length; j++ ) {
-		l = list.slice();
-
-		// Copy over non-signature source files...
-		tmp = file.confs[ j ].src;
-		for ( i = 0; i < tmp.length; i++ ) {
-			if ( RE_MANIFEST_LOOP_FILE.test( tmp[ i ] ) === false ) {
-				l.push( tmp[ i ] );
-			}
-		}
-		l.sort();
-
-		// Replace the list of source files:
-		file.confs[ j ].src = l;
-	}
-	err = writeFile( MANIFEST, JSON.stringify( file, null, 2 )+'\n', FOPTS );
-	if ( err ) {
-		throw err;
-	}
-}
-
 
 // MAIN //
 
@@ -608,7 +435,7 @@ function main() {
 	debug( 'Data types: %s', DTYPES.join( ', ' ) );
 
 	// Generate the list of loop signatures:
-	sigs = signatures( DTYPES );
+	sigs = signatures( DTYPES, SPECIAL_LOOPS );
 	debug( 'Signatures: %s', '\n'+sigs.join( '\n' ) );
 
 	// Remove loop files from output directories:
@@ -629,11 +456,11 @@ function main() {
 
 	// Update the main header file to include the loop header files:
 	debug( 'Updating main header file: %s', INCLUDE_MAIN );
-	updateMainHeader( sigs );
+	updateMainHeader( INCLUDE_MAIN, FOPTS, sigs );
 
 	// Update the package manifest to include the loop source files:
 	debug( 'Updating manifest file: %s', MANIFEST );
-	updateManifest( sigs );
+	updateManifest( MANIFEST, FOPTS, RE_MANIFEST_LOOP_FILE, sigs );
 
 	// Update the package README to include the loop interfaces:
 	debug( 'Updating README file: %s', README );


### PR DESCRIPTION
## Description
This PR addresses the `max-lines` linting failure in `predicate_loops.js` reported by the automated JavaScript lint workflow. 

The `predicate_loops.js` file previously exceeded the strict 300-line limit. To resolve this without altering the core logic, I refactored the script by extracting four helper functions into their own files within the `lib/` directory:
* `callbackBody` -> `lib/callback_body.js`
* `signatures` -> `lib/signatures.js`
* `updateManifest` -> `lib/update_manifest.js`
* `updateMainHeader` -> `lib/update_main_header.js`

The main script was updated to `require()` these modules, bringing it comfortably under the maximum line limit. All new files strictly adhere to `stdlib` project conventions, including proper Apache license headers and the required `// MODULES //`, `// MAIN //`, and `// EXPORTS //` block dividers. Unused variables were also removed from the main script.

## Related Issues
resolves #6355

## Checklist
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)