### PR TITLE
bench: refactor to use dynamic memory allocation in `blas/ext/base/dssumpw`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/c/benchmark.length.c
@@ -96,11 +96,12 @@ static float rand_float( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
+	float *x;
 	double v;
 	double t;
 	int i;
 
+	x = (float *) malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float()*20000.0f ) - 10000.0f;
 	}
@@ -118,6 +119,7 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
@@ -130,11 +132,12 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
+	float *x;
 	double v;
 	double t;
 	int i;
 
+	x = (float *) malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float()*20000.0f ) - 10000.0f;
 	}
@@ -152,6 +155,7 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 


### PR DESCRIPTION
Resolves a part of #8643.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates the benchmark files for `blas/ext/base/dssumpw` to use dynamic memory allocation for large arrays in C benchmarks.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8643

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation
-   [ ] Test/benchmark generation
-   [ ] Documentation
-   [ ] Research and understanding

#### Disclosure

NA

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
