### PR TITLE
fix: incorrect function call to cblas in `blas/base/ddot`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ddot/src/ddot_cblas.c
+++ b/lib/node_modules/@stdlib/blas/base/ddot/src/ddot_cblas.c
@@ -50,5 +50,5 @@ double API_SUFFIX(c_ddot)( const CBLAS_INT N, const double *X, const CBLAS_INT s
 double API_SUFFIX(c_ddot_ndarray)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX, const double *Y, const CBLAS_INT strideY, const CBLAS_INT offsetY ) {
 	X += stdlib_strided_min_view_buffer_index( N, strideX, offsetX ); // adjust array pointer
 	Y += stdlib_strided_min_view_buffer_index( N, strideY, offsetY ); // adjust array pointer
-	return API_SUFFIX(cblas_ddot_ndarray)( N, X, strideX, Y, strideY );
+	return API_SUFFIX(cblas_ddot)( N, X, strideX, Y, strideY );
 }


### PR DESCRIPTION
## Description

After running the build linking `ddot` against `openblas` with the command `node-gyp rebuild -- -Dblas=openblas`, encountered this error:
```bash
node: symbol lookup error: [...]/stdlib/lib/node_modules/@stdlib/blas/base/ddot/src/addon.node: undefined symbol: cblas_ddot_ndarray
```

The function call to cblas should be `cblas_ddot` as revealed by the command below.

```bash
nm -D /usr/lib/x86_64-linux-gnu/libopenblas.so | grep cblas_ddot
0000000000158da0 T cblas_ddot
```

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md