### PR TITLE
bench: refactor to use string interpolation in blas/ext/base/dapxsumkbn

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dapxsumkbn = require( './../lib/dapxsumkbn.js' );
 
@@ -95,7 +96,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/benchmark/benchmark.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
 
@@ -100,7 +101,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::native:len='+len, opts, f );
+		bench( format( '%s::native:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/benchmark/benchmark.ndarray.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dapxsumkbn = require( './../lib/ndarray.js' );
 
@@ -95,7 +96,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':ndarray:len='+len, f );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/benchmark/benchmark.ndarray.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
 
@@ -100,7 +101,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::native:ndarray:len='+len, opts, f );
+		bench( format( '%s::native:ndarray:len=%d', pkg, len ), opts, f );
 	}
 }
 


### PR DESCRIPTION
Ref: #8647.

## Description

### What is the purpose of this pull request?

This pull request:

- Refactors the JavaScript benchmarks in `@stdlib/blas/ext/base/dapxsumkbn` to use string interpolation (`@stdlib/string/format`) for generating benchmark names instead of string concatenation, as outlined in the tracking issue [#8647](https://github.com/stdlib-js/stdlib/issues/8647).

## Related Issues

Does this pull request have any related issues?

This pull request has the following related issues:

- [#8647](https://github.com/stdlib-js/stdlib/issues/8647)

## Questions

Any questions for reviewers of this pull request?

No.

## Other

Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
