### PR TITLE
chore: fix JavaScript lint errors (issue #10927)

### DIFF
--- a/lib/node_modules/@stdlib/utils/regexp-from-string/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/regexp-from-string/examples/index.js
@@ -27,7 +27,7 @@ console.log( reFromString( '/[A-Z]*/' ) );
 // => /[A-Z]*/
 
 console.log( reFromString( '/\\\\\\\//ig' ) ); // eslint-disable-line no-useless-escape
-// => /\\\//ig
+// => /\\\//gi
 
 console.log( reFromString( '/[A-Z]{0,}/' ) );
 // => /[A-Z]{0,}/


### PR DESCRIPTION

Resolves #10927.

## Description

> What is the purpose of this pull request?

This pull request:

-   Corrects the expected output comment in `utils/regexp-from-string` example file from `// => /\\\/ig` to `// => /\\\//gi`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #10927 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
