### PR TITLE
feat: add ndarray/base/scalar-dtype (issue #11002)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/atleastnd/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/atleastnd/lib/main.js
@@ -21,10 +21,6 @@
 // MODULES //
 
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
-var isComplexLike = require( '@stdlib/assert/is-complex-like' );
-var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
-var complexDataType = require( '@stdlib/complex/dtype' );
 var broadcastScalar = require( '@stdlib/ndarray/base/broadcast-scalar' );
 var dims = require( '@stdlib/ndarray/base/ndims' );
 var defaults = require( '@stdlib/ndarray/defaults' );
@@ -36,13 +32,11 @@ var getOrder = require( '@stdlib/ndarray/base/order' );
 var getDType = require( '@stdlib/ndarray/base/dtype' );
 var getData = require( '@stdlib/ndarray/base/data-buffer' );
 var ones = require( '@stdlib/array/base/ones' );
+var scalarDType = require( '@stdlib/ndarray/base/scalar-dtype' );
 
 
 // VARIABLES //
 
-var DEFAULT_REAL = defaults.get( 'dtypes.real_floating_point' );
-var DEFAULT_CMPLX = defaults.get( 'dtypes.complex_floating_point' );
-var DEFAULT_BOOL = defaults.get( 'dtypes.boolean' );
 var ORDER = defaults.get( 'order' );
 
 
@@ -107,19 +101,8 @@ function atleastnd( ndims, arrays ) {
 			out.push( new ndarray( getDType( v ), getData( v ), shape, strides, getOffset( v ), getOrder( v ) ) ); // eslint-disable-line max-len
 			continue;
 		}
-		// For scalar values, resolve a corresponding ndarray data type...
-		if ( isNumber( v ) ) { // TODO: consider abstracting this logic to an `ndarray/base/scalar-dtype` (???) package, as this logic is found elsewhere (e.g., `ndarray/from-scalar`) and it would be good to avoid duplication, especially as we add support for more ndarray data types
-			dt = DEFAULT_REAL;
-		} else if ( isBoolean( v ) ) {
-			dt = DEFAULT_BOOL;
-		} else if ( isComplexLike( v ) ) {
-			dt = complexDataType( v );
-			if ( dt === null ) {
-				dt = DEFAULT_CMPLX;
-			}
-		} else {
-			dt = 'generic';
-		}
+
+		dt = scalarDType( v );
 		out.push( broadcastScalar( v, dt, ones( ndims ), ORDER ) );
 	}
 	return out;

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/examples/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var scalarDType = require( './../lib' );
+
+console.log( scalarDType( 5 ) );
+// => float64
+
+console.log( scalarDType( true ) );
+// => bool
+
+console.log( scalarDType( {} ) );
+// => generic

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/lib/main.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// MODULES //
+
+var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var isComplexLike = require( '@stdlib/assert/is-complex-like' );
+var complexDataType = require( '@stdlib/complex/dtype' );
+var defaults = require( '@stdlib/ndarray/defaults' );
+
+// VARIABLES //
+
+var DEFAULT_REAL = defaults.get( 'dtypes.real_floating_point' );
+var DEFAULT_CMPLX = defaults.get( 'dtypes.complex_floating_point' );
+var DEFAULT_BOOL = defaults.get( 'dtypes.boolean' );
+
+// MAIN //
+
+function scalarDType( v ) {
+	if ( isNumber( v ) ) {
+		return DEFAULT_REAL;
+	}
+	if ( isBoolean( v ) ) {
+		return DEFAULT_BOOL;
+	}
+	if ( isComplexLike( v ) ) {
+		var dt = complexDataType( v );
+		return ( dt === null ) ? DEFAULT_CMPLX : dt;
+	}
+	return 'generic';
+}
+
+module.exports = scalarDType;

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/package.json
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@stdlib/ndarray/base/scalar-dtype",
+  "version": "0.0.0",
+  "main": "./lib",
+  "scripts": {
+    "test": "node ./test/test.js"
+  }
+}

--- a/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/scalar-dtype/test/test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var tape = require( 'tape' );
+var scalarDType = require( './../lib' );
+
+tape( 'returns dtype for number', function test( t ) {
+	t.strictEqual( scalarDType( 5 ), 'float64', 'returns float64' );
+	t.end();
+});
+
+tape( 'returns dtype for boolean', function test( t ) {
+	t.strictEqual( scalarDType( true ), 'bool', 'returns bool' );
+	t.end();
+});
+
+tape( 'returns generic for objects', function test( t ) {
+	t.strictEqual( scalarDType( {} ), 'generic', 'returns generic' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #11002.

## Description

> What is the purpose of this pull request?

This pull request introduces a new utility `@stdlib/ndarray/base/scalar-dtype` to resolve a default ndarray data type from a scalar value.

Previously, scalar-to-dtype resolution logic was duplicated across multiple packages such as:
- `ndarray/base/atleastnd`
- `ndarray/from-scalar`

This PR extracts that logic into a reusable module, improving maintainability, consistency, and making it easier to extend support for additional data types in the future.

Changes include:
- Adding new package `@stdlib/ndarray/base/scalar-dtype`
- Refactoring `ndarray/base/atleastnd` to use the new utility
- Removing duplicated scalar dtype resolution logic

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11002

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

I consulted ChatGPT to better understand the existing codebase and refactoring approach. The implementation and final changes were written and verified manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md