### PR TITLE
chore: fix JavaScript lint errors (issue #11082)

### DIFF
--- a/lib/node_modules/@stdlib/utils/copy/lib/deep_copy.js
+++ b/lib/node_modules/@stdlib/utils/copy/lib/deep_copy.js
@@ -262,7 +262,7 @@ function deepCopy( val, copy, cache, refs, level ) {
 				continue;
 			}
 			// Plain array or object...
-			ref = ( isArray( x ) ) ? new Array( x.length ) : {};
+			ref = ( isArray( x ) ) ? [] : {};
 			cache.push( x );
 			refs.push( ref );
 			if ( parent === 'array' ) {


### PR DESCRIPTION
## Related Issues

resolves #11082

## Description

Fixed a JavaScript linting failure detected in the automated lint 
workflow. The `stdlib/no-new-array` rule disallows use of the `new 
Array()` constructor. Replaced the offending usage in `deep_copy.js` 
with an array literal `[]`, which is the idiomatic stdlib convention.

**File changed:**
`lib/node_modules/@stdlib/utils/copy/lib/deep_copy.js`

**Change:**
\```javascript
// Before
ref = ( isArray( x ) ) ? new Array( x.length ) : {};

// After
ref = ( isArray( x ) ) ? [] : {};
\```

## Checklist

- [x] The fix addresses the lint error reported in the automated workflow
- [x] No unrelated files were modified
- [x] Commit message follows the project conventions
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)