### PR TITLE
bench: refactor to use string interpolation in blas/ext/base/gsumpw

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gsumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumpw/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsumpw = require( './../lib/main.js' );
 
@@ -95,7 +96,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gsumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumpw/benchmark/benchmark.ndarray.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var gsumpw = require( './../lib/ndarray.js' );
 
@@ -95,7 +96,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':ndarray:len='+len, f );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
Ref: #8647.

## Description

### What is the purpose of this pull request?

This pull request:

- Refactors the JavaScript benchmarks in `@stdlib/blas/ext/base/gsumpw` to use string interpolation (`@stdlib/string/format`) for generating benchmark names instead of string concatenation, as outlined in the tracking issue [#8647](https://github.com/stdlib-js/stdlib/issues/8647).

## Related Issues

Does this pull request have any related issues?

This pull request has the following related issues:

- [#8647](https://github.com/stdlib-js/stdlib/issues/8647)

## Questions

Any questions for reviewers of this pull request?

No.

## Other

Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
