### PR TITLE
Fix-JavaScript-lint-errors-#10801

### DIFF
--- a/lib/node_modules/@stdlib/array/base/cusome-by-right/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/cusome-by-right/lib/main.js
@@ -37,7 +37,7 @@ var assign = require( './assign.js' );
 *
 * @example
 * function fcn( value ) {
-* 	return ( value > 0 );
+*     return ( value > 0 );
 * }
 *
 * var x = [ 1, 1, 0, 0, 0 ];


### PR DESCRIPTION
Resolves #10801.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a JSDoc indentation lint error in `@stdlib/array/base/cusome-by-right` by replacing a tab character with spaces in the `@example` block of `lib/main.js`, resolving the `stdlib/jsdoc-no-tabs` rule violation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #10801

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

Claude Code was used to help identify the lint issue location and verify the fix against the project's code style conventions. The fix itself (replacing tab with spaces) was authored and committed manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
