### PR TITLE
chore: fix JavaScript lint errors (issue #10084)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/asinh-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/asinh-by/test/test.main.js
@@ -74,7 +74,8 @@ tape( 'the function computes the hyperbolic arcsine via a callback function', fu
 	asinhBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -82,7 +83,8 @@ tape( 'the function computes the hyperbolic arcsine via a callback function', fu
 	asinhBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
## Description

Replace `new Array( 5 )` with `x = []; x.length = 5;` in `@stdlib/math/strided/special/asinh-by/test/test.main.js` to satisfy the `stdlib/no-new-array` lint rule. The sparse array behavior is preserved by setting `.length` on an empty array literal.

## Related Issues

Resolves #10084

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

- [X] Yes
- [ ] No

- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

Co-authored-by: Egger <egger@horny-toad.com>