### PR TITLE
feat: add `ndarray/base/scalar-dtype`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/atleastnd/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/atleastnd/lib/main.js
@@ -21,10 +21,6 @@
 // MODULES //
 
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
-var isComplexLike = require( '@stdlib/assert/is-complex-like' );
-var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
-var complexDataType = require( '@stdlib/complex/dtype' );
 var broadcastScalar = require( '@stdlib/ndarray/base/broadcast-scalar' );
 var dims = require( '@stdlib/ndarray/base/ndims' );
 var defaults = require( '@stdlib/ndarray/defaults' );
@@ -34,15 +30,13 @@ var getStrides = require( '@stdlib/ndarray/base/strides' );
 var getOffset = require( '@stdlib/ndarray/base/offset' );
 var getOrder = require( '@stdlib/ndarray/base/order' );
 var getDType = require( '@stdlib/ndarray/base/dtype' );
+var scalarDType = require( '@stdlib/ndarray/base/scalar-dtype' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
 var ones = require( '@stdlib/array/base/ones' );
 
 
 // VARIABLES //
 
-var DEFAULT_REAL = defaults.get( 'dtypes.real_floating_point' );
-var DEFAULT_CMPLX = defaults.get( 'dtypes.complex_floating_point' );
-var DEFAULT_BOOL = defaults.get( 'dtypes.boolean' );
 var ORDER = defaults.get( 'order' );
 
 
@@ -108,18 +102,7 @@ function atleastnd( ndims, arrays ) {
 			continue;
 		}
 		// For scalar values, resolve a corresponding ndarray data type...
-		if ( isNumber( v ) ) { // TODO: consider abstracting this logic to an `ndarray/base/scalar-dtype` (???) package, as this logic is found elsewhere (e.g., `ndarray/from-scalar`) and it would be good to avoid duplication, especially as we add support for more ndarray data types
-			dt = DEFAULT_REAL;
-		} else if ( isBoolean( v ) ) {
-			dt = DEFAULT_BOOL;
-		} else if ( isComplexLike( v ) ) {
-			dt = complexDataType( v );
-			if ( dt === null ) {
-				dt = DEFAULT_CMPLX;
-			}
-		} else {
-			dt = 'generic';
-		}
+		dt = scalarDType(v);
 		out.push( broadcastScalar( v, dt, ones( ndims ), ORDER ) );
 	}
 	return out;

