### PR TITLE
refactor: allow remark-lint-expected-html-sections to be disabled

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-expected-html-sections/lib/linter.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-expected-html-sections/lib/linter.js
@@ -30,6 +30,44 @@ var keys = require( '@stdlib/utils/keys' );
 var debug = logger( 'remark-lint-expected-html-sections' );
 var RE_SECTION_START = /<section(?:\s+class="([^"]*)")?>/;
 var RE_SECTION_END = /<\/section>/;
+var RE_HTML_COMMENT = /^\s*<!--[\s\S]*-->\s*$/;
+
+
+// FUNCTIONS //
+
+/**
+* Returns a message anchor node.
+*
+* @private
+* @param {Node} tree - abstract syntax tree (AST)
+* @returns {Node} anchor node
+*/
+function getAnchorNode( tree ) {
+	var node;
+	var i;
+
+	for ( i = 0; i < tree.children.length; i++ ) {
+		node = tree.children[ i ];
+		if ( node.type === 'html' && RE_HTML_COMMENT.test( node.value ) ) {
+			continue;
+		}
+		return node;
+	}
+	return tree;
+}
+
+/**
+* Reports a lint message.
+*
+* @private
+* @param {File} file - virtual file
+* @param {Node} node - anchor node
+* @param {string} msg - message
+* @returns {void}
+*/
+function reportMessage( file, node, msg ) {
+	file.message( msg, node, 'remark-lint:expected-html-sections' );
+}
 
 
 // MAIN //
@@ -60,6 +98,7 @@ function factory( options ) {
 		var sectionsFound;
 		var sectionStack;
 		var missingRoot;
+		var anchorNode;
 		var missingC;
 		var schema;
 		var msg;
@@ -77,6 +116,9 @@ function factory( options ) {
 			'root': {},
 			'c': {}
 		};
+
+		// Anchor messages to content nodes so inline lint comments can control reporting:
+		anchorNode = getAnchorNode( tree );
 
 		// Visit all HTML nodes to build section structure:
 		visit( tree, 'html', visitor );
@@ -101,7 +143,7 @@ function factory( options ) {
 		if ( missingRoot.length > 0 ) {
 			msg = 'Missing required root-level sections: `' + missingRoot.join( '`, `' ) + '`. Required sections are: `' + requiredRootSections.join( '`, `' ) + '`.   missing-required-sections';
 			debug( msg );
-			file.message( msg, tree, 'remark-lint:expected-html-sections' );
+			reportMessage( file, anchorNode, msg );
 		}
 
 		// If 'c' section exists, check its requirements:
@@ -119,7 +161,7 @@ function factory( options ) {
 			if ( missingC.length > 0 ) {
 				msg = 'Missing required sections in "c" section: `' + missingC.join( '`, `' ) + '`. Required C sections are: `' + requiredCSections.join( '`, `' ) + '`.   missing-required-c-sections';
 				debug( msg );
-				file.message( msg, sectionsFound.root.c.node, 'remark-lint:expected-html-sections' );
+				reportMessage( file, sectionsFound.root.c.node, msg );
 			}
 		}
 


### PR DESCRIPTION
Refactor behavior of `remark-lint-expected-html-sections` so that it reports from an anchor node and can be disabled with inline comments.

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

## Description

This pull request:

-   Refactors the `remark-lint-expected-html-sections` so that it can be disabled in markdown files by using `<!-- lint disable expected-html-sections -->`
-  Previous behavior made it so that dummy sections had to be added to avoid the lint error as it did not emit position-aware lint messages, see, e.g.
		https://github.com/stdlib-js/stdlib/blob/23a64281b4c5e5ba7b31520e6f8a9b683a28c7e8/README.md?plain=1#L23-L35

### AI Description
1. Refactored the expected-html-sections linter to report root-level missing-section messages on an anchor content node instead of the document root.
2. Added helper functions to:
	- pick the first non-HTML-comment top-level node as the anchor
	- centralize message reporting through a single reporter function

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Entirely AI generated, though I've validated it through running `make lint-markdown` on files with and without the disabling line in them. 

Full session output in [gist here](https://gist.github.com/batpigandme/914917043ef557d80e608e0e8ca79a31).

_n.b._ Force-pushed a commit to use `Generated-by: GPT-5-3-Codex` tag in footer.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
