### PR TITLE
chore: fix JavaScript lint errors (issue #10528)

### DIFF
--- a/lib/node_modules/@stdlib/stats/kstest/test/test.marsaglia.js
+++ b/lib/node_modules/@stdlib/stats/kstest/test/test.marsaglia.js
@@ -43,11 +43,19 @@ tape( 'the function correctly evaluates the CDF of D_n', function test( t ) {
 	var n;
 	var i;
 
-	d = [ 0.3, -0.1, 1.5, 0.5, 0.1, 0.1, 0.05, 0.05, 0.8, 0.274 ]; // eslint-disable-line array-element-newline
-	n = [ 10.0, 10.0, 10.0, 20.0, 10.0, 20.0, 300.0, 80.0, 1.0, 10.0 ]; // eslint-disable-line array-element-newline
+	d = [ 0.3, -0.1, 1.5, 0.5, 0.1, 0.1, 0.05, 0.05, 0.8, 0.274 ];
+	n = [ 10.0, 10.0, 10.0, 20.0, 10.0, 20.0, 300.0, 80.0, 1.0, 10.0 ];
 	expected = [
-		0.7294644, 0.0, 1.0, 0.9999621, 0.0003629,
-		0.0237449, 0.5725584, 0.0175789, 0.6, 0.6284796
+		0.7294644,
+		0.0,
+		1.0,
+		0.9999621,
+		0.0003629,
+		0.0237449,
+		0.5725584,
+		0.0175789,
+		0.6,
+		0.6284796
 	];
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = pKolmogorov( d[ i ], n[ i ] ).toFixed( 7 );

--- a/lib/node_modules/@stdlib/utils/pluck/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/utils/pluck/benchmark/benchmark.js
@@ -37,13 +37,13 @@ bench( pkg, function benchmark( b ) {
 	var i;
 	var j;
 
-	arr = new Array( 100 );
-	for ( i = 0; i < arr.length; i++ ) {
-		tmp = new Array( 5 );
-		for ( j = 0; j < tmp.length; j++ ) {
-			tmp[ j ] = round( randu()*100.0*(j+1.0) );
+	arr = [];
+	for ( i = 0; i < 100; i++ ) {
+		tmp = [];
+		for ( j = 0; j < 5; j++ ) {
+			tmp.push( round( randu()*100.0*(j+1.0) ) );
 		}
-		arr[ i ] = tmp;
+		arr.push( tmp );
 	}
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION
## Description

Fixes the JavaScript lint errors reported in issue #10528.

### Changes

- **`lib/node_modules/@stdlib/stats/kstest/test/test.marsaglia.js`**:
  - Remove unused `eslint-disable-line array-element-newline` directives on lines 46-47
  - Fix `array-element-newline` errors in the `expected` array by placing each element on its own line

- **`lib/node_modules/@stdlib/utils/pluck/benchmark/benchmark.js`**:
  - Replace `new Array( 100 )` and `new Array( 5 )` constructors with array literals and `push()` to satisfy the `stdlib/no-new-array` lint rule

### Related Issues

Resolves #10528

---

Co-authored-by: Egger <egger@horny-toad.com>

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)