### PR TITLE
build: add `eslint.flat.config.js` for ESLint v8

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,161 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var globals = require( 'globals' );
+var pluginN = require( 'eslint-plugin-n' );
+var pluginCspell = require( '@cspell/eslint-plugin' );
+var pluginJsdoc = require( 'eslint-plugin-jsdoc' );
+var stdlibPlugin = require( './lib/node_modules/@stdlib/_tools/eslint/rules/scripts/plugin.js' );
+var allRules = require( './etc/eslint/rules' );
+var overrides = require( './etc/eslint/overrides' );
+
+
+// VARIABLES //
+
+var restrictedSyntaxConfig = overrides[ 2 ].rules[ 'no-restricted-syntax' ];
+var nonClonableRules = {};
+var rules = {};
+var val;
+var key;
+var i;
+
+
+// FUNCTIONS //
+
+/**
+* Tests whether a value can be structured-cloned.
+*
+* @private
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating whether the value is clonable
+*/
+function isClonable( value ) {
+	try {
+		// eslint-disable-next-line n/no-unsupported-features/es-builtins
+		if ( typeof structuredClone === 'function' ) {
+			structuredClone( value );
+		}
+		return true;
+	} catch ( e ) {
+		return false;
+	}
+}
+
+
+// MAIN //
+
+// Separate rules containing non-clonable values:
+for ( key in allRules ) {
+	val = allRules[ key ];
+	if ( isClonable( val ) ) {
+		rules[ key ] = val;
+	} else {
+		nonClonableRules[ key ] = val;
+	}
+}
+
+module.exports = [
+	// Global ignores:
+	{
+		'ignores': [
+			'**/build/',
+			'**/reports/',
+			'dist/',
+			'.git*'
+		]
+	},
+
+	// Base JavaScript config:
+	{
+		'files': [ '**/*.js' ],
+		'languageOptions': {
+			'ecmaVersion': 6,
+			'sourceType': 'script',
+			'globals': {
+				...globals.browser,
+				...globals.node,
+				...globals.commonjs,
+				...globals.worker
+			}
+		},
+		'plugins': {
+			'n': pluginN,
+			'jsdoc': pluginJsdoc,
+			'@cspell': pluginCspell,
+			'stdlib': stdlibPlugin
+		},
+		'rules': rules
+	},
+
+	// REPL namespace files:
+	{
+		'files': [ '**/lib/node_modules/@stdlib/**/lib/[a-z].js' ],
+		'rules': {
+			'stdlib/repl-namespace-order': 'error'
+		}
+	},
+
+	// Benchmarks:
+	{
+		'files': [ '**/benchmark/**/*.js' ],
+		'rules': {
+			'no-new-wrappers': 'warn',
+			'max-lines': [ 'warn', {
+				'max': 1000,
+				'skipBlankLines': true,
+				'skipComments': true
+			}],
+			'jsdoc/require-jsdoc': 'off',
+			'no-restricted-syntax': restrictedSyntaxConfig
+		}
+	},
+
+	// Examples:
+	{
+		'files': [ '**/examples/**/*.js' ],
+		'rules': {
+			'no-console': 'off',
+			'vars-on-top': 'off',
+			'jsdoc/require-jsdoc': 'off',
+			'stdlib/jsdoc-private-annotation': 'off',
+			'stdlib/require-order': 'off',
+			'stdlib/require-file-extensions': 'off',
+			'no-restricted-syntax': restrictedSyntaxConfig
+		}
+	},
+
+	// Tests:
+	{
+		'files': [ '**/test/**/*.js' ],
+		'rules': {
+			'no-empty-function': 'off',
+			'jsdoc/require-jsdoc': 'off',
+			'no-undefined': 'off',
+			'max-lines': [ 'warn', {
+				'max': 1000,
+				'skipBlankLines': true,
+				'skipComments': true
+			}],
+			'no-restricted-syntax': restrictedSyntaxConfig
+		}
+	}
+];

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,162 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var globals = require( 'globals' );
+var pluginN = require( 'eslint-plugin-n' );
+var pluginCspell = require( '@cspell/eslint-plugin' );
+var pluginJsdoc = require( 'eslint-plugin-jsdoc' );
+var stdlibPlugin = require( './lib/node_modules/@stdlib/_tools/eslint/rules/scripts/plugin.js' );
+var allRules = require( './etc/eslint/rules' );
+var overrides = require( './etc/eslint/overrides' );
+
+
+// VARIABLES //
+
+var restrictedSyntaxConfig = overrides[ 1 ].rules[ 'no-restricted-syntax' ];
+var nonClonableRules = {};
+var rules = {};
+var val;
+var key;
+var i;
+
+
+// FUNCTIONS //
+
+/**
+* Tests whether a value can be structured-cloned.
+*
+* @private
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating whether the value is clonable
+*/
+function isClonable( value ) {
+	try {
+		// eslint-disable-next-line n/no-unsupported-features/es-builtins
+		if ( typeof structuredClone === 'function' ) {
+			structuredClone( value );
+		}
+		return true;
+	} catch ( e ) {
+		return false;
+	}
+}
+
+
+// MAIN //
+
+// Separate rules that contain non-clonable values (e.g., remark plugin
+// instances) because ESLint flat config internally clones config objects:
+for ( key in allRules ) {
+	val = allRules[ key ];
+	if ( isClonable( val ) ) {
+		rules[ key ] = val;
+	} else {
+		nonClonableRules[ key ] = val;
+	}
+}
+
+module.exports = [
+	// Global ignores:
+	{
+		'ignores': [
+			'**/build/',
+			'**/reports/',
+			'dist/',
+			'.git*'
+		]
+	},
+
+	// Base JavaScript config:
+	{
+		'files': [ '**/*.js' ],
+		'languageOptions': {
+			'ecmaVersion': 6,
+			'sourceType': 'script',
+			'globals': {
+				...globals.browser,
+				...globals.node,
+				...globals.commonjs,
+				...globals.worker
+			}
+		},
+		'plugins': {
+			'n': pluginN,
+			'jsdoc': pluginJsdoc,
+			'@cspell': pluginCspell,
+			'stdlib': stdlibPlugin
+		},
+		'rules': rules
+	},
+
+	// REPL namespace files:
+	{
+		'files': [ '**/lib/node_modules/@stdlib/**/lib/[a-z].js' ],
+		'rules': {
+			'stdlib/repl-namespace-order': 'error'
+		}
+	},
+
+	// Benchmarks:
+	{
+		'files': [ '**/benchmark/**/*.js' ],
+		'rules': {
+			'no-new-wrappers': 'warn',
+			'max-lines': [ 'warn', {
+				'max': 1000,
+				'skipBlankLines': true,
+				'skipComments': true
+			}],
+			'jsdoc/require-jsdoc': 'off',
+			'no-restricted-syntax': restrictedSyntaxConfig
+		}
+	},
+
+	// Examples:
+	{
+		'files': [ '**/examples/**/*.js' ],
+		'rules': {
+			'no-console': 'off',
+			'vars-on-top': 'off',
+			'jsdoc/require-jsdoc': 'off',
+			'stdlib/jsdoc-private-annotation': 'off',
+			'stdlib/require-order': 'off',
+			'stdlib/require-file-extensions': 'off',
+			'no-restricted-syntax': restrictedSyntaxConfig
+		}
+	},
+
+	// Tests:
+	{
+		'files': [ '**/test/**/*.js' ],
+		'rules': {
+			'no-empty-function': 'off',
+			'jsdoc/require-jsdoc': 'off',
+			'no-undefined': 'off',
+			'max-lines': [ 'warn', {
+				'max': 1000,
+				'skipBlankLines': true,
+				'skipComments': true
+			}],
+			'no-restricted-syntax': restrictedSyntaxConfig
+		}
+	}
+];

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -20,12 +20,19 @@
 
 // MODULES //
 
+var path = require( 'path' );
 var globals = require( 'globals' );
+var tsParser = require( '@typescript-eslint/parser' );
+var tsPlugin = require( '@typescript-eslint/eslint-plugin' );
+var stylisticTs = require( '@stylistic/eslint-plugin-ts' );
 var pluginN = require( 'eslint-plugin-n' );
 var pluginCspell = require( '@cspell/eslint-plugin' );
 var pluginJsdoc = require( 'eslint-plugin-jsdoc' );
+var pluginImport = require( 'eslint-plugin-import' );
+var pluginExpectType = require( 'eslint-plugin-expect-type' );
 var stdlibPlugin = require( './lib/node_modules/@stdlib/_tools/eslint/rules/scripts/plugin.js' );
 var allRules = require( './etc/eslint/rules' );
+var tsRules = require( './etc/eslint/rules/typescript.js' );
 var overrides = require( './etc/eslint/overrides' );
 
 
@@ -157,6 +164,39 @@ module.exports = [
 				'skipComments': true
 			}],
 			'no-restricted-syntax': restrictedSyntaxConfig
+		}
+	},
+
+	// TypeScript declarations:
+	{
+		'files': [ '**/*.d.ts' ],
+		'languageOptions': {
+			'parser': tsParser,
+			'sourceType': 'module',
+			'parserOptions': {
+				'project': path.join( __dirname, 'tsconfig.json' )
+			},
+			'globals': {
+				...globals.browser,
+				...globals.node
+			}
+		},
+		'plugins': {
+			'@typescript-eslint': tsPlugin,
+			'@stylistic/ts': stylisticTs,
+			'jsdoc': pluginJsdoc,
+			'import': pluginImport,
+			'expect-type': pluginExpectType,
+			'stdlib': stdlibPlugin
+		},
+		'rules': tsRules
+	},
+
+	// TypeScript test files:
+	{
+		'files': [ '**/test/**/*.ts' ],
+		'rules': {
+			'jsdoc/require-jsdoc': 'off'
 		}
 	}
 ];

