### PR TITLE
bench: refactor to use string interpolation in @stdlib/stats/base/dists/discrete-uniform/kurtosis

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/benchmark/benchmark.js
@@ -20,12 +20,12 @@
 
 // MODULES //
 
-var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
+var kurtosis = require( './../lib' );
+var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
-var kurtosis = require( './../lib' );
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/benchmark/benchmark.native.js
@@ -20,12 +20,13 @@
 
 // MODULES //
 
-var resolve = require( 'path' ).resolve;
-var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var resolve = require( 'path' ).resolve;
+var format = require( '@stdlib/string/format' );
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -39,7 +40,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var min;
 	var max;
 	var len;


### PR DESCRIPTION
## Description

This PR refactors the benchmark files to use string interpolation for benchmark names and corrects the variable sorting order in the main loop to follow the convention `len, max, min, i, y`.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md) document.
- [x] I have followed the prevailing [coding style](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md#style-guide).
- [x] I have confirmed that the [changes are correct](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md#testing).