### PR TITLE
fix(remark): move HTML section linters and skip YAML frontmatter

### DIFF
--- a/etc/remark/plugins/index.js
+++ b/etc/remark/plugins/index.js
@@ -22,11 +22,13 @@
 
 var plugins = [];
 
-plugins.push( require( './frontmatter' ) );
-plugins = plugins.concat( require( './lint' ) );
-plugins.push( require( './eslint' ) );
-plugins.push( require( './lint-equations' ) );
-plugins.push( require( './validate-links' ) );
+plugins.push(require( './frontmatter' ));
+plugins = plugins.concat(require( './lint' ));
+plugins.push(require( './eslint' ));
+plugins.push(require( './lint-equations' ));
+plugins.push(require( './lint-expected-html-sections' ));
+plugins.push(require( './lint-html-section-structure' ));
+plugins.push(require( './validate-links' ));
 
 
 // EXPORTS //

--- a/etc/remark/plugins/index.js
+++ b/etc/remark/plugins/index.js
@@ -26,8 +26,6 @@ plugins.push( require( './frontmatter' ) );
 plugins = plugins.concat( require( './lint' ) );
 plugins.push( require( './eslint' ) );
 plugins.push( require( './lint-equations' ) );
-plugins.push( require( './lint-expected-html-sections' ) );
-plugins.push( require( './lint-html-section-structure' ) );
 plugins.push( require( './validate-links' ) );
 
 

--- a/etc/remark/plugins/lint/index.js
+++ b/etc/remark/plugins/lint/index.js
@@ -1323,6 +1323,16 @@ plugins.push([
 	[ 'error', '-' ]
 ]);
 
+/**
+* Validate HTML section hierarchy in README files according to stdlib conventions.
+*/
+plugins.push( require( './../lint-expected-html-sections' ) );
+
+/**
+* Validate HTML section structure in README files.
+*/
+plugins.push( require( './../lint-html-section-structure' ) );
+
 
 // EXPORTS //
 

--- a/etc/remark/plugins/lint/index.js
+++ b/etc/remark/plugins/lint/index.js
@@ -23,7 +23,7 @@
 /**
 * Lint plugins.
 */
-var plugins = [ require( 'remark-lint' ) ];
+var plugins = [require( 'remark-lint' )];
 
 /**
 * Require blockquotes to have `2` character indentation.
@@ -42,7 +42,7 @@ var plugins = [ require( 'remark-lint' ) ];
 */
 plugins.push([
 	require( 'remark-lint-blockquote-indentation' ),
-	[ 'error', 2 ]
+	['error', 2]
 ]);
 
 /**
@@ -88,7 +88,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-checkbox-content-indent' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /* eslint-disable stdlib/jsdoc-no-multiple-blank-lines */
@@ -117,7 +117,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-code-block-style' ),
-	[ 'error', 'fenced' ]
+	['error', 'fenced']
 ]);
 
 /* eslint-enable stdlib/jsdoc-no-multiple-blank-lines */
@@ -139,7 +139,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-definition-case' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -159,7 +159,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-definition-spacing' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /* eslint-disable stdlib/jsdoc-no-multiple-blank-lines */
@@ -181,7 +181,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-emphasis-marker' ),
-	[ 'error', '_' ]
+	['error', '_']
 ]);
 
 /* eslint-enable stdlib/jsdoc-no-multiple-blank-lines */