--- a/eslint.flat.config.js
+++ b/eslint.flat.config.js
@@ -16,6 +16,8 @@
 * limitations under the License.
 */
 
+/* eslint-disable n/no-unpublished-require */
+
 'use strict';
 
 // MODULES //
@@ -24,56 +26,24 @@ var globals = require( 'globals' );
 var pluginN = require( 'eslint-plugin-n' );
 var pluginCspell = require( '@cspell/eslint-plugin' );
 var pluginJsdoc = require( 'eslint-plugin-jsdoc' );
+var assign = require( './lib/node_modules/@stdlib/object/assign' );
 var stdlibPlugin = require( './lib/node_modules/@stdlib/_tools/eslint/rules/scripts/plugin.js' );
-var allRules = require( './etc/eslint/rules' );
-var overrides = require( './etc/eslint/overrides' );
+var restrictedSyntaxConfig = require( './etc/eslint/overrides/restricted_syntax.js' );
+var rules = require( './etc/eslint/rules' );
 
 
 // VARIABLES //
 
-var restrictedSyntaxConfig = overrides[ 2 ].rules[ 'no-restricted-syntax' ];
-var nonClonableRules = {};
-var rules = {};
-var val;
-var key;
-var i;
-
-
-// FUNCTIONS //
-
-/**
-* Tests whether a value can be structured-cloned.
-*
-* @private
-* @param {*} value - value to test
-* @returns {boolean} boolean indicating whether the value is clonable
-*/
-function isClonable( value ) {
-	try {
-		// eslint-disable-next-line n/no-unsupported-features/es-builtins
-		if ( typeof structuredClone === 'function' ) {
-			structuredClone( value );
-		}
-		return true;
-	} catch ( e ) {
-		return false;
-	}
-}
+var globalVars;
+var config;
 
 
 // MAIN //
 
-// Separate rules containing non-clonable values:
-for ( key in allRules ) {
-	val = allRules[ key ];
-	if ( isClonable( val ) ) {
-		rules[ key ] = val;
-	} else {
-		nonClonableRules[ key ] = val;
-	}
-}
+globalVars = assign( {}, globals.browser, globals.node );
+globalVars = assign( globalVars, globals.commonjs, globals.worker );
 
