### PR TITLE
bench: refactor to use string interpolation in blas/ext/base/gsort2ins

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.mostly_sorted_few_uniques.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.mostly_sorted_few_uniques.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -125,7 +126,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::mostly_sorted,few_uniques:len='+len, opts, f );
+		bench( format( '%s::mostly_sorted,few_uniques:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.mostly_sorted_few_uniques.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.mostly_sorted_few_uniques.ndarray.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -125,7 +126,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::mostly_sorted,few_uniques:ndarray:len='+len, opts, f );
+		bench( format( '%s::mostly_sorted,few_uniques:ndarray:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.mostly_sorted_random.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.mostly_sorted_random.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -116,7 +117,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::mostly_sorted,random:len='+len, opts, f );
+		bench( format( '%s::mostly_sorted,random:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.mostly_sorted_random.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.mostly_sorted_random.ndarray.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -116,7 +117,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::mostly_sorted,random:ndarray:len='+len, opts, f );
+		bench( format( '%s::mostly_sorted,random:ndarray:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_mostly_sorted_few_uniques.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_mostly_sorted_few_uniques.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -125,7 +126,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::reverse_mostly_sorted,few_uniques:len='+len, opts, f );
+		bench( format( '%s::reverse_mostly_sorted,few_uniques:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_mostly_sorted_few_uniques.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_mostly_sorted_few_uniques.ndarray.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -125,7 +126,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::reverse_mostly_sorted,few_uniques:ndarray:len='+len, opts, f );
+		bench( format( '%s::reverse_mostly_sorted,few_uniques:ndarray:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_mostly_sorted_random.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_mostly_sorted_random.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -116,7 +117,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::reverse_mostly_sorted,random:len='+len, opts, f );
+		bench( format( '%s::reverse_mostly_sorted,random:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_mostly_sorted_random.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_mostly_sorted_random.ndarray.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -116,7 +117,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::reverse_mostly_sorted,random:ndarray:len='+len, opts, f );
+		bench( format( '%s::reverse_mostly_sorted,random:ndarray:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_sorted_few_uniques.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_sorted_few_uniques.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -126,7 +127,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::reverse_sorted,few_uniques:len='+len, opts, f );
+		bench( format( '%s::reverse_sorted,few_uniques:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_sorted_few_uniques.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_sorted_few_uniques.ndarray.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -126,7 +127,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::reverse_sorted,few_uniques:ndarray:len='+len, opts, f );
+		bench( format( '%s::reverse_sorted,few_uniques:ndarray:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_sorted_random.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_sorted_random.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -116,7 +117,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::reverse_sorted,random:len='+len, opts, f );
+		bench( format( '%s::reverse_sorted,random:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_sorted_random.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.rev_sorted_random.ndarray.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -116,7 +117,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::reverse_sorted,random:ndarray:len='+len, opts, f );
+		bench( format( '%s::reverse_sorted,random:ndarray:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.sorted_few_uniques.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.sorted_few_uniques.js
@@ -25,6 +25,7 @@ var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -122,7 +123,7 @@ function main() {
 			'iterations': 1e7 / len
 		};
 		f = createBenchmark( opts.iterations, len );
-		bench( pkg+'::sorted,few_uniques:len='+len, opts, f );
+		bench( format( '%s::sorted,few_uniques:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.sorted_few_uniques.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.sorted_few_uniques.ndarray.js
@@ -25,6 +25,7 @@ var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -122,7 +123,7 @@ function main() {
 			'iterations': 1e7 / len
 		};
 		f = createBenchmark( opts.iterations, len );
-		bench( pkg+'::sorted,few_uniques:ndarray:len='+len, opts, f );
+		bench( format( '%s::sorted,few_uniques:ndarray:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.sorted_random.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.sorted_random.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -111,7 +112,7 @@ function main() {
 			'iterations': 1e7 / len
 		};
 		f = createBenchmark( opts.iterations, len );
-		bench( pkg+'::sorted,random:len='+len, opts, f );
+		bench( format( '%s::sorted,random:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.sorted_random.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.sorted_random.ndarray.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -111,7 +112,7 @@ function main() {
 			'iterations': 1e7 / len
 		};
 		f = createBenchmark( opts.iterations, len );
-		bench( pkg+'::sorted,random:ndarray:len='+len, opts, f );
+		bench( format( '%s::sorted,random:ndarray:len=%d', pkg, len ), opts, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.unsorted_few_uniques.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.unsorted_few_uniques.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -119,7 +120,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::unsorted,few_uniques:len='+len, opts, f );
+		bench( format( '%s::unsorted,few_uniques:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.unsorted_few_uniques.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.unsorted_few_uniques.ndarray.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -119,7 +120,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::unsorted,few_uniques:ndarray:len='+len, opts, f );
+		bench( format( '%s::unsorted,few_uniques:ndarray:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.unsorted_random.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.unsorted_random.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/main.js' );
 
@@ -116,7 +117,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::unsorted,random:len='+len, opts, f );
+		bench( format( '%s::unsorted,random:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.unsorted_random.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/benchmark/benchmark.unsorted_random.ndarray.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsort2ins = require( './../lib/ndarray.js' );
 
@@ -116,7 +117,7 @@ function main() {
 		opts = {
 			'iterations': iter
 		};
-		bench( pkg+'::unsorted,random:ndarray:len='+len, opts, f );
+		bench( format( '%s::unsorted,random:ndarray:len=%d', pkg, len ), opts, f );
 		iter = floor( sqrt( iter ) );
 	}
 }


### PR DESCRIPTION
Ref: #8647.

## Description

### What is the purpose of this pull request?

This pull request:

- Refactors the JavaScript benchmarks in `@stdlib/blas/ext/base/gsort2ins` to use string interpolation (`@stdlib/string/format`) for generating benchmark names instead of string concatenation, as outlined in the tracking issue [#8647](https://github.com/stdlib-js/stdlib/issues/8647).

## Related Issues

Does this pull request have any related issues?

This pull request has the following related issues:

- [#8647](https://github.com/stdlib-js/stdlib/issues/8647)

## Questions

Any questions for reviewers of this pull request?

No.

## Other

Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
