### PR TITLE
chore: fix JavaScript lint errors in ztest benchmark

### DIFF
--- a/lib/node_modules/@stdlib/stats/ztest/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/ztest/benchmark/benchmark.js
@@ -34,20 +34,18 @@ var ztest = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var result;
 	var sigma;
-	var len;
 	var x;
 	var i;
 
-	x = new Array( 100 );
-	len = x.length;
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu()*50.0;
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
+		x.push( randu() * 50.0 );
 	}
 	sigma = stdev( 0.0, 50.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x[ i % x.length ] = randu()*50.0;
+		x[ i % x.length ] = randu() * 50.0;
 		result = ztest( x, sigma );
 		if ( typeof result !== 'object' ) {
 			b.fail( 'should return an object' );
@@ -65,14 +63,12 @@ bench( pkg+'::one-sided', function benchmark( b ) {
 	var result;
 	var sigma;
 	var opts;
-	var len;
 	var x;
 	var i;
 
-	x = new Array( 100 );
-	len = x.length;
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu()*50.0;
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
+		x.push(randu() * 50.0 );
 	}
 	opts = {
 		'alternative': 'less'
@@ -81,7 +77,7 @@ bench( pkg+'::one-sided', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x[ i % x.length ] = randu()*50.0;
+		x[ i % x.length ] = randu() * 50.0;
 		result = ztest( x, sigma, opts );
 		if ( typeof result !== 'object' ) {
 			b.fail( 'should return an object' );
@@ -100,14 +96,12 @@ bench( pkg+':print', function benchmark( b ) {
 	var result;
 	var output;
 	var sigma;
-	var len;
 	var x;
 	var i;
 
-	x = new Array( 100 );
-	len = x.length;
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu()*50.0;
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
+		x.push( randu() * 50.0 );
 	}
 	sigma = stdev( 0.0, 50.0 );
 	result = ztest( x, sigma );


### PR DESCRIPTION
### Summary
This PR resolves linting errors in lib/node_modules/@stdlib/stats/ztest/benchmark/benchmark.js by replacing new Array() with array literals and using .push() for population.

### Changes
- Replaced new Array( 100 ) with [].
- Added a  .push() loop to correctly populate the benchmark data.
- Removed unused len variables.

Fixes #11065