### PR TITLE
build: add `_tools/lint/manifest-json-deps`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/README.md
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/README.md
@@ -1,0 +1,244 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Lint
+
+> Lint manifest.json dependencies to ensure all required packages are listed.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var lint = require( '@stdlib/_tools/lint/manifest-json-deps' );
+```
+
+#### lint( \[options,] clbk )
+
+Asynchronously lints manifest.json dependencies by analyzing C source file `#include` directives and verifying that the corresponding `@stdlib` packages are listed in each configuration's `dependencies` array.
+
+```javascript
+lint( onLint );
+
+function onLint( error, errs ) {
+    if ( error ) {
+        throw error;
+    }
+    if ( errs && errs.length ) {
+        console.error( JSON.stringify( errs ) );
+    } else {
+        console.log( 'No detected errors.' );
+    }
+}
+```
+
+The function accepts the following `options`:
+
+-   **dir**: root directory from which to search for manifest.json files. May be either an absolute file path or a path relative to the current working directory. Default: current working directory.
+-   **pattern**: glob pattern for finding manifest.json files. Default: `**/@stdlib/**/manifest.json`.
+-   **ignore**: glob pattern(s) to exclude.
+
+Each lint error is represented by an `object` having the following fields:
+
+-   **file**: manifest.json file path.
+-   **errors**: array of error objects, each with `message`, `conf`, and `dependency` fields.
+
+To lint starting from a descendant directory, set the `dir` option.
+
+```javascript
+var opts = {
+    'dir': '/foo/bar/baz'
+};
+
+lint( opts, onLint );
+
+function onLint( error, errs ) {
+    if ( error ) {
+        throw error;
+    }
+    if ( errs && errs.length ) {
+        console.error( JSON.stringify( errs ) );
+    } else {
+        console.log( 'No detected errors.' );
+    }
+}
+```
+
+#### lint.sync( \[options] )
+
+Synchronously lints manifest.json dependencies.
+
+```javascript
+var errs = lint.sync();
+if ( errs && errs.length ) {
+    console.error( JSON.stringify( errs ) );
+} else {
+    console.log( 'No detected errors.' );
+}
+```
+
+The function accepts the same `options` as `lint()` above.
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The linter analyzes C source files (`.c`) for `#include "stdlib/..."` directives and maps each include path to an `@stdlib` package name.
+-   The mapping converts underscores in header paths to hyphens in package names (e.g., `stdlib/napi/argv_double.h` maps to `@stdlib/napi/argv-double`).
+-   For `build` configurations (non-WASM), the linter also scans `src/addon.c` if present, as it is compiled during builds but not listed in the manifest's `src` array.
+-   Self-references (a package including its own headers) are automatically excluded.
+-   Fortran files (`.f`) are skipped as they do not contain `#include` directives.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var lint = require( '@stdlib/_tools/lint/manifest-json-deps' );
+
+var opts = {
+    'dir': './',
+    'pattern': '**/@stdlib/math/**/manifest.json'
+};
+
+lint( opts, onLint );
+
+function onLint( error, errors ) {
+    if ( error ) {
+        throw error;
+    }
+    if ( errors && errors.length ) {
+        console.error( JSON.stringify( errors ) );
+    } else {
+        console.log( 'No detected errors.' );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+* * *
+
+<section class="cli">
+
+## CLI
+
+<section class="usage">
+
+### Usage
+
+```text
+Usage: lint-manifest-json-deps [options] [<dir>]
+
+Options:
+
+  -h,   --help                Print this message.
+  -V,   --version             Print the package version.
+        --pattern pattern     Inclusion glob pattern.
+        --ignore pattern      Exclusion glob pattern.
+        --format fmt          Output format: 'pretty' or 'ndjson'. Default: 'pretty'.
+        --split sep           Separator used to split stdin data. Default: /\\r?\\n/.
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+### Notes
+
+-   If part of a [standard stream][standard-stream] pipeline, results are written to `stdout` as newline-delimited JSON ([NDJSON][ndjson]). Otherwise, results are pretty printed by default.
+
+-   If not provided a `dir` argument, the current working directory is the search directory.
+
+-   To provide multiple exclusion glob patterns, set multiple `--ignore` option arguments.
+
+    ```bash
+    $ lint-manifest-json-deps --ignore=node_modules/** --ignore=build/** --ignore=reports/**
+    ```
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ lint-manifest-json-deps
+
+/path/to/lib/node_modules/@stdlib/math/base/special/abs/manifest.json
+
+    message: Missing dependency "@stdlib/napi/argv-double" in conf [task:build, wasm:false].
+    conf: task:build, wasm:false
+    dependency: @stdlib/napi/argv-double
+
+1 errors
+```
+
+To output results as newline-delimited JSON ([NDJSON][ndjson]),
+
+```bash
+$ lint-manifest-json-deps --format ndjson
+{"file":"/path/to/manifest.json","message":"Missing dependency...","conf":"task:build","dependency":"@stdlib/napi/argv-double"}
+...
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[ndjson]: http://ndjson.org/
+
+[standard-stream]: https://en.wikipedia.org/wiki/Pipeline_%28Unix%29
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/bin/cli
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/bin/cli
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var CLI = require( '@stdlib/cli/ctor' );
+var stdin = require( '@stdlib/process/read-stdin' );
+var stdinStream = require( '@stdlib/streams/node/stdin' );
+var stdoutStream = require( '@stdlib/streams/node/stdout' );
+var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
+var isRegExpString = require( '@stdlib/assert/is-regexp-string' );
+var reFromString = require( '@stdlib/utils/regexp-from-string' );
+var cwd = require( '@stdlib/process/cwd' );
+var lint = require( './../lib' );
+var lintFiles = require( './../lib/lint.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Prints lint errors as newline-delimited JSON.
+*
+* @private
+* @param {ObjectArray} errs - lint errors
+*/
+function ndjson( errs ) {
+	var errors;
+	var err;
+	var i;
+	var j;
+
+	for ( i = 0; i < errs.length; i++ ) {
+		errors = errs[ i ].errors;
+		for ( j = 0; j < errors.length; j++ ) {
+			err = {};
+			err.file = errs[ i ].file;
+			err.message = errors[ j ].message;
+			err.conf = errors[ j ].conf;
+			err.dependency = errors[ j ].dependency;
+			console.error( JSON.stringify( err ) ); // eslint-disable-line no-console
+		}
+	}
+}
+
+/**
+* Pretty prints lint errors.
+*
+* @private
+* @param {ObjectArray} errs - lint errors
+*/
+function prettyPrint( errs ) {
+	/* eslint-disable no-console */
+	var errors;
+	var total;
+	var i;
+	var j;
+
+	total = 0;
+
+	console.error( '' );
+	for ( i = 0; i < errs.length; i++ ) {
+		console.error( errs[ i ].file );
+		errors = errs[ i ].errors;
+		for ( j = 0; j < errors.length; j++ ) {
+			console.error( '' );
+			console.error( '    message: %s', errors[ j ].message );
+			if ( errors[ j ].conf ) {
+				console.error( '    conf: %s', errors[ j ].conf );
+			}
+			if ( errors[ j ].dependency ) {
+				console.error( '    dependency: %s', errors[ j ].dependency );
+			}
+			total += 1;
+		}
+		console.error( '' );
+	}
+	console.error( '%d errors', total );
+	console.error( '' );
+
+	/* eslint-enable no-console */
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+* @returns {void}
+*/
+function main() {
+	var flags;
+	var args;
+	var opts;
+	var cli;
+	var fmt;
+
+	// Create a command-line interface:
+	cli = new CLI({
+		'pkg': require( './../package.json' ),
+		'options': require( './../etc/cli_opts.json' ),
+		'help': readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			'encoding': 'utf8'
+		})
+	});
+
+	// Get any provided command-line options:
+	flags = cli.flags();
+	if ( flags.help || flags.version ) {
+		return;
+	}
+
+	// Get any provided command-line arguments:
+	args = cli.args();
+
+	if ( flags.format ) {
+		fmt = flags.format;
+	} else if ( stdoutStream.isTTY ) {
+		fmt = 'pretty';
+	} else {
+		fmt = 'ndjson';
+	}
+	opts = {};
+	opts.dir = args[ 0 ] || cwd();
+
+	// Check if we are receiving a list of filenames from `stdin`...
+	if ( !stdinStream.isTTY ) {
+		if ( flags.split ) {
+			if ( !isRegExpString( flags.split ) ) {
+				flags.split = '/'+flags.split+'/';
+			}
+			opts.split = reFromString( flags.split );
+		} else {
+			opts.split = RE_EOL;
+		}
+		return stdin( onRead );
+	}
+	if ( flags.pattern ) {
+		opts.pattern = flags.pattern;
+	}
+	if ( flags.ignore ) {
+		if ( typeof flags.ignore === 'string' ) {
+			opts.ignore = [ flags.ignore ];
+		} else {
+			opts.ignore = flags.ignore;
+		}
+	}
+	lint( opts, onFinish );
+
+	/**
+	* Callback invoked upon reading from `stdin`.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Buffer} data - data
+	* @returns {void}
+	*/
+	function onRead( error, data ) {
+		var i;
+		if ( error ) {
+			return cli.error( error );
+		}
+		data = data.toString().split( opts.split );
+
+		// Check if input data had a trailing newline...
+		if ( data[ data.length-1 ] === '' ) {
+			data.length -= 1;
+		}
+		if ( data.length === 0 ) {
+			return;
+		}
+		// Resolve absolute file paths...
+		for ( i = 0; i < data.length; i++ ) {
+			data[ i ] = resolve( opts.dir, data[ i ] );
+		}
+		lintFiles( data, onFinish );
+	}
+
+	/**
+	* Callback invoked after linting.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {(ObjectArray|null)} errs - lint errors
+	* @returns {void}
+	*/
+	function onFinish( error, errs ) {
+		if ( error ) {
+			return cli.error( error );
+		}
+		if ( errs ) {
+			if ( fmt === 'ndjson' ) {
+				ndjson( errs );
+			} else {
+				prettyPrint( errs );
+			}
+			return cli.close( 1 );
+		}
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/docs/usage.txt
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/docs/usage.txt
@@ -1,0 +1,10 @@
+Usage: lint-manifest-json-deps [options] [<dir>]
+
+Options:
+
+  -h,   --help                Print this message.
+  -V,   --version             Print the package version.
+        --pattern pattern     Inclusion glob pattern.
+        --ignore pattern      Exclusion glob pattern.
+        --format fmt          Output format: 'pretty' or 'ndjson'. Default: 'pretty'.
+        --split sep           Separator used to split stdin data. Default: /\\r?\\n/.

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/etc/cli_opts.json
@@ -1,0 +1,20 @@
+{
+	"string": [
+		"pattern",
+		"ignore",
+		"format",
+		"split"
+	],
+	"boolean": [
+		"help",
+		"version"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		]
+	}
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/examples/index.js
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var lint = require( './../lib' );
+
+lint( onLint );
+
+function onLint( error, errs ) {
+	if ( error ) {
+		throw error;
+	}
+	if ( errs && errs.length ) {
+		console.error( JSON.stringify( errs, null, 2 ) );
+	} else {
+		console.log( 'No detected errors.' );
+	}
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/async.js
@@ -1,0 +1,119 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var glob = require( 'glob' );
+var logger = require( 'debug' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var copy = require( '@stdlib/utils/copy' );
+var format = require( '@stdlib/string/format' );
+var validate = require( './validate.js' );
+var lint = require( './lint.js' );
+
+
+// VARIABLES //
+
+var DEFAULTS = require( './config.json' );
+var debug = logger( 'lint:manifest-json-deps:async' );
+
+
+// MAIN //
+
+/**
+* Asynchronously lints manifest.json dependencies to ensure all required packages are listed.
+*
+* @param {Options} [options] - function options
+* @param {string} [options.dir] - root directory from which to search for manifest.json files to lint
+* @param {string} [options.pattern] - glob pattern
+* @param {(string|StringArray)} [options.ignore] - glob pattern(s) to exclude
+* @param {Function} clbk - callback to invoke upon completion
+* @throws {TypeError} must provide valid options
+* @throws {TypeError} callback argument must be a function
+*
+* @example
+* lint( onLint );
+*
+* function onLint( error, errs ) {
+*     if ( error ) {
+*         throw error;
+*     }
+*     if ( errs && errs.length ) {
+*         console.error( JSON.stringify( errs ) );
+*     } else {
+*         console.log( 'No detected errors.' );
+*     }
+* }
+*/
+function lintAsync( options, clbk ) {
+	var opts;
+	var err;
+	var cb;
+
+	if ( arguments.length === 1 ) {
+		cb = options;
+		opts = copy( DEFAULTS );
+	} else {
+		opts = copy( DEFAULTS );
+		cb = clbk;
+		err = validate( opts, options );
+		if ( err ) {
+			throw err;
+		}
+	}
+	if ( !isFunction( cb ) ) {
+		throw new TypeError( format( 'invalid argument. Callback argument must be a function. Value: `%s`.', cb ) );
+	}
+
+	// Find manifest.json files:
+	debug( 'Searching for manifest.json files.' );
+	glob( opts.pattern, {
+		'cwd': opts.dir,
+		'ignore': opts.ignore,
+		'realpath': true
+	}, onGlob );
+
+	/**
+	* Callback invoked upon completing glob search.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {StringArray} files - file paths
+	* @returns {void}
+	*/
+	function onGlob( error, files ) {
+		if ( error ) {
+			debug( 'Encountered an error when searching for files: %s', error.message );
+			return cb( error );
+		}
+		debug( 'Found %d files.', files.length );
+		if ( files.length ) {
+			debug( 'Processing files.' );
+			lint( files, cb );
+		} else {
+			return cb( null, null );
+		}
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = lintAsync;

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/check_deps.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/check_deps.js
@@ -1,0 +1,217 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var relative = require( 'path' ).relative;
+var join = require( 'path' ).join;
+var logger = require( 'debug' );
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var existsSync = require( '@stdlib/fs/exists' ).sync;
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var objectKeys = require( '@stdlib/utils/keys' );
+var dirname = require( '@stdlib/utils/dirname' );
+var format = require( '@stdlib/string/format' );
+var extractIncludes = require( './extract_includes.js' );
+var resolvePkg = require( './resolve_pkg.js' );
+
+
+// VARIABLES //
+
+var debug = logger( 'lint:manifest-json-deps:check' );
+var STDLIB_DIR_SUFFIX = join( 'lib', 'node_modules', '@stdlib' );
+var RE_STDLIB_DIR = new RegExp( '(.*' + STDLIB_DIR_SUFFIX.replace( /[/\\]/g, '[/\\\\]' ) + ')' );
+
+
+// FUNCTIONS //
+
+/**
+* Derives the stdlib root directory from a manifest file path.
+*
+* @private
+* @param {string} manifestPath - absolute path to manifest.json
+* @returns {(string|null)} absolute path to lib/node_modules/@stdlib or null
+*/
+function resolveStdlibDir( manifestPath ) {
+	var match = RE_STDLIB_DIR.exec( manifestPath );
+	if ( match ) {
+		return match[ 1 ];
+	}
+	return null;
+}
+
+/**
+* Derives the package name from a manifest file path.
+*
+* @private
+* @param {string} manifestPath - absolute path to manifest.json
+* @param {string} stdlibDir - absolute path to lib/node_modules/@stdlib
+* @returns {string} package name (e.g., "@stdlib/blas/base/shared")
+*/
+function deriveSelfPkg( manifestPath, stdlibDir ) {
+	var rel = relative( stdlibDir, dirname( manifestPath ) );
+	return '@stdlib/' + rel.replace( /\\/g, '/' );
+}
+
+/**
+* Builds a descriptive label for a configuration entry.
+*
+* @private
+* @param {Object} conf - configuration entry
+* @returns {string} label
+*/
+function confLabel( conf ) {
+	var parts = [];
+	var keys = [ 'task', 'os', 'blas', 'wasm' ];
+	var i;
+	for ( i = 0; i < keys.length; i++ ) {
+		if ( hasOwnProp( conf, keys[ i ] ) ) {
+			parts.push( keys[ i ] + ':' + String( conf[ keys[ i ] ] ) );
+		}
+	}
+	if ( parts.length === 0 ) {
+		return 'default';
+	}
+	return parts.join( ', ' );
+}
+
+
+// MAIN //
+
+/**
+* Checks manifest.json dependencies against C source file includes.
+*
+* @private
+* @param {string} manifestPath - absolute path to manifest.json
+* @param {Object} manifest - parsed manifest.json contents
+* @returns {ObjectArray} array of error objects (empty if no issues found)
+*
+* @example
+* var manifest = {
+*     'confs': []
+* };
+*
+* var errors = checkDeps( '/tmp/manifest.json', manifest );
+* // returns []
+*/
+function checkDeps( manifestPath, manifest ) {
+	var declaredDeps;
+	var manifestDir;
+	var stdlibDir;
+	var srcFiles;
+	var includes;
+	var selfPkg;
+	var errors;
+	var label;
+	var text;
+	var pkg;
+	var src;
+	var i;
+	var j;
+	var k;
+
+	stdlibDir = resolveStdlibDir( manifestPath );
+	if ( !stdlibDir ) {
+		debug( 'Unable to resolve stdlib directory from: %s', manifestPath );
+		return [];
+	}
+	manifestDir = dirname( manifestPath );
+	selfPkg = deriveSelfPkg( manifestPath, stdlibDir );
+	debug( 'Checking dependencies for: %s', selfPkg );
+
+	errors = [];
+
+	for ( i = 0; i < manifest.confs.length; i++ ) {
+		label = confLabel( manifest.confs[ i ] );
+		debug( 'Processing conf [%s]', label );
+
+		// Collect source files for this configuration:
+		srcFiles = [];
+		src = manifest.confs[ i ].src;
+		if ( src ) {
+			for ( j = 0; j < src.length; j++ ) {
+				// Only process C source files (skip Fortran .f files):
+				if ( /\.c$/.test( src[ j ] ) ) {
+					srcFiles.push( resolve( manifestDir, src[ j ] ) );
+				}
+			}
+		}
+
+		// If this is a non-WASM build task, also check addon.c (WASM builds do not compile addon.c):
+		if ( manifest.confs[ i ].task === 'build' && !manifest.confs[ i ].wasm ) {
+			src = join( manifestDir, 'src', 'addon.c' );
+			if ( existsSync( src ) ) {
+				srcFiles.push( src );
+			}
+		}
+
+		if ( srcFiles.length === 0 ) {
+			debug( 'No C source files found for conf [%s]. Skipping.', label );
+			continue;
+		}
+
+		// Collect all required packages from source file includes:
+		includes = {};
+		for ( j = 0; j < srcFiles.length; j++ ) {
+			debug( 'Reading source file: %s', srcFiles[ j ] );
+			text = readFileSync( srcFiles[ j ], {
+				'encoding': 'utf8'
+			});
+			if ( text instanceof Error ) {
+				debug( 'Error reading source file: %s', text.message );
+				continue;
+			}
+			src = extractIncludes( text );
+			for ( k = 0; k < src.length; k++ ) {
+				pkg = resolvePkg( src[ k ], stdlibDir );
+				if ( pkg && pkg !== selfPkg ) {
+					includes[ pkg ] = true;
+				}
+			}
+		}
+
+		// Check which required packages are missing from declared dependencies:
+		declaredDeps = {};
+		src = manifest.confs[ i ].dependencies;
+		if ( src ) {
+			for ( j = 0; j < src.length; j++ ) {
+				declaredDeps[ src[ j ] ] = true;
+			}
+		}
+
+		src = objectKeys( includes );
+		for ( j = 0; j < src.length; j++ ) {
+			if ( !declaredDeps[ src[ j ] ] ) {
+				errors.push({
+					'message': format( 'Missing dependency "%s" in conf [%s].', src[ j ], label ),
+					'conf': label,
+					'dependency': src[ j ]
+				});
+			}
+		}
+	}
+	return errors;
+}
+
+
+// EXPORTS //
+
+module.exports = checkDeps;

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/config.json
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/config.json
@@ -1,0 +1,11 @@
+{
+  "dir": "./lib/node_modules",
+  "pattern": "**/@stdlib/**/manifest.json",
+  "ignore": [
+    "**/snippets/manifest.json",
+    "node_modules/**",
+    "**/build/**",
+    "reports/**",
+    ".git*"
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/extract_includes.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/extract_includes.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// VARIABLES //
+
+var RE_INCLUDE = /^[ \t]*#include\s+"(stdlib\/[^"]+)"/;
+
+
+// MAIN //
+
+/**
+* Extracts stdlib include paths from C source text.
+*
+* @private
+* @param {string} text - C source file contents
+* @returns {StringArray} array of stdlib header paths (e.g., "stdlib/napi/argv_double.h")
+*
+* @example
+* var text = '#include "stdlib/math/base/special/abs.h"\n#include <stdint.h>\n';
+* var out = extractIncludes( text );
+* // returns [ 'stdlib/math/base/special/abs.h' ]
+*/
+function extractIncludes( text ) {
+	var lines;
+	var match;
+	var out;
+	var i;
+
+	out = [];
+	lines = text.split( '\n' );
+	for ( i = 0; i < lines.length; i++ ) {
+		match = RE_INCLUDE.exec( lines[ i ] );
+		if ( match ) {
+			out.push( match[ 1 ] );
+		}
+	}
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = extractIncludes;

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/index.js
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Lint manifest.json dependencies to ensure all required packages are listed.
+*
+* @module @stdlib/_tools/lint/manifest-json-deps
+*
+* @example
+* var lint = require( '@stdlib/_tools/lint/manifest-json-deps' );
+*
+* lint( onLint );
+*
+* function onLint( error, errs ) {
+*     if ( error ) {
+*         throw error;
+*     }
+*     if ( errs && errs.length ) {
+*         console.error( JSON.stringify( errs ) );
+*     } else {
+*         console.log( 'No detected errors.' );
+*     }
+* }
+*
+* @example
+* var lintSync = require( '@stdlib/_tools/lint/manifest-json-deps' ).sync;
+*
+* var errs = lintSync();
+* if ( errs && errs.length ) {
+*     console.error( JSON.stringify( errs ) );
+* } else {
+*     console.log( 'No detected errors.' );
+* }
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var lint = require( './async.js' );
+var sync = require( './sync.js' );
+
+
+// MAIN //
+
+setReadOnly( lint, 'sync', sync );
+
+
+// EXPORTS //
+
+module.exports = lint;

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/lint.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/lint.js
@@ -1,0 +1,133 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var logger = require( 'debug' );
+var readJSON = require( '@stdlib/fs/read-json' );
+var checkDeps = require( './check_deps.js' );
+
+
+// VARIABLES //
+
+var debug = logger( 'lint:manifest-json-deps:linter' );
+
+
+// MAIN //
+
+/**
+* Reads and lints manifest.json files for dependency validation.
+*
+* @private
+* @param {StringArray} files - list of manifest.json files
+* @param {Callback} clbk - callback to invoke upon completion
+* @returns {void}
+*/
+function lint( files, clbk ) {
+	var total;
+	var out;
+	var i;
+
+	total = files.length;
+	out = [];
+	i = -1;
+
+	return next();
+
+	/**
+	* Processes the next manifest.json file.
+	*
+	* @private
+	* @returns {void}
+	*/
+	function next() {
+		i += 1;
+		if ( i >= total ) {
+			debug( 'Processed all files.' );
+			return done();
+		}
+		debug( 'Processing file %d of %d: %s', i+1, total, files[ i ] );
+		readJSON( files[ i ], onRead );
+	}
+
+	/**
+	* Callback invoked upon reading a manifest.json file.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Object} json - JSON object
+	* @returns {void}
+	*/
+	function onRead( error, json ) {
+		var errs;
+		var j;
+
+		j = i + 1;
+		if ( error ) {
+			debug( 'Encountered an error reading file: %s (%d of %d). Error: %s', files[ i ], j, total, error.message );
+			out.push({
+				'file': files[ i ],
+				'errors': [
+					{
+						'message': 'Failed to parse manifest.json: ' + error.message
+					}
+				]
+			});
+		} else {
+			debug( 'Successfully read file: %s (%d of %d).', files[ i ], j, total );
+
+			debug( 'Checking dependencies.' );
+			errs = checkDeps( files[ i ], json );
+			if ( errs.length > 0 ) {
+				debug( 'Found %d missing dependencies.', errs.length );
+				out.push({
+					'file': files[ i ],
+					'errors': errs
+				});
+			} else {
+				debug( 'All dependencies are present.' );
+			}
+		}
+		if ( j < total ) {
+			debug( 'Processed %d of %d files.', j, total );
+			return next();
+		}
+		debug( 'Processed all files.' );
+		return done();
+	}
+
+	/**
+	* Callback invoked upon completion.
+	*
+	* @private
+	* @returns {void}
+	*/
+	function done() {
+		if ( out.length ) {
+			return clbk( null, out );
+		}
+		return clbk( null, null );
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = lint;

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/resolve_pkg.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/resolve_pkg.js
@@ -1,0 +1,88 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var join = require( 'path' ).join;
+var existsSync = require( '@stdlib/fs/exists' ).sync;
+
+
+// VARIABLES //
+
+var cache = {};
+
+
+// MAIN //
+
+/**
+* Resolves a C header include path to an `@stdlib` package name.
+*
+* ## Notes
+*
+* -   The function uses a progressive stripping approach: it first tries the full path (with underscores converted to hyphens), and if that does not match a package directory, it strips the last path segment and retries. This handles sub-headers like `stdlib/blas/base/shared/macros.h` which map to `@stdlib/blas/base/shared`.
+* -   Results are memoized for performance.
+*
+* @private
+* @param {string} headerPath - header include path (e.g., "stdlib/napi/argv_double.h")
+* @param {string} stdlibDir - absolute path to `lib/node_modules/@stdlib`
+* @returns {(string|null)} resolved package name (e.g., "@stdlib/napi/argv-double") or null
+*
+* @example
+* var pkg = resolvePkg( 'stdlib/nonexistent/pkg.h', '/nonexistent/path' );
+* // returns null
+*/
+function resolvePkg( headerPath, stdlibDir ) {
+	var candidate;
+	var parts;
+	var idx;
+
+	if ( cache[ headerPath ] !== void 0 ) {
+		return cache[ headerPath ];
+	}
+	// Strip "stdlib/" prefix and ".h" extension:
+	parts = headerPath.slice( 7 ).replace( /\.h$/, '' );
+
+	while ( parts ) {
+		// Try with underscores replaced by hyphens:
+		candidate = parts.replace( /_/g, '-' );
+		if ( existsSync( join( stdlibDir, candidate ) ) ) {
+			cache[ headerPath ] = '@stdlib/' + candidate;
+			return cache[ headerPath ];
+		}
+		// Try with underscores preserved:
+		if ( candidate !== parts && existsSync( join( stdlibDir, parts ) ) ) {
+			cache[ headerPath ] = '@stdlib/' + parts;
+			return cache[ headerPath ];
+		}
+		// Strip the last path segment and retry:
+		idx = parts.lastIndexOf( '/' );
+		if ( idx === -1 ) {
+			break;
+		}
+		parts = parts.substring( 0, idx );
+	}
+	cache[ headerPath ] = null;
+	return null;
+}
+
+
+// EXPORTS //
+
+module.exports = resolvePkg;

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/sync.js
@@ -1,0 +1,141 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var logger = require( 'debug' );
+var glob = require( 'glob' ).sync;
+var cwd = require( '@stdlib/process/cwd' );
+var copy = require( '@stdlib/utils/copy' );
+var readJSON = require( '@stdlib/fs/read-json' ).sync;
+var checkDeps = require( './check_deps.js' );
+var validate = require( './validate.js' );
+
+
+// VARIABLES //
+
+var DEFAULTS = require( './config.json' );
+var debug = logger( 'lint:manifest-json-deps:sync' );
+
+
+// MAIN //
+
+/**
+* Synchronously lints manifest.json dependencies to ensure all required packages are listed.
+*
+* @param {Options} [options] - function options
+* @param {string} [options.dir] - root directory from which to search for manifest.json files to lint
+* @param {string} [options.pattern] - glob pattern
+* @param {(string|StringArray)} [options.ignore] - glob pattern(s) to exclude
+* @throws {TypeError} must provide valid options
+* @returns {(ObjectArray|null)} lint errors or null
+*
+* @example
+* var errs = lintSync();
+* if ( errs ) {
+*     console.error( JSON.stringify( errs ) );
+* } else {
+*     console.log( 'No detected errors.' );
+* }
+*/
+function lintSync( options ) {
+	var files;
+	var gopts;
+	var total;
+	var file;
+	var opts;
+	var errs;
+	var err;
+	var dir;
+	var out;
+	var i;
+	var j;
+
+	opts = copy( DEFAULTS );
+	if ( arguments.length ) {
+		err = validate( opts, options );
+		if ( err ) {
+			throw err;
+		}
+	}
+	if ( opts.dir ) {
+		dir = resolve( cwd(), opts.dir );
+	} else {
+		dir = cwd();
+	}
+	gopts = {
+		'cwd': dir,
+		'ignore': opts.ignore,
+		'realpath': true // return absolute file paths
+	};
+	debug( 'Glob options: %s', JSON.stringify( gopts ) );
+
+	debug( 'Searching for manifest.json files.' );
+	files = glob( opts.pattern, gopts );
+
+	total = files.length;
+	debug( 'Found %d files.', total );
+	if ( total === 0 ) {
+		return null;
+	}
+	debug( 'Processing files.' );
+	out = [];
+	for ( i = 0; i < total; i++ ) {
+		j = i + 1;
+		debug( 'Reading file: %s (%d of %d).', files[ i ], j, total );
+		file = readJSON( files[ i ] );
+		if ( file instanceof Error ) {
+			debug( 'Encountered an error reading file: %s (%d of %d). Error: %s', files[ i ], j, total, file.message );
+			out.push({
+				'file': files[ i ],
+				'errors': [
+					{
+						'message': 'Failed to parse manifest.json: ' + file.message
+					}
+				]
+			});
+		} else {
+			debug( 'Successfully read file: %s (%d of %d).', files[ i ], j, total );
+			debug( 'Checking dependencies.' );
+			errs = checkDeps( files[ i ], file );
+			if ( errs.length > 0 ) {
+				debug( 'Found %d missing dependencies.', errs.length );
+				out.push({
+					'file': files[ i ],
+					'errors': errs
+				});
+			} else {
+				debug( 'All dependencies are present.' );
+			}
+		}
+		debug( 'Processed %d of %d files.', j, total );
+	}
+	debug( 'Processed all files.' );
+	if ( out.length ) {
+		return out;
+	}
+	return null;
+}
+
+
+// EXPORTS //
+
+module.exports = lintSync;

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/validate.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/lib/validate.js
@@ -1,0 +1,81 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isObject = require( '@stdlib/assert/is-plain-object' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
+
+
+// MAIN //
+
+/**
+* Validates function options.
+*
+* @private
+* @param {Object} opts - destination object
+* @param {Options} options - function options
+* @param {string} [options.dir] - root directory from which to search for manifest.json files to lint
+* @param {string} [options.pattern] - glob pattern
+* @param {(string|StringArray)} [options.ignore] - glob pattern(s) to exclude
+* @returns {(Error|null)} null or an error object
+*
+* @example
+* var opts = {};
+* var options = {
+*     'dir': './foo/bar'
+* };
+* var err = validate( opts, options );
+* if ( err ) {
+*     throw err;
+* }
+*/
+function validate( opts, options ) {
+	if ( !isObject( options ) ) {
+		return new TypeError( format( 'invalid argument. Options argument must be an object. Value: `%s`.', options ) );
+	}
+	if ( hasOwnProp( options, 'dir' ) ) {
+		opts.dir = options.dir;
+		if ( !isString( opts.dir ) ) {
+			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'dir', opts.dir ) );
+		}
+	}
+	if ( hasOwnProp( options, 'pattern' ) ) {
+		opts.pattern = options.pattern;
+		if ( !isString( opts.pattern ) ) {
+			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'pattern', opts.pattern ) );
+		}
+	}
+	if ( hasOwnProp( options, 'ignore' ) ) {
+		opts.ignore = options.ignore;
+		if ( !isString( opts.ignore ) && !isStringArray( opts.ignore ) ) {
+			return new TypeError( format( 'invalid option. `%s` option must be a string or an array of strings. Option: `%s`.', 'ignore', opts.ignore ) );
+		}
+	}
+	return null;
+}
+
+
+// EXPORTS //
+
+module.exports = validate;

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/package.json
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@stdlib/_tools/lint/manifest-json-deps",
+  "version": "0.0.0",
+  "description": "Lint manifest.json dependencies to ensure all required packages are listed.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "lint-manifest-json-deps": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "tools",
+    "tool",
+    "lint",
+    "linter",
+    "manifest",
+    "json",
+    "dependencies",
+    "native",
+    "addon"
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/missing-dep/manifest.json
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/missing-dep/manifest.json
@@ -1,0 +1,43 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/missing-dep/src/main.c
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/missing-dep/src/main.c
@@ -1,0 +1,25 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/blas/base/shared.h"
+#include "stdlib/strided/base/stride2offset.h"
+#include <stdint.h>
+
+void foo( void ) {
+	return;
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/self-reference/manifest.json
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/self-reference/manifest.json
@@ -1,0 +1,41 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/self-reference/src/main.c
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/self-reference/src/main.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <stdint.h>
+
+void foo( void ) {
+	return;
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/valid/manifest.json
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/valid/manifest.json
@@ -1,0 +1,44 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/strided/base/stride2offset"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/valid/src/main.c
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/valid/src/main.c
@@ -1,0 +1,25 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/blas/base/shared.h"
+#include "stdlib/strided/base/stride2offset.h"
+#include <stdint.h>
+
+void foo( void ) {
+	return;
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/with-addon/manifest.json
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/with-addon/manifest.json
@@ -1,0 +1,59 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared",
+        "@stdlib/napi/export",
+        "@stdlib/napi/argv"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/blas/base/shared"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/with-addon/src/addon.c
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/with-addon/src/addon.c
@@ -1,0 +1,26 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/blas/base/shared.h"
+#include "stdlib/napi/export.h"
+#include "stdlib/napi/argv.h"
+#include <node_api.h>
+
+void init( void ) {
+	return;
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/with-addon/src/main.c
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/fixtures/with-addon/src/main.c
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/blas/base/shared.h"
+#include <stdint.h>
+
+void foo( void ) {
+	return;
+}

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.check_deps.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.check_deps.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var checkDeps = require( './../lib/check_deps.js' );
+
+
+// VARIABLES //
+
+var FIXTURES = resolve( __dirname, 'fixtures' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof checkDeps, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an empty array when all dependencies are declared', function test( t ) {
+	var manifestPath = resolve( FIXTURES, 'valid', 'manifest.json' );
+	var manifest = require( manifestPath ); // eslint-disable-line stdlib/no-dynamic-require
+	var errors = checkDeps( manifestPath, manifest );
+	t.strictEqual( errors.length, 0, 'returns empty array' );
+	t.end();
+});
+
+tape( 'the function reports missing dependencies', function test( t ) {
+	var manifestPath = resolve( FIXTURES, 'missing-dep', 'manifest.json' );
+	var manifest = require( manifestPath ); // eslint-disable-line stdlib/no-dynamic-require
+	var errors = checkDeps( manifestPath, manifest );
+	t.ok( errors.length > 0, 'returns errors' );
+	t.ok( errors[ 0 ].dependency.indexOf( 'stride2offset' ) !== -1, 'reports missing strided dep' );
+	t.end();
+});
+
+tape( 'the function includes addon.c for non-WASM build confs', function test( t ) {
+	var manifestPath = resolve( FIXTURES, 'with-addon', 'manifest.json' );
+	var manifest = require( manifestPath ); // eslint-disable-line stdlib/no-dynamic-require
+	var errors = checkDeps( manifestPath, manifest );
+
+	// All build deps (including napi from addon.c) are listed, so no errors expected:
+	t.strictEqual( errors.length, 0, 'returns no errors' );
+	t.end();
+});
+
+tape( 'the function does not include addon.c for non-build confs', function test( t ) {
+	var manifestPath;
+	var manifest;
+	var errors;
+
+	manifestPath = resolve( FIXTURES, 'with-addon', 'manifest.json' );
+	manifest = require( manifestPath ); // eslint-disable-line stdlib/no-dynamic-require
+
+	errors = checkDeps( manifestPath, manifest );
+
+	// The benchmark conf does not include addon.c, so napi deps are not required:
+	t.strictEqual( errors.length, 0, 'returns no errors for benchmark conf' );
+	t.end();
+});
+
+tape( 'the function handles manifests outside of the stdlib tree gracefully', function test( t ) {
+	var manifest = {
+		'confs': [
+			{
+				'task': 'build',
+				'src': [ './src/main.c' ],
+				'dependencies': []
+			}
+		]
+	};
+	var errors = checkDeps( '/tmp/fake/manifest.json', manifest );
+	t.strictEqual( errors.length, 0, 'returns empty array' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.extract_includes.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.extract_includes.js
@@ -1,0 +1,111 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var extractIncludes = require( './../lib/extract_includes.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof extractIncludes, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an empty array for source with no stdlib includes', function test( t ) {
+	var text = '#include <stdint.h>\n#include <stdlib.h>\n';
+	var out = extractIncludes( text );
+	t.deepEqual( out, [], 'returns empty array' );
+	t.end();
+});
+
+tape( 'the function extracts a single stdlib include directive', function test( t ) {
+	var text = '#include "stdlib/math/base/special/abs.h"\n';
+	var out = extractIncludes( text );
+	t.deepEqual( out, [ 'stdlib/math/base/special/abs.h' ], 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function extracts multiple stdlib include directives', function test( t ) {
+	var expected;
+	var text;
+	var out;
+
+	text = '#include "stdlib/blas/base/shared.h"\n';
+	text += '#include <stdint.h>\n';
+	text += '#include "stdlib/napi/argv_double.h"\n';
+	text += '#include "stdlib/strided/base/stride2offset.h"\n';
+
+	expected = [
+		'stdlib/blas/base/shared.h',
+		'stdlib/napi/argv_double.h',
+		'stdlib/strided/base/stride2offset.h'
+	];
+
+	out = extractIncludes( text );
+	t.deepEqual( out, expected, 'returns expected values' );
+	t.end();
+});
+
+tape( 'the function ignores system includes', function test( t ) {
+	var text = '#include <stdint.h>\n#include <node_api.h>\n#include <math.h>\n';
+	var out = extractIncludes( text );
+	t.deepEqual( out, [], 'returns empty array' );
+	t.end();
+});
+
+tape( 'the function ignores relative includes', function test( t ) {
+	var text = '#include "main.h"\n#include "addon.h"\n';
+	var out = extractIncludes( text );
+	t.deepEqual( out, [], 'returns empty array' );
+	t.end();
+});
+
+tape( 'the function ignores includes in doc comments', function test( t ) {
+	var text;
+	var out;
+
+	text = '/**\n';
+	text += '* @example\n';
+	text += '* #include "stdlib/math/base/special/abs.h"\n';
+	text += '*/\n';
+	text += '#include "stdlib/blas/base/shared.h"\n';
+
+	out = extractIncludes( text );
+	t.deepEqual( out, [ 'stdlib/blas/base/shared.h' ], 'ignores doc comment includes' );
+	t.end();
+});
+
+tape( 'the function handles tab-indented includes', function test( t ) {
+	var text = '\t#include "stdlib/napi/export.h"\n';
+	var out = extractIncludes( text );
+	t.deepEqual( out, [ 'stdlib/napi/export.h' ], 'handles tab indentation' );
+	t.end();
+});
+
+tape( 'the function handles space-indented includes', function test( t ) {
+	var text = '    #include "stdlib/napi/export.h"\n';
+	var out = extractIncludes( text );
+	t.deepEqual( out, [ 'stdlib/napi/export.h' ], 'handles space indentation' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var lint = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof lint, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a `sync` method', function test( t ) {
+	t.strictEqual( typeof lint.sync, 'function', 'has `sync` method' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.resolve_pkg.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.resolve_pkg.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var resolvePkg = require( './../lib/resolve_pkg.js' );
+
+
+// VARIABLES //
+
+var STDLIB_DIR = resolve( __dirname, '..', '..', '..', '..' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof resolvePkg, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function resolves a simple header path to a package name', function test( t ) {
+	var pkg = resolvePkg( 'stdlib/blas/base/shared.h', STDLIB_DIR );
+	t.strictEqual( pkg, '@stdlib/blas/base/shared', 'resolves correctly' );
+	t.end();
+});
+
+tape( 'the function resolves a header with underscores to a hyphenated package name', function test( t ) {
+	var pkg = resolvePkg( 'stdlib/napi/argv_double.h', STDLIB_DIR );
+	t.strictEqual( pkg, '@stdlib/napi/argv-double', 'resolves underscores to hyphens' );
+	t.end();
+});
+
+tape( 'the function resolves a complex hyphenated package name', function test( t ) {
+	var pkg = resolvePkg( 'stdlib/napi/argv_strided_float64array.h', STDLIB_DIR );
+	t.strictEqual( pkg, '@stdlib/napi/argv-strided-float64array', 'resolves complex hyphens' );
+	t.end();
+});
+
+tape( 'the function resolves a sub-header by stripping trailing path segments', function test( t ) {
+	var pkg = resolvePkg( 'stdlib/blas/base/shared/macros.h', STDLIB_DIR );
+	t.strictEqual( pkg, '@stdlib/blas/base/shared', 'resolves sub-header to parent package' );
+	t.end();
+});
+
+tape( 'the function returns null for an unresolvable header path', function test( t ) {
+	var pkg = resolvePkg( 'stdlib/nonexistent/package/foo.h', STDLIB_DIR );
+	t.strictEqual( pkg, null, 'returns null' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.validate.js
+++ b/lib/node_modules/@stdlib/_tools/lint/manifest-json-deps/test/test.validate.js
@@ -1,0 +1,87 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var validate = require( './../lib/validate.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof validate, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns null for valid options', function test( t ) {
+	var opts = {};
+	var err = validate( opts, {
+		'dir': './foo/bar',
+		'pattern': '**/manifest.json',
+		'ignore': [ 'node_modules/**' ]
+	});
+	t.strictEqual( err, null, 'returns null' );
+	t.strictEqual( opts.dir, './foo/bar', 'sets dir' );
+	t.strictEqual( opts.pattern, '**/manifest.json', 'sets pattern' );
+	t.deepEqual( opts.ignore, [ 'node_modules/**' ], 'sets ignore' );
+	t.end();
+});
+
+tape( 'the function returns a TypeError for non-object options', function test( t ) {
+	var err = validate( {}, 'not an object' );
+	t.ok( err instanceof TypeError, 'returns TypeError' );
+	t.end();
+});
+
+tape( 'the function returns a TypeError for invalid `dir` option', function test( t ) {
+	var err = validate( {}, {
+		'dir': 123
+	});
+	t.ok( err instanceof TypeError, 'returns TypeError' );
+	t.end();
+});
+
+tape( 'the function returns a TypeError for invalid `pattern` option', function test( t ) {
+	var err = validate( {}, {
+		'pattern': 123
+	});
+	t.ok( err instanceof TypeError, 'returns TypeError' );
+	t.end();
+});
+
+tape( 'the function returns a TypeError for invalid `ignore` option', function test( t ) {
+	var err = validate( {}, {
+		'ignore': 123
+	});
+	t.ok( err instanceof TypeError, 'returns TypeError' );
+	t.end();
+});
+
+tape( 'the function accepts a string `ignore` option', function test( t ) {
+	var opts = {};
+	var err = validate( opts, {
+		'ignore': 'node_modules/**'
+	});
+	t.strictEqual( err, null, 'returns null' );
+	t.strictEqual( opts.ignore, 'node_modules/**', 'sets ignore' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a new lint tool (`@stdlib/_tools/lint/manifest-json-deps`) that validates `manifest.json` dependencies by cross-referencing C source file `#include` directives against declared dependencies.

The tool:
- Parses C source files for `#include "stdlib/..."` directives
- Maps include paths to `@stdlib` package names (handling underscore-to-hyphen conversion and sub-header resolution)
- Scans `src/addon.c` for non-WASM build configurations (since addon.c is compiled but not listed in manifest `src` arrays)
- Excludes self-references and skips Fortran files
- Reports any missing dependencies per configuration

This is part 1 of a series adding manifest.json validation tooling (see Related Issues).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This is the first in a series of PRs adding manifest.json tooling parity with the existing package.json tooling:

1. **This PR**: `_tools/lint/manifest-json-deps` (dependency linter — highest priority)
2. `_tools/manifest-json/validate` + `_tools/lint/manifest-json` (schema validation)
3. `_tools/manifest-json/standardize` + auto-fix scripts (standardization)
4. Makefile integration (`make lint-manifest-json`, `make lint-manifest-json-deps`)

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code with direction and review from the author.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md