### PR TITLE
feat: add `stats/strided/nancount`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/nancount/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/README.md
@@ -1,0 +1,173 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# nancount
+
+> Calculate the count of a strided array, ignoring `NaN` values.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var nancount = require( '@stdlib/stats/strided/nancount' );
+```
+
+#### nancount( N, x, strideX )
+
+Computes the count of a strided array, ignoring `NaN` values.
+
+```javascript
+var x = [ 1.0, -2.0, NaN, 2.0 ];
+
+var v = nancount( x.length, x, 1 );
+// returns 3
+```
+
+The function has the following parameters:
+
+-   **N**: number of indexed elements.
+-   **x**: input [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
+-   **strideX**: stride length for `x`.
+
+The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to calculate the count of every other element in `x`,
+
+```javascript
+var x = [ 1.0, 2.0, 2.0, -7.0, -2.0, 3.0, 4.0, 2.0, NaN, NaN ];
+
+var v = nancount( 5, x, 2 );
+// returns 4
+```
+
+Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
+
+<!-- eslint-disable stdlib/capitalized-comments -->
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var x0 = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, NaN, NaN, 4.0 ] );
+var x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+var v = nancount( 4, x1, 2 );
+// returns 3
+```
+
+#### nancount.ndarray( N, x, strideX, offsetX )
+
+Computes the count of a strided array, ignoring `NaN` values and using alternative indexing semantics.
+
+```javascript
+var x = [ 1.0, -2.0, NaN, 2.0 ];
+
+var v = nancount.ndarray( x.length, x, 1, 0 );
+// returns 3
+```
+
+The function has the following additional parameters:
+
+-   **offsetX**: starting index for `x`.
+
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameter supports indexing semantics based on a starting index. For example, to calculate the count for every other element in `x` starting from the second element
+
+```javascript
+var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, NaN, NaN, 2.0, 3.0, 4.0 ];
+
+var v = nancount.ndarray( 5, x, 2, 1 );
+// returns 4
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If `N <= 0`, both functions return `0`.
+-   Both functions support array-like objects having getter and setter accessors for array element access (e.g., [`@stdlib/array/base/accessor`][@stdlib/array/base/accessor]).
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var uniform = require( '@stdlib/random/base/uniform' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var nancount = require( '@stdlib/stats/strided/nancount' );
+
+function rand() {
+    if ( bernoulli( 0.8 ) < 1 ) {
+        return NaN;
+    }
+    return uniform( -50.0, 50.0 );
+}
+
+var x = filledarrayBy( 10, 'float64', rand );
+console.log( x );
+
+var v = nancount( x.length, x, 1 );
+console.log( v );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+
+[mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+[@stdlib/array/base/accessor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/base/accessor
+
+<!-- <related-links> -->
+
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/strided/nancount/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # nancount
 
-> Calculate the count of a strided array, ignoring `NaN` values.
+> Calculate the number of non-`NaN` elements in a strided array.
 
 <section class="intro">
 
@@ -38,7 +38,7 @@ var nancount = require( '@stdlib/stats/strided/nancount' );
 
 #### nancount( N, x, strideX )
 
-Computes the count of a strided array, ignoring `NaN` values.
+Calculate the number of non-`NaN` elements in a strided array
 
 ```javascript
 var x = [ 1.0, -2.0, NaN, 2.0 ];
@@ -78,7 +78,7 @@ var v = nancount( 4, x1, 2 );
 
 #### nancount.ndarray( N, x, strideX, offsetX )
 
-Computes the count of a strided array, ignoring `NaN` values and using alternative indexing semantics.
+Calculate the number of non-`NaN` elements in a  strided array
 
 ```javascript
 var x = [ 1.0, -2.0, NaN, 2.0 ];

--- a/lib/node_modules/@stdlib/stats/strided/nancount/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/README.md
@@ -53,7 +53,7 @@ The function has the following parameters:
 -   **x**: input [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
 -   **strideX**: stride length for `x`.
 
-The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to calculate the count of every other element in `x`,
+The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to calculate the count for every other element in `x`,
 
 ```javascript
 var x = [ 1.0, 2.0, 2.0, -7.0, -2.0, 3.0, 4.0, 2.0, NaN, NaN ];
@@ -78,7 +78,7 @@ var v = nancount( 4, x1, 2 );
 
 #### nancount.ndarray( N, x, strideX, offsetX )
 
-Calculate the number of non-`NaN` elements in a  strided array
+Calculates the number of non-`NaN` elements in a strided array using alternative indexing semantics.
 
 ```javascript
 var x = [ 1.0, -2.0, NaN, 2.0 ];

--- a/lib/node_modules/@stdlib/stats/strided/nancount/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/README.md
@@ -38,7 +38,7 @@ var nancount = require( '@stdlib/stats/strided/nancount' );
 
 #### nancount( N, x, strideX )
 
-Calculate the number of non-`NaN` elements in a strided array
+Calculates the number of non-`NaN` elements in a strided array.
 
 ```javascript
 var x = [ 1.0, -2.0, NaN, 2.0 ];

