### PR TITLE
bench: add missing method name in benchmark description

### DIFF
--- a/lib/node_modules/@stdlib/array/little-endian-factory/benchmark/benchmark.of.js
+++ b/lib/node_modules/@stdlib/array/little-endian-factory/benchmark/benchmark.of.js
@@ -52,7 +52,7 @@ bench( format( '%s:of', pkg ), function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:len=5', pkg ), function benchmark( b ) {
+bench( format( '%s:of:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;


### PR DESCRIPTION
## Summary

Adds missing `:of:` method name to the benchmark format string in `@stdlib/array/little-endian-factory/benchmark/benchmark.of.js`.

## Changes

Line 55: `'%s:len=5'` -> `'%s:of:len=5'`

The first benchmark in the file correctly uses `'%s:of'` (line 36), but the second benchmark was missing the method name segment.

Closes #11151

This contribution was developed with AI assistance (Claude Code).

---

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)