### PR TITLE
chore: fix JavaScript lint errors (issue #10722)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/srotm/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/test/test.ndarray.js
@@ -287,20 +287,20 @@ tape( 'the function applies a plane rotation', function test( t ) {
 
 	srotm( 3, x, 2, 0, y, 2, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		2.0,
 		-24.0, // 1
 		4.0,
 		-30.0  // 2
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		7.0,
 		6.0, // 1
 		9.0,
 		10.0 // 2
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -323,20 +323,20 @@ tape( 'the function applies a plane rotation', function test( t ) {
 
 	srotm( 2, x, 3, 0, y, 3, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		6.0, // 0
 		2.0,
 		3.0,
 		9.0, // 1
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-1.0, // 0
 		7.0,
 		8.0,
 		-4.0, // 1
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -370,20 +370,20 @@ tape( 'the function supports an `x` stride', function test( t ) {
 
 	srotm( 2, x, 2, 0, y, 1, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-17.0, // 0
 		2.0,
 		-18.0, // 1
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		8.0,  // 0
 		13.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -406,20 +406,20 @@ tape( 'the function supports an `x` stride', function test( t ) {
 
 	srotm( 2, x, 3, 0, y, 1, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		2.0,
 		3.0,
 		-21.0, // 1
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		8.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -477,20 +477,20 @@ tape( 'the function supports an `x` offset', function test( t ) {
 
 	srotm( 2, x, -2, 2, y, 1, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-21.0, // 1
 		2.0,
 		-18.0, // 0
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		6.0,  // 0
 		2.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -513,20 +513,20 @@ tape( 'the function supports an `x` offset', function test( t ) {
 
 	srotm( 3, x, -2, 4, y, 1, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		8.0, // 2
 		2.0,
 		7.0, // 1
 		4.0,
 		6.0  // 0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-5.0, // 0
 		-3.0, // 1
 		-1.0, // 2
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -559,20 +559,20 @@ tape( 'the function supports a `y` stride', function test( t ) {
 
 	srotm( 3, x, 1, 0, y, 2, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-17.0, // 0
 		-22.0, // 1
 		-27.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		8.0,  // 0
 		7.0,
 		12.0, // 1
 		9.0,
 		16.0  // 2
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -595,20 +595,20 @@ tape( 'the function supports a `y` stride', function test( t ) {
 
 	srotm( 2, x, 1, 0, y, 3, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		-27.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		7.0,
 		8.0,
 		4.0, // 1
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -666,20 +666,20 @@ tape( 'the function supports a `y` offset', function test( t ) {
 
 	srotm( 2, x, 1, 0, y, -2, 2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		8.0, // 0
 		6.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-2.0, // 1
 		7.0,
 		-1.0, // 0
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -702,20 +702,20 @@ tape( 'the function supports a `y` offset', function test( t ) {
 
 	srotm( 3, x, 1, 0, y, -2, 4, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-30.0, // 0
 		-24.0, // 1
 		-18.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		6.0, // 2
 		7.0,
 		4.0, // 1
 		9.0,
 		2.0  // 0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );


### PR DESCRIPTION
Resolves #10722 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Removed prohibited spaces between opening parentheses and nested array expressions (e.g., `new Float32Array( [ ... ] )` → `new Float32Array([ ... ])`).
- Ensured compliance with `stdlib/eol-open-bracket-spacing` and `stdlib/line-closing-bracket-spacing` rules.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #10722 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