--- a/lib/node_modules/@stdlib/ndarray/base/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/lib/index.js
@@ -1085,6 +1085,15 @@ setReadOnly( ns, 'reverse', require( '@stdlib/ndarray/base/reverse' ) );
 setReadOnly( ns, 'reverseDimension', require( '@stdlib/ndarray/base/reverse-dimension' ) );
 
 /**
+* @name scalarDType
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/ndarray/base/scalar-dtype}
+*/
+setReadOnly( ns, 'scalarDType', require( '@stdlib/ndarray/base/scalar-dtype' ) );
+
+/**
 * @name serializeMetaData
 * @memberof ns
 * @readonly

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/README.md
@@ -1,0 +1,147 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# scalar-dtype
+
+> Return the default [ndarray][@stdlib/ndarray/base/ctor] data type for a given scalar value.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var scalarDType = require( '@stdlib/ndarray/base/scalar-dtype' );
+```
+
+#### scalarDType( value )
+
+Returns the default [ndarray][@stdlib/ndarray/base/ctor] data type for a given scalar value.
+
+```javascript
+var dt = scalarDType( 3.14 );
+// returns 'float64'
+
+dt = scalarDType( true );
+// returns 'bool'
+
+dt = scalarDType( 'hello' );
+// returns 'generic'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+If the `value`
+
+-   is a number, returns the default real-valued floating-point data type.
+-   is a boolean, returns the default boolean data type.
+-   is a complex number object of a known complex data type, returns the data type.
+-   is a complex number object of an unknown complex data type, returns the default complex-valued floating-point data type.
+-   is any other value type, returns `'generic'`.
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var Complex128 = require( '@stdlib/complex/float64/ctor' );
+var scalarDType = require( '@stdlib/ndarray/base/scalar-dtype' );
+
+// Number:
+var dt = scalarDType( 3.14 );
+console.log( dt );
+// => 'float64'
+
+// Boolean:
+dt = scalarDType( true );
+console.log( dt );
+// => 'bool'
+
+// Known complex dtype (complex64):
+dt = scalarDType( new Complex64( 1.0, 2.0 ) );
+console.log( dt );
+// => 'complex64'
+
+// Known complex dtype (complex128):
+dt = scalarDType( new Complex128( 1.0, 2.0 ) );
+console.log( dt );
+// => 'complex128'
+
+// Generic fallback:
+dt = scalarDType( 'hello' );
+console.log( dt );
+// => 'generic'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/ndarray/base/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/base/ctor
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/benchmark/benchmark.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var pkg = require( './../package.json' ).name;
+var scalarDType = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var dt;
+	var i;
+
+	values = [
+		3.14,
+		true,
+		new Complex64( 1.0, 2.0 ),
+		'hello'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		dt = scalarDType( values[ i%values.length ] );
+		if ( typeof dt !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( typeof dt !== 'string' ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/docs/repl.txt
@@ -1,0 +1,22 @@
+
+{{alias}}( value )
+    Returns the default ndarray data type for a given scalar value.
+
+    Parameters
+    ----------
+    value: scalar
+        Input scalar.
+
+    Returns
+    -------
+    dt: string
+        ndarray data type.
+
+    Examples
+    --------
+    > var dt = {{alias}}( 3.14 )
+    'float64'
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/docs/types/index.d.ts
@@ -1,0 +1,46 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* Returns the number of ndarray dimensions.
+*
+* @param value - input scalar
+* @returns ndarray data type
+*
+* @example
+* var dt = scalarDType( 3.14 );
+* // returns 'float64'
+*
+* @example
+* var dt = scalarDType( true );
+* // returns 'bool'
+*
+* @example
+* var dt = scalarDType( 'hello' );
+* // returns 'generic'
+*/
+declare function scalarDType( value: any ): string;
+
+
+// EXPORTS //
+
+export = scalarDType;

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/docs/types/test.ts
@@ -1,0 +1,40 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Complex64 = require( '@stdlib/complex/float32/ctor' );
+import Complex128 = require( '@stdlib/complex/float64/ctor' );
+import scalarDType = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	scalarDType( 3.14 ); // $ExpectType string
+	scalarDType( true ); // $ExpectType string
+	scalarDType( new Complex64( 1.0, 2.0 ) ); // $ExpectType string
+	scalarDType( new Complex128( 1.0, 2.0 ) ); // $ExpectType string
+	scalarDType( 'hello' ); // $ExpectType string
+}
+
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	scalarDType(); // $ExpectError
+	scalarDType( 3.14, {} ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/examples/index.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var Complex128 = require( '@stdlib/complex/float64/ctor' );
+var scalarDType = require( './../lib' );
+
+var dt;
+
+// Number:
+dt = scalarDType( 3.14 );
+console.log( dt );
+// => 'float64'
+
+// Boolean:
+dt = scalarDType( true );
+console.log( dt );
+// => 'bool'
+
+// Known complex dtype (complex64):
+dt = scalarDType( new Complex64( 1.0, 2.0 ) );
+console.log( dt );
+// => 'complex64'
+
+// Known complex dtype (complex128):
+dt = scalarDType( new Complex128( 1.0, 2.0 ) );
+console.log( dt );
+// => 'complex128'
+
+// Generic fallback:
+dt = scalarDType( 'hello' );
+console.log( dt );
+// => 'generic'

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return the default ndarray data type for a given scalar value.
+*
+* @module @stdlib/ndarray/base/scalar-dtype
+*
+* @example
+* var scalarDType = require( '@stdlib/ndarray/base/scalar-dtype' );
+*
+* var dt = scalarDType( 3.14 );
+* // returns 'float64'
+*
+* dt = scalarDType( true );
+* // returns 'bool'
+*
+* dt = scalarDType( 'hello' );
+* // returns 'generic'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/lib/main.js
@@ -1,0 +1,86 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var isComplexLike = require( '@stdlib/assert/is-complex-like' );
+var complexDType = require( '@stdlib/complex/dtype' );
+var defaults = require( '@stdlib/ndarray/defaults' );
+
+
+// VARIABLES //
+
+var DEFAULT_REAL = defaults.get( 'dtypes.real_floating_point' );
+var DEFAULT_CMPLX = defaults.get( 'dtypes.complex_floating_point' );
+var DEFAULT_BOOL = defaults.get( 'dtypes.boolean' );
+
+
+// MAIN //
+
+/**
+* Returns the default ndarray data type for a given scalar value.
+*
+* ## Notes
+*
+* -   If the `value`
+*
+*     -   is a number, returns the default real-valued floating-point data type.
+*     -   is a boolean, returns the default boolean data type.
+*     -   is a complex number object of a known complex data type, returns the data type.
+*     -   is a complex number object of an unknown complex data type, returns the default complex-valued floating-point data type.
+*     -   is any other value type, returns `'generic'`.
+*
+* @param {*} value - input scalar
+* @returns {string} ndarray data type
+*
+* @example
+* var dt = scalarDType( 3.14 );
+* // returns 'float64'
+*
+* @example
+* var dt = scalarDType( true );
+* // returns 'bool'
+*
+* @example
+* var dt = scalarDType( 'hello' );
+* // returns 'generic'
+*/
+function scalarDType( value ) {
+	var dt;
+
+	if ( isNumber( value ) ) {
+		return DEFAULT_REAL;
+	}
+	if ( isBoolean( value ) ) {
+		return DEFAULT_BOOL;
+	}
+	if ( isComplexLike( value ) ) {
+		dt = complexDType( value );
+		return ( dt === null ) ? DEFAULT_CMPLX : dt;
+	}
+	return 'generic';
+}
+
+
+// EXPORTS //
+
+module.exports = scalarDType;

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/package.json
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/package.json
@@ -31,8 +31,19 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "@stdlib/assert/is-boolean": "^0.0.0",
+    "@stdlib/assert/is-complex-like": "^0.0.0",
+    "@stdlib/assert/is-number": "^0.0.0",
+    "@stdlib/complex/dtype": "^0.0.0",
+    "@stdlib/ndarray/defaults": "^0.0.0"
+  },
+  "devDependencies": {
+    "@stdlib/bench": "^0.0.0",
+    "@stdlib/complex/float32/ctor": "^0.0.0",
+    "@stdlib/complex/float64/ctor": "^0.0.0",
+    "@stdlib/ndarray/zeros": "^0.0.0"
+  },
   "engines": {
     "node": ">=0.10.0",
     "npm": ">2.7.0"

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/package.json
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@stdlib/ndarray/base/scalar-dtype",
+  "version": "0.0.0",
+  "description": "Return the default ndarray data type for a given scalar value.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "types",
+    "base",
+    "ndarray",
+    "dtype",
+    "data type",
+    "scalar",
+    "default",
+    "number",
+    "boolean",
+    "complex",
+    "generic",
+    "utilities",
+    "utility",
+    "utils",
+    "util"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/package.json
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/package.json
@@ -31,19 +31,8 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "dependencies": {
-    "@stdlib/assert/is-boolean": "^0.0.0",
-    "@stdlib/assert/is-complex-like": "^0.0.0",
-    "@stdlib/assert/is-number": "^0.0.0",
-    "@stdlib/complex/dtype": "^0.0.0",
-    "@stdlib/ndarray/defaults": "^0.0.0"
-  },
-  "devDependencies": {
-    "@stdlib/bench": "^0.0.0",
-    "@stdlib/complex/float32/ctor": "^0.0.0",
-    "@stdlib/complex/float64/ctor": "^0.0.0",
-    "@stdlib/ndarray/zeros": "^0.0.0"
-  },
+  "dependencies": {},
+  "devDependencies": {},
   "engines": {
     "node": ">=0.10.0",
     "npm": ">2.7.0"

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/test/test.js
@@ -1,0 +1,108 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var Complex128 = require( '@stdlib/complex/float64/ctor' );
+var defaults = require( '@stdlib/ndarray/defaults' );
+var scalarDType = require( './../lib' );
+
+
+// VARIABLES //
+
+var DEFAULT_REAL = defaults.get( 'dtypes.real_floating_point' );
+var DEFAULT_CMPLX = defaults.get( 'dtypes.complex_floating_point' );
+var DEFAULT_BOOL = defaults.get( 'dtypes.boolean' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof scalarDType, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns the default real floating-point dtype for number primitives', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		0,
+		1,
+		-1,
+		3.14,
+		-3.14,
+		NaN,
+		Infinity,
+		-Infinity
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( scalarDType( values[ i ] ), DEFAULT_REAL, 'returns expected value for ' + values[ i ] );
+	}
+	t.end();
+});
+
+tape( 'the function returns the default boolean dtype for boolean primitives', function test( t ) {
+	t.strictEqual( scalarDType( true ), DEFAULT_BOOL, 'returns expected value for true' );
+	t.strictEqual( scalarDType( false ), DEFAULT_BOOL, 'returns expected value for false' );
+	t.end();
+});
+
+tape( 'the function returns the correct dtype for complex number objects with a known dtype', function test( t ) {
+	t.strictEqual( scalarDType( new Complex64( 1.0, 2.0 ) ), 'complex64', 'returns expected value for Complex64' );
+	t.strictEqual( scalarDType( new Complex128( 1.0, 2.0 ) ), 'complex128', 'returns expected value for Complex128' );
+	t.end();
+});
+
+tape( 'the function returns the default complex floating-point dtype for complex-like objects with an unknown dtype', function test( t ) {
+	var v = {
+		're': 1.0,
+		'im': 2.0
+	};
+	t.strictEqual( scalarDType( v ), DEFAULT_CMPLX, 'returns expected value for plain complex-like object' );
+	t.end();
+});
+
+tape( 'the function returns `generic` for all other value types', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'hello',
+		'',
+		[],
+		[ 1, 2, 3 ],
+		{},
+		{
+			'a': 1
+		},
+		null,
+		void 0
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( scalarDType( values[ i ] ), 'generic', 'returns expected value for ' + values[ i ] );
+	}
+	t.end();
+});


### PR DESCRIPTION

Resolves #11002 .

## Description

> What is the purpose of this pull request?

This pull request:

-   add new `ndarray/base/scalar-dtype` package
-   update `ndarray/base/atleastnd` to use `scalar-dtype`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11002 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- [x] Tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] Documentation is complete (README, repl.txt, types)
- [x] Package registered in `ndarray/base` namespace

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I used Claude to generate the initial implementations. All code was reviewed and verified manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
