### PR TITLE
fix: remove unused eslint-disable directive

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-negative-zero/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-negative-zero/benchmark/benchmark.js
@@ -16,7 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers, no-undefined, no-empty-function */
 
 'use strict';
 


### PR DESCRIPTION
Resolves #10927

## Description

Removes an unused eslint-disable directive in
lib/node_modules/@stdlib/assert/is-negative-zero/benchmark/benchmark.js.

The directive disabled the `no-new-wrappers` rule, but ESLint reports that
no issues from this rule were present, so the directive is unnecessary.

- [x] Read, understood, and followed the contributing guidelines