### PR TITLE
chore: fix JavaScript lint errors (issue #10017)

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/mskmidrange/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/mskmidrange/benchmark/benchmark.js
@@ -27,7 +27,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
-var mskmidrange = require( './../lib/mskmidrange.js' );
+var mskmidrange = require( './../lib/main.js' );
 
 
 // VARIABLES //


### PR DESCRIPTION
## Description

Fix the require path in `@stdlib/stats/strided/mskmidrange/benchmark/benchmark.js` from `./../lib/mskmidrange.js` (which does not exist) to `./../lib/main.js` to resolve the `stdlib/require-file-extensions` lint error.

## Related Issues

Resolves #10017

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

- [X] Yes
- [ ] No

- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

Co-authored-by: Egger <egger@horny-toad.com>