### PR TITLE
chore: fix JavaScript lint errors (issue #10708)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.tostring.js
+++ b/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.tostring.js
@@ -175,7 +175,8 @@ tape( 'a FancyArray constructor returns an instance which has a custom `toString
 	var arr;
 
 	dtype = 'generic';
-	buffer = new Array( 1e4 );
+	buffer = [];
+	buffer.length = 1e4;
 	shape = [ buffer.length ];
 	order = 'row-major';
 	strides = [ 1 ];


### PR DESCRIPTION
Resolves #10708 .

## Description

> What is the purpose of this pull request?

This pull request:

- Replaces the prohibited `new Array()` constructor with an array literal and manual length assignment to satisfy the `stdlib/no-new-array` rule.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   resolves #10708 .

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
