### PR TITLE
chore: fix JavaScript lint errors (issue #9867)

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/path/lib/render/utils/zip.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/path/lib/render/utils/zip.js
@@ -40,9 +40,9 @@ function zip( x, y ) {
 	if ( x.length !== y.length ) {
 		throw new Error( format( 'invalid arguments. Must provide equal length array-like objects. x length: `%u`. y length: `%u`.', x.length, y.length ) );
 	}
-	out = new Array( x.length );
+	out = [];
 	for ( i = 0; i < x.length; i++ ) {
-		out[ i ] = [ x[i], y[i] ];
+		out.push( [ x[i], y[i] ] );
 	}
 	return out;
 }


### PR DESCRIPTION
## Description

Replace `new Array( x.length )` with an empty array literal and `push` in `@stdlib/plot/components/svg/path/lib/render/utils/zip.js` to satisfy the `stdlib/no-new-array` lint rule.

## Related Issues

Resolves #9867

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

- [X] Yes
- [ ] No

- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

Co-authored-by: Egger <egger@horny-toad.com>