### PR TITLE
feat: add `tools/c-impl-status` to track all C dependecy implementation status of a package

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/README.md
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2021 The Stdlib Authors.
+Copyright (c) 2026 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/README.md
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/README.md
@@ -1,0 +1,213 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2021 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# C Implementation Status
+
+> Check C implementation status for a stdlib package and its dependencies.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var cImplStatus = require( '@stdlib/_tools/pkgs/c-impl-status' );
+```
+
+#### cImplStatus( pkg\[, options] )
+
+Returns C implementation status for a package and its dependencies.
+
+```javascript
+var result = cImplStatus( '@stdlib/math/base/special/beta' );
+// returns {...}
+```
+
+The function accepts the following `options`:
+
+-   **dev**: `boolean` indicating whether to include development dependencies. Default: `false`.
+-   **includeSelf**: `boolean` indicating whether to include the package itself in results. Default: `true`.
+
+The returned object has the following fields:
+
+-   **pkg**: package name
+
+-   **pkgStatus**: object with package's own C implementation status
+
+    -   **hasSrc**: `boolean` indicating if `src/` directory exists
+    -   **hasC**: `boolean` indicating if C files exist
+    -   **cFileCount**: number of `.c` files
+    -   **hFileCount**: number of `.h` files
+    -   **needsC**: `boolean` indicating if package needs C implementation
+    -   **needsSrc**: `boolean` indicating if package needs `src/` directory
+    -   **isJSOnly**: `boolean` indicating if package is JS-only by design
+
+-   **deps**: array of dependency status objects
+
+-   **summary**: object with counts
+
+    -   **total**: total number of dependencies
+    -   **hasC**: number with C implementation
+    -   **noC**: number needing C implementation
+    -   **noSrc**: number that are JS-only (tools/constants)
+    -   **notFound**: number not found in stdlib (external)
+
+-   **blocking**: array of packages that need C implementation before this package
+
+-   **ready**: `boolean` indicating if all dependencies have C (package is ready for C implementation)
+
+-   **error**: error message if package not found
+
+Each dependency status object has:
+
+-   **pkg**: package name
+-   **status**: one of `has_c`, `no_c`, `no_src`, `js_only`, or `not_found`
+-   **hasC**: `boolean` indicating if C implementation exists
+-   **hasSrc**: `boolean` indicating if `src/` directory exists
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   Status types:
+
+    | Status      | Symbol | Description                                      |
+    | ----------- | ------ | ------------------------------------------------ |
+    | `has_c`     | ✓      | Has C implementation with `.c` files             |
+    | `no_c`      | ✗      | Has `src/` directory but no `.c` files (needs C) |
+    | `no_src`    | ✗      | No `src/` directory (needs src + C)              |
+    | `js_only`   | -      | JS-only by design (tools/constants/utils)        |
+    | `not_found` | ?      | Package not found (external dependency)          |
+
+-   The following packages are considered JS-only by design and do not need C implementations:
+
+    -   `@stdlib/math/base/tools/*`
+    -   `@stdlib/constants/*`
+    -   `@stdlib/utils/*`
+    -   `@stdlib/array/base/*`
+    -   `@stdlib/assert/*`
+    -   `@stdlib/types`
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var cImplStatus = require( '@stdlib/_tools/pkgs/c-impl-status' );
+
+var result = cImplStatus( '@stdlib/math/base/special/beta' );
+console.dir( result );
+```
+
+</section>
+
+<!-- /.examples -->
+
+* * *
+
+<section class="cli">
+
+## CLI
+
+<section class="usage">
+
+### Usage
+
+```text
+Usage: stdlib-c-impl-status [options] <package>
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+         --dev                 Include development dependencies.
+         --json                Output full result as JSON.
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+### Notes
+
+-   Use cases:
+
+    1.  **Before implementing C for a package**: check if all dependencies have C implementations.
+    2.  **Dependency ladder analysis**: identify blocking packages that need C first.
+    3.  **Progress tracking**: see which packages in a dependency chain need work.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ stdlib-c-impl-status @stdlib/math/base/special/betainc
+```
+
+```bash
+$ stdlib-c-impl-status @stdlib/math/base/special/sici
+```
+
+```bash
+$ stdlib-c-impl-status @stdlib/math/base/special/beta
+```
+
+```bash
+$ stdlib-c-impl-status @stdlib/math/base/special/gammainc --json
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/bin/cli
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/bin/cli
@@ -3,7 +3,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/bin/cli
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/bin/cli
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var CLI = require( '@stdlib/cli/ctor' );
+var cImplStatus = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns a status indicator string.
+*
+* @private
+* @param {string} status - status type
+* @returns {string} indicator
+*/
+function statusIndicator( status ) {
+	if ( status === 'has_c' ) {
+		return '✓';
+	}
+	if ( status === 'no_c' ) {
+		return '✗';
+	}
+	if ( status === 'no_src' ) {
+		return '✗';
+	}
+	if ( status === 'js_only' ) {
+		return '-';
+	}
+	return '?';
+}
+
+/**
+* Returns a status description string.
+*
+* @private
+* @param {Object} dep - dependency object
+* @returns {string} description
+*/
+function statusDescription( dep ) {
+	if ( dep.status === 'has_c' ) {
+		return dep.cFileCount + ' C file' + ( ( dep.cFileCount === 1 ) ? '' : 's' ) +
+			( ( dep.hFileCount > 0 ) ? ', ' + dep.hFileCount + ' header' + ( ( dep.hFileCount === 1 ) ? '' : 's' ) : '' );
+	}
+	if ( dep.status === 'no_c' ) {
+		return 'has src/, needs C';
+	}
+	if ( dep.status === 'no_src' ) {
+		return 'needs src/ + C';
+	}
+	if ( dep.status === 'js_only' ) {
+		return 'JS-only (tools/constants)';
+	}
+	return 'external package';
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var result;
+	var flags;
+	var opts;
+	var args;
+	var cli;
+	var i;
+
+	// Create a command-line interface:
+	cli = new CLI({
+		'pkg': require( './../package.json' ),
+		'options': require( './../etc/cli_opts.json' ),
+		'help': readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			'encoding': 'utf8'
+		})
+	});
+
+	// Get any provided command-line options:
+	flags = cli.flags();
+	if ( flags.help || flags.version ) {
+		return;
+	}
+
+	// Get any provided command-line arguments:
+	args = cli.args();
+
+	if ( args.length === 0 ) {
+		cli.error( new Error( 'invalid argument. Must provide a package name. Usage: stdlib-c-impl-status <package>' ) );
+		return;
+	}
+
+	// Extract options...
+	opts = {
+		'dev': flags.dev || false,
+		'includeSelf': true
+	};
+
+	// Get C implementation status:
+	try {
+		result = cImplStatus( args[ 0 ], opts );
+	} catch ( err ) {
+		cli.error( err );
+		return;
+	}
+
+	// Check for errors
+	if ( result.error ) {
+		cli.error( new Error( result.error ) );
+		return;
+	}
+
+	// Output JSON if requested
+	if ( flags.json ) {
+		console.log( JSON.stringify( result, null, 2 ) );
+		return;
+	}
+
+	// Output summary
+	console.log( '' );
+	console.log( 'Package: ' + result.pkg );
+
+	// Show package status
+	if ( result.pkgStatus ) {
+		if ( result.pkgStatus.hasC ) {
+			console.log( 'Package C status: ✓ Has C implementation (' + result.pkgStatus.cFileCount + ' C files)' );
+		} else if ( result.pkgStatus.hasSrc ) {
+			console.log( 'Package C status: ✗ Has src/ but needs C files added' );
+		} else if ( result.pkgStatus.needsSrc ) {
+			console.log( 'Package C status: ✗ Needs src/ directory + C implementation' );
+		} else if ( result.pkgStatus.isJSOnly ) {
+			console.log( 'Package C status: - JS-only by design (no C needed)' );
+		}
+	}
+
+	console.log( '' );
+	console.log( 'Dependencies summary:' );
+	console.log( '  Total: ' + result.summary.total );
+	console.log( '  Has C: ' + result.summary.hasC );
+	console.log( '  Needs C: ' + result.summary.noC );
+	console.log( '  JS-only (tools/constants): ' + result.summary.noSrc );
+	console.log( '  External: ' + result.summary.notFound );
+	console.log( '' );
+
+	// Output readiness status
+	if ( result.ready ) {
+		if ( result.pkgStatus && result.pkgStatus.hasC ) {
+			console.log( '✅ DONE - package has C and all dependencies have C.' );
+		} else if ( result.pkgStatus && !result.pkgStatus.hasSrc ) {
+			if ( result.pkgStatus.needsSrc ) {
+				console.log( '✅ READY for C implementation - all dependencies have C. Add src/ directory first.' );
+			} else if ( result.pkgStatus.isJSOnly ) {
+				console.log( 'ℹ️  JS-only package (tools/constants) - no C needed.' );
+			}
+		} else {
+			console.log( '✅ READY for C implementation - all dependencies have C.' );
+		}
+	} else {
+		console.log( '⚠️  NOT READY - ' + result.blocking.length + ' blocking package(s) need C implementation.' );
+	}
+	console.log( '' );
+
+	// Output dependencies with status
+	if ( result.deps.length > 0 ) {
+		console.log( 'Dependencies:' );
+		for ( i = 0; i < result.deps.length; i++ ) {
+			console.log( '  ' + statusIndicator( result.deps[ i ].status ) + ' ' + result.deps[ i ].pkg +
+				' (' + statusDescription( result.deps[ i ] ) + ')' );
+		}
+		console.log( '' );
+	}
+
+	// Output blocking packages (dependencies that need C first)
+	if ( result.blocking.length > 0 ) {
+		console.log( 'Blocking packages (implement C for these first):' );
+		for ( i = 0; i < result.blocking.length; i++ ) {
+			if ( result.blocking[ i ].status === 'no_src' ) {
+				console.log( '  ✗ ' + result.blocking[ i ].pkg + ' (needs src/ + C)' );
+			} else {
+				console.log( '  ✗ ' + result.blocking[ i ].pkg + ' (has src/, needs C files)' );
+			}
+		}
+		console.log( '' );
+	}
+
+	// Legend
+	console.log( 'Legend:' );
+	console.log( '  ✓  Has C implementation' );
+	console.log( '  ✗  Needs C implementation (missing src/ or C files)' );
+	console.log( '  -  JS-only by design (tools/constants)' );
+	console.log( '  ?  External package (not in stdlib)' );
+	console.log( '' );
+}
+
+main();

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/bin/cli
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/bin/cli
@@ -112,7 +112,7 @@ function main() {
 	args = cli.args();
 
 	if ( args.length === 0 ) {
-		cli.error( new Error( 'invalid argument. Must provide a package name. Usage: stdlib-c-impl-status <package>' ) );
+		cli.error( new Error( 'invalid argument. Must provide a package name. Usage: stdlib-c-impl-status <package>' ), 0 );
 		return;
 	}
 

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/docs/usage.txt
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/docs/usage.txt
@@ -1,0 +1,38 @@
+
+Usage: stdlib-c-impl-status [options] <package>
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+  --dev                 Include development dependencies.
+  --json                Output full result as JSON.
+
+Description:
+
+  Check C implementation status for a package and its dependencies.
+
+  For each dependency, reports:
+  - ✓  Has C implementation (with file count)
+  - ✗  Has src/ but needs C implementation
+  - -  JS-only package (no src/ directory)
+  - ?  External package (not found in stdlib)
+
+  Also lists blocking packages (those needing C implementation before
+  this package can have C added).
+
+Exit Codes:
+
+  0  Success
+  1  Error (invalid arguments, package not found, etc.)
+
+Examples:
+
+  # Check C implementation status for a package:
+  $ stdlib-c-impl-status @stdlib/math/base/special/betainc
+
+  # Get JSON output:
+  $ stdlib-c-impl-status @stdlib/math/base/special/gammainc --json
+
+  # Include dev dependencies:
+  $ stdlib-c-impl-status @stdlib/math/base/special/sici --dev

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/etc/cli_opts.json
@@ -1,0 +1,17 @@
+{
+	"boolean": [
+		"help",
+		"version",
+		"dev",
+		"json"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		]
+	}
+}
+

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/examples/index.js
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var cImplStatus = require( './../lib' );
+
+var result;
+var i;
+
+// Check a package with C implementation:
+result = cImplStatus( '@stdlib/math/base/special/abs' );
+console.log( 'Package: ' + result.pkg );
+console.log( 'Ready: ' + result.ready );
+console.log( 'Blocking: ' + result.blocking.length );
+console.log( '' );
+
+// Check a package without C implementation:
+result = cImplStatus( '@stdlib/math/base/special/betainc' );
+console.log( 'Package: ' + result.pkg );
+console.log( 'Ready: ' + result.ready );
+console.log( 'Blocking packages:' );
+for ( i = 0; i < result.blocking.length; i++ ) {
+	console.log( '  - ' + result.blocking[ i ].pkg );
+}
+console.log( '' );
+
+// Get JSON output:
+result = cImplStatus( '@stdlib/math/base/special/sin' );
+console.log( JSON.stringify( result, null, 2 ) );

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/config.json
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/config.json
@@ -1,0 +1,6 @@
+{
+  "dev": false,
+  "includeSelf": true,
+  "json": false,
+  "quiet": false
+}

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/has_c_impl.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/has_c_impl.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/has_c_impl.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/has_c_impl.js
@@ -1,0 +1,162 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var join = require( 'path' ).join;
+var readdirSync = require( 'fs' ).readdirSync;
+var statSync = require( 'fs' ).statSync;
+var logger = require( 'debug' );
+var endsWith = require( '@stdlib/string/base/ends-with' );
+var exists = require( '@stdlib/fs/exists' ).sync;
+
+
+// VARIABLES //
+
+var debug = logger( 'pkgs:c-impl-status' );
+
+// Resolve to lib/node_modules where stdlib packages live
+var ROOT = resolve( __dirname, '..', '..', '..', '..', '..', '..', '..', 'lib', 'node_modules' );
+
+
+// FUNCTIONS //
+
+/**
+* Recursively find all files with a given extension in a directory.
+*
+* @private
+* @param {string} dir - directory path
+* @param {string} ext - extension to filter (e.g., '.c')
+* @returns {Array} array of relative file paths
+*/
+function findFilesRecursive( dir, ext ) {
+	var filePath;
+	var result;
+	var files;
+	var stat;
+	var i;
+
+	result = [];
+	try {
+		files = readdirSync( dir );
+	} catch ( err ) {
+		debug( 'Error reading directory %s: %s', dir, err.message );
+		return result;
+	}
+
+	for ( i = 0; i < files.length; i++ ) {
+		filePath = join( dir, files[ i ] );
+		try {
+			stat = statSync( filePath );
+		} catch ( err ) {
+			debug( 'Error getting stat for %s: %s', filePath, err.message );
+			continue;
+		}
+
+		if ( stat.isDirectory() ) {
+			// Recursively search subdirectories
+			result = result.concat( findFilesRecursive( filePath, ext ) );
+		} else if ( endsWith( files[ i ], ext, files[ i ].length ) ) {
+			result.push( files[ i ] );
+		}
+	}
+
+	return result;
+}
+
+
+// MAIN //
+
+/**
+* Checks if a package has C implementation.
+*
+* @private
+* @param {string} pkg - package name (e.g., '@stdlib/math/base/special/beta')
+* @returns {(Object|null)} result object with C implementation status, or null if package doesn't exist
+*
+* @example
+* var status = hasCImpl( '@stdlib/math/base/special/beta' );
+* // returns { 'hasSrc': true, 'hasC': true, 'cFileCount': 2, 'hFileCount': 2, ... }
+*
+* @example
+* var status = hasCImpl( '@stdlib/constants/float64/pi' );
+* // returns { 'hasSrc': false, 'hasC': false, ... }
+*
+* @example
+* var status = hasCImpl( '@stdlib/nonexistent/package' );
+* // returns null
+*/
+function hasCImpl( pkg ) {
+	var pkgPath;
+	var srcPath;
+	var cFiles;
+	var hFiles;
+	var result;
+
+	// Resolve package path
+	pkgPath = resolve( ROOT, pkg );
+
+	debug( 'Checking package: %s at path: %s', pkg, pkgPath );
+
+	// Check if package exists
+	if ( !exists( pkgPath ) ) {
+		debug( 'Package not found: %s', pkg );
+		return null;
+	}
+
+	// Check for src directory
+	srcPath = join( pkgPath, 'src' );
+	if ( !exists( srcPath ) ) {
+		debug( 'No src/ directory for package: %s', pkg );
+		return {
+			'pkg': pkg,
+			'hasSrc': false,
+			'hasC': false,
+			'cFileCount': 0,
+			'hFileCount': 0,
+			'cFiles': [],
+			'hFiles': []
+		};
+	}
+
+	// Recursively find C and header files
+	cFiles = findFilesRecursive( srcPath, '.c' );
+	hFiles = findFilesRecursive( srcPath, '.h' );
+
+	result = {
+		'pkg': pkg,
+		'hasSrc': true,
+		'hasC': cFiles.length > 0,
+		'cFileCount': cFiles.length,
+		'hFileCount': hFiles.length,
+		'cFiles': cFiles,
+		'hFiles': hFiles
+	};
+
+	debug( 'Package %s: hasSrc=%s, hasC=%s, cFiles=%d, hFiles=%d', pkg, result.hasSrc, result.hasC, result.cFileCount, result.hFileCount );
+
+	return result;
+}
+
+
+// EXPORTS //
+
+module.exports = hasCImpl;

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/index.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return C implementation status for a package and its dependencies.
+*
+* @module @stdlib/_tools/pkgs/c-impl-status
+*
+* @example
+* var cImplStatus = require( '@stdlib/_tools/pkgs/c-impl-status' );
+*
+* var result = cImplStatus( '@stdlib/math/base/special/betainc' );
+* // returns { pkg: '...', deps: [...], summary: {...}, blocking: [...] }
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/main.js
@@ -1,0 +1,340 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
+var copy = require( '@stdlib/utils/copy' );
+var depList = require( '@stdlib/_tools/pkgs/dep-list' );
+var validate = require( './validate.js' );
+var hasCImpl = require( './has_c_impl.js' );
+var config = require( './config.json' );
+
+
+// FUNCTIONS //
+
+/**
+* Checks if a package is JS-only by design (tools, constants, utils, etc.).
+*
+* @private
+* @param {string} pkg - package name
+* @returns {boolean} true if package is JS-only by design
+*/
+function isJSOnlyPackage( pkg ) {
+	// Tools packages are JS-only by design
+	if ( pkg.indexOf( '/tools/' ) !== -1 ) {
+		return true;
+	}
+	// Constants packages are JS-only by design
+	if ( pkg.indexOf( '/constants/' ) !== -1 ) {
+		return true;
+	}
+	// Types packages are JS-only
+	if ( pkg.indexOf( '/types' ) !== -1 ) {
+		return true;
+	}
+	// Most utils packages are JS-only
+	if ( pkg.indexOf( '/utils/' ) !== -1 ) {
+		return true;
+	}
+	// Array packages (mostly utilities)
+	if ( pkg.indexOf( '/array/base/' ) !== -1 ) {
+		return true;
+	}
+	// Number utilities that don't need C
+	if ( pkg.indexOf( '/number/' ) !== -1 && pkg.indexOf( '/ctor' ) === -1 ) {
+		return true;
+	}
+	// Assert packages (mostly JS assertions)
+	if ( pkg.indexOf( '/assert/' ) !== -1 && pkg.indexOf( '/napi/' ) === -1 ) {
+		return true;
+	}
+	// String utilities
+	if ( pkg.indexOf( '/string/' ) !== -1 ) {
+		return true;
+	}
+	// Symbol utilities
+	if ( pkg.indexOf( '/symbol/' ) !== -1 ) {
+		return true;
+	}
+	// Process utilities
+	if ( pkg.indexOf( '/process/' ) !== -1 ) {
+		return true;
+	}
+	// OS utilities
+	if ( pkg.indexOf( '/os/' ) !== -1 ) {
+		return true;
+	}
+	// Console utilities
+	if ( pkg.indexOf( '/console/' ) !== -1 ) {
+		return true;
+	}
+	// Buffer utilities (mostly JS)
+	if ( pkg.indexOf( '/buffer/' ) !== -1 ) {
+		return true;
+	}
+	// Stream utilities
+	if ( pkg.indexOf( '/stream/' ) !== -1 ) {
+		return true;
+	}
+	// REPL utilities
+	if ( pkg.indexOf( '/repl/' ) !== -1 ) {
+		return true;
+	}
+	// FS utilities (mostly JS wrappers)
+	if ( pkg.indexOf( '/fs/' ) !== -1 ) {
+		return true;
+	}
+	// HTTP utilities
+	if ( pkg.indexOf( '/http/' ) !== -1 ) {
+		return true;
+	}
+	// Net utilities
+	if ( pkg.indexOf( '/net/' ) !== -1 ) {
+		return true;
+	}
+	// Path utilities
+	if ( pkg.indexOf( '/path/' ) !== -1 ) {
+		return true;
+	}
+	// Crypto utilities (mostly JS wrappers around native)
+	if ( pkg.indexOf( '/crypto/' ) !== -1 ) {
+		return true;
+	}
+	// Zlib utilities
+	if ( pkg.indexOf( '/zlib/' ) !== -1 ) {
+		return true;
+	}
+	// Error utilities
+	if ( pkg.indexOf( '/error/' ) !== -1 ) {
+		return true;
+	}
+	// Debug utilities
+	if ( pkg.indexOf( '/debug/' ) !== -1 ) {
+		return true;
+	}
+	return false;
+}
+
+/**
+* Comparator function for sorting package names in ascending order.
+*
+* @private
+* @param {string} a - package name
+* @param {string} b - package name
+* @returns {number} comparison value
+*/
+function ascending( a, b ) {
+	if ( a < b ) {
+		return -1;
+	}
+	if ( a === b ) {
+		return 0;
+	}
+	return 1;
+}
+
+
+// MAIN //
+
+/**
+* Returns C implementation status for a package and its dependencies.
+*
+* @param {string} pkg - package name
+* @param {Options} [options] - function options
+* @param {boolean} [options.dev=false] - include dev dependencies
+* @param {boolean} [options.includeSelf=true] - include the package itself in results
+* @throws {TypeError} first argument must be a string
+* @throws {TypeError} options argument must be an object
+* @throws {TypeError} must provide valid options
+* @returns {(Object|null)} result object with C implementation status
+*
+* @example
+* var result = cImplStatus( '@stdlib/math/base/special/beta' );
+* // returns {...}
+*
+* @example
+* var result = cImplStatus( '@stdlib/math/base/special/gammainc', { 'dev': true } );
+* // returns {...}
+*/
+function cImplStatus( pkg, options ) {
+	var depStatus;
+	var result;
+	var status;
+	var opts;
+	var deps;
+	var err;
+	var i;
+
+	if ( !isString( pkg ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a string. Value: `%s`.', pkg ) );
+	}
+	opts = copy( config );
+	if ( arguments.length > 1 ) {
+		err = validate( opts, options );
+		if ( err ) {
+			throw err;
+		}
+	}
+
+	// Initialize result
+	result = {
+		'pkg': pkg,
+		'deps': [],
+		'summary': {
+			'total': 0,
+			'hasC': 0,
+			'noC': 0,
+			'notFound': 0,
+			'noSrc': 0
+		},
+		'blocking': [],
+		'ready': true
+	};
+
+	// Check the package itself first (before resolving deps)
+	status = hasCImpl( pkg );
+	if ( status === null ) {
+		// Package not found in stdlib
+		result.ready = false;
+		result.error = 'Package not found: ' + pkg;
+		return result;
+	}
+
+	// Get dependencies (package exists, so resolution should succeed)
+	deps = depList( pkg, opts );
+
+	// Store package status
+	result.pkgStatus = {
+		'hasSrc': status.hasSrc,
+		'hasC': status.hasC,
+		'cFileCount': status.cFileCount,
+		'hFileCount': status.hFileCount
+	};
+
+	// Track if package itself has C
+	if ( status.hasSrc && !status.hasC ) {
+		// Package has src/ but no C files - it needs C implementation
+		// But it's ready to implement if deps are ready
+		result.pkgStatus.needsC = true;
+	} else if ( !status.hasSrc ) {
+		// No src directory - check if it's JS-only by design or needs C
+		if ( isJSOnlyPackage( pkg ) ) {
+			// JS-only package (tools, constants, etc.)
+			result.pkgStatus.isJSOnly = true;
+		} else {
+			// Package needs C implementation (no src/, but should have one)
+			// But it's ready to implement if deps are ready
+			result.pkgStatus.needsSrc = true;
+		}
+	}
+
+	// Sort dependencies alphabetically
+	deps.sort( ascending );
+
+	// Check each dependency
+	for ( i = 0; i < deps.length; i++ ) {
+		status = hasCImpl( deps[ i ] );
+		depStatus = null;
+
+		if ( status === null ) {
+			// Package not found (could be external dependency or non-stdlib package)
+			depStatus = {
+				'pkg': deps[ i ],
+				'status': 'not_found',
+				'hasC': null,
+				'hasSrc': null
+			};
+			result.summary.notFound += 1;
+		} else if ( !status.hasSrc ) {
+			// No src directory - check if it's JS-only by design or needs C
+			if ( isJSOnlyPackage( deps[ i ] ) ) {
+				// JS-only package (tools, constants, etc.)
+				depStatus = {
+					'pkg': deps[ i ],
+					'status': 'js_only',
+					'hasC': false,
+					'hasSrc': false
+				};
+				result.summary.noSrc += 1;
+			} else {
+				// Package needs C implementation (no src/, but should have one)
+				depStatus = {
+					'pkg': deps[ i ],
+					'status': 'no_src',
+					'hasC': false,
+					'hasSrc': false
+				};
+				result.summary.noC += 1;
+
+				// Add to blocking list - this dependency needs C first
+				result.blocking.push({
+					'pkg': deps[ i ],
+					'status': 'no_src',
+					'hasC': false,
+					'hasSrc': false
+				});
+				result.ready = false;
+			}
+		} else if ( status.hasC ) {
+			// Has C implementation
+			depStatus = {
+				'pkg': deps[ i ],
+				'status': 'has_c',
+				'hasC': true,
+				'hasSrc': true,
+				'cFileCount': status.cFileCount,
+				'hFileCount': status.hFileCount,
+				'cFiles': status.cFiles,
+				'hFiles': status.hFiles
+			};
+			result.summary.hasC += 1;
+		} else {
+			// Has src/ but no C files - needs C implementation
+			depStatus = {
+				'pkg': deps[ i ],
+				'status': 'no_c',
+				'hasC': false,
+				'hasSrc': true
+			};
+			result.summary.noC += 1;
+
+			// Add to blocking list - this dependency needs C first
+			result.blocking.push({
+				'pkg': deps[ i ],
+				'status': 'no_c',
+				'hasC': false,
+				'hasSrc': true
+			});
+			result.ready = false;
+		}
+
+		result.deps.push( depStatus );
+		result.summary.total += 1;
+	}
+
+	return result;
+}
+
+
+// EXPORTS //
+
+module.exports = cImplStatus;

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/main.js
@@ -43,6 +43,10 @@ function isJSOnlyPackage( pkg ) {
 	if ( pkg.indexOf( '/tools/' ) !== -1 ) {
 		return true;
 	}
+	// napi packages are JS-only by design (Node.js native addon argument parsing utilities)
+	if ( /(?:^|\/)@stdlib\/napi(\/|$)/.test( pkg ) ) {
+		return true;
+	}
 	// Constants packages are JS-only by design
 	if ( pkg.indexOf( '/constants/' ) !== -1 ) {
 		return true;

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/validate.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/validate.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/validate.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/lib/validate.js
@@ -1,0 +1,88 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isObject = require( '@stdlib/assert/is-plain-object' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
+
+
+// MAIN //
+
+/**
+* Validates function options.
+*
+* @private
+* @param {Object} opts - destination object
+* @param {Options} options - function options
+* @param {boolean} [options.dev=false] - include dev dependencies
+* @param {boolean} [options.includeSelf=true] - include the package itself
+* @param {boolean} [options.json=false] - output as JSON
+* @param {boolean} [options.quiet=false] - suppress summary output
+* @returns {(Error|null)} error object or null
+*
+* @example
+* var opts = {};
+* var options = {
+*     'dev': true
+* };
+*
+* var err = validate( opts, options );
+* if ( err ) {
+*    throw err;
+* }
+*/
+function validate( opts, options ) {
+	if ( !isObject( options ) ) {
+		return new TypeError( format( 'invalid argument. Options argument must be an object. Value: `%s`.', options ) );
+	}
+	if ( hasOwnProp( options, 'dev' ) ) {
+		opts.dev = options.dev;
+		if ( !isBoolean( opts.dev ) ) {
+			return new TypeError( format( 'invalid option. `%s` option must be a boolean. Option: `%s`.', 'dev', opts.dev ) );
+		}
+	}
+	if ( hasOwnProp( options, 'includeSelf' ) ) {
+		opts.includeSelf = options.includeSelf;
+		if ( !isBoolean( opts.includeSelf ) ) {
+			return new TypeError( format( 'invalid option. `%s` option must be a boolean. Option: `%s`.', 'includeSelf', opts.includeSelf ) );
+		}
+	}
+	if ( hasOwnProp( options, 'json' ) ) {
+		opts.json = options.json;
+		if ( !isBoolean( opts.json ) ) {
+			return new TypeError( format( 'invalid option. `%s` option must be a boolean. Option: `%s`.', 'json', opts.json ) );
+		}
+	}
+	if ( hasOwnProp( options, 'quiet' ) ) {
+		opts.quiet = options.quiet;
+		if ( !isBoolean( opts.quiet ) ) {
+			return new TypeError( format( 'invalid option. `%s` option must be a boolean. Option: `%s`.', 'quiet', opts.quiet ) );
+		}
+	}
+	return null;
+}
+
+
+// EXPORTS //
+
+module.exports = validate;

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/package.json
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "@stdlib/_tools/pkgs/c-impl-status",
+  "version": "0.0.0",
+  "description": "Check C implementation status for a package and its dependencies.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "stdlib-c-impl-status": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {
+    "@stdlib/assert-has-own-property": "^0.2.2",
+    "@stdlib/assert-is-boolean": "^0.2.2",
+    "@stdlib/assert/is-object": "^0.2.2",
+    "@stdlib/assert/is-string": "^0.2.2",
+    "@stdlib/cli-ctor": "^0.2.2",
+    "@stdlib/fs-exists": "^0.2.2",
+    "@stdlib/fs-read-file": "^0.2.2",
+    "@stdlib/string-format": "^0.2.2",
+    "@stdlib/string-base-ends-with": "^0.2.2",
+    "@stdlib/utils-copy": "^0.2.2",
+    "@stdlib/_tools/pkgs/dep-list": "^0.2.2",
+    "debug": "^4.3.4"
+  },
+  "devDependencies": {
+    "@stdlib/assert/is-plain-object": "^0.2.2",
+    "@stdlib/assert/is-array": "^0.2.2",
+    "@stdlib/assert/is-browser": "^0.2.2",
+    "@stdlib/assert/is-windows": "^0.2.2",
+    "@stdlib/regexp/eol": "^0.2.2",
+    "@stdlib/process/exec-path": "^0.2.2"
+  },
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "tools",
+    "tool",
+    "c",
+    "implementation",
+    "native",
+    "addons",
+    "status",
+    "dependencies",
+    "check"
+  ]
+}
+

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.cli.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.cli.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.cli.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.cli.js
@@ -1,0 +1,231 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var exec = require( 'child_process' ).exec;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var EXEC_PATH = require( '@stdlib/process/exec-path' );
+
+
+// VARIABLES //
+
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+var opts = {
+	'skip': IS_BROWSER || IS_WINDOWS
+};
+
+
+// FIXTURES //
+
+var PKG_VERSION = require( './../package.json' ).version;
+
+
+// TESTS //
+
+tape( 'command-line interface', function test( t ) {
+	t.ok( true, __filename );
+	t.end();
+});
+
+tape( 'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'--help'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'-h'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'--version'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'-V'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface prints C implementation status', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'@stdlib/math/base/special/beta'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString().indexOf( 'Package:' ) !== -1, true, 'prints package status' );
+			t.strictEqual( stdout.toString().indexOf( 'Dependencies summary:' ) !== -1, true, 'prints summary' );
+			t.strictEqual( stdout.toString().indexOf( 'Legend:' ) !== -1, true, 'prints legend' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface supports JSON output', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'@stdlib/math/base/special/beta',
+		'--json'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		var result;
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			try {
+				result = JSON.parse( stdout.toString() );
+				t.strictEqual( typeof result.pkg, 'string', 'has pkg property' );
+				t.strictEqual( Array.isArray( result.deps ), true, 'has deps array' );
+				t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+			} catch ( err ) {
+				t.fail( err.message );
+			}
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface supports dev dependencies', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'@stdlib/math/base/special/beta',
+		'--dev'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString().indexOf( 'Package:' ) !== -1, true, 'prints package status' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface prints an error when no package is provided', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stderr.toString().indexOf( 'Error' ) !== -1, true, 'prints error message' );
+		}
+		t.end();
+	}
+});

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.has_c_impl.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.has_c_impl.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.has_c_impl.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.has_c_impl.js
@@ -1,0 +1,74 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isObject = require( '@stdlib/assert/is-plain-object' );
+var hasCImpl = require( './../lib/has_c_impl.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.equal( typeof hasCImpl, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an object for packages that exist', function test( t ) {
+	var result = hasCImpl( '@stdlib/math/base/special/beta' );
+	t.equal( isObject( result ), true, 'returns an object' );
+	t.equal( typeof result.hasSrc, 'boolean', 'has hasSrc' );
+	t.equal( typeof result.hasC, 'boolean', 'has hasC' );
+	t.equal( typeof result.cFileCount, 'number', 'has cFileCount' );
+	t.equal( typeof result.hFileCount, 'number', 'has hFileCount' );
+	t.end();
+});
+
+tape( 'the function returns null for packages that do not exist', function test( t ) {
+	var result = hasCImpl( '@stdlib/nonexistent/package' );
+	t.equal( result, null, 'returns null for nonexistent package' );
+	t.end();
+});
+
+tape( 'the function correctly identifies packages with C implementation', function test( t ) {
+	var result = hasCImpl( '@stdlib/math/base/special/abs' );
+	t.equal( result.hasC, true, 'abs has C implementation' );
+	t.equal( result.hasSrc, true, 'abs has src directory' );
+	t.ok( result.cFileCount > 0, 'abs has C files' );
+	t.end();
+});
+
+tape( 'the function correctly identifies packages without src directory', function test( t ) {
+	var result = hasCImpl( '@stdlib/constants/float64/pi' );
+	t.equal( result.hasSrc, false, 'constants package has no src directory' );
+	t.equal( result.hasC, false, 'constants package has no C' );
+	t.end();
+});
+
+tape( 'the function correctly identifies JS-only packages', function test( t ) {
+	var result = hasCImpl( '@stdlib/math/base/tools/evalpoly' );
+
+	// Tools packages typically don't have src directories:
+	t.equal( result.hasSrc, false, 'tools package typically has no src directory' );
+	t.equal( result.hasC, false, 'tools package has no C' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.js
@@ -1,0 +1,198 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isObject = require( '@stdlib/assert/is-plain-object' );
+var isArray = require( '@stdlib/assert/is-array' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var cImplStatus = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.equal( typeof cImplStatus, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided a first argument which is not a string, the function throws an error', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			cImplStatus( value );
+		};
+	}
+});
+
+tape( 'if provided an options argument which is not an object, the function throws an error', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			cImplStatus( '@stdlib/math/base/special/beta', value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid option', function test( t ) {
+	t.throws( foo, TypeError, 'throws error' );
+	t.end();
+	function foo() {
+		var opts = {
+			'dev': 123
+		};
+		cImplStatus( '@stdlib/math/base/special/beta', opts );
+	}
+});
+
+tape( 'the function returns an object', function test( t ) {
+	var result = cImplStatus( '@stdlib/math/base/special/beta' );
+	t.equal( isObject( result ), true, 'returns an object' );
+	t.end();
+});
+
+tape( 'the returned object has expected properties', function test( t ) {
+	var result = cImplStatus( '@stdlib/math/base/special/beta' );
+	t.equal( typeof result.pkg, 'string', 'has pkg property' );
+	t.equal( isArray( result.deps ), true, 'has deps array' );
+	t.equal( isObject( result.summary ), true, 'has summary object' );
+	t.equal( isArray( result.blocking ), true, 'has blocking array' );
+	t.equal( isBoolean( result.ready ), true, 'has ready boolean' );
+	t.equal( isObject( result.pkgStatus ), true, 'has pkgStatus object' );
+	t.end();
+});
+
+tape( 'the summary object has expected properties', function test( t ) {
+	var result = cImplStatus( '@stdlib/math/base/special/beta' );
+	t.equal( typeof result.summary.total, 'number', 'has total' );
+	t.equal( typeof result.summary.hasC, 'number', 'has hasC' );
+	t.equal( typeof result.summary.noC, 'number', 'has noC' );
+	t.equal( typeof result.summary.noSrc, 'number', 'has noSrc' );
+	t.equal( typeof result.summary.notFound, 'number', 'has notFound' );
+	t.end();
+});
+
+tape( 'the pkgStatus object has expected properties', function test( t ) {
+	var result = cImplStatus( '@stdlib/math/base/special/beta' );
+	t.equal( isBoolean( result.pkgStatus.hasSrc ), true, 'has hasSrc' );
+	t.equal( isBoolean( result.pkgStatus.hasC ), true, 'has hasC' );
+	t.equal( typeof result.pkgStatus.cFileCount, 'number', 'has cFileCount' );
+	t.equal( typeof result.pkgStatus.hFileCount, 'number', 'has hFileCount' );
+	t.end();
+});
+
+tape( 'each dependency has expected properties', function test( t ) {
+	var result = cImplStatus( '@stdlib/math/base/special/beta' );
+	var dep;
+	var i;
+
+	for ( i = 0; i < result.deps.length; i++ ) {
+		dep = result.deps[ i ];
+		t.equal( typeof dep.pkg, 'string', 'dep has pkg' );
+		t.equal( typeof dep.status, 'string', 'dep has status' );
+		t.equal( typeof dep.hasC, 'boolean', 'dep has hasC' );
+
+		if ( dep.status === 'has_c' ) {
+			t.equal( typeof dep.cFileCount, 'number', 'has_c dep has cFileCount' );
+			t.equal( typeof dep.hFileCount, 'number', 'has_c dep has hFileCount' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function correctly identifies packages with C implementation', function test( t ) {
+	var result = cImplStatus( '@stdlib/math/base/special/abs' );
+
+	// Abs is a simple package that has a C implementation:
+	t.equal( result.ready, true, 'abs package should be ready' );
+	t.equal( result.blocking.length, 0, 'abs should have no blocking deps' );
+	t.equal( result.pkgStatus.hasC, true, 'abs has C implementation' );
+	t.end();
+});
+
+tape( 'the function correctly identifies JS-only packages', function test( t ) {
+	var result = cImplStatus( '@stdlib/constants/float64/pi' );
+
+	// Constants packages are JS-only by design:
+	t.equal( result.pkgStatus.hasSrc, false, 'constants package has no src/' );
+	t.equal( result.pkgStatus.hasC, false, 'constants package has no C' );
+	t.equal( result.pkgStatus.isJSOnly, true, 'constants package is marked as JS-only' );
+	t.end();
+});
+
+tape( 'the function handles dev dependencies option', function test( t ) {
+	var result1 = cImplStatus( '@stdlib/math/base/special/beta', {
+		'dev': false
+	});
+	var result2 = cImplStatus( '@stdlib/math/base/special/beta', {
+		'dev': true
+	});
+
+	// Dev dependencies should result in more or equal dependencies:
+	t.ok( result2.summary.total >= result1.summary.total, 'dev includes more or equal deps' );
+	t.end();
+});
+
+tape( 'the function handles nonexistent packages', function test( t ) {
+	var result = cImplStatus( '@stdlib/nonexistent/package' );
+	t.equal( result.ready, false, 'nonexistent package is not ready' );
+	t.ok( result.error, 'nonexistent package has error' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.validate.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.validate.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.validate.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/test/test.validate.js
@@ -1,0 +1,150 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var validate = require( './../lib/validate.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof validate, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided an `options` argument which is not an `object`, the function returns a type error', function test( t ) {
+	var values;
+	var opts;
+	var err;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		opts = {};
+		err = validate( opts, values[i] );
+		t.strictEqual( err instanceof TypeError, true, 'returns a type error when provided '+values[i] );
+	}
+	t.end();
+});
+
+tape( 'if provided a `dev` option which is not a `boolean`, the function returns a type error', function test( t ) {
+	var values;
+	var opts;
+	var err;
+	var i;
+
+	values = [
+		'abc',
+		5,
+		NaN,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		opts = {};
+		err = validate( opts, {
+			'dev': values[i]
+		});
+		t.strictEqual( err instanceof TypeError, true, 'returns a type error when provided '+values[i] );
+	}
+	t.end();
+});
+
+tape( 'if provided an `includeSelf` option which is not a `boolean`, the function returns a type error', function test( t ) {
+	var values;
+	var opts;
+	var err;
+	var i;
+
+	values = [
+		'abc',
+		5,
+		NaN,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		opts = {};
+		err = validate( opts, {
+			'includeSelf': values[i]
+		});
+		t.strictEqual( err instanceof TypeError, true, 'returns a type error when provided '+values[i] );
+	}
+	t.end();
+});
+
+tape( 'the function returns `null` if all options are valid', function test( t ) {
+	var opts;
+	var obj;
+	var err;
+
+	opts = {
+		'dev': false,
+		'includeSelf': true
+	};
+	obj = {};
+	err = validate( obj, opts );
+
+	t.strictEqual( err, null, 'returns null' );
+	t.strictEqual( obj.dev, opts.dev, 'sets dev option' );
+	t.strictEqual( obj.includeSelf, opts.includeSelf, 'sets includeSelf option' );
+
+	t.end();
+});
+
+tape( 'the function ignores unsupported/unrecognized options', function test( t ) {
+	var opts;
+	var obj;
+	var err;
+
+	opts = {
+		'beep': 'boop',
+		'a': 'b',
+		'c': [ 1, 2, 3 ]
+	};
+	obj = {};
+	err = validate( obj, opts );
+
+	t.strictEqual( err, null, 'returns null' );
+	t.deepEqual( obj, {}, 'does not set any options' );
+	t.end();
+});


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-  This tool sees all the dependency of a package and sees weather its C implementation is present or not.
-  If the dependency is of tool folder or any other util package then ignores weather the C implementation exist.
-  If the package is not from any tools/utils folder then it shows that the package requires its C implementation first.

- Example 1: 
Input: 
```c
node lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/bin/cli @stdlib/math/base/special/betainc
```
Output: 
```c

Package: @stdlib/math/base/special/betainc
Package C status: ✗ Needs src/ directory + C implementation

Dependencies summary:
  Total: 1
  Has C: 0
  Needs C: 1
  JS-only (tools/constants): 0
  External: 0

⚠️  NOT READY - 1 blocking package(s) need C implementation.

Dependencies:
  ✗ @stdlib/math/base/special/kernel-betainc (needs src/ + C)

Blocking packages (implement C for these first):
  ✗ @stdlib/math/base/special/kernel-betainc (needs src/ + C)

Legend:
  ✓  Has C implementation
  ✗  Needs C implementation (missing src/ or C files)
  -  JS-only by design (tools/constants)
  ?  External package (not in stdlib)

```

- Example 2: 
Input: 
```c
node lib/node_modules/@stdlib/_tools/pkgs/c-impl-status/bin/cli @stdlib/math/base/special/polygamma
```
Output: 
```c

Package: @stdlib/math/base/special/polygamma
Package C status: ✗ Needs src/ directory + C implementation

Dependencies summary:
  Total: 29
  Has C: 18
  Needs C: 0
  JS-only (tools/constants): 10
  External: 1

✅ READY for C implementation - all dependencies have C. Add src/ directory first.

Dependencies:
  - @stdlib/array/base/zeros (JS-only (tools/constants))
  - @stdlib/constants/float64/eps (JS-only (tools/constants))
  - @stdlib/constants/float64/ln-pi (JS-only (tools/constants))
  - @stdlib/constants/float64/ln-two (JS-only (tools/constants))
  - @stdlib/constants/float64/max (JS-only (tools/constants))
  - @stdlib/constants/float64/max-ln (JS-only (tools/constants))
  - @stdlib/constants/float64/ninf (JS-only (tools/constants))
  - @stdlib/constants/float64/pi (JS-only (tools/constants))
  - @stdlib/constants/float64/pinf (JS-only (tools/constants))
  ✓ @stdlib/math/base/assert/is-nonnegative-integer (2 C files)
  ✓ @stdlib/math/base/special/abs (2 C files)
  ✓ @stdlib/math/base/special/bernoulli (2 C files)
  ✓ @stdlib/math/base/special/cospi (2 C files)
  ✓ @stdlib/math/base/special/digamma (2 C files)
  ✓ @stdlib/math/base/special/exp (2 C files)
  ✓ @stdlib/math/base/special/factorial (2 C files)
  ✓ @stdlib/math/base/special/floor (2 C files)
  ✓ @stdlib/math/base/special/gammaln (2 C files)
  ✓ @stdlib/math/base/special/ldexp (2 C files)
  ✓ @stdlib/math/base/special/ln (2 C files)
  ✓ @stdlib/math/base/special/min (2 C files)
  ✓ @stdlib/math/base/special/pow (2 C files)
  ✓ @stdlib/math/base/special/riemann-zeta (2 C files)
  ✓ @stdlib/math/base/special/signum (2 C files)
  ✓ @stdlib/math/base/special/sinpi (2 C files)
  ✓ @stdlib/math/base/special/trigamma (2 C files)
  ✓ @stdlib/math/base/special/trunc (2 C files)
  - @stdlib/math/base/tools/evalpoly (JS-only (tools/constants))
  ? debug (external package)

Legend:
  ✓  Has C implementation
  ✗  Needs C implementation (missing src/ or C files)
  -  JS-only by design (tools/constants)
  ?  External package (not in stdlib)
```


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
