### PR TITLE
chore: fix EditorConfig lint errors (issue #10943)

### DIFF
--- a/lib/node_modules/@stdlib/stats/wilcoxon/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/wilcoxon/examples/index.js
@@ -38,14 +38,14 @@ for ( i = 0; i < arr.length; i++ ) {
 out = wilcoxon( arr );
 console.log( out.print() );
 /* e.g., =>
-    One-Sample Wilcoxon signed rank test
+	One-Sample Wilcoxon signed rank test
 
-    Alternative hypothesis: Median of `x` is not equal to 0
+	Alternative hypothesis: Median of `x` is not equal to 0
 
-        pValue: 0.7714
-        statistic: 2438.5
+		pValue: 0.7714
+		statistic: 2438.5
 
-    Test Decision: Fail to reject null in favor of alternative at 5% significance level
+	Test Decision: Fail to reject null in favor of alternative at 5% significance level
 */
 
 // Test whether distribution has median of five:
@@ -54,12 +54,12 @@ out = wilcoxon( arr, {
 });
 console.log( out.print() );
 /* e.g, =>
-    One-Sample Wilcoxon signed rank test
+	One-Sample Wilcoxon signed rank test
 
-    Alternative hypothesis: Median of `x` is not equal to 5
+	Alternative hypothesis: Median of `x` is not equal to 5
 
-        pValue: 0.0529
-        statistic: 1961.5
+		pValue: 0.0529
+		statistic: 1961.5
 
-    Test Decision: Fail to reject null in favor of alternative at 5% significance level
+	Test Decision: Fail to reject null in favor of alternative at 5% significance level
 */


### PR DESCRIPTION
## Related Issues

resolves #10943

## Description

Fixed EditorConfig lint errors in `lib/node_modules/@stdlib/stats/wilcoxon/examples/index.js`.

The two multi-line comment blocks were using spaces for indentation instead of tabs, violating the project's EditorConfig rules. Replaced all leading spaces with tabs on the affected lines (41, 43, 45-46, 48, 57, 59, 61-62, 64).

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)