### PR TITLE
chore: fix JavaScript lint errors (issue #10722)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/srotm/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/test/test.ndarray.js
@@ -287,20 +287,20 @@ tape( 'the function applies a plane rotation', function test( t ) {
 
 	srotm( 3, x, 2, 0, y, 2, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		2.0,
 		-24.0, // 1
 		4.0,
 		-30.0  // 2
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		7.0,
 		6.0, // 1
 		9.0,
 		10.0 // 2
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -323,20 +323,20 @@ tape( 'the function applies a plane rotation', function test( t ) {
 
 	srotm( 2, x, 3, 0, y, 3, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		6.0, // 0
 		2.0,
 		3.0,
 		9.0, // 1
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-1.0, // 0
 		7.0,
 		8.0,
 		-4.0, // 1
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -370,20 +370,20 @@ tape( 'the function supports an `x` stride', function test( t ) {
 
 	srotm( 2, x, 2, 0, y, 1, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-17.0, // 0
 		2.0,
 		-18.0, // 1
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		8.0,  // 0
 		13.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -406,20 +406,20 @@ tape( 'the function supports an `x` stride', function test( t ) {
 
 	srotm( 2, x, 3, 0, y, 1, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		2.0,
 		3.0,
 		-21.0, // 1
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		8.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -477,20 +477,20 @@ tape( 'the function supports an `x` offset', function test( t ) {
 
 	srotm( 2, x, -2, 2, y, 1, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-21.0, // 1
 		2.0,
 		-18.0, // 0
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		6.0,  // 0
 		2.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -513,20 +513,20 @@ tape( 'the function supports an `x` offset', function test( t ) {
 
 	srotm( 3, x, -2, 4, y, 1, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		8.0, // 2
 		2.0,
 		7.0, // 1
 		4.0,
 		6.0  // 0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-5.0, // 0
 		-3.0, // 1
 		-1.0, // 2
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -559,20 +559,20 @@ tape( 'the function supports a `y` stride', function test( t ) {
 
 	srotm( 3, x, 1, 0, y, 2, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-17.0, // 0
 		-22.0, // 1
 		-27.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		8.0,  // 0
 		7.0,
 		12.0, // 1
 		9.0,
 		16.0  // 2
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -595,20 +595,20 @@ tape( 'the function supports a `y` stride', function test( t ) {
 
 	srotm( 2, x, 1, 0, y, 3, 0, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-18.0, // 0
 		-27.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		2.0, // 0
 		7.0,
 		8.0,
 		4.0, // 1
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -666,20 +666,20 @@ tape( 'the function supports a `y` offset', function test( t ) {
 
 	srotm( 2, x, 1, 0, y, -2, 2, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		8.0, // 0
 		6.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		-2.0, // 1
 		7.0,
 		-1.0, // 0
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -702,20 +702,20 @@ tape( 'the function supports a `y` offset', function test( t ) {
 
 	srotm( 3, x, 1, 0, y, -2, 4, param );
 
-	xe = new Float32Array( [
+	xe = new Float32Array([
 		-30.0, // 0
 		-24.0, // 1
 		-18.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float32Array( [
+	]);
+	ye = new Float32Array([
 		6.0, // 2
 		7.0,
 		4.0, // 1
 		9.0,
 		2.0  // 0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );


### PR DESCRIPTION
## Description

Fixes the 40 bracket spacing lint errors reported in issue #10722.

### Changes

- **`lib/node_modules/@stdlib/blas/base/srotm/test/test.ndarray.js`**: Remove spaces between opening/closing parentheses and nested array expressions in multiline `Float32Array` constructors. Changes `new Float32Array( [\n...\n] );` to `new Float32Array([\n...\n]);` to satisfy the `stdlib/eol-open-bracket-spacing` and `stdlib/line-closing-bracket-spacing` lint rules (20 occurrences, 40 total errors fixed).

### Related Issues

Resolves #10722

---

Co-authored-by: Egger <egger@horny-toad.com>