### PR TITLE
chore: address commit comments for commit f63b6ef

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/pmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/pmf/README.md
@@ -55,7 +55,7 @@ var pmf = require( '@stdlib/stats/base/dists/poisson/pmf' );
 
 #### pmf( x, lambda )
 
-Evaluates the [probability mass function][pmf] (PMF) of a [Poisson][poisson-distribution] distribution with mean parameter `lambda` at value `x`.
+Evaluates the [probability mass function][pmf] (PMF) of a [Poisson][poisson-distribution] distribution with mean parameter `lambda`.
 
 ```javascript
 var y = pmf( 4.0, 3.0 );
@@ -168,7 +168,7 @@ logEachMap( 'x: %d, λ: %0.4f, P(X=x;λ): %0.4f', x, lambda, pmf );
 
 #### stdlib_base_dists_poisson_pmf( x, lambda )
 
-Evaluates the [probability mass function][pmf] (PMF) of a [Poisson][poisson-distribution] distribution with mean parameter `lambda` at value `x`.
+Evaluates the [probability mass function][pmf] (PMF) of a [Poisson][poisson-distribution] distribution with mean parameter `lambda`.
 
 ```c
 double out = stdlib_base_dists_poisson_pmf( 4.0, 3.0 );


### PR DESCRIPTION
Resolves #10979.

## Description

> What is the purpose of this pull request?

This pull request:

- Addresses commit comments for commit `f63b6ef`.
- Removes the redundant phrase **"at value x"** from the Poisson PMF README documentation in the C API section to improve clarity and wording.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #10979

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The change only affects documentation (`README.md`) and does not modify any implementation or functionality.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

I consulted ChatGPT to better understand the repository structure and confirm the wording change, but the documentation edit itself was performed manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md