### PR TITLE
chore: fix JavaScript lint errors (issue #10708)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.tostring.js
+++ b/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.tostring.js
@@ -175,7 +175,10 @@ tape( 'a FancyArray constructor returns an instance which has a custom `toString
 	var arr;
 
 	dtype = 'generic';
-	buffer = new Array( 1e4 );
+	buffer = [];
+    for ( var i = 0; i < 1e4; i++ ) {
+         buffer.push( 0 );
+    }
 	shape = [ buffer.length ];
 	order = 'row-major';
 	strides = [ 1 ];


### PR DESCRIPTION
## Description
Replaced `new Array()` constructor with array literal and push, 
as required by the `stdlib/no-new-array` lint rule.

## Related Issues
resolves #10708