### PR TITLE
chore: fix C lint errors #10945

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/smskinv/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/math/strided/special/smskinv/benchmark/c/benchmark.length.c
@@ -115,9 +115,9 @@ float rand_uniformf( float a, float b ) {
 */
 static double benchmark( int iterations, int len ) {
 	double elapsed;
-	uint8_t m[ len ];
-	float x[ len ];
-	float y[ len ];
+	uint8_t m[ len ] = { 0 };
+	float x[ len ] = { 0 };
+	float y[ len ] = { 0 };
 	double t;
 	int i;
 


### PR DESCRIPTION
Resolves #10945 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes C lint warnings in `benchmark.length.c` for `@stdlib/math/strided/special/smskinv`.
-   Initializes arrays `x`, `m`, and `y` at declaration to avoid potential use of uninitialized variables reported by cppcheck.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #10945

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
