### PR TITLE
feat: add C implementation for `@stdlib/stats/base/dists/chi/kurtosis`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025, 2026 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2025, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025, 2026 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2025, 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/benchmark.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/benchmark.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025, 2026 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/benchmark.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2025, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/binding.gyp
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/binding.gyp
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2025, 2026 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/binding.gyp
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2025, 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025, 2026 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2025, 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/example.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/example.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025, 2026 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/example.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2025, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include.gypi
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include.gypi
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2025, 2026 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include.gypi
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2025, 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include/stdlib/stats/base/dists/chi/kurtosis.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include/stdlib/stats/base/dists/chi/kurtosis.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include/stdlib/stats/base/dists/chi/kurtosis.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include/stdlib/stats/base/dists/chi/kurtosis.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025, 2026 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include/stdlib/stats/base/dists/chi/kurtosis.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include/stdlib/stats/base/dists/chi/kurtosis.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2025, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/index.js
@@ -35,7 +35,14 @@
 
 // MODULES //
 
-var main = require( './main.js' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var polyfill = require( './main.js' );
+
+
+// VARIABLES //
+
+var kurtosis = tryRequire( require.resolve( './native.js' ) );
+var main = ( kurtosis instanceof Error ) ? polyfill : kurtosis;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025, 2026 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2025, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/package.json
@@ -34,6 +34,7 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
+  "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": ">=0.10.0",

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/package.json
@@ -34,9 +34,7 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "devDependencies": {
-    "proxyquire": "^2.1.3"
-  },
+  "devDependencies": {},
   "engines": {
     "node": ">=0.10.0",
     "npm": ">2.7.0"

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/package.json
@@ -34,8 +34,9 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "proxyquire": "^2.1.3"
+  },
   "engines": {
     "node": ">=0.10.0",
     "npm": ">2.7.0"

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/package.json
@@ -34,7 +34,9 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "proxyquire": "^2.1.3"
+  },
   "engines": {
     "node": ">=0.10.0",
     "npm": ">2.7.0"

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025, 2026 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2025, 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/addon.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/addon.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025, 2026 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/addon.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2025, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/main.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/main.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025, 2026 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/main.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2025, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -82,4 +83,22 @@ tape( 'the function returns the excess kurtosis of a chi distribution', function
 		}
 	}
 	t.end();
+});
+
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', function test( t ) {
+	var kurtosis;
+	var main;
+
+	main = require( './../lib/main.js' );
+
+	kurtosis = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( kurtosis, main, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
+// eslint-disable-next-line node/no-unpublished-require
 var proxyquire = require( 'proxyquire' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018, 2026 The Stdlib Authors.
+* Copyright (c) 2018 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@
 // MODULES //
 
 var tape = require( 'tape' );
-
-// eslint-disable-next-line node/no-unpublished-require
 var proxyquire = require( 'proxyquire' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2018, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
+
 // eslint-disable-next-line node/no-unpublished-require
 var proxyquire = require( 'proxyquire' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var proxyquire = require( 'proxyquire' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -34,9 +33,7 @@ var data = require( './fixtures/julia/data.json' );
 
 // VARIABLES //
 
-var kurtosis = proxyquire( './../lib', {
-	'./native.js': new Error( 'Unable to load addon.' )
-});
+var kurtosis = require( './../lib/main.js' );
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025, 2026 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
@@ -1,0 +1,92 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+
+
+// FIXTURES //
+
+var data = require( './fixtures/julia/data.json' );
+
+
+// VARIABLES //
+
+var kurtosis = proxyquire( './../lib', {
+	'./native.js': new Error( 'Unable to load addon.' )
+});
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof kurtosis, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for `k`, the function returns `NaN`', function test( t ) {
+	var v = kurtosis( NaN );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided a degrees of freedom parameter `k` that is not a positive number, the function returns `NaN`', function test( t ) {
+	var v;
+
+	v = kurtosis( -1.0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = kurtosis( 0.0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = kurtosis( NINF );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the excess kurtosis of a chi distribution', function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var k;
+	var i;
+	var y;
+
+	expected = data.expected;
+	k = data.k;
+	for ( i = 0; i < expected.length; i++ ) {
+		y = kurtosis( k[i] );
+		if ( y === expected[i] ) {
+			t.strictEqual( y, expected[i], 'k:'+k[i]+', y: '+y+', expected: '+expected[i] );
+		} else {
+			delta = abs( y - expected[ i ] );
+			tol = 1e-8 * abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2025, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025, 2026 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2025, 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

This pull request adds a native C implementation for `@stdlib/stats/base/dists/chi/kurtosis`, resolving issue #3491.

The excess kurtosis of a chi distribution with degrees of freedom `k` is:

```
kurtosis = (2 / sigma2) * (1 - mu * sigma * g1 - sigma2)
```

where `mu = mean(k)`, `sigma2 = variance(k)`, `sigma = sqrt(sigma2)`, and `g1 = skewness(k)`.

### Changes

- Adds `src/main.c` implementing the kurtosis formula in C
- Adds `src/addon.c` N-API wrapper using `STDLIB_MATH_BASE_NAPI_MODULE_D_D`
- Adds `include/stdlib/stats/base/dists/chi/kurtosis.h` header
- Adds build files (`binding.gyp`, `include.gypi`, `src/Makefile`)
- Adds `manifest.json` with required C library dependencies (mean, variance, skewness, sqrt, is-nan)
- Updates `lib/index.js` to load native addon with pure-JS fallback
- Adds `lib/native.js` native addon loader
- Adds `test/test.native.js` for native addon testing
- Adds `test/test.main.js` for JS fallback coverage (100% coverage)
- Adds native benchmarks and C examples

## Related Issues

Ref: #3491

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).
