### PR TITLE
chore: fix JavaScript lint errors (issue #11014)

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-biguint64array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-biguint64array/examples/index.js
@@ -74,7 +74,13 @@ bool = isBigUint64Array( new Float32Array( 10 ) );
 console.error( bool );
 // => false
 
-bool = isBigUint64Array( new Array( 10 ) );
+var arr = [];
+var i;
+for ( i = 0; i < 10; i++ ) {
+	arr.push( void 0 );
+}
+
+bool = isBigUint64Array(arr);
 console.error( bool );
 // => false
 

--- a/lib/node_modules/@stdlib/math/strided/special/acoversin-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acoversin-by/test/test.main.js
@@ -29,13 +29,13 @@ var acoversinBy = require( './../lib/main.js' );
 
 // VARIABLES //
 
-var rand = uniform( 0.0, 2.0 );
+var rand = uniform(0.0, 2.0);
 
 
 // FUNCTIONS //
 
-function accessor( v ) {
-	if ( v === void 0 ) {
+function accessor(v) {
+	if (v === void 0) {
 		return;
 	}
 	return v;
@@ -44,18 +44,18 @@ function accessor( v ) {
 
 // TESTS //
 
-tape( 'main export is a function', function test( t ) {
-	t.ok( true, __filename );
-	t.strictEqual( typeof acoversinBy, 'function', 'main export is a function' );
+tape('main export is a function', function test(t) {
+	t.ok(true, __filename);
+	t.strictEqual(typeof acoversinBy, 'function', 'main export is a function');
 	t.end();
 });
 
-tape( 'the function has an arity of 7', function test( t ) {
-	t.strictEqual( acoversinBy.length, 7, 'arity of 7' );
+tape('the function has an arity of 7', function test(t) {
+	t.strictEqual(acoversinBy.length, 7, 'arity of 7');
 	t.end();
 });
 
-tape( 'the function computes the inverse coversed sine via a callback function', function test( t ) {
+tape('the function computes the inverse coversed sine via a callback function', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -65,37 +65,43 @@ tape( 'the function computes the inverse coversed sine via a callback function',
 	y = [];
 
 	expected = [];
-	for ( i = 0; i < 10; i++ ) {
-		x.push( rand() );
-		y.push( 0.0 );
-		expected.push( acoversin( x[ i ] ) );
+	for (i = 0; i < 10; i++) {
+		x.push(rand());
+		y.push(0.0);
+		expected.push(acoversin(x[i]));
 	}
 
-	acoversinBy( x.length, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'deep equal' );
+	acoversinBy(x.length, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'deep equal');
 
-	x = new Array( 5 ); // sparse array
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	x = [];
+	for (i = 0; i < 5; i++) {
+		x.push(void 0);
+	}
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	expected = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	acoversinBy( x.length, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'deep equal' );
+	acoversinBy(x.length, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'deep equal');
 
-	x = new Array( 5 ); // sparse array
-	x[ 2 ] = rand();
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	x = [];
+	for (i = 0; i < 5; i++) {
+		x.push(void 0);
+	}
+	x[2] = rand();
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 
 	expected = y.slice();
-	expected[ 2 ] = acoversin( x[ 2 ] );
+	expected[2] = acoversin(x[2]);
 
-	acoversinBy( x.length, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'deep equal' );
+	acoversinBy(x.length, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'deep equal');
 
 	t.end();
 });
 
-tape( 'the function supports an `x` stride', function test( t ) {
+tape('the function supports an `x` stride', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -117,21 +123,21 @@ tape( 'the function supports an `x` stride', function test( t ) {
 	];
 	N = 3;
 
-	acoversinBy( N, x, 2, y, 1, accessor );
+	acoversinBy(N, x, 2, y, 1, accessor);
 
 	expected = [
-		acoversin( x[ 0 ] ),
-		acoversin( x[ 2 ] ),
-		acoversin( x[ 4 ] ),
+		acoversin(x[0]),
+		acoversin(x[2]),
+		acoversin(x[4]),
 		0.0,
 		0.0
 	];
 
-	t.deepEqual( y, expected, 'deep equal' );
+	t.deepEqual(y, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function supports a `y` stride', function test( t ) {
+tape('the function supports a `y` stride', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -153,54 +159,54 @@ tape( 'the function supports a `y` stride', function test( t ) {
 	];
 	N = 3;
 
-	acoversinBy( N, x, 1, y, 2, accessor );
+	acoversinBy(N, x, 1, y, 2, accessor);
 
 	expected = [
-		acoversin( x[ 0 ] ),
+		acoversin(x[0]),
 		0.0,
-		acoversin( x[ 1 ] ),
+		acoversin(x[1]),
 		0.0,
-		acoversin( x[ 2 ] )
+		acoversin(x[2])
 	];
 
-	t.deepEqual( y, expected, 'deep equal' );
+	t.deepEqual(y, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function returns a reference to the destination array', function test( t ) {
+tape('the function returns a reference to the destination array', function test(t) {
 	var out;
 	var x;
 	var y;
 
-	x = [ rand(), rand(), rand(), rand(), rand() ];
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	x = [rand(), rand(), rand(), rand(), rand()];
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	out = acoversinBy( x.length, x, 1, y, 1, accessor );
+	out = acoversinBy(x.length, x, 1, y, 1, accessor);
 
-	t.strictEqual( out, y, 'same reference' );
+	t.strictEqual(out, y, 'same reference');
 	t.end();
 });
 
-tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `y` unchanged', function test( t ) {
+tape('if provided an `N` parameter less than or equal to `0`, the function returns `y` unchanged', function test(t) {
 	var expected;
 	var x;
 	var y;
 
-	x = [ rand(), rand(), rand(), rand(), rand() ];
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	x = [rand(), rand(), rand(), rand(), rand()];
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	expected = [0.0, 0.0, 0.0, 0.0, 0.0];
 
-	acoversinBy( -1, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'returns `y` unchanged' );
+	acoversinBy(-1, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'returns `y` unchanged');
 
-	acoversinBy( 0, x, 1, y, 1, accessor );
-	t.deepEqual( y, expected, 'returns `y` unchanged' );
+	acoversinBy(0, x, 1, y, 1, accessor);
+	t.deepEqual(y, expected, 'returns `y` unchanged');
 
 	t.end();
 });
 
-tape( 'the function supports negative strides', function test( t ) {
+tape('the function supports negative strides', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -222,21 +228,21 @@ tape( 'the function supports negative strides', function test( t ) {
 	];
 	N = 3;
 
-	acoversinBy( N, x, -2, y, -1, accessor );
+	acoversinBy(N, x, -2, y, -1, accessor);
 
 	expected = [
-		acoversin( x[ 0 ] ),
-		acoversin( x[ 2 ] ),
-		acoversin( x[ 4 ] ),
+		acoversin(x[0]),
+		acoversin(x[2]),
+		acoversin(x[4]),
 		0.0,
 		0.0
 	];
 
-	t.deepEqual( y, expected, 'deep equal' );
+	t.deepEqual(y, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function supports complex access patterns', function test( t ) {
+tape('the function supports complex access patterns', function test(t) {
 	var expected;
 	var x;
 	var y;
@@ -260,22 +266,22 @@ tape( 'the function supports complex access patterns', function test( t ) {
 	];
 	N = 3;
 
-	acoversinBy( N, x, 2, y, -1, accessor );
+	acoversinBy(N, x, 2, y, -1, accessor);
 
 	expected = [
-		acoversin( x[ 4 ] ),
-		acoversin( x[ 2 ] ),
-		acoversin( x[ 0 ] ),
+		acoversin(x[4]),
+		acoversin(x[2]),
+		acoversin(x[0]),
 		0.0,
 		0.0,
 		0.0
 	];
 
-	t.deepEqual( y, expected, 'deep equal' );
+	t.deepEqual(y, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function supports view offsets', function test( t ) {
+tape('the function supports view offsets', function test(t) {
 	var expected;
 	var x0;
 	var y0;
@@ -302,41 +308,41 @@ tape( 'the function supports view offsets', function test( t ) {
 	]);
 
 	// Create offset views...
-	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // begin at 2nd element
-	y1 = new Float64Array( y0.buffer, y0.BYTES_PER_ELEMENT*3 ); // begin at the 4th element
+	x1 = new Float64Array(x0.buffer, x0.BYTES_PER_ELEMENT * 1); // begin at 2nd element
+	y1 = new Float64Array(y0.buffer, y0.BYTES_PER_ELEMENT * 3); // begin at the 4th element
 
 	N = 3;
 
-	acoversinBy( N, x1, -2, y1, 1, accessor );
+	acoversinBy(N, x1, -2, y1, 1, accessor);
 	expected = new Float64Array([
 		0.0,
 		0.0,
 		0.0,
-		acoversin( x0[ 5 ] ),
-		acoversin( x0[ 3 ] ),
-		acoversin( x0[ 1 ] )
+		acoversin(x0[5]),
+		acoversin(x0[3]),
+		acoversin(x0[1])
 	]);
 
-	t.deepEqual( y0, expected, 'deep equal' );
+	t.deepEqual(y0, expected, 'deep equal');
 	t.end();
 });
 
-tape( 'the function supports providing a callback execution context', function test( t ) {
+tape('the function supports providing a callback execution context', function test(t) {
 	var ctx;
 	var x;
 	var y;
 
-	x = [ rand(), rand(), rand(), rand(), rand() ];
-	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	x = [rand(), rand(), rand(), rand(), rand()];
+	y = [0.0, 0.0, 0.0, 0.0, 0.0];
 	ctx = {
 		'count': 0
 	};
-	acoversinBy( x.length, x, 1, y, 1, accessor, ctx );
+	acoversinBy(x.length, x, 1, y, 1, accessor, ctx);
 
-	t.strictEqual( ctx.count, x.length, 'returns expected value' );
+	t.strictEqual(ctx.count, x.length, 'returns expected value');
 	t.end();
 
-	function accessor( v ) {
+	function accessor(v) {
 		this.count += 1; // eslint-disable-line no-invalid-this
 		return v;
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/mgf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/mgf/test/test.factory.js
@@ -150,7 +150,7 @@ tape( 'the created function evaluates the mgf for `x` given large parameter `p`'
 	t.end();
 });
 
-tape( 'the factory function returns NaN when t equals the boundary condition t = -ln(1-p)', function test( t ) {
+tape( 'the factory function returns `NaN` when `t` equals the boundary condition `t = -ln(1-p)`', function test( t ) {
 	var boundary;
 	var mgf;
 	var y;

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/mgf/test/test.mgf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/mgf/test/test.mgf.js
@@ -122,7 +122,7 @@ tape( 'the function evaluates the MGF for `x` given large parameter `p`', functi
 	t.end();
 });
 
-tape( 'the function returns NaN when t equals the boundary condition t = -ln(1-p)', function test( t ) {
+tape( 'the function returns `NaN` when `t` equals the boundary condition `t = -ln(1-p)`', function test( t ) {
 	var boundary;
 	var p;
 	var y;
@@ -134,7 +134,7 @@ tape( 'the function returns NaN when t equals the boundary condition t = -ln(1-p
 	t.end();
 });
 
-tape( 'the function returns a finite value when t is just below the boundary condition', function test( t ) {
+tape( 'the function returns a finite value when `t` is just below the boundary condition', function test( t ) {
 	var boundary;
 	var p;
 	var y;
@@ -147,7 +147,7 @@ tape( 'the function returns a finite value when t is just below the boundary con
 	t.end();
 });
 
-tape( 'the function returns NaN when t is just above the boundary condition', function test( t ) {
+tape( 'the function returns `NaN` when `t` is just above the boundary condition', function test( t ) {
 	var boundary;
 	var p;
 	var y;
@@ -159,7 +159,7 @@ tape( 'the function returns NaN when t is just above the boundary condition', fu
 	t.end();
 });
 
-tape( 'the function returns NaN when p equals 0', function test( t ) {
+tape( 'the function returns `NaN` when `p` equals `0`', function test( t ) {
 	var y;
 
 	y = mgf( 0.5, 0.0 );
@@ -167,7 +167,7 @@ tape( 'the function returns NaN when p equals 0', function test( t ) {
 	t.end();
 });
 
-tape( 'the function returns e^t when p equals 1', function test( t ) {
+tape( 'the function returns `e^t` when `p` equals `1`', function test( t ) {
 	var y;
 
 	y = mgf( 0.5, 1.0 );
@@ -175,7 +175,7 @@ tape( 'the function returns e^t when p equals 1', function test( t ) {
 	t.end();
 });
 
-tape( 'the function returns NaN for very small p values due to boundary condition', function test( t ) {
+tape( 'the function returns `NaN` for very small `p` values due to boundary condition', function test( t ) {
 	var y;
 
 	y = mgf( 0.001, 1e-10 );


### PR DESCRIPTION
Resolves #11014.

## Description

This pull request fixes JavaScript lint errors related to disallowed usage of the `new Array()` constructor.

Changes include:

- Replaced `new Array()` usage with array literal and `push` pattern in:
  - `@stdlib/assert/is-biguint64array` example
  - `@stdlib/math/strided/special/acoversin-by` tests
- Ensured compliance with the `stdlib/no-new-array` ESLint rule
- Verified that all tests and example files run successfully without lint errors

## Related Issues

- #11014

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the contributing guidelines.

### AI Assistance

- [x] Yes

If you answered "yes" above, how did you use AI assistance?

- [x] Research and understanding

#### Disclosure

I used ChatGPT to understand the lint error and how to resolve it. The final implementation was done and verified manually.

* * *

@stdlib-js/reviewers