### PR TITLE
chore: fix JavaScript lint errors (issue #11014)

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-biguint64array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-biguint64array/examples/index.js
@@ -74,7 +74,7 @@ bool = isBigUint64Array( new Float32Array( 10 ) );
 console.error( bool );
 // => false
 
-bool = isBigUint64Array( new Array( 10 ) );
+bool = isBigUint64Array( [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] );
 console.error( bool );
 // => false
 

--- a/lib/node_modules/@stdlib/math/strided/special/acoversin-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acoversin-by/test/test.main.js
@@ -74,8 +74,8 @@ tape( 'the function computes the inverse coversed sine via a callback function',
 	acoversinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = [];
-	x.length = 5; // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
+	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -83,8 +83,8 @@ tape( 'the function computes the inverse coversed sine via a callback function',
 	acoversinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = [];
-	x.length = 5; // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
+	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 

--- a/lib/node_modules/@stdlib/math/strided/special/acoversin-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acoversin-by/test/test.main.js
@@ -74,7 +74,8 @@ tape( 'the function computes the inverse coversed sine via a callback function',
 	acoversinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -82,7 +83,8 @@ tape( 'the function computes the inverse coversed sine via a callback function',
 	acoversinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
Resolves #11014.

## Description

This pull request fixes 3 JavaScript lint errors reported by the `stdlib/no-new-array` ESLint rule.

### Changes Made

- **`lib/node_modules/@stdlib/assert/is-biguint64array/examples/index.js`** (1 error)
  - Replace `new Array( 10 )` with array literal `[ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]`
  - This example only tests that a regular Array returns `false`; sparse-array semantics are not required here

- **`lib/node_modules/@stdlib/math/strided/special/acoversin-by/test/test.main.js`** (2 errors)
  - Replace `new Array( 5 )` with `x = []; x.length = 5;` to preserve sparse-array semantics in tests
  - The accessor callback relies on holes (`v === void 0`) to short-circuit; `[]; .length = 5` produces the same sparse behavior as `new Array( 5 )`

## Related Issues

- Resolves #11014

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] Yes

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored with Claude Code assistance. AI identified the lint violations, researched existing stdlib PRs for the canonical fix pattern, and generated the replacement code. The sparse-array equivalence (`[] + .length` vs `new Array()`) was manually verified.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md