### PR TITLE
chore: fix JavaScript lint errors (issue #11147)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/org-repos/lib/validate.js
+++ b/lib/node_modules/@stdlib/_tools/github/org-repos/lib/validate.js
@@ -56,13 +56,13 @@ function validate( opts, options ) {
 	if ( hasOwnProp( options, 'token' ) ) {
 		opts.token = options.token;
 		if ( !isString( opts.token ) ) {
-			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'token',  opts.token ) );
+			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'token', opts.token ) );
 		}
 	}
 	if ( hasOwnProp( options, 'useragent' ) ) {
 		opts.useragent = options.useragent;
 		if ( !isString( opts.useragent ) ) {
-			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'useragent',  opts.useragent ) );
+			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'useragent', opts.useragent ) );
 		}
 	}
 	return null;

--- a/lib/node_modules/@stdlib/_tools/scripts/transform.js
+++ b/lib/node_modules/@stdlib/_tools/scripts/transform.js
@@ -63,6 +63,84 @@ var ERROR_NAMES = [
 * @param {Object} api - JSCodeshift API
 * @returns {Object} transformed file
 */
+/**
+	* Tests whether a variable declaration is for the `@stdlib/string-format` require.
+	*
+	* @private
+	* @param {Object} path - AST node path
+	* @returns {boolean} boolean indicating whether a variable declaration is for the `@stdlib/string-format` require
+	*/
+function onStringFormat( path ) {
+	var node = path.node;
+	return node.init &&
+			node.init.type === 'CallExpression' &&
+			node.init.callee.name === 'require' &&
+			node.init.arguments[0].value === '@stdlib/string-format';
+}
+/**
+	* Returns false if the node index is equal to zero and true otherwise.
+	*
+	* @private
+	* @param {Object} path - AST node path
+	* @param {number} idx - node index
+	* @returns {boolean} boolean indicating whether to keep the node
+	*/
+function dropFirst( path, idx ) {
+	return idx !== 0;
+}
+/**
+	* Deletes the comments associated with a given node.
+	*
+	* @private
+	* @param {Object} path - AST node path
+	* @returns {void}
+	*/
+function deleteComment( path ) {
+	var i;
+	if ( path.node.comments ) {
+		for ( i = 0; i < path.node.comments.length; i++ ) {
+			if ( contains( path.node.comments[ i ].value, '@license Apache-2.0' ) ) {
+				path.node.comments[ i ].value = '* @license Apache-2.0 ';
+			}
+		}
+	}
+}
+/**
+	* Rewrites a `require` statement to include the `/dist` directory if the module being required starts with `@stdlib`.
+	*
+	* @private
+	* @param {Object} path - AST node path
+	* @returns {void}
+	*/
+function rewriteRequire( path ) {
+	if ( startsWith( path.value.arguments[0].value, '@stdlib' ) ) {
+		path.value.arguments[0].value += '/dist';
+	}
+}
+/**
+	* Tests whether a path is a require call for `@stdlib/error-tools-fmtprodmsg`.
+	*
+	* @private
+	* @param {Object} path - AST node path
+	* @returns {boolean} boolean indicating whether a path is a require call for `@stdlib/error-tools-fmtprodmsg`
+	*/
+function hasRequire( path ) {
+	return path.value.callee.name === 'require' &&
+			path.value.arguments[ 0 ].value === '@stdlib/error-tools-fmtprodmsg';
+}
+/**
+* Transforms a file for a production build.
+*
+* ## Notes
+*
+* -   This code is adapted from the respective stdlib [GitHub Action][1].
+*
+* [1]: https://github.com/stdlib-js/transform-errors-action
+*
+* @param {Object} fileInfo - file information
+* @param {Object} api - JSCodeshift API
+* @returns {Object} transformed file
+*/
 function transformer( fileInfo, api ) {
 	var formatRequire;
 	var replacement;
@@ -122,21 +200,6 @@ function transformer( fileInfo, api ) {
 	return replace( out, RE_INDENT, '\n' );
 
 	/**
-	* Tests whether a variable declaration is for the `@stdlib/string-format` require.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @returns {boolean} boolean indicating whether a variable declaration is for the `@stdlib/string-format` require
-	*/
-	function onStringFormat( path ) {
-		var node = path.node;
-		return node.init &&
-			node.init.type === 'CallExpression' &&
-			node.init.callee.name === 'require' &&
-			node.init.arguments[0].value === '@stdlib/string-format';
-	}
-
-	/**
 	* Assigns the variable name for the `@stdlib/string-format` require.
 	*
 	* @private
@@ -145,49 +208,6 @@ function transformer( fileInfo, api ) {
 	*/
 	function assignFormatVar( path ) {
 		formatVar = path.node.id.name;
-	}
-
-	/**
-	* Returns false if the node index is equal to zero and true otherwise.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @param {number} idx - node index
-	* @returns {boolean} boolean indicating whether to keep the node
-	*/
-	function dropFirst( path, idx ) {
-		return idx !== 0;
-	}
-
-	/**
-	* Deletes the comments associated with a given node.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @returns {void}
-	*/
-	function deleteComment( path ) {
-		var i;
-		if ( path.node.comments ) {
-			for ( i = 0; i < path.node.comments.length; i++ ) {
-				if ( contains( path.node.comments[ i ].value, '@license Apache-2.0' ) ) {
-					path.node.comments[ i ].value = '* @license Apache-2.0 ';
-				}
-			}
-		}
-	}
-
-	/**
-	* Rewrites a `require` statement to include the `/dist` directory if the module being required starts with `@stdlib`.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @returns {void}
-	*/
-	function rewriteRequire( path ) {
-		if ( startsWith( path.value.arguments[0].value, '@stdlib' ) ) {
-			path.value.arguments[0].value += '/dist';
-		}
 	}
 
 	/**
@@ -243,22 +263,11 @@ function transformer( fileInfo, api ) {
 						]))
 					]);
 					debug( 'Adding `require` call to `@stdlib/error-tools-fmtprodmsg`...' );
-					j( root.find( j.Declaration ).at( 0 ).get() ).insertBefore( formatRequire );
+					j( root.find( j.Declaration ).at( 0 ).get() )
+						.insertBefore( formatRequire );
 				}
 			}
 		}
-	}
-
-	/**
-	* Tests whether a path is a require call for `@stdlib/error-tools-fmtprodmsg`.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @returns {boolean} boolean indicating whether a path is a require call for `@stdlib/error-tools-fmtprodmsg`
-	*/
-	function hasRequire( path ) {
-		return path.value.callee.name === 'require' &&
-			path.value.arguments[ 0 ].value === '@stdlib/error-tools-fmtprodmsg';
 	}
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/nans/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/README.md
@@ -1,0 +1,134 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# nans
+
+> Create a NaN-filled [ndarray][@stdlib/ndarray/base/ctor] having a specified shape and [data type][@stdlib/ndarray/dtypes].
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var nans = require( '@stdlib/ndarray/base/nans' );
+```
+
+#### nans( dtype, shape, order )
+
+Creates a NaN-filled [ndarray][@stdlib/ndarray/base/ctor] having a specified shape and [data type][@stdlib/ndarray/dtypes].
+
+```javascript
+var getDType = require( '@stdlib/ndarray/dtype' );
+
+var arr = nans( 'float64', [ 2, 2 ], 'row-major' );
+// returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+
+var dt = String( getDType( arr ) );
+// returns 'float64'
+```
+
+The function accepts the following arguments:
+
+-   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Must be a floating-point or "generic" [data type][@stdlib/ndarray/dtypes].
+-   **shape**: array shape.
+-   **order**: specifies whether an [ndarray][@stdlib/ndarray/base/ctor] is `'row-major'` (C-style) or `'column-major'` (Fortran-style).
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var nans = require( '@stdlib/ndarray/base/nans' );
+
+var dt = [
+    'float64',
+    'float32',
+    'complex128',
+    'complex64',
+    'generic'
+];
+
+// Generate NaN-filled arrays...
+var arr;
+var i;
+for ( i = 0; i < dt.length; i++ ) {
+    arr = nans( dt[ i ], [ 2, 2 ], 'row-major' );
+    console.log( ndarray2array( arr ) );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/ndarray/base/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/base/ctor
+
+[@stdlib/ndarray/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/dtypes
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.js
@@ -1,0 +1,120 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nans = require( './../lib' );
+
+
+// MAIN //
+
+bench( format( '%s:dtype=float64', pkg ), function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = nans( 'float64', [ 0 ], 'row-major' );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( arr ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:dtype=float32', pkg ), function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = nans( 'float32', [ 0 ], 'row-major' );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( arr ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:dtype=complex128', pkg ), function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = nans( 'complex128', [ 0 ], 'row-major' );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( arr ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:dtype=complex64', pkg ), function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = nans( 'complex64', [ 0 ], 'row-major' );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( arr ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:dtype=generic', pkg ), function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = nans( 'generic', [ 0 ], 'row-major' );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( arr ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.complex128.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.complex128.js
@@ -1,0 +1,94 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nans = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nans( 'complex128', [ len ], 'row-major' );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=complex128,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.complex64.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.complex64.js
@@ -1,0 +1,94 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nans = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nans( 'complex64', [ len ], 'row-major' );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=complex64,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.float32.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.float32.js
@@ -1,0 +1,94 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nans = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nans( 'float32', [ len ], 'row-major' );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=float32,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.float64.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.float64.js
@@ -1,0 +1,94 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nans = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nans( 'float64', [ len ], 'row-major' );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=float64,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.generic.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/benchmark/benchmark.size.generic.js
@@ -1,0 +1,94 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nans = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nans( 'generic', [ len ], 'row-major' );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=generic,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/docs/repl.txt
@@ -1,0 +1,30 @@
+
+{{alias}}( dtype, shape, order )
+    Returns a NaN-filled ndarray having a specified shape and data type.
+
+    Parameters
+    ----------
+    dtype: string|DataType
+        Underlying data type. Must be a floating-point or "generic" data
+        type.
+
+    shape: ArrayLikeObject<integer>
+        Array shape.
+
+    order: string
+        Specifies whether an array is row-major (C-style) or column-major
+        (Fortran-style).
+
+    Returns
+    -------
+    out: ndarray
+        Output array.
+
+    Examples
+    --------
+    > var arr = {{alias}}( 'float64', [ 2, 2 ], 'row-major' )
+    <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/ndarray/base/nans/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/docs/types/index.d.ts
@@ -1,0 +1,142 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Shape, Order, typedndarray, genericndarray, float64ndarray, float32ndarray, complex128ndarray, complex64ndarray, FloatingPointAndGenericDataType, GenericDataType, Float64DataType, Float32DataType, Complex128DataType, Complex64DataType } from '@stdlib/types/ndarray';
+
+/**
+* Creates a NaN-filled array having a specified shape and data type.
+*
+* @param dtype - underlying data type
+* @param shape - array shape
+* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
+* @returns NaN-filled array
+*
+* @example
+* var getDType = require( '@stdlib/ndarray/dtype' );
+*
+* var arr = nans( 'float64', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var dt = String( getDType( arr ) );
+* // returns 'float64'
+*/
+declare function nans( dtype: Float64DataType, shape: Shape, order: Order ): float64ndarray;
+
+/**
+* Creates a NaN-filled array having a specified shape and data type.
+*
+* @param dtype - underlying data type
+* @param shape - array shape
+* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
+* @returns NaN-filled array
+*
+* @example
+* var getDType = require( '@stdlib/ndarray/dtype' );
+*
+* var arr = nans( 'float32', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var dt = String( getDType( arr ) );
+* // returns 'float32'
+*/
+declare function nans( dtype: Float32DataType, shape: Shape, order: Order ): float32ndarray;
+
+/**
+* Creates a NaN-filled array having a specified shape and data type.
+*
+* @param dtype - underlying data type
+* @param shape - array shape
+* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
+* @returns NaN-filled array
+*
+* @example
+* var getDType = require( '@stdlib/ndarray/dtype' );
+*
+* var arr = nans( 'complex128', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>
+*
+* var dt = String( getDType( arr ) );
+* // returns 'complex128'
+*/
+declare function nans( dtype: Complex128DataType, shape: Shape, order: Order ): complex128ndarray;
+
+/**
+* Creates a NaN-filled array having a specified shape and data type.
+*
+* @param dtype - underlying data type
+* @param shape - array shape
+* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
+* @returns NaN-filled array
+*
+* @example
+* var getDType = require( '@stdlib/ndarray/dtype' );
+*
+* var arr = nans( 'complex64', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>
+*
+* var dt = String( getDType( arr ) );
+* // returns 'complex64'
+*/
+declare function nans( dtype: Complex64DataType, shape: Shape, order: Order ): complex64ndarray;
+
+/**
+* Creates a NaN-filled array having a specified shape and data type.
+*
+* @param dtype - underlying data type
+* @param shape - array shape
+* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
+* @returns NaN-filled array
+*
+* @example
+* var getDType = require( '@stdlib/ndarray/dtype' );
+*
+* var arr = nans( 'generic', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var dt = String( getDType( arr ) );
+* // returns 'generic'
+*/
+declare function nans( dtype: GenericDataType, shape: Shape, order: Order ): genericndarray<number>;
+
+/**
+* Creates a NaN-filled array having a specified shape and data type.
+*
+* @param dtype - underlying data type
+* @param shape - array shape
+* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
+* @returns NaN-filled array
+*
+* @example
+* var getDType = require( '@stdlib/ndarray/dtype' );
+*
+* var arr = nans( 'float64', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var dt = String( getDType( arr ) );
+* // returns 'float64'
+*/
+declare function nans( dtype: FloatingPointAndGenericDataType, shape: Shape, order: Order ): typedndarray<number>;
+
+
+// EXPORTS //
+
+export = nans;

--- a/lib/node_modules/@stdlib/ndarray/base/nans/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/docs/types/test.ts
@@ -1,0 +1,82 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import nans = require( './index' );
+
+
+// TESTS //
+
+// The function returns an ndarray...
+{
+	nans( 'float64', [ 2, 2 ], 'row-major' ); // $ExpectType float64ndarray
+	nans( 'float32', [ 2, 2 ], 'row-major' ); // $ExpectType float32ndarray
+	nans( 'complex128', [ 2, 2 ], 'row-major' ); // $ExpectType complex128ndarray
+	nans( 'complex64', [ 2, 2 ], 'row-major' ); // $ExpectType complex64ndarray
+	nans( 'generic', [ 2, 2 ], 'row-major' ); // $ExpectType genericndarray<number>
+
+	nans( 'float64', [ 2, 2 ], 'column-major' ); // $ExpectType float64ndarray
+	nans( 'float32', [ 2, 2 ], 'column-major' ); // $ExpectType float32ndarray
+	nans( 'complex128', [ 2, 2 ], 'column-major' ); // $ExpectType complex128ndarray
+	nans( 'complex64', [ 2, 2 ], 'column-major' ); // $ExpectType complex64ndarray
+	nans( 'generic', [ 2, 2 ], 'column-major' ); // $ExpectType genericndarray<number>
+}
+
+// The compiler throws an error if the function is provided a first argument which is an unrecognized/unsupported data type...
+{
+	nans( '10', [ 2, 2 ], 'row-major' ); // $ExpectError
+	nans( 10, [ 2, 2 ], 'row-major' ); // $ExpectError
+	nans( false, [ 2, 2 ], 'row-major' ); // $ExpectError
+	nans( true, [ 2, 2 ], 'row-major' ); // $ExpectError
+	nans( null, [ 2, 2 ], 'row-major' ); // $ExpectError
+	nans( [], [ 2, 2 ], 'row-major' ); // $ExpectError
+	nans( {}, [ 2, 2 ], 'row-major' ); // $ExpectError
+	nans( ( x: number ): number => x, [ 2, 2 ], 'row-major' ); // $ExpectError
+}
+
+// The compiler throws an error if the function is not provided a valid shape for the second argument...
+{
+	nans( 'float32', '10', 'row-major' ); // $ExpectError
+	nans( 'float32', 10, 'row-major' ); // $ExpectError
+	nans( 'float32', false, 'row-major' ); // $ExpectError
+	nans( 'float32', true, 'row-major' ); // $ExpectError
+	nans( 'float32', null, 'row-major' ); // $ExpectError
+	nans( 'float32', undefined, 'row-major' ); // $ExpectError
+	nans( 'float32', [ '5' ], 'row-major' ); // $ExpectError
+	nans( 'float32', {}, 'row-major' ); // $ExpectError
+	nans( 'float32', ( x: number ): number => x, 'row-major' ); // $ExpectError
+}
+
+// The compiler throws an error if the function is not provided a valid order for the third argument...
+{
+	nans( 'float32', [ 2, 2 ], '10' ); // $ExpectError
+	nans( 'float32', [ 2, 2 ], 10 ); // $ExpectError
+	nans( 'float32', [ 2, 2 ], false ); // $ExpectError
+	nans( 'float32', [ 2, 2 ], true ); // $ExpectError
+	nans( 'float32', [ 2, 2 ], null ); // $ExpectError
+	nans( 'float32', [ 2, 2 ], undefined ); // $ExpectError
+	nans( 'float32', [ 2, 2 ], [ '5' ] ); // $ExpectError
+	nans( 'float32', [ 2, 2 ], {} ); // $ExpectError
+	nans( 'float32', [ 2, 2 ], ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	nans( 'float64' ); // $ExpectError
+	nans( 'float64', [ 2, 2 ] ); // $ExpectError
+	nans( 'float64', [ 2, 2 ], 'row-major', 1 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/ndarray/base/nans/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/examples/index.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var nans = require( './../lib' );
+
+var dt = [
+	'float64',
+	'float32',
+	'complex128',
+	'complex64',
+	'generic'
+];
+
+// Generate NaN-filled arrays...
+var arr;
+var i;
+for ( i = 0; i < dt.length; i++ ) {
+	arr = nans( dt[ i ], [ 2, 2 ], 'row-major' );
+	console.log( ndarray2array( arr ) );
+}

--- a/lib/node_modules/@stdlib/ndarray/base/nans/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/lib/index.js
@@ -1,0 +1,44 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Create a NaN-filled ndarray having a specified shape and data type.
+*
+* @module @stdlib/ndarray/base/nans
+*
+* @example
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var nans = require( '@stdlib/ndarray/base/nans' );
+*
+* var arr = nans( 'float32', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var dt = String( getDType( arr ) );
+* // returns 'float32'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/ndarray/base/nans/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/lib/main.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isComplexFloatingPointDataType = require( '@stdlib/ndarray/base/assert/is-complex-floating-point-data-type' ); // eslint-disable-line id-length
+var empty = require( '@stdlib/ndarray/base/empty' );
+var fill = require( '@stdlib/ndarray/base/fill' );
+var CNAN = require( '@stdlib/constants/complex128/nan' );
+
+
+// MAIN //
+
+/**
+* Creates a NaN-filled ndarray having a specified shape and data type.
+*
+* @param {*} dtype - floating-point or generic data type
+* @param {NonNegativeIntegerArray} shape - array shape
+* @param {string} order - array order
+* @throws {TypeError} first argument must be a recognized data type
+* @returns {ndarray} ndarray
+*
+* @example
+* var getDType = require( '@stdlib/ndarray/dtype' );
+*
+* var arr = nans( 'float32', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var dt = String( getDType( arr ) );
+* // returns 'float32'
+*/
+function nans( dtype, shape, order ) {
+	if ( isComplexFloatingPointDataType( dtype ) ) {
+		return fill( empty( dtype, shape, order ), CNAN );
+	}
+	return fill( empty( dtype, shape, order ), NaN );
+}
+
+
+// EXPORTS //
+
+module.exports = nans;

--- a/lib/node_modules/@stdlib/ndarray/base/nans/package.json
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@stdlib/ndarray/base/nans",
+  "version": "0.0.0",
+  "description": "Create a NaN-filled ndarray having a specified shape and data type.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "types",
+    "base",
+    "data",
+    "structure",
+    "vector",
+    "ndarray",
+    "matrix",
+    "fill",
+    "filled",
+    "nans",
+    "nan"
+  ]
+}

--- a/lib/node_modules/@stdlib/ndarray/base/nans/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/test/test.js
@@ -1,0 +1,276 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var Float32Array = require( '@stdlib/array/float32' );
+var Complex64Array = require( '@stdlib/array/complex64' );
+var Complex128Array = require( '@stdlib/array/complex128' );
+var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var instanceOf = require( '@stdlib/assert/instance-of' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var getShape = require( '@stdlib/ndarray/shape' );
+var getDType = require( '@stdlib/ndarray/dtype' );
+var getData = require( '@stdlib/ndarray/data-buffer' );
+var getOrder = require( '@stdlib/ndarray/order' );
+var nans = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Tests whether all elements in an array are NaN.
+*
+* @private
+* @param {Collection} arr - input array
+* @returns {boolean} boolean indicating whether all elements are NaN
+*/
+function allNaN( arr ) {
+	var i;
+	for ( i = 0; i < arr.length; i++ ) {
+		if ( !isnan( arr[ i ] ) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nans, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided an unrecognized/unsupported data type', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		'beep',
+		'nans',
+		'int32',
+		'uint32',
+		'int16',
+		'uint16',
+		'int8',
+		'uint8',
+		'uint8c',
+		'binary',
+		'Int32',
+		'Uint32',
+		'Int16',
+		'Uint16',
+		'Int8',
+		'Uint8',
+		'Uint8c',
+		'uint8_clamped',
+		'Float64',
+		'Float32',
+		'FLOAT64',
+		'FLOAT32'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nans( value, 10, 'row-major' );
+		};
+	}
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float64, order=row-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'float64', [ 2, 2 ], 'row-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float64, order=column-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'float64', [ 2, 2 ], 'column-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float32, order=row-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'float32', [ 2, 2 ], 'row-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float32, order=column-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'float32', [ 2, 2 ], 'column-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex128, order=row-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'complex128', [ 2, 2 ], 'row-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex128', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex128Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( reinterpret128( getData( arr ), 0 ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex128, order=column-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'complex128', [ 2, 2 ], 'column-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex128', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex128Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( reinterpret128( getData( arr ), 0 ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex64, order=row-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'complex64', [ 2, 2 ], 'row-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( reinterpret64( getData( arr ), 0 ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex64, order=column-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'complex64', [ 2, 2 ], 'column-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( reinterpret64( getData( arr ), 0 ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=generic, order=row-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'generic', [ 2, 2 ], 'row-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=generic, order=column-major)', function test( t ) {
+	var arr;
+
+	arr = nans( 'generic', [ 2, 2 ], 'column-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports zero-dimensional arrays', function test( t ) {
+	var arr;
+
+	arr = nans( 'float64', [], 'row-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports empty arrays', function test( t ) {
+	var arr;
+
+	arr = nans( 'float64', [ 2, 0, 2 ], 'row-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 0, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( getData( arr ).length, 0, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves #11147
.

## Description

> What is the purpose of this pull request?

This pull request:

-   {{TODO: Moved helper functions (onStringFormat, dropFirst, deleteComment, rewriteRequire, and hasRequire) from the transformer scope to the module scope to resolve stdlib/no-unnecessary-nested-functions}}

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{{TODO: add related issue number}}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
