### PR TITLE
fix: `dgemm` not handling conjugate-transpose

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/README.md
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/README.md
@@ -1,0 +1,125 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isTransposed
+
+> Test whether an input value indicates that a matrix should be transposed.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+Test whether an input value indicates that a matrix should be transposed.
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
+```
+
+#### isTransposed( value )
+
+Test whether an input value indicates that a matrix should be transposed.
+
+```javascript
+var bool = isTransposed( 'transpose' );
+// returns true
+
+bool = isTransposed( 'conjugate-transpose' );
+// returns true
+
+bool = isTransposed( 'no-transpose' );
+// returns false
+
+bool = isTransposed( 'foo' );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
+
+var bool = isTransposed( 'transpose' );
+// returns true
+
+bool = isTransposed( 'conjugate-transpose' );
+// returns true
+
+bool = isTransposed( 'no-transpose' );
+// returns false
+
+bool = isTransposed( 'foo' );
+// returns false
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/benchmark/benchmark.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var isTransposed = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'transpose',
+		'conjugate-transpose',
+		'no-transpose',
+		'foo',
+		'bar',
+		'',
+		'beep',
+		'boop'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = isTransposed( values[ i%values.length ] );
+		if ( typeof out !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( out ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/docs/repl.txt
@@ -1,0 +1,29 @@
+
+{{alias}}( value )
+    Test whether an input value indicates that a matrix should be transposed.
+
+    Parameters
+    ----------
+    value: any
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating if an input value indicates that a matrix should be
+        transposed.
+
+    Examples
+    --------
+    > var bool = {{alias}}( 'transpose' )
+    true
+    > bool = {{alias}}( 'conjugate-transpose' )
+    true
+    > bool = {{alias}}( 'no-transpose' )
+    false
+    > bool = {{alias}}( 'foo' )
+    false
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/docs/types/index.d.ts
@@ -1,0 +1,45 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Test whether an input value indicates that a matrix should be transposed.
+*
+* @param value - value to test
+* @returns boolean indicating whether an input value indicates that a matrix should be transposed.
+*
+* @example
+* var bool = isTransposed( 'transpose' );
+* // returns true
+*
+* bool = isTransposed( 'conjugate-transpose' );
+* // returns true
+*
+* bool = isTransposed( 'no-transpose' );
+* // returns false
+*
+* bool = isTransposed( 'foo' );
+* // returns false
+*/
+declare function isTransposed( value: any ): boolean;
+
+
+// EXPORTS //
+
+export = isTransposed;

--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/docs/types/test.ts
@@ -1,0 +1,34 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isTransposed = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isTransposed( 'transpose' ); // $ExpectType boolean
+	isTransposed( 'foo' ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isTransposed(); // $ExpectError
+	isTransposed( 'foo', 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/examples/index.js
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var isTransposed = require( './../lib' );
+
+var bool = isTransposed( 'transpose' );
+console.log( bool );
+// => true
+
+bool = isTransposed( 'conjugate-transpose' );
+console.log( bool );
+// => true
+
+bool = isTransposed( 'no-transpose' );
+console.log( bool );
+// => false
+
+bool = isTransposed( 'foo' );
+console.log( bool );
+// => false

--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/lib/index.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test whether an input value indicates that a matrix should be transposed.
+*
+* @module @stdlib/blas/base/assert/is-transposed
+*
+* @example
+* var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
+* var bool = isTransposed( 'transpose' );
+* // returns true
+*
+* bool = isTransposed( 'conjugate-transpose' );
+* // returns true
+*
+* bool = isTransposed( 'no-transpose' );
+* // returns false
+*
+* bool = isTransposed( 'foo' );
+* // returns false
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/lib/main.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Test whether an input value indicates that a matrix should be transposed.
+*
+* @name isTransposed
+* @type {Function}
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating whether an input value indicates that a matrix should be transposed.
+*
+* @example
+* var bool = isTransposed( 'transpose' );
+* // returns true
+*
+* bool = isTransposed( 'conjugate-transpose' );
+* // returns true
+*
+* bool = isTransposed( 'no-transpose' );
+* // returns false
+*
+* bool = isTransposed( 'foo' );
+* // returns false
+*/
+function isTransposed( value ) {
+	return ( ( value === 'transpose' ) || ( value === 'conjugate-transpose' ) );
+}
+
+
+// EXPORTS //
+
+module.exports = isTransposed;

--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/package.json
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@stdlib/blas/base/assert/is-transposed",
+  "version": "0.0.0",
+  "description": "Test whether an input value indicates that a matrix should be transposed.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "types",
+    "base",
+    "blas",
+    "transpose",
+    "multidimensional",
+    "ndarray",
+    "array",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "assert",
+    "test",
+    "check",
+    "is",
+    "valid",
+    "validate",
+    "validation",
+    "isvalid"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/blas/base/assert/is-transposed/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/assert/is-transposed/test/test.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isTransposed = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isTransposed, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a transpose operation', function test( t ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'transpose',
+		'conjugate-transpose'
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		bool = isTransposed( values[ i ] );
+		t.strictEqual( bool, true, 'returns expected value when provided '+values[ i ] );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a transpose operation', function test( t ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'no-transpose',
+		'c',
+		'fortran',
+		'c-style',
+		'fortran-style',
+		'',
+		'beep',
+		'boop',
+		'foo',
+		'bar',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		bool = isTransposed( values[ i ] );
+		t.strictEqual( bool, false, 'returns expected value when provided '+values[ i ] );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/blas/base/dgemm/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemm/lib/base.js
@@ -23,6 +23,7 @@
 // MODULES //
 
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var ddot = require( '@stdlib/blas/base/ddot' ).ndarray;
 var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 
@@ -33,29 +34,6 @@ var bsize = blockSize( 'float64', 'float64' ); // TODO: consider using a larger 
 
 
 // FUNCTIONS //
-
-/**
-* Tests whether a provided string indicates to transpose a matrix.
-*
-* @private
-* @param {string} str - input string
-* @returns {boolean} boolean indicating whether to transpose a matrix
-*
-* @example
-* var bool = isTransposed( 'transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'conjugate-transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'no-transpose' );
-* // returns false
-*/
-function isTransposed( str ) { // TODO: consider moving to a separate helper utility package
-	return ( str !== 'no-transpose' );
-}
 
 /**
 * Fills a matrix with zeros.

--- a/lib/node_modules/@stdlib/blas/base/dgemm/lib/dgemm.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemm/lib/dgemm.js
@@ -25,6 +25,7 @@ var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
 var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operation' );
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major-string' );
 var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var format = require( '@stdlib/string/format' );
 var base = require( './base.js' );
 
@@ -104,7 +105,7 @@ function dgemm( order, transA, transB, M, N, K, alpha, A, LDA, B, LDB, beta, C, 
 	iscm = isColumnMajor( order );
 	if (
 		( isrm && transA === 'no-transpose' ) ||
-		( iscm && transA === 'transpose' )
+		( iscm && isTransposed( transA ) )
 	) {
 		nrowsa = K;
 	} else {
@@ -112,7 +113,7 @@ function dgemm( order, transA, transB, M, N, K, alpha, A, LDA, B, LDB, beta, C, 
 	}
 	if (
 		( isrm && transB === 'no-transpose' ) ||
-		( iscm && transB === 'transpose' )
+		( iscm && isTransposed( transB ) )
 	) {
 		nrowsb = N;
 	} else {

--- a/lib/node_modules/@stdlib/blas/base/dgemv/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/lib/base.js
@@ -21,34 +21,9 @@
 // MODULES //
 
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var dfill = require( '@stdlib/blas/ext/base/dfill' ).ndarray;
 var dscal = require( '@stdlib/blas/base/dscal' ).ndarray;
-
-
-// FUNCTIONS //
-
-/**
-* Tests whether a provided string indicates to transpose a matrix.
-*
-* @private
-* @param {string} str - input string
-* @returns {boolean} boolean indicating whether to transpose a matrix
-*
-* @example
-* var bool = isTransposed( 'transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'conjugate-transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'no-transpose' );
-* // returns false
-*/
-function isTransposed( str ) { // TODO: consider moving to a separate helper utility package
-	return ( str !== 'no-transpose' );
-}
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/blas/base/ggemm/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemm/lib/accessors.js
@@ -23,6 +23,7 @@
 // MODULES //
 
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var gdot = require( '@stdlib/blas/base/gdot' ).ndarray;
 var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 
@@ -33,29 +34,6 @@ var bsize = blockSize( 'float64', 'float64' ); // TODO: consider using a larger 
 
 
 // FUNCTIONS //
-
-/**
-* Tests whether a provided string indicates to transpose a matrix.
-*
-* @private
-* @param {string} str - input string
-* @returns {boolean} boolean indicating whether to transpose a matrix
-*
-* @example
-* var bool = isTransposed( 'transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'conjugate-transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'no-transpose' );
-* // returns false
-*/
-function isTransposed( str ) { // TODO: consider moving to a separate helper utility package
-	return ( str !== 'no-transpose' );
-}
 
 /**
 * Fills a matrix with zeros.

--- a/lib/node_modules/@stdlib/blas/base/ggemm/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemm/lib/base.js
@@ -24,6 +24,7 @@
 
 var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var gdot = require( '@stdlib/blas/base/gdot' ).ndarray;
 var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 var accessors = require( './accessors.js' );
@@ -35,29 +36,6 @@ var bsize = blockSize( 'float64', 'float64' ); // TODO: consider using a larger 
 
 
 // FUNCTIONS //
-
-/**
-* Tests whether a provided string indicates to transpose a matrix.
-*
-* @private
-* @param {string} str - input string
-* @returns {boolean} boolean indicating whether to transpose a matrix
-*
-* @example
-* var bool = isTransposed( 'transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'conjugate-transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'no-transpose' );
-* // returns false
-*/
-function isTransposed( str ) { // TODO: consider moving to a separate helper utility package
-	return ( str !== 'no-transpose' );
-}
 
 /**
 * Fills a matrix with zeros.

--- a/lib/node_modules/@stdlib/blas/base/ggemm/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemm/lib/main.js
@@ -25,6 +25,7 @@ var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
 var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operation' );
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major-string' );
 var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var format = require( '@stdlib/string/format' );
 var base = require( './base.js' );
 
@@ -102,7 +103,7 @@ function ggemm( order, transA, transB, M, N, K, alpha, A, LDA, B, LDB, beta, C, 
 	iscm = isColumnMajor( order );
 	if (
 		( isrm && transA === 'no-transpose' ) ||
-		( iscm && transA === 'transpose' )
+		( iscm && isTransposed( transA ) )
 	) {
 		nrowsa = K;
 	} else {
@@ -110,7 +111,7 @@ function ggemm( order, transA, transB, M, N, K, alpha, A, LDA, B, LDB, beta, C, 
 	}
 	if (
 		( isrm && transB === 'no-transpose' ) ||
-		( iscm && transB === 'transpose' )
+		( iscm && isTransposed( transB ) )
 	) {
 		nrowsb = N;
 	} else {

--- a/lib/node_modules/@stdlib/blas/base/ggemv/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemv/lib/accessors.js
@@ -21,34 +21,9 @@
 // MODULES //
 
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var gfill = require( '@stdlib/blas/ext/base/gfill' ).ndarray;
 var gscal = require( '@stdlib/blas/base/gscal' ).ndarray;
-
-
-// FUNCTIONS //
-
-/**
-* Tests whether a provided string indicates to transpose a matrix.
-*
-* @private
-* @param {string} str - input string
-* @returns {boolean} boolean indicating whether to transpose a matrix
-*
-* @example
-* var bool = isTransposed( 'transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'conjugate-transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'no-transpose' );
-* // returns false
-*/
-function isTransposed( str ) { // TODO: consider moving to a separate helper utility package
-	return ( str !== 'no-transpose' );
-}
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/blas/base/ggemv/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemv/lib/base.js
@@ -22,35 +22,10 @@
 
 var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var gfill = require( '@stdlib/blas/ext/base/gfill' ).ndarray;
 var gscal = require( '@stdlib/blas/base/gscal' ).ndarray;
 var accessors = require( './accessors.js' );
-
-
-// FUNCTIONS //
-
-/**
-* Tests whether a provided string indicates to transpose a matrix.
-*
-* @private
-* @param {string} str - input string
-* @returns {boolean} boolean indicating whether to transpose a matrix
-*
-* @example
-* var bool = isTransposed( 'transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'conjugate-transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'no-transpose' );
-* // returns false
-*/
-function isTransposed( str ) { // TODO: consider moving to a separate helper utility package
-	return ( str !== 'no-transpose' );
-}
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/blas/base/sgemm/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemm/lib/base.js
@@ -23,6 +23,7 @@
 // MODULES //
 
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var sdot = require( '@stdlib/blas/base/sdot' ).ndarray;
 var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
@@ -34,29 +35,6 @@ var bsize = blockSize( 'float32', 'float32' ); // TODO: consider using a larger 
 
 
 // FUNCTIONS //
-
-/**
-* Tests whether a provided string indicates to transpose a matrix.
-*
-* @private
-* @param {string} str - input string
-* @returns {boolean} boolean indicating whether to transpose a matrix
-*
-* @example
-* var bool = isTransposed( 'transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'conjugate-transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'no-transpose' );
-* // returns false
-*/
-function isTransposed( str ) { // TODO: consider moving to a separate helper utility package
-	return ( str !== 'no-transpose' );
-}
 
 /**
 * Fills a matrix with zeros.

--- a/lib/node_modules/@stdlib/blas/base/sgemm/lib/sgemm.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemm/lib/sgemm.js
@@ -25,6 +25,7 @@ var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
 var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operation' );
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major-string' );
 var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var format = require( '@stdlib/string/format' );
 var base = require( './base.js' );
 
@@ -104,7 +105,7 @@ function sgemm( order, transA, transB, M, N, K, alpha, A, LDA, B, LDB, beta, C, 
 	iscm = isColumnMajor( order );
 	if (
 		( isrm && transA === 'no-transpose' ) ||
-		( iscm && transA === 'transpose' )
+		( iscm && isTransposed( transA ) )
 	) {
 		nrowsa = K;
 	} else {
@@ -112,7 +113,7 @@ function sgemm( order, transA, transB, M, N, K, alpha, A, LDA, B, LDB, beta, C, 
 	}
 	if (
 		( isrm && transB === 'no-transpose' ) ||
-		( iscm && transB === 'transpose' )
+		( iscm && isTransposed( transB ) )
 	) {
 		nrowsb = N;
 	} else {

--- a/lib/node_modules/@stdlib/blas/base/sgemv/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/lib/base.js
@@ -22,34 +22,9 @@
 
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
+var isTransposed = require( '@stdlib/blas/base/assert/is-transposed' );
 var sfill = require( '@stdlib/blas/ext/base/sfill' ).ndarray;
 var sscal = require( '@stdlib/blas/base/sscal' ).ndarray;
-
-
-// FUNCTIONS //
-
-/**
-* Tests whether a provided string indicates to transpose a matrix.
-*
-* @private
-* @param {string} str - input string
-* @returns {boolean} boolean indicating whether to transpose a matrix
-*
-* @example
-* var bool = isTransposed( 'transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'conjugate-transpose' );
-* // returns true
-*
-* @example
-* var bool = isTransposed( 'no-transpose' );
-* // returns false
-*/
-function isTransposed( str ) { // TODO: consider moving to a separate helper utility package
-	return ( str !== 'no-transpose' );
-}
 
 
 // MAIN //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

`dgemm` does not handle conjugate-transpose explicitly since the if conditions only checked if `transA === 'transpose'` which is dangerous.  
Therefore, I decided to implement the `TODO:`s and refactored `isTransposed` function into a new package.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md