### PR TITLE
bench: refactor to use string interpolation in @stdlib/stats/base/dists/discrete-uniform/mean

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/benchmark/benchmark.js
@@ -31,11 +31,11 @@ var mean = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
-	var min;
-	var max;
 	var len;
-	var y;
+	var max;
+	var min;
 	var i;
+	var y;
 
 	len = 100;
 	min = new Float64Array( len );

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/benchmark/benchmark.native.js
@@ -21,11 +21,12 @@
 // MODULES //
 
 var resolve = require( 'path' ).resolve;
-var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
+var bench = require( '@stdlib/bench' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -39,12 +40,12 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
-	var min;
-	var max;
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var len;
-	var y;
+	var max;
+	var min;
 	var i;
+	var y;
 
 	len = 100;
 	min = new Float64Array( len );


### PR DESCRIPTION
## Description

This PR refactors the benchmark files to use string interpolation for benchmark names and corrects the variable sorting order in the main loop to follow the convention `len, max, min, i, y`.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md) document.
- [x] I have followed the prevailing [coding style](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md#style-guide).
- [x] I have confirmed that the [changes are correct](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md#testing).