### PR TITLE
chore: remove unused ESLint directive (#11099)

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-nonpositive-number-array/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-nonpositive-number-array/benchmark/benchmark.js
@@ -50,7 +50,7 @@ function createBenchmark( fcn, len, primitives ) {
 		}
 	} else {
 		for ( i = 0; i < len; i++ ) {
-			x.push( new Number( -1.0 ) ); // eslint-disable-line no-new-wrappers
+			x.push( new Number( -1.0 ) );
 		}
 	}
 	return benchmark;


### PR DESCRIPTION
## Summary

Removes an unused `eslint-disable-line no-new-wrappers` directive on line 53 of `lib/node_modules/@stdlib/assert/is-nonpositive-number-array/benchmark/benchmark.js`. The `no-new-wrappers` rule no longer reports on that line, so the disable comment itself causes a lint failure.

## Changes

One line: removed `// eslint-disable-line no-new-wrappers` from the `new Number(-1.0)` call in the benchmark's `createBenchmark` function.

## Testing

The CI workflow run at https://github.com/stdlib-js/stdlib/actions/runs/23415770324 shows this is the only lint error. Removing the unused directive resolves it.

Fixes #11099

This contribution was developed with AI assistance (Claude Code).

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)