### PR TITLE
docs: fix incorrect return value in C usage section

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/README.md
@@ -173,7 +173,7 @@ Returns the [variance][variance] of a [triangular][triangular-distribution] dist
 
 ```c
 double out = stdlib_base_dists_triangular_variance( 0.0, 1.0, 0.5 );
-// returns ~0.056
+// returns ~0.042
 ```
 
 The function accepts the following arguments:


### PR DESCRIPTION
Resolves NA.

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes an incorrect return value shown in the **C usage example** in `stats/base/dists/triangular/variance/README.md`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md