### PR TITLE
chore: fix JavaScript lint errors (issue #11065)

### DIFF
--- a/lib/node_modules/@stdlib/stats/ztest/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/ztest/benchmark/benchmark.js
@@ -34,14 +34,12 @@ var ztest = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var result;
 	var sigma;
-	var len;
 	var x;
 	var i;
 
-	x = new Array( 100 );
-	len = x.length;
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu()*50.0;
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
+		x.pusha( randu()*50.0 );
 	}
 	sigma = stdev( 0.0, 50.0 );
 
@@ -65,14 +63,12 @@ bench( pkg+'::one-sided', function benchmark( b ) {
 	var result;
 	var sigma;
 	var opts;
-	var len;
 	var x;
 	var i;
 
-	x = new Array( 100 );
-	len = x.length;
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu()*50.0;
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
+		x.push( randu()*50.0 );
 	}
 	opts = {
 		'alternative': 'less'
@@ -100,14 +96,12 @@ bench( pkg+':print', function benchmark( b ) {
 	var result;
 	var output;
 	var sigma;
-	var len;
 	var x;
 	var i;
 
-	x = new Array( 100 );
-	len = x.length;
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu()*50.0;
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
+		x.push( randu()*50.0 );
 	}
 	sigma = stdev( 0.0, 50.0 );
 	result = ztest( x, sigma );

--- a/lib/node_modules/@stdlib/stats/ztest/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/ztest/benchmark/benchmark.js
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 
 	x = [];
 	for ( i = 0; i < 100; i++ ) {
-		x.pusha( randu()*50.0 );
+		x.push( randu()*50.0 );
 	}
 	sigma = stdev( 0.0, 50.0 );
 


### PR DESCRIPTION
Resolves #11065 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes JavaScript lint errors in `stats/ztest` benchmark file by removing usage of the disallowed `new Array()` constructor.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11065 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
