### PR TITLE
fix: correct regex flag order in example output

### DIFF
--- a/lib/node_modules/@stdlib/utils/regexp-from-string/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/regexp-from-string/examples/index.js
@@ -27,7 +27,7 @@ console.log( reFromString( '/[A-Z]*/' ) );
 // => /[A-Z]*/
 
 console.log( reFromString( '/\\\\\\\//ig' ) ); // eslint-disable-line no-useless-escape
-// => /\\\//ig
+// => /\\\//gi
 
 console.log( reFromString( '/[A-Z]{0,}/' ) );
 // => /[A-Z]{0,}/


### PR DESCRIPTION
Resolves #10906
## Description

This pull request fixes an incorrect example output in
lib/node_modules/@stdlib/utils/regexp-from-string/examples/index.js.

The example showed:

/\\\//ig

but the expected output is:

/\\\//gi

This change updates the example comment to match the expected doctest output.
- [x] Read, understood, and followed the contributing guidelines