### PR TITLE
fix: correct grammar in ndarray type test comments

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/ones-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/ones-like/docs/types/test.ts
@@ -41,7 +41,7 @@ import onesLike = require( './index' );
 	onesLike( ones( 'generic', sh, ord ) ); // $ExpectType genericndarray<number>
 }
 
-// The compiler throws an error if the function is provided a first argument is not an ndarray which has a recognized/supported data type...
+// The compiler throws an error if the function is provided a first argument which is not an ndarray having a recognized/supported data type...
 {
 	onesLike( '10' ); // $ExpectError
 	onesLike( 10 ); // $ExpectError

--- a/lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/test.ts
@@ -41,7 +41,7 @@ import zerosLike = require( './index' );
 	zerosLike( zeros( 'generic', sh, ord ) ); // $ExpectType genericndarray<number>
 }
 
-// The compiler throws an error if the function is provided a first argument is not an ndarray which has a recognized/supported data type...
+// The compiler throws an error if the function is provided a first argument which is not an ndarray having a recognized/supported data type...
 {
 	zerosLike( '10' ); // $ExpectError
 	zerosLike( 10 ); // $ExpectError


### PR DESCRIPTION
## Summary

Fixes a grammatical error in TypeScript type test comments for `@stdlib/ndarray/base/ones-like` and `@stdlib/ndarray/base/zeros-like`.

## Changes

**Before:** "The compiler throws an error if the function is provided a first argument is not an ndarray which has a recognized/supported data type"

**After:** "The compiler throws an error if the function is provided a first argument which is not an ndarray having a recognized/supported data type"

## Files Modified

- `lib/node_modules/@stdlib/ndarray/base/ones-like/docs/types/test.ts` (line 44)
- `lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/test.ts` (line 44)

Closes #11152

This contribution was developed with AI assistance (Claude Code).

---

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)