### PR TITLE
chore: resolve JavaScript lint errors in `utils/copy`

### DIFF
--- a/lib/node_modules/@stdlib/utils/copy/lib/deep_copy.js
+++ b/lib/node_modules/@stdlib/utils/copy/lib/deep_copy.js
@@ -262,7 +262,7 @@ function deepCopy( val, copy, cache, refs, level ) {
 				continue;
 			}
 			// Plain array or object...
-			ref = ( isArray( x ) ) ? new Array( x.length ) : {};
+			ref = ( isArray( x ) ) ? new Array( x.length ) : {}; // eslint-disable-line stdlib/no-new-array
 			cache.push( x );
 			refs.push( ref );
 			if ( parent === 'array' ) {

--- a/lib/node_modules/@stdlib/utils/copy/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/copy/lib/main.js
@@ -67,7 +67,7 @@ function copy( value, level ) {
 	} else {
 		level = PINF;
 	}
-	out = ( isArray( value ) ) ? new Array( value.length ) : {};
+	out = ( isArray( value ) ) ? new Array( value.length ) : {}; // eslint-disable-line stdlib/no-new-array
 	return deepCopy( value, out, [value], [out], level );
 }
 


### PR DESCRIPTION
## Summary
Fixes #11082

Resolves the `stdlib/no-new-array` lint error in the deep copy module by adding targeted eslint-disable-line comments where `new Array(length)` is intentionally required for sparse array preservation.

## Changes
- `lib/node_modules/@stdlib/utils/copy/lib/deep_copy.js` (line 265): Added `// eslint-disable-line stdlib/no-new-array`
- `lib/node_modules/@stdlib/utils/copy/lib/main.js` (line 70): Added `// eslint-disable-line stdlib/no-new-array`

## Rationale
`new Array(x.length)` cannot be replaced with `[]` because sparse array copies must preserve the `.length` property. The test suite explicitly verifies `actual.length === 100` for sparse arrays. This pattern follows existing project precedent (e.g., `@stdlib/stats/kstest/lib/main.js`).

## Test plan
- [x] ESLint passes on both modified files
- [x] Deep copy functionality verified: sparse arrays, nested arrays, standard objects all copy correctly

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)