### PR TITLE
bench: refactor to use string interpolation in blas/ext/index-of

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/index-of/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/blas/ext/index-of/benchmark/benchmark.assign.js
@@ -26,6 +26,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var zeros = require( '@stdlib/ndarray/zeros' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var indexOf = require( './../lib' );
 
@@ -106,7 +107,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':assign:dtype='+options.dtype+',len='+len, f );
+		bench( format( '%s:assign:dtype=%s,len=%d', pkg, options.dtype, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/index-of/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/index-of/benchmark/benchmark.js
@@ -25,6 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var indexOf = require( './../lib' );
 
@@ -98,7 +99,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':dtype='+options.dtype+',len='+len, f );
+		bench( format( '%s:dtype=%s,len=%d', pkg, options.dtype, len ), f );
 	}
 }
 


### PR DESCRIPTION
Ref: #8647.

## Description

### What is the purpose of this pull request?

This pull request:

- Refactors the JavaScript benchmarks in `@stdlib/blas/ext/index-of` to use string interpolation (`@stdlib/string/format`) for generating benchmark names instead of string concatenation, as outlined in the tracking issue [#8647](https://github.com/stdlib-js/stdlib/issues/8647).

## Related Issues

Does this pull request have any related issues?

This pull request has the following related issues:

- [#8647](https://github.com/stdlib-js/stdlib/issues/8647)

## Questions

Any questions for reviewers of this pull request?

No.

## Other

Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
