### PR TITLE
bench: refactor to use string interpolation in blas/sdot

### DIFF
--- a/lib/node_modules/@stdlib/blas/sdot/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/sdot/benchmark/benchmark.js
@@ -25,6 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var array = require( '@stdlib/ndarray/array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var sdot = require( './../lib/main.js' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::vectors:len='+len, f );
+		bench( format( '%s::vectors:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/sdot/benchmark/benchmark.stack.js
+++ b/lib/node_modules/@stdlib/blas/sdot/benchmark/benchmark.stack.js
@@ -26,6 +26,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var numel = require( '@stdlib/ndarray/base/numel' );
 var array = require( '@stdlib/ndarray/array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var sdot = require( './../lib/main.js' );
 
@@ -111,11 +112,11 @@ function main() {
 
 		shape = [ 2, N/2 ];
 		f = createBenchmark( shape );
-		bench( pkg+'::stacks:size='+N+',ndims='+shape.length+',shape=('+shape.join( ',' )+')', f );
+		bench( format( '%s::stacks:size=%d,ndims=%d,shape=(%s)', pkg, N, shape.length, shape.join( ',' ) ), f );
 
 		shape = [ N/2, 2 ];
 		f = createBenchmark( shape );
-		bench( pkg+'::stacks:size='+N+',ndims='+shape.length+',shape=('+shape.join( ',' )+')', f );
+		bench( format( '%s::stacks:size=%d,ndims=%d,shape=(%s)', pkg, N, shape.length, shape.join( ',' ) ), f );
 	}
 }
 


### PR DESCRIPTION
Ref: #8647.

## Description

### What is the purpose of this pull request?

This pull request:

- Refactors the JavaScript benchmarks in `@stdlib/blas/sdot` to use string interpolation (`@stdlib/string/format`) for generating benchmark names instead of string concatenation, as outlined in the tracking issue [#8647](https://github.com/stdlib-js/stdlib/issues/8647).

## Related Issues

Does this pull request have any related issues?

This pull request has the following related issues:

- [#8647](https://github.com/stdlib-js/stdlib/issues/8647)

## Questions

Any questions for reviewers of this pull request?

No.

## Other

Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