-module.exports = [
+config = [
 	// Global ignores:
 	{
 		'ignores': [
@@ -90,12 +60,7 @@ module.exports = [
 		'languageOptions': {
 			'ecmaVersion': 6,
 			'sourceType': 'script',
-			'globals': {
-				...globals.browser,
-				...globals.node,
-				...globals.commonjs,
-				...globals.worker
-			}
+			'globals': globalVars
 		},
 		'plugins': {
 			'n': pluginN,
@@ -159,3 +124,8 @@ module.exports = [
 		}
 	}
 ];
+
+
+// EXPORTS //
+
+module.exports = config;

--- a/etc/eslint/overrides/index.js
+++ b/etc/eslint/overrides/index.js
@@ -21,48 +21,7 @@
 // MODULES //
 
 var resolve = require( 'path' ).resolve;
-
-
-// VARIABLES //
-
-var restrictedSyntaxConfig = [ 'error',
-	'ArrowFunctionExpression',
-	'ClassBody',
-	'ClassDeclaration',
-	'ClassExpression',
-	'DebuggerStatement',
-	'ExperimentalRestProperty',
-	'ExperimentalSpreadProperty',
-
-	// 'FunctionExpression',
-	'LabeledStatement',
-	'RestElement',
-	'SpreadElement',
-	'TaggedTemplateExpression',
-	'TemplateElement',
-	'TemplateLiteral',
-	'WithStatement',
-	'YieldExpression',
-	'JSXIdentifier',
-	'JSXNamespacedName',
-	'JSXMemberExpression',
-	'JSXEmptyExpression',
-	'JSXExpressionContainer',
-	'JSXElement',
-	'JSXClosingElement',
-	'JSXOpeningElement',
-	'JSXAttribute',
-	'JSXSpreadAttribute',
-	'JSXText',
-	'ExportDefaultDeclaration',
-	'ExportNamedDeclaration',
-	'ExportAllDeclaration',
-	'ExportSpecifier',
-	'ImportDeclaration',
-	'ImportSpecifier',
-	'ImportDefaultSpecifier',
-	'ImportNamespaceSpecifier'
-];
+var restrictedSyntaxConfig = require( './restricted_syntax.js' );
 
 
 // MAIN //

--- a/etc/eslint/overrides/restricted_syntax.js
+++ b/etc/eslint/overrides/restricted_syntax.js
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+var rule = [ 'error',
+	'ArrowFunctionExpression',
+	'ClassBody',
+	'ClassDeclaration',
+	'ClassExpression',
+	'DebuggerStatement',
+	'ExperimentalRestProperty',
+	'ExperimentalSpreadProperty',
+
+	// 'FunctionExpression',
+	'LabeledStatement',
+	'RestElement',
+	'SpreadElement',
+	'TaggedTemplateExpression',
+	'TemplateElement',
+	'TemplateLiteral',
+	'WithStatement',
+	'YieldExpression',
+	'JSXIdentifier',
+	'JSXNamespacedName',
+	'JSXMemberExpression',
+	'JSXEmptyExpression',
+	'JSXExpressionContainer',
+	'JSXElement',
+	'JSXClosingElement',
+	'JSXOpeningElement',
+	'JSXAttribute',
+	'JSXSpreadAttribute',
+	'JSXText',
+	'ExportDefaultDeclaration',
+	'ExportNamedDeclaration',
+	'ExportAllDeclaration',
+	'ExportSpecifier',
+	'ImportDeclaration',
+	'ImportSpecifier',
+	'ImportDefaultSpecifier',
+	'ImportNamespaceSpecifier'
+];
+
+
+// EXPORTS //
+
+module.exports = rule;

--- a/etc/eslint/rules/stdlib.js
+++ b/etc/eslint/rules/stdlib.js
@@ -1,4 +1,4 @@
-/* eslint-disable stdlib/jsdoc-doctest-marker, stdlib/jsdoc-doctest, stdlib/jsdoc-example-require-spacing, stdlib/jsdoc-no-tabs */
+/* eslint-disable stdlib/jsdoc-doctest-marker, stdlib/jsdoc-example-require-spacing, stdlib/jsdoc-no-tabs */
 
 /**
 * @license Apache-2.0
@@ -1720,7 +1720,7 @@ rules[ 'stdlib/jsdoc-list-item-spacing' ] = 'error';
 */
 rules[ 'stdlib/jsdoc-markdown-remark' ] = [ 'error',
 	{
-		'config': require( './../../remark/.remarkrc.jsdoc.js' )
+		'configPath': require.resolve( './../../remark/.remarkrc.jsdoc.js' )
 	}
 ];
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/README.md
@@ -40,8 +40,6 @@ var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-markdown-remark' );
 
 [ESLint rule][eslint-rules] to enforce that JSDoc descriptions are valid Markdown (using [remark][remark]). To configure the [remark][remark] processor to lint Markdown, set the `config` option with the lint configuration when enabling the [ESLint rule][eslint-rules].
 
-To keep rule options serializable (e.g., when using an ESLint flat config), set the `configPath` option to an absolute path for a CommonJS module which exports a remark configuration.
-
 **Bad**:
 
 <!-- eslint-disable stdlib/jsdoc-markdown-remark, stdlib/jsdoc-code-block-style -->
@@ -85,6 +83,16 @@ function beep() {
 </section>
 
 <!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   To keep rule options serializable (e.g., when using an ESLint flat config), set the `configPath` option to an absolute path for a CommonJS module which exports a remark configuration.
+
+</section>
+
+<!-- /.notes -->
 
 <section class="examples">
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/README.md
@@ -40,6 +40,8 @@ var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-markdown-remark' );
 
 [ESLint rule][eslint-rules] to enforce that JSDoc descriptions are valid Markdown (using [remark][remark]). To configure the [remark][remark] processor to lint Markdown, set the `config` option with the lint configuration when enabling the [ESLint rule][eslint-rules].
 
+To keep rule options serializable (e.g., when using an ESLint flat config), set the `configPath` option to an absolute path for a CommonJS module which exports a remark configuration.
+
 **Bad**:
 
 <!-- eslint-disable stdlib/jsdoc-markdown-remark, stdlib/jsdoc-code-block-style -->

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/README.md
@@ -107,12 +107,9 @@ var noDuplicateHeadings = require( 'remark-lint-no-duplicate-headings' );
 var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-markdown-remark' );
 
 var linter = new Linter();
-var config;
-var result;
-var code;
 
 // Generate our source code containing a single lint error (a duplicate heading):
-code = [
+var code = [
     '/**',
     '* Beep boop.',
     '*',
@@ -160,7 +157,7 @@ code = [
 ].join( '\n' );
 
 // Create a remark configuration:
-config = {
+var config = {
     'plugins': [
         [ remarkLint ],
         [ noDuplicateHeadings, [ 'error' ] ]
@@ -171,7 +168,7 @@ config = {
 linter.defineRule( 'jsdoc-markdown-remark', rule );
 
 // Lint the code:
-result = linter.verify( code, {
+var result = linter.verify( code, {
     'rules': {
         'jsdoc-markdown-remark': [ 'error', {
             'config': config

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/lib/main.js
@@ -46,18 +46,19 @@ var rule;
 */
 function main( context ) {
 	var options;
+	var config;
 	var source;
 	var lint;
-	var opts;
 
 	options = context.options[ 0 ];
-	opts = {};
-	if ( hasOwnProp( options, 'config' ) ) {
-		opts.config = options.config;
+	if ( hasOwnProp( options, 'configPath' ) ) {
+		config = require( options.configPath ); // eslint-disable-line stdlib/no-dynamic-require
+	} else if ( hasOwnProp( options, 'config' ) ) {
+		config = options.config;
 	} else {
-		opts.config = {};
+		config = {};
 	}
-	lint = remark().use( opts.config ).processSync;
+	lint = remark().use( config ).processSync;
 	source = context.sourceCode;
 
 	return {
@@ -151,6 +152,9 @@ rule = {
 				'properties': {
 					'config': {
 						'type': 'object'
+					},
+					'configPath': {
+						'type': 'string'
 					}
 				},
 				'additionalProperties': false

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/test/fixtures/invalid.js
@@ -23,20 +23,12 @@
 var config = require( './config.js' );
 
 
-// VARIABLES //
-
-var errors;
-var invalid;
-var test;
-var code;
-
-
 // MAIN //
 
 // Create our test cases:
-invalid = [];
+var invalid = [];
 
-code = [
+var code = [
 	'/**',
 	'* Beep boop.',
 	'*',
@@ -48,14 +40,14 @@ code = [
 	'    console.log( "boop" );',
 	'}'
 ].join( '\n' );
-errors = [
+var errors = [
 	{
 		'message': '5:1-5:8  error    Do not use headings with similar content (3:1)  no-duplicate-headings  remark-lint',
 		'type': null
 	}
 ];
 
-test = {
+var test = {
 	'code': code,
 	'options': [
 		{

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-markdown-remark/test/fixtures/invalid.js
@@ -25,8 +25,10 @@ var config = require( './config.js' );
 
 // VARIABLES //
 
+var errors;
 var invalid;
 var test;
+var code;
 
 
 // MAIN //
@@ -34,30 +36,44 @@ var test;
 // Create our test cases:
 invalid = [];
 
+code = [
+	'/**',
+	'* Beep boop.',
+	'*',
+	'* ## Beep',
+	'*',
+	'* ## Beep',
+	'*/',
+	'function beep() {',
+	'    console.log( "boop" );',
+	'}'
+].join( '\n' );
+errors = [
+	{
+		'message': '5:1-5:8  error    Do not use headings with similar content (3:1)  no-duplicate-headings  remark-lint',
+		'type': null
+	}
+];
+
 test = {
-	'code': [
-		'/**',
-		'* Beep boop.',
-		'*',
-		'* ## Beep',
-		'*',
-		'* ## Beep',
-		'*/',
-		'function beep() {',
-		'    console.log( "boop" );',
-		'}'
-	].join( '\n' ),
+	'code': code,
 	'options': [
 		{
 			'config': config
 		}
 	],
-	'errors': [
+	'errors': errors
+};
+invalid.push( test );
+
+test = {
+	'code': code,
+	'options': [
 		{
-			'message': '5:1-5:8  error    Do not use headings with similar content (3:1)  no-duplicate-headings  remark-lint',
-			'type': null
+			'configPath': require.resolve( './config.js' )
 		}
-	]
+	],
+	'errors': errors
 };
 invalid.push( test );
 

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jsdoc": "^46.8.2",
     "eslint-plugin-stdlib": "file:./etc/eslint/plugin",
+    "globals": "^16.1.0",
     "exorcist": "^2.0.0",
     "factor-bundle": "^2.5.0",
     "gh-pages": "git+https://github.com/Planeshifter/gh-pages.git#main",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "eslint-plugin-expect-type": "^0.2.3",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jsdoc": "^46.8.2",
+    "globals": "^16.1.0",
     "exorcist": "^2.0.0",
     "factor-bundle": "^2.5.0",
     "gh-pages": "git+https://github.com/Planeshifter/gh-pages.git#main",


### PR DESCRIPTION
Progresses https://github.com/stdlib-js/metr-issue-tracker/issues/54.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds `eslint.config.cjs` flat config alongside the legacy `.eslintrc.*` configuration
-   Inlines stdlib rules as a runtime plugin object via `lib/node_modules/@stdlib/_tools/eslint/rules/scripts/plugin.js`.
-   Reuses existing rule definitions from `etc/eslint/rules/`.
-   Separates non-clonable rule options (remark plugin instances) from the main rules object to work around `structuredClone` limitations in ESLint's flat config internals.
-   Adds `globals` package for flat config environment definitions.
-   Legacy `.eslintrc.*` files remain in place as the default workflow.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   https://github.com/stdlib-js/metr-issue-tracker/issues/54

## Questions

> Any questions for reviewers of this pull request?

Files under `lib/node_modules/` are hard-ignored by ESLint v8 flat config (`**/node_modules/**` is always ignored). Full `lib/` linting via flat config requires ESLint v9, which allows `!**/node_modules/` ignore overrides. This is expected and will be resolved in PR 11.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Stacked on #10966. Usage: `ESLINT_USE_FLAT_CONFIG=true npx eslint -c eslint.config.cjs <file>`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md