### PR TITLE
chore: fix JavaScript lint errors (issue #10708)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.tostring.js
+++ b/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.tostring.js
@@ -175,7 +175,8 @@ tape( 'a FancyArray constructor returns an instance which has a custom `toString
 	var arr;
 
 	dtype = 'generic';
-	buffer = new Array( 1e4 );
+	buffer = [];
+	buffer.length = 1e4;
 	shape = [ buffer.length ];
 	order = 'row-major';
 	strides = [ 1 ];


### PR DESCRIPTION
## Description

Fixes the `stdlib/no-new-array` lint error reported in issue #10708 by replacing the `new Array()` constructor with an array literal.

### Changes

- **`lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.tostring.js`** (line 178): Replace `new Array( 1e4 )` with `buffer = []; buffer.length = 1e4;` to create a sparse array without using the `Array` constructor.

### Related Issues

Resolves #10708

---

Co-authored-by: Egger <egger@horny-toad.com>

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)