--- a/lib/node_modules/@stdlib/stats/strided/nancount/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/benchmark/benchmark.js
@@ -1,0 +1,111 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var format = require( '@stdlib/string/format' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var nancount = require( './../lib/main.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns a random number.
+*
+* @private
+* @returns {number} random number
+*/
+function rand() {
+	if ( bernoulli( 0.8 ) < 1 ) {
+		return NaN;
+	}
+	return uniform( -10.0, 10.0 );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = filledarrayBy( len, 'generic', rand );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = nancount( x.length, x, 1 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/nancount/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/benchmark/benchmark.ndarray.js
@@ -1,0 +1,111 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var format = require( '@stdlib/string/format' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var nancount = require( './../lib/ndarray.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns a random number.
+*
+* @private
+* @returns {number} random number
+*/
+function rand() {
+	if ( bernoulli( 0.8 ) < 1 ) {
+		return NaN;
+	}
+	return uniform( -10.0, 10.0 );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = filledarrayBy( len, 'generic', rand );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = nancount( x.length, x, 1, 0 );
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:ndarray:len=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/stats/strided/nancount/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/docs/repl.txt
@@ -49,8 +49,8 @@
     Computes the number of non-`NaN` elements in a strided array.
 
     While typed array views mandate a view offset based on the underlying
-    buffer, the `offset` parameter supports indexing semantics based on a
-    starting index.
+    buffer, the offset parameter supports indexing semantics based on a starting
+    index.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/stats/strided/nancount/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/docs/repl.txt
@@ -1,0 +1,89 @@
+
+{{alias}}( N, x, strideX )
+    Computes the count of a strided array, ignoring `NaN` values.
+
+    The `N` and stride parameters determine which elements in the strided array
+    are accessed at runtime.
+
+    Indexing is relative to the first index. To introduce an offset, use a typed
+    array view.
+
+    If `N <= 0`, the function returns `0`.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Array<number>|TypedArray
+        Input array.
+
+    strideX: integer
+        Stride length.
+
+    Returns
+    -------
+    out: integer
+        Count.
+
+    Examples
+    --------
+    // Standard Usage:
+    > var x = [ 1.0, -2.0, NaN, 2.0 ];
+    > {{alias}}( x.length, x, 1 )
+    3
+
+    // Using `N` and stride parameters:
+    > x = [ -2.0, 1.0, 1.0, -5.0, 2.0, -1.0, NaN, NaN ];
+    > {{alias}}( 4, x, 2 )
+    3
+
+    // Using view offsets:
+    > var x0 = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 3.0, 2.0, 5.0, -1.0, NaN, NaN ] );
+    > var x1 = new {{alias:@stdlib/array/float64}}( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
+    > {{alias}}( 4, x1, 2 )
+    3
+
+
+{{alias}}.ndarray( N, x, strideX, offsetX )
+    Computes the count of a strided array, ignoring `NaN` values and using
+    alternative indexing semantics.
+
+    While typed array views mandate a view offset based on the underlying
+    buffer, the `offset` parameter supports indexing semantics based on a
+    starting index.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Array<number>|TypedArray
+        Input array.
+
+    strideX: integer
+        Stride length.
+
+    offsetX: integer
+        Starting index.
+
+    Returns
+    -------
+    out: integer
+        Count.
+
+    Examples
+    --------
+    // Standard Usage:
+    > var x = [ 1.0, -2.0, NaN, 2.0 ];
+    > {{alias}}.ndarray( x.length, x, 1, 0 )
+    3
+
+    // Using offset parameter:
+    > var x = [ 1.0, -2.0, 3.0, 2.0, 5.0, -1.0, NaN, NaN ];
+    > {{alias}}.ndarray( 4, x, 2, 1 )
+    3
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/stats/strided/nancount/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/docs/repl.txt
@@ -1,6 +1,6 @@
 
 {{alias}}( N, x, strideX )
-    Computes the count of a strided array, ignoring `NaN` values.
+    Computes the number of non-`NaN` elements in a strided array.
 
     The `N` and stride parameters determine which elements in the strided array
     are accessed at runtime.
@@ -46,8 +46,7 @@
 
 
 {{alias}}.ndarray( N, x, strideX, offsetX )
-    Computes the count of a strided array, ignoring `NaN` values and using
-    alternative indexing semantics.
+    Computes the number of non-`NaN` elements in a strided array.
 
     While typed array views mandate a view offset based on the underlying
     buffer, the `offset` parameter supports indexing semantics based on a

--- a/lib/node_modules/@stdlib/stats/strided/nancount/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/docs/types/index.d.ts
@@ -43,7 +43,7 @@ interface Routine {
 	* var x = [ 1.0, -2.0, NaN, 2.0 ];
 	*
 	* var v = nancount( x.length, x, 1 );
-	* // returns 3.0
+	* // returns 3
 	*/
 	( N: number, x: InputArray, strideX: number ): number;
 
@@ -60,7 +60,7 @@ interface Routine {
 	* var x = [ 1.0, -2.0, NaN, 2.0 ];
 	*
 	* var v = nancount.ndarray( x.length, x, 1, 0 );
-	* // returns 3.0
+	* // returns 3
 	*/
 	ndarray( N: number, x: InputArray, strideX: number, offsetX: number ): number;
 }
@@ -77,13 +77,13 @@ interface Routine {
 * var x = [ 1.0, -2.0, NaN, 2.0 ];
 *
 * var v = nancount( x.length, x, 1 );
-* // returns 3.0
+* // returns 3
 *
 * @example
 * var x = [ 1.0, -2.0, NaN, 2.0 ];
 *
 * var v = nancount.ndarray( x.length, x, 1, 0 );
-* // returns 3.0
+* // returns 3
 */
 declare var nancount: Routine;
 

--- a/lib/node_modules/@stdlib/stats/strided/nancount/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/docs/types/index.d.ts
@@ -32,7 +32,7 @@ type InputArray = NumericArray | Collection<number> | AccessorArrayLike<number>;
 */
 interface Routine {
 	/**
-	* Computes the count of a strided array, ignoring `NaN` values.
+	* Computes the number of non-`NaN` elements in a strided array.
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
@@ -48,7 +48,7 @@ interface Routine {
 	( N: number, x: InputArray, strideX: number ): number;
 
 	/**
-	* Computes the count of a strided array, ignoring `NaN` values and using alternative indexing semantics.
+	* Computes the number of non-`NaN` elements in a strided array.
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
@@ -66,7 +66,7 @@ interface Routine {
 }
 
 /**
-* Computes the count of a strided array, ignoring `NaN` values.
+* Computes the number of non-`NaN` elements in a strided array.
 *
 * @param N - number of indexed elements
 * @param x - input array

--- a/lib/node_modules/@stdlib/stats/strided/nancount/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/docs/types/index.d.ts
@@ -1,0 +1,93 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { NumericArray, Collection, AccessorArrayLike } from '@stdlib/types/array';
+
+/**
+* Input array.
+*/
+type InputArray = NumericArray | Collection<number> | AccessorArrayLike<number>;
+
+/**
+* Interface describing `nancount`.
+*/
+interface Routine {
+	/**
+	* Computes the count of a strided array, ignoring `NaN` values.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - stride length
+	* @returns count
+	*
+	* @example
+	* var x = [ 1.0, -2.0, NaN, 2.0 ];
+	*
+	* var v = nancount( x.length, x, 1 );
+	* // returns 3.0
+	*/
+	( N: number, x: InputArray, strideX: number ): number;
+
+	/**
+	* Computes the count of a strided array, ignoring `NaN` values and using alternative indexing semantics.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - stride length
+	* @param offsetX - starting index
+	* @returns count
+	*
+	* @example
+	* var x = [ 1.0, -2.0, NaN, 2.0 ];
+	*
+	* var v = nancount.ndarray( x.length, x, 1, 0 );
+	* // returns 3.0
+	*/
+	ndarray( N: number, x: InputArray, strideX: number, offsetX: number ): number;
+}
+
+/**
+* Computes the count of a strided array, ignoring `NaN` values.
+*
+* @param N - number of indexed elements
+* @param x - input array
+* @param strideX - stride length
+* @returns count
+*
+* @example
+* var x = [ 1.0, -2.0, NaN, 2.0 ];
+*
+* var v = nancount( x.length, x, 1 );
+* // returns 3.0
+*
+* @example
+* var x = [ 1.0, -2.0, NaN, 2.0 ];
+*
+* var v = nancount.ndarray( x.length, x, 1, 0 );
+* // returns 3.0
+*/
+declare var nancount: Routine;
+
+
+// EXPORTS //
+
+export = nancount;

--- a/lib/node_modules/@stdlib/stats/strided/nancount/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/docs/types/test.ts
@@ -1,0 +1,158 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import AccessorArray = require( '@stdlib/array/base/accessor' );
+import nancount = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	const x = new Float64Array( 10 );
+
+	nancount( x.length, x, 1 ); // $ExpectType number
+	nancount( x.length, new AccessorArray( x ), 1 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	nancount( '10', x, 1 ); // $ExpectError
+	nancount( true, x, 1 ); // $ExpectError
+	nancount( false, x, 1 ); // $ExpectError
+	nancount( null, x, 1 ); // $ExpectError
+	nancount( undefined, x, 1 ); // $ExpectError
+	nancount( [], x, 1 ); // $ExpectError
+	nancount( {}, x, 1 ); // $ExpectError
+	nancount( ( x: number ): number => x, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a numeric array...
+{
+	const x = new Float64Array( 10 );
+
+	nancount( x.length, 10, 1 ); // $ExpectError
+	nancount( x.length, '10', 1 ); // $ExpectError
+	nancount( x.length, true, 1 ); // $ExpectError
+	nancount( x.length, false, 1 ); // $ExpectError
+	nancount( x.length, null, 1 ); // $ExpectError
+	nancount( x.length, undefined, 1 ); // $ExpectError
+	nancount( x.length, {}, 1 ); // $ExpectError
+	nancount( x.length, ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	nancount( x.length, x, '10' ); // $ExpectError
+	nancount( x.length, x, true ); // $ExpectError
+	nancount( x.length, x, false ); // $ExpectError
+	nancount( x.length, x, null ); // $ExpectError
+	nancount( x.length, x, undefined ); // $ExpectError
+	nancount( x.length, x, [] ); // $ExpectError
+	nancount( x.length, x, {} ); // $ExpectError
+	nancount( x.length, x, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+
+	nancount(); // $ExpectError
+	nancount( x.length ); // $ExpectError
+	nancount( x.length, x ); // $ExpectError
+	nancount( x.length, x, 1, 10 ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a number...
+{
+	const x = new Float64Array( 10 );
+
+	nancount.ndarray( x.length, x, 1, 0 ); // $ExpectType number
+	nancount.ndarray( x.length, new AccessorArray( x ), 1, 0 ); // $ExpectType number
+}
+
+// The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	nancount.ndarray( '10', x, 1, 0 ); // $ExpectError
+	nancount.ndarray( true, x, 1, 0 ); // $ExpectError
+	nancount.ndarray( false, x, 1, 0 ); // $ExpectError
+	nancount.ndarray( null, x, 1, 0 ); // $ExpectError
+	nancount.ndarray( undefined, x, 1, 0 ); // $ExpectError
+	nancount.ndarray( [], x, 1, 0 ); // $ExpectError
+	nancount.ndarray( {}, x, 1, 0 ); // $ExpectError
+	nancount.ndarray( ( x: number ): number => x, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a second argument which is not a numeric array...
+{
+	const x = new Float64Array( 10 );
+
+	nancount.ndarray( x.length, 10, 1, 0 ); // $ExpectError
+	nancount.ndarray( x.length, '10', 1, 0 ); // $ExpectError
+	nancount.ndarray( x.length, true, 1, 0 ); // $ExpectError
+	nancount.ndarray( x.length, false, 1, 0 ); // $ExpectError
+	nancount.ndarray( x.length, null, 1, 0 ); // $ExpectError
+	nancount.ndarray( x.length, undefined, 1, 0 ); // $ExpectError
+	nancount.ndarray( x.length, {}, 1, 0 ); // $ExpectError
+	nancount.ndarray( x.length, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	nancount.ndarray( x.length, x, '10', 0 ); // $ExpectError
+	nancount.ndarray( x.length, x, true, 0 ); // $ExpectError
+	nancount.ndarray( x.length, x, false, 0 ); // $ExpectError
+	nancount.ndarray( x.length, x, null, 0 ); // $ExpectError
+	nancount.ndarray( x.length, x, undefined, 0 ); // $ExpectError
+	nancount.ndarray( x.length, x, [], 0 ); // $ExpectError
+	nancount.ndarray( x.length, x, {}, 0 ); // $ExpectError
+	nancount.ndarray( x.length, x, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	nancount.ndarray( x.length, x, 1, '10' ); // $ExpectError
+	nancount.ndarray( x.length, x, 1, true ); // $ExpectError
+	nancount.ndarray( x.length, x, 1, false ); // $ExpectError
+	nancount.ndarray( x.length, x, 1, null ); // $ExpectError
+	nancount.ndarray( x.length, x, 1, undefined ); // $ExpectError
+	nancount.ndarray( x.length, x, 1, [] ); // $ExpectError
+	nancount.ndarray( x.length, x, 1, {} ); // $ExpectError
+	nancount.ndarray( x.length, x, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+
+	nancount.ndarray(); // $ExpectError
+	nancount.ndarray( x.length ); // $ExpectError
+	nancount.ndarray( x.length, x ); // $ExpectError
+	nancount.ndarray( x.length, x, 1 ); // $ExpectError
+	nancount.ndarray( x.length, x, 1, 0, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/strided/nancount/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/examples/index.js
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var uniform = require( '@stdlib/random/base/uniform' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var nancount = require( './../lib' );
+
+function rand() {
+	if ( bernoulli( 0.8 ) < 1 ) {
+		return NaN;
+	}
+	return uniform( -50.0, 50.0 );
+}
+
+var x = filledarrayBy( 10, 'float64', rand );
+console.log( x );
+
+var v = nancount( x.length, x, 1 );
+console.log( v );

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
@@ -21,7 +21,7 @@
 // MAIN //
 
 /**
-* Computes the count of a strided array, ignoring `NaN` values.
+* Computes the number of non-`NaN` elements in a strided array.
 *
 * @private
 * @param {PositiveInteger} N - number of indexed elements

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
@@ -55,6 +55,10 @@ function nancount( N, x, strideX, offsetX ) {
 	// Cache a reference to the element accessor:
 	get = x.accessors[ 0 ];
 
+	if ( strideX === 0 ) {
+		v = get( xbuf, ix );
+		return ( v === v ) ? N : 0;
+	}
 	ix = offsetX;
 	n = 0;
 	for ( i = 0; i < N; i++ ) {

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
@@ -30,7 +30,7 @@
 * @param {Array<Function>} x.accessors - array element accessors
 * @param {integer} strideX - stride length
 * @param {NonNegativeInteger} offsetX - starting index
-* @returns {number} count
+* @returns {NonNegativeInteger} count
 *
 * @example
 * var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
@@ -39,7 +39,7 @@
 * var x = toAccessorArray( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ] );
 *
 * var v = nancount( 5, arraylike2object( x ), 2, 1 );
-* // returns 4.0
+* // returns 4
 */
 function nancount( N, x, strideX, offsetX ) {
 	var xbuf;

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
@@ -1,0 +1,73 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Computes the count of a strided array, ignoring `NaN` values.
+*
+* @private
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Object} x - input array object
+* @param {Collection} x.data - input array data
+* @param {Array<Function>} x.accessors - array element accessors
+* @param {integer} strideX - stride length
+* @param {NonNegativeInteger} offsetX - starting index
+* @returns {number} count
+*
+* @example
+* var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+* var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
+*
+* var x = toAccessorArray( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ] );
+*
+* var v = nancount( 5, arraylike2object( x ), 2, 1 );
+* // returns 4.0
+*/
+function nancount( N, x, strideX, offsetX ) {
+	var xbuf;
+	var get;
+	var ix;
+	var v;
+	var n;
+	var i;
+
+	// Cache reference to array data:
+	xbuf = x.data;
+
+	// Cache a reference to the element accessor:
+	get = x.accessors[ 0 ];
+
+	ix = offsetX;
+	n = 0;
+	for ( i = 0; i < N; i++ ) {
+		v = get( xbuf, ix );
+		if ( v === v ) {
+			n += 1;
+		}
+		ix += strideX;
+	}
+	return n;
+}
+
+
+// EXPORTS //
+
+module.exports = nancount;

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/accessors.js
@@ -56,7 +56,7 @@ function nancount( N, x, strideX, offsetX ) {
 	get = x.accessors[ 0 ];
 
 	if ( strideX === 0 ) {
-		v = get( xbuf, ix );
+		v = get( xbuf, offsetX );
 		return ( v === v ) ? N : 0;
 	}
 	ix = offsetX;

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Compute the count of a strided array, ignoring `NaN` values.
+* Compute the number of non-`NaN` elements in a strided array.
 *
 * @module @stdlib/stats/strided/nancount
 *

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/index.js
@@ -29,7 +29,7 @@
 * var x = [ 1.0, -2.0, NaN, 2.0 ];
 *
 * var v = nancount( x.length, x, 1 );
-* // returns 3.0
+* // returns 3
 *
 * @example
 * var nancount = require( '@stdlib/stats/strided/nancount' );
@@ -37,7 +37,7 @@
 * var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ];
 *
 * var v = nancount.ndarray( 5, x, 2, 1 );
-* // returns 4.0
+* // returns 4
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/index.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute the count of a strided array, ignoring `NaN` values.
+*
+* @module @stdlib/stats/strided/nancount
+*
+* @example
+* var nancount = require( '@stdlib/stats/strided/nancount' );
+*
+* var x = [ 1.0, -2.0, NaN, 2.0 ];
+*
+* var v = nancount( x.length, x, 1 );
+* // returns 3.0
+*
+* @example
+* var nancount = require( '@stdlib/stats/strided/nancount' );
+*
+* var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ];
+*
+* var v = nancount.ndarray( 5, x, 2, 1 );
+* // returns 4.0
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var main = require( './main.js' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+setReadOnly( main, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = main;
+
+// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/main.js
@@ -32,13 +32,13 @@ var ndarray = require( './ndarray.js' );
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NumericArray} x - input array
 * @param {integer} strideX - stride length
-* @returns {number} count
+* @returns {NonNegativeInteger} count
 *
 * @example
 * var x = [ 1.0, -2.0, NaN, 2.0 ];
 *
 * var v = nancount( x.length, x, 1 );
-* // returns 3.0
+* // returns 3
 */
 function nancount( N, x, strideX ) {
 	return ndarray( N, x, strideX, stride2offset( N, strideX ) );

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/main.js
@@ -27,7 +27,7 @@ var ndarray = require( './ndarray.js' );
 // MAIN //
 
 /**
-* Computes the count of a strided array, ignoring `NaN` values.
+* Computes the number of non-`NaN` elements in a strided array.
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NumericArray} x - input array

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/main.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var stride2offset = require( '@stdlib/strided/base/stride2offset' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+/**
+* Computes the count of a strided array, ignoring `NaN` values.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {NumericArray} x - input array
+* @param {integer} strideX - stride length
+* @returns {number} count
+*
+* @example
+* var x = [ 1.0, -2.0, NaN, 2.0 ];
+*
+* var v = nancount( x.length, x, 1 );
+* // returns 3.0
+*/
+function nancount( N, x, strideX ) {
+	return ndarray( N, x, strideX, stride2offset( N, strideX ) );
+}
+
+
+// EXPORTS //
+
+module.exports = nancount;

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/ndarray.js
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
+var accessors = require( './accessors.js' );
+
+
+// MAIN //
+
+/**
+* Computes the count of a strided array, ignoring `NaN` values.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {NumericArray} x - input array
+* @param {integer} strideX - stride length
+* @param {NonNegativeInteger} offsetX - starting index
+* @returns {number} count
+*
+* @example
+* var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ];
+*
+* var v = nancount( 5, x, 2, 1 );
+* // returns 4.0
+*/
+function nancount( N, x, strideX, offsetX ) {
+	var ix;
+	var o;
+	var n;
+	var i;
+	var v;
+
+	if ( N <= 0 ) {
+		return 0;
+	}
+	o = arraylike2object( x );
+	if ( o.accessorProtocol ) {
+		return accessors( N, o, strideX, offsetX );
+	}
+	if ( strideX === 0 ) {
+		return ( x[ offsetX ] === x[ offsetX ] ) ? N : 0;
+	}
+	ix = offsetX;
+	n = 0;
+	for ( i = 0; i < N; i++ ) {
+		v = x[ ix ];
+		if ( v === v ) {
+			n += 1;
+		}
+		ix += strideX;
+	}
+	return n;
+}
+
+
+// EXPORTS //
+
+module.exports = nancount;

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/ndarray.js
@@ -27,7 +27,7 @@ var accessors = require( './accessors.js' );
 // MAIN //
 
 /**
-* Computes the count of a strided array, ignoring `NaN` values.
+* Computes the number of non-`NaN` elements in a strided array.
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NumericArray} x - input array

--- a/lib/node_modules/@stdlib/stats/strided/nancount/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/lib/ndarray.js
@@ -33,13 +33,13 @@ var accessors = require( './accessors.js' );
 * @param {NumericArray} x - input array
 * @param {integer} strideX - stride length
 * @param {NonNegativeInteger} offsetX - starting index
-* @returns {number} count
+* @returns {NonNegativeInteger} count
 *
 * @example
 * var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ];
 *
 * var v = nancount( 5, x, 2, 1 );
-* // returns 4.0
+* // returns 4
 */
 function nancount( N, x, strideX, offsetX ) {
 	var ix;

--- a/lib/node_modules/@stdlib/stats/strided/nancount/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/stats/strided/nancount",
+  "version": "0.0.0",
+  "description": "Calculate the count of a strided array, ignoring NaN values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "count",
+    "nancount",
+    "number",
+    "length",
+    "size",
+    "strided",
+    "strided array",
+    "array"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/stats/strided/nancount/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/strided/nancount",
   "version": "0.0.0",
-  "description": "Calculate the count of a strided array, ignoring NaN values.",
+  "description": "Calculate the number of non-`NaN` elements in a strided array.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var nancount = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nancount, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof nancount.ndarray, 'function', 'method is a function' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.main.js
@@ -154,6 +154,18 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns `N` i
 	t.end();
 });
 
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `N` if first element is valid (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount( x.length, toAccessorArray( x ), 0 );
+	t.strictEqual( v, x.length, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` if first element is NaN', function test( t ) {
 	var x;
 	var v;
@@ -161,6 +173,18 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` i
 	x = [ NaN, -2.0, -4.0, 5.0, 3.0 ];
 
 	v = nancount( x.length, x, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` if first element is NaN (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ NaN, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount( x.length, toAccessorArray( x ), 0 );
 	t.strictEqual( v, 0, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.main.js
@@ -119,6 +119,29 @@ tape( 'the function supports a `stride` parameter', function test( t ) {
 	t.end();
 });
 
+tape( 'the function supports a `stride` parameter (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0,
+		NaN,  // 4
+		NaN
+	];
+
+	v = nancount( 5, toAccessorArray( x ), 2 );
+
+	t.strictEqual( v, 4, 'returns expected value' );
+	t.end();
+});
+
 tape( 'the function supports a negative `stride` parameter', function test( t ) {
 	var x;
 	var v;
@@ -137,6 +160,29 @@ tape( 'the function supports a negative `stride` parameter', function test( t ) 
 	];
 
 	v = nancount( 5, x, -2 );
+
+	t.strictEqual( v, 4, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		NaN,  // 4
+		NaN,
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	];
+
+	v = nancount( 5, toAccessorArray( x ), -2 );
 
 	t.strictEqual( v, 4, 'returns expected value' );
 	t.end();

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.main.js
@@ -39,7 +39,7 @@ tape( 'the function has an arity of 3', function test( t ) {
 	t.end();
 });
 
-tape( 'the function calculates the count of a strided array, ignoring `NaN` values', function test( t ) {
+tape( 'the function counts the number of non-`NaN` elements in a  strided array', function test( t ) {
 	var x;
 	var v;
 
@@ -62,7 +62,7 @@ tape( 'the function calculates the count of a strided array, ignoring `NaN` valu
 	t.end();
 });
 
-tape( 'the function calculates the count of a strided array, ignoring `NaN` values (accessors)', function test( t ) {
+tape( 'the function counts the number of non-`NaN` elements in a  strided array (accessors)', function test( t ) {
 	var x;
 	var v;
 

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.main.js
@@ -1,0 +1,194 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+var Float64Array = require( '@stdlib/array/float64' );
+var nancount = require( './../lib/main.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nancount, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 3', function test( t ) {
+	t.strictEqual( nancount.length, 3, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function calculates the count of a strided array, ignoring `NaN` values', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0, NaN, NaN ];
+	v = nancount( x.length, x, 1 );
+	t.strictEqual( v, 6, 'returns expected value' );
+
+	x = [ -4.0, NaN, -5.0 ];
+	v = nancount( x.length, x, 1 );
+	t.strictEqual( v, 2, 'returns expected value' );
+
+	x = [ NaN ];
+	v = nancount( x.length, x, 1 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	x = [ NaN, NaN ];
+	v = nancount( x.length, x, 1 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function calculates the count of a strided array, ignoring `NaN` values (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0, NaN, NaN ];
+	v = nancount( x.length, toAccessorArray( x ), 1 );
+	t.strictEqual( v, 6, 'returns expected value' );
+
+	x = [ -4.0, NaN, -5.0 ];
+	v = nancount( x.length, toAccessorArray( x ), 1 );
+	t.strictEqual( v, 2, 'returns expected value' );
+
+	x = [ NaN ];
+	v = nancount( x.length, toAccessorArray( x ), 1 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `0`', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount( 0, x, 1 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	v = nancount( -1, x, 1 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0,
+		NaN,  // 4
+		NaN
+	];
+
+	v = nancount( 5, x, 2 );
+
+	t.strictEqual( v, 4, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		NaN,  // 4
+		NaN,
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	];
+
+	v = nancount( 5, x, -2 );
+
+	t.strictEqual( v, 4, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `N` if first element is valid', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount( x.length, x, 0 );
+	t.strictEqual( v, x.length, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` if first element is NaN', function test( t ) {
+	var x;
+	var v;
+
+	x = [ NaN, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount( x.length, x, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports view offsets', function test( t ) {
+	var x0;
+	var x1;
+	var v;
+
+	x0 = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0,  // 3
+		6.0,
+		NaN,  // 4
+		NaN
+	]);
+
+	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+	v = nancount( 5, x1, 2 );
+	t.strictEqual( v, 4, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
@@ -34,69 +34,69 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
-	t.strictEqual( typeof nancount.ndarray, 'function', 'method is a function' );
+tape( 'the function has an arity of 4', function test( t ) {
+	t.strictEqual( nancount.length, 4, 'has expected arity' );
 	t.end();
 });
 
-tape( 'the method calculates the count of a strided array, ignoring `NaN` values', function test( t ) {
+tape( 'the function calculates the count of a strided array, ignoring `NaN` values', function test( t ) {
 	var x;
 	var v;
 
 	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0, NaN, NaN ];
-	v = nancount.ndarray( x.length, x, 1, 0 );
+	v = nancount( x.length, x, 1, 0 );
 	t.strictEqual( v, 6, 'returns expected value' );
 
 	x = [ -4.0, NaN, -5.0 ];
-	v = nancount.ndarray( x.length, x, 1, 0 );
+	v = nancount( x.length, x, 1, 0 );
 	t.strictEqual( v, 2, 'returns expected value' );
 
 	x = [ NaN ];
-	v = nancount.ndarray( x.length, x, 1, 0 );
+	v = nancount( x.length, x, 1, 0 );
 	t.strictEqual( v, 0, 'returns expected value' );
 
 	x = [ NaN, NaN ];
-	v = nancount.ndarray( x.length, x, 1, 0 );
+	v = nancount( x.length, x, 1, 0 );
 	t.strictEqual( v, 0, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'the method calculates the count of a strided array, ignoring `NaN` values (accessors)', function test( t ) {
+tape( 'the function calculates the count of a strided array, ignoring `NaN` values (accessors)', function test( t ) {
 	var x;
 	var v;
 
 	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0, NaN, NaN ];
-	v = nancount.ndarray( x.length, toAccessorArray( x ), 1, 0 );
+	v = nancount( x.length, toAccessorArray( x ), 1, 0 );
 	t.strictEqual( v, 6, 'returns expected value' );
 
 	x = [ -4.0, NaN, -5.0 ];
-	v = nancount.ndarray( x.length, toAccessorArray( x ), 1, 0 );
+	v = nancount( x.length, toAccessorArray( x ), 1, 0 );
 	t.strictEqual( v, 2, 'returns expected value' );
 
 	x = [ NaN ];
-	v = nancount.ndarray( x.length, toAccessorArray( x ), 1, 0 );
+	v = nancount( x.length, toAccessorArray( x ), 1, 0 );
 	t.strictEqual( v, 0, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'if provided an `N` parameter less than or equal to `0`, the method returns `0`', function test( t ) {
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `0`', function test( t ) {
 	var x;
 	var v;
 
 	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
 
-	v = nancount.ndarray( 0, x, 1, 0 );
+	v = nancount( 0, x, 1, 0 );
 	t.strictEqual( v, 0, 'returns expected value' );
 
-	v = nancount.ndarray( -1, x, 1, 0 );
+	v = nancount( -1, x, 1, 0 );
 	t.strictEqual( v, 0, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'the method supports a `stride` parameter', function test( t ) {
+tape( 'the function supports a `stride` parameter', function test( t ) {
 	var x;
 	var v;
 
@@ -113,13 +113,13 @@ tape( 'the method supports a `stride` parameter', function test( t ) {
 		NaN
 	];
 
-	v = nancount.ndarray( 5, x, 2, 0 );
+	v = nancount( 5, x, 2, 0 );
 
 	t.strictEqual( v, 4, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the method supports a negative `stride` parameter', function test( t ) {
+tape( 'the function supports a negative `stride` parameter', function test( t ) {
 	var x;
 	var v;
 
@@ -136,37 +136,37 @@ tape( 'the method supports a negative `stride` parameter', function test( t ) {
 		2.0
 	];
 
-	v = nancount.ndarray( 5, x, -2, x.length-2 );
+	v = nancount( 5, x, -2, x.length-2 );
 
 	t.strictEqual( v, 4, 'returns expected value' );
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0`, the method returns `N` if first element is valid', function test( t ) {
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `N` if first element is valid', function test( t ) {
 	var x;
 	var v;
 
 	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
 
-	v = nancount.ndarray( x.length, x, 0, 0 );
+	v = nancount( x.length, x, 0, 0 );
 	t.strictEqual( v, x.length, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0`, the method returns `0` if first element is NaN', function test( t ) {
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` if first element is NaN', function test( t ) {
 	var x;
 	var v;
 
 	x = [ NaN, -2.0, -4.0, 5.0, 3.0 ];
 
-	v = nancount.ndarray( x.length, x, 0, 0 );
+	v = nancount( x.length, x, 0, 0 );
 	t.strictEqual( v, 0, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'the method supports view offsets', function test( t ) {
+tape( 'the function supports view offsets', function test( t ) {
 	var x0;
 	var x1;
 	var v;
@@ -187,7 +187,7 @@ tape( 'the method supports view offsets', function test( t ) {
 
 	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
 
-	v = nancount.ndarray( 5, x1, 2, 0 );
+	v = nancount( 5, x1, 2, 0 );
 	t.strictEqual( v, 4, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
@@ -39,7 +39,7 @@ tape( 'the function has an arity of 4', function test( t ) {
 	t.end();
 });
 
-tape( 'the function calculates the count of a strided array, ignoring `NaN` values', function test( t ) {
+tape( 'the function counts the number of non-`NaN` elements in a strided array', function test( t ) {
 	var x;
 	var v;
 
@@ -62,7 +62,7 @@ tape( 'the function calculates the count of a strided array, ignoring `NaN` valu
 	t.end();
 });
 
-tape( 'the function calculates the count of a strided array, ignoring `NaN` values (accessors)', function test( t ) {
+tape( 'the function counts the number of non-`NaN` elements in a strided array (accessors)', function test( t ) {
 	var x;
 	var v;
 

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
@@ -1,0 +1,194 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+var Float64Array = require( '@stdlib/array/float64' );
+var nancount = require( './../lib/ndarray.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nancount, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof nancount.ndarray, 'function', 'method is a function' );
+	t.end();
+});
+
+tape( 'the method calculates the count of a strided array, ignoring `NaN` values', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0, NaN, NaN ];
+	v = nancount.ndarray( x.length, x, 1, 0 );
+	t.strictEqual( v, 6, 'returns expected value' );
+
+	x = [ -4.0, NaN, -5.0 ];
+	v = nancount.ndarray( x.length, x, 1, 0 );
+	t.strictEqual( v, 2, 'returns expected value' );
+
+	x = [ NaN ];
+	v = nancount.ndarray( x.length, x, 1, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	x = [ NaN, NaN ];
+	v = nancount.ndarray( x.length, x, 1, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method calculates the count of a strided array, ignoring `NaN` values (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0, NaN, NaN ];
+	v = nancount.ndarray( x.length, toAccessorArray( x ), 1, 0 );
+	t.strictEqual( v, 6, 'returns expected value' );
+
+	x = [ -4.0, NaN, -5.0 ];
+	v = nancount.ndarray( x.length, toAccessorArray( x ), 1, 0 );
+	t.strictEqual( v, 2, 'returns expected value' );
+
+	x = [ NaN ];
+	v = nancount.ndarray( x.length, toAccessorArray( x ), 1, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the method returns `0`', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount.ndarray( 0, x, 1, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	v = nancount.ndarray( -1, x, 1, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method supports a `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0,
+		NaN,  // 4
+		NaN
+	];
+
+	v = nancount.ndarray( 5, x, 2, 0 );
+
+	t.strictEqual( v, 4, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method supports a negative `stride` parameter', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		NaN,  // 4
+		NaN,
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	];
+
+	v = nancount.ndarray( 5, x, -2, x.length-2 );
+
+	t.strictEqual( v, 4, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the method returns `N` if first element is valid', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount.ndarray( x.length, x, 0, 0 );
+	t.strictEqual( v, x.length, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the method returns `0` if first element is NaN', function test( t ) {
+	var x;
+	var v;
+
+	x = [ NaN, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount.ndarray( x.length, x, 0, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method supports view offsets', function test( t ) {
+	var x0;
+	var x1;
+	var v;
+
+	x0 = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0,  // 3
+		6.0,
+		NaN,  // 4
+		NaN
+	]);
+
+	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+	v = nancount.ndarray( 5, x1, 2, 0 );
+	t.strictEqual( v, 4, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
@@ -119,6 +119,29 @@ tape( 'the function supports a `stride` parameter', function test( t ) {
 	t.end();
 });
 
+tape( 'the function supports a `stride` parameter (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0,
+		NaN,  // 4
+		NaN
+	];
+
+	v = nancount( 5, toAccessorArray( x ), 2, 0 );
+
+	t.strictEqual( v, 4, 'returns expected value' );
+	t.end();
+});
+
 tape( 'the function supports a negative `stride` parameter', function test( t ) {
 	var x;
 	var v;
@@ -137,6 +160,29 @@ tape( 'the function supports a negative `stride` parameter', function test( t ) 
 	];
 
 	v = nancount( 5, x, -2, x.length-2 );
+
+	t.strictEqual( v, 4, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		NaN,  // 4
+		NaN,
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	];
+
+	v = nancount( 5, toAccessorArray( x ), -2, x.length-2 );
 
 	t.strictEqual( v, 4, 'returns expected value' );
 	t.end();

--- a/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nancount/test/test.ndarray.js
@@ -154,6 +154,18 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns `N` i
 	t.end();
 });
 
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `N` if first element is valid (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount( x.length, toAccessorArray( x ), 0, 0 );
+	t.strictEqual( v, x.length, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` if first element is NaN', function test( t ) {
 	var x;
 	var v;
@@ -161,6 +173,18 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` i
 	x = [ NaN, -2.0, -4.0, 5.0, 3.0 ];
 
 	v = nancount( x.length, x, 0, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` if first element is NaN (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ NaN, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = nancount( x.length, toAccessorArray( x ), 0, 0 );
 	t.strictEqual( v, 0, 'returns expected value' );
 
 	t.end();


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a new function `stats/strided/nancount` to count the number of non-NaN elements in a strided array
-   implements the core logic for iterating over a strided array and excluding `NaN` values from the count
-   includes relevant documentation and examples

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md