@@ -236,7 +236,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-fenced-code-marker' ),
-	[ 'error', '`' ]
+	['error', '`']
 ]);
 
 /**
@@ -246,7 +246,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-file-extension' ),
-	[ 'error', 'md' ]
+	['error', 'md']
 ]);
 
 /**
@@ -256,7 +256,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-final-definition' ),
-	[ 'off' ]
+	['off']
 ]);
 
 /**
@@ -266,7 +266,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-final-newline' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -276,7 +276,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-first-heading-level' ),
-	[ 'error', 1 ]
+	['error', 1]
 ]);
 
 /**
@@ -286,7 +286,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-hard-break-spaces' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -296,7 +296,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-heading-increment' ),
-	[ 'off' ]
+	['off']
 ]);
 
 /**
@@ -322,7 +322,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-heading-style' ),
-	[ 'error', 'atx' ]
+	['error', 'atx']
 ]);
 
 /**
@@ -332,7 +332,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-linebreak-style' ),
-	[ 'error', 'unix' ]
+	['error', 'unix']
 ]);
 
 /**
@@ -352,7 +352,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-link-title-style' ),
-	[ 'error', '"' ]
+	['error', '"']
 ]);
 
 /**
@@ -375,7 +375,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-list-item-bullet-indent' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -400,7 +400,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-list-item-content-indent' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -432,7 +432,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-list-item-indent' ),
-	[ 'error', 'tab-size' ]
+	['error', 'tab-size']
 ]);
 
 /**
@@ -467,7 +467,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-list-item-spacing' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -477,7 +477,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-maximum-heading-length' ),
-	[ 'error', 80 ]
+	['error', 80]
 ]);
 
 /**
@@ -487,7 +487,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-maximum-line-length' ),
-	[ 'off' ]
+	['off']
 ]);
 
 /**
@@ -508,7 +508,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-auto-link-without-protocol' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -533,7 +533,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-blockquote-without-marker' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -543,7 +543,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-consecutive-blank-lines' ),
-	[ 'off' ]
+	['off']
 ]);
 
 /**
@@ -566,7 +566,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-duplicate-definitions' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -590,7 +590,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-duplicate-headings' ),
-	[ 'off' ]
+	['off']
 ]);
 
 /**
@@ -619,7 +619,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-duplicate-headings-in-section' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -644,7 +644,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-emphasis-as-heading' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -665,7 +665,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-empty-url' ),
-	[ 'error']
+	['error']
 ]);
 
 /**
@@ -675,7 +675,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-file-name-articles' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -685,7 +685,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-file-name-consecutive-dashes' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -695,7 +695,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-file-name-irregular-characters' ),
-	[ 'error', '\\.a-zA-Z0-9-_' ]
+	['error', '\\.a-zA-Z0-9-_']
 ]);
 
 /**
@@ -705,7 +705,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-file-name-mixed-case' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -715,7 +715,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-file-name-outer-dashes' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -740,7 +740,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-heading-content-indent' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -774,7 +774,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-heading-indent' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -790,7 +790,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-heading-like-paragraph' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -806,7 +806,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-heading-punctuation' ),
-	[ 'error', '.,;:!?' ]
+	['error', '.,;:!?']
 ]);
 
 /**
@@ -825,7 +825,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-html' ),
-	[ 'off' ]
+	['off']
 ]);
 
 /**
@@ -846,7 +846,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-inline-padding' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -867,7 +867,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-literal-urls' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -914,7 +914,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-multiple-toplevel-headings' ),
-	[ 'off' ]
+	['off']
 ]);
 
 /**
@@ -938,7 +938,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-paragraph-content-indent' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -963,7 +963,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-reference-like-url' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -980,7 +980,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-shell-dollars' ),
-	[ 'off' ]
+	['off']
 ]);
 
 /**
@@ -1005,7 +1005,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-shortcut-reference-image' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -1030,7 +1030,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-shortcut-reference-link' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -1059,7 +1059,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-table-indentation' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -1069,7 +1069,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-tabs' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -1099,7 +1099,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-undefined-references' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -1122,7 +1122,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-no-unused-definitions' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -1145,7 +1145,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-ordered-list-marker-style' ),
-	[ 'error', '.' ]
+	['error', '.']
 ]);
 
 /**
@@ -1172,7 +1172,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-ordered-list-marker-value' ),
-	[ 'off', 'ordered' ]
+	['off', 'ordered']
 ]);
 
 /* eslint-disable stdlib/jsdoc-no-multiple-blank-lines */
@@ -1195,7 +1195,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-rule-style' ),
-	[ 'error', '* * *' ]
+	['error', '* * *']
 ]);
 
 /* eslint-enable stdlib/jsdoc-no-multiple-blank-lines */
@@ -1218,7 +1218,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-strong-marker' ),
-	[ 'error', '*' ]
+	['error', '*']
 ]);
 
 /**
@@ -1243,7 +1243,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-table-cell-padding' ),
-	[ 'error', 'padded' ]
+	['error', 'padded']
 ]);
 
 /**
@@ -1268,7 +1268,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-table-pipe-alignment' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -1293,7 +1293,7 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-table-pipes' ),
-	[ 'error' ]
+	['error']
 ]);
 
 /**
@@ -1320,18 +1320,8 @@ plugins.push([
 */
 plugins.push([
 	require( 'remark-lint-unordered-list-marker-style' ),
-	[ 'error', '-' ]
+	['error', '-']
 ]);
-
-/**
-* Validate HTML section hierarchy in README files according to stdlib conventions.
-*/
-plugins.push( require( './../lint-expected-html-sections' ) );
-
-/**
-* Validate HTML section structure in README files.
-*/
-plugins.push( require( './../lint-html-section-structure' ) );
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-expected-html-sections/lib/linter.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-expected-html-sections/lib/linter.js
@@ -48,6 +48,9 @@ function getAnchorNode( tree ) {
 
 	for ( i = 0; i < tree.children.length; i++ ) {
 		node = tree.children[ i ];
+		if ( node.type === 'yaml' ) {
+			continue;
+		}
 		if ( node.type === 'html' && RE_HTML_COMMENT.test( node.value ) ) {
 			continue;
 		}


### PR DESCRIPTION
Move HTML section linting plugins to the central linting plugin list to ensure consistent configuration and update the expected sections linter to ignore YAML frontmatter when searching for anchor nodes so that `<-- lint disable ... -->` comments work properly with `remark-lint` and `unified-message-control`.

Assisted-by: Claude-Opus-4-6

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed 
  ---

## Description

> What is the purpose of this pull request?

This pull request:

Extends https://github.com/stdlib-js/stdlib/pull/11009 to make the lint disabling less brittle, and compatible with the use of YAML frontmatter (discovered that it wasn't when trying to use a GitHub Agentic Workflow, the structure of which is [YAML and Markdown](https://github.github.com/gh-aw/reference/workflow-structure/)).

### AI Description

1. **`etc/remark/plugins/lint/index.js`** — Moved `lint-expected-html-sections` and `lint-html-section-structure` into the lint plugin batch so their transforms run _before_ `remark-message-control`'s one-shot message filter. This is the core fix that makes `<!-- lint disable expected-html-sections -->` work.
2. **`lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-expected-html-sections/lib/linter.js`** — Updated `getAnchorNode` to skip `yaml` frontmatter nodes, so messages in files with YAML frontmatter aren't anchored before disable comments.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used Claude Opus 4.6 to troubleshoot failing disabling of linter. Full session here: https://app.warp.dev/conversation/b9bc28f8-92dc-45a6-b94f-825c576ed398

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
