### PR TITLE
fix: replace new Array() with array literal

### DIFF
--- a/lib/node_modules/@stdlib/process/umask/scripts/binary_to_symbolic.js
+++ b/lib/node_modules/@stdlib/process/umask/scripts/binary_to_symbolic.js
@@ -37,7 +37,7 @@ var j;
 TOTAL = 8 * 8 * 8 * 8;
 
 // For each integer value (octal number), determine the symbolic notation equivalent to the value's binary representation...
-masks = new Array( TOTAL );
+masks = [];
 for ( i = 0; i < TOTAL; i++ ) {
 	tmp = '';
 


### PR DESCRIPTION
Resolves #10945

## Description
Replaced the use of the `new Array()` constructor with an array literal
to comply with the `stdlib/no-new-array` lint rule in

lib/node_modules/@stdlib/process/umask/scripts/binary_to_symbolic.js.

- [x] Read, understood, and followed the contributing guidelines