### PR TITLE
docs: fix C codeblocks in `stats/base/dists/erlang/variance`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/variance/README.md
@@ -171,7 +171,7 @@ logEachMap( 'k: %d, λ: %0.4f, Var(X;k,λ): %0.4f', k, lambda, variance );
 Returns the [variance][variance] of an [Erlang][erlang-distribution] distribution with parameters `k` (shape parameter) and `lambda` (rate parameter).
 
 ```c
-double y = stdlib_base_dists_beta_variance( 1, 1.0 );
+double y = stdlib_base_dists_erlang_variance( 1, 1.0 );
 // returns 1.0
 ```
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed 
  ---

Resolves NA.

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes an incorrect function call in the **C usage example** in `stats/base/dists/erlang/variance/README.md`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md