### PR TITLE
Revert 2 spaces indention to 4 spaces fixes #10850

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/array/lib/copy_view.js
+++ b/lib/node_modules/@stdlib/ndarray/array/lib/copy_view.js
@@ -20,15 +20,7 @@
 
 // MODULES //
 
-var isEqualDataType = require( '@stdlib/ndarray/base/assert/is-equal-data-type' );
-var allocUnsafe = require( '@stdlib/buffer/alloc-unsafe' );
-var bufferCtors = require( '@stdlib/ndarray/base/buffer-ctors' );
-var getShape = require( '@stdlib/ndarray/shape' );
-var getOrder = require( '@stdlib/ndarray/order' );
-var numel = require( '@stdlib/ndarray/base/numel' );
-var shape2strides = require( '@stdlib/ndarray/base/shape2strides' );
-var assign = require( '@stdlib/ndarray/base/assign' );
-var zeros = require( '@stdlib/array/base/zeros' );
+var copy = require( '@stdlib/ndarray/copy' );
 
 
 // MAIN //
@@ -52,35 +44,11 @@ var zeros = require( '@stdlib/array/base/zeros' );
 * var b = copyView( vec, 'float64' );
 * // returns <Float64Array>[ 3.0, 2.0, 1.0 ]
 */
-function copyView( arr, dtype ) { // TODO: consider replacing with `@stdlib/ndarray[/base]/copy` once created
-	var obuf;
-	var ctor;
-	var out;
-	var len;
-	var ord;
-	var sh;
-
-	sh = getShape( arr );
-	ord = getOrder( arr );
-	len = numel( sh );
-	if ( isEqualDataType( dtype, 'generic' ) ) {
-		obuf = zeros( len );
-	} else if ( isEqualDataType( dtype, 'binary' ) ) {
-		obuf = allocUnsafe( len );
-	} else {
-		ctor = bufferCtors( dtype );
-		obuf = new ctor( len );
-	}
-	out = {
-		'dtype': dtype,
-		'data': obuf,
-		'shape': sh,
-		'strides': shape2strides( sh, ord ),
-		'offset': 0,
-		'order': ord
-	};
-	assign( [ arr, out ] );
-	return obuf;
+function copyView( arr, dtype ) {
+	var out = copy( arr, {
+		'dtype': dtype
+	});
+	return out.data;
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dmeanors/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dmeanors/README.md
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,8 +33,8 @@ The [arithmetic mean][arithmetic-mean] is defined as
 ```
 
 <!-- <div class="equation" align="center" data-raw-text="\mu = \frac{1}{n} \sum_{i=0}^{n-1} x_i" data-equation="eq:arithmetic_mean">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@42d8f64d805113ab899c79c7c39d6c6bac7fe25c/lib/node_modules/@stdlib/stats/base/ndarray/mean/docs/img/equation_arithmetic_mean.svg" alt="Equation for the arithmetic mean.">
-    <br>
+        <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@42d8f64d805113ab899c79c7c39d6c6bac7fe25c/lib/node_modules/@stdlib/stats/base/ndarray/mean/docs/img/equation_arithmetic_mean.svg" alt="Equation for the arithmetic mean.">
+        <br>
 </div> -->
 
 <!-- </equation> -->
@@ -68,7 +68,7 @@ var v = dmeanors( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing a one-dimensional input ndarray.
+-     **arrays**: array-like object containing a one-dimensional input ndarray.
 
 </section>
 
@@ -78,8 +78,8 @@ The function has the following parameters:
 
 ## Notes
 
--   If provided an empty one-dimensional ndarray, the function returns `NaN`.
--   Ordinary recursive summation (i.e., a "simple" sum) is performant, but can incur significant numerical error. If performance is paramount and error tolerated, using ordinary recursive summation to compute an arithmetic mean is acceptable; in all other cases, exercise due caution.
+-     If provided an empty one-dimensional ndarray, the function returns `NaN`.
+-     Ordinary recursive summation (i.e., a "simple" sum) is performant, but can incur significant numerical error. If performance is paramount and error tolerated, using ordinary recursive summation to compute an arithmetic mean is acceptable; in all other cases, exercise due caution.
 
 </section>
 
@@ -98,7 +98,7 @@ var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var dmeanors = require( '@stdlib/stats/base/ndarray/dmeanors' );
 
 var xbuf = discreteUniform( 10, -50, 50, {
-    'dtype': 'float64'
+        'dtype': 'float64'
 });
 var x = new ndarray( 'float64', xbuf, [ xbuf.length ], [ 1 ], 0, 'row-major' );
 console.log( ndarray2array( x ) );
@@ -168,7 +168,7 @@ stdlib_ndarray_free( x );
 
 The function accepts the following arguments:
 
--   **arrays**: `[in] struct ndarray**` list containing a one-dimensional input ndarray.
+-     **arrays**: `[in] struct ndarray**` list containing a one-dimensional input ndarray.
 
 ```c
 double stdlib_stats_dmeanors( const struct ndarray *arrays[] );
@@ -204,49 +204,49 @@ double stdlib_stats_dmeanors( const struct ndarray *arrays[] );
 #include <stdio.h>
 
 int main( void ) {
-     // Create a data buffer:
-     const double data[] = { 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0 };
+         // Create a data buffer:
+         const double data[] = { 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0 };
 
-     // Specify the number of array dimensions:
-     const int64_t ndims = 1;
+         // Specify the number of array dimensions:
+         const int64_t ndims = 1;
 
-     // Specify the array shape:
-     int64_t shape[] = { 4 };
+         // Specify the array shape:
+         int64_t shape[] = { 4 };
 
-     // Specify the array strides:
-     int64_t strides[] = { 2*STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
+         // Specify the array strides:
+         int64_t strides[] = { 2*STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
 
-     // Specify the byte offset:
-     const int64_t offset = 0;
+         // Specify the byte offset:
+         const int64_t offset = 0;
 
-     // Specify the array order:
-     const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
+         // Specify the array order:
+         const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
 
-     // Specify the index mode:
-     const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
+         // Specify the index mode:
+         const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
 
-     // Specify the subscript index modes:
-     int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
-     const int64_t nsubmodes = 1;
+         // Specify the subscript index modes:
+         int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+         const int64_t nsubmodes = 1;
 
-     // Create an ndarray:
-     struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)data, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
-     if ( x == NULL ) {
-          fprintf( stderr, "Error allocating memory.\n" );
-          exit( 1 );
-     }
+         // Create an ndarray:
+         struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)data, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+         if ( x == NULL ) {
+                    fprintf( stderr, "Error allocating memory.\n" );
+                    exit( 1 );
+         }
 
-     // Define a list of ndarrays:
-     const struct ndarray *arrays[] = { x };
+         // Define a list of ndarrays:
+         const struct ndarray *arrays[] = { x };
 
-     // Compute the arithmetic mean value:
-     double v = stdlib_stats_dmeanors( arrays );
+         // Compute the arithmetic mean value:
+         double v = stdlib_stats_dmeanors( arrays );
 
-     // Print the result:
-     printf( "mean: %lf\n", v );
+         // Print the result:
+         printf( "mean: %lf\n", v );
 
-     // Free allocated memory:
-     stdlib_ndarray_free( x );
+         // Free allocated memory:
+         stdlib_ndarray_free( x );
 }
 ```
 


### PR DESCRIPTION
Resolves #10850 

## Description

> What is the purpose of this pull request?

This pull request:

-   Reverts all 2 spaces identation to 4 spaces in README.md


## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
