### PR TITLE
docs: correct C return annotation in `stats/base/dists/geometric/stdev`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/stdev/README.md
@@ -151,7 +151,7 @@ Returns the [standard deviation][standard-deviation] of a [geometric][geometric-
 
 ```c
 double out = stdlib_base_dists_geometric_stdev( 0.5 );
-// returns 1.0
+// returns ~1.414
 ```
 
 The function accepts the following arguments:


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed
   ---

Resolves NA.

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes an incorrect return value shown in the **C usage block** in `stats/base/dists/geometric/stdev/README.md`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md