### PR TITLE
chore: address commit comments for commit `be0ff01` (issue #11005)

### DIFF
--- a/.github/workflows/scripts/run_affected_benchmarks/run
+++ b/.github/workflows/scripts/run_affected_benchmarks/run
@@ -142,7 +142,7 @@ main() {
 	# Run JS benchmarks:
 	if [ -n "${js_bench_files}" ]; then
 		# Invoke make in batches to avoid "Argument list too long" errors:
-		printf '%s\n' ${js_bench_files} | xargs -s 65536 sh -c 'make benchmark-javascript-files FILES="$*"' _
+		printf '%s\n' ${js_bench_files} | xargs sh -c 'make benchmark-javascript-files FILES="$*"' _
 	else
 		echo 'No JavaScript benchmarks to run.' >&2
 	fi
@@ -174,7 +174,7 @@ main() {
 
 	if [ -n "${c_bench_files}" ]; then
 		# Invoke make in batches to avoid "Argument list too long" errors:
-		printf '%s\n' ${c_bench_files} | xargs -s 65536 sh -c 'make benchmark-c-files FILES="$*"' _
+		printf '%s\n' ${c_bench_files} | xargs sh -c 'make benchmark-c-files FILES="$*"' _
 	else
 		echo 'No C benchmarks to run.' >&2
 	fi

--- a/.github/workflows/scripts/run_affected_tests/run
+++ b/.github/workflows/scripts/run_affected_tests/run
@@ -165,9 +165,8 @@ main() {
 	files=$(echo "${files}" | grep -v '/fixtures/') || true
 
 	if [[ -n "${files}" ]]; then
-		# Invoke make in batches to avoid "Argument list too long" errors
-		# when the total length of file paths exceeds OS limits:
-		printf '%s\n' ${files} | xargs -s 65536 sh -c 'make test-javascript-files-min FILES="$*"' _
+		# Invoke make in batches to avoid "Argument list too long" errors:
+		printf '%s\n' ${files} | xargs sh -c 'make test-javascript-files-min FILES="$*"' _
 	fi
 
 	cleanup


### PR DESCRIPTION
Resolves #11005.

## Description

> What is the purpose of this pull request?

This pull request:

-   removes the hardcoded `-s 65536` size limit from three `xargs` invocations across two CI scripts (`.github/workflows/scripts/run_affected_tests/run` and `.github/workflows/scripts/run_affected_benchmarks/run`), as the limit is system-dependent and should not be hardcoded — `xargs` will use the OS default instead
-   collapses a two-line inline comment into a single line in `.github/workflows/scripts/run_affected_tests/run` to adhere to the project convention of keeping comments on a single line

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11005

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The four commit comments being addressed are:

-   https://github.com/stdlib-js/stdlib/commit/be0ff0117ac453022a1bad95129ff16145f02e7e#r179638814 — single-line comment convention (`run_affected_tests/run`)
-   https://github.com/stdlib-js/stdlib/commit/be0ff0117ac453022a1bad95129ff16145f02e7e#r179638903 — remove `-s 65536` (`run_affected_tests/run`)
-   https://github.com/stdlib-js/stdlib/commit/be0ff0117ac453022a1bad95129ff16145f02e7e#r179638891 — remove `-s 65536` (`run_affected_benchmarks/run`, JS benchmarks)
-   https://github.com/stdlib-js/stdlib/commit/be0ff0117ac453022a1bad95129ff16145f02e7e#r179638898 — remove `-s 65536` (`run_affected_benchmarks/run`, C benchmarks)

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

I used AI assistance to understand the codebase, identify the relevant files and lines, and understand what the commit comments were requesting. The proposed changes were reviewed and applied manually by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md