### PR TITLE
build: add Makefile targets for manifest.json linting

### DIFF
--- a/tools/make/lib/lint/Makefile
+++ b/tools/make/lib/lint/Makefile
@@ -27,6 +27,7 @@ include $(TOOLS_MAKE_LIB_DIR)/lint/git/Makefile
 include $(TOOLS_MAKE_LIB_DIR)/lint/javascript/Makefile
 include $(TOOLS_MAKE_LIB_DIR)/lint/julia/Makefile
 include $(TOOLS_MAKE_LIB_DIR)/lint/license-headers/Makefile
+include $(TOOLS_MAKE_LIB_DIR)/lint/manifest_json.mk
 include $(TOOLS_MAKE_LIB_DIR)/lint/markdown/Makefile
 include $(TOOLS_MAKE_LIB_DIR)/lint/package_json.mk
 include $(TOOLS_MAKE_LIB_DIR)/lint/pkgs/Makefile
@@ -51,7 +52,7 @@ include $(TOOLS_MAKE_LIB_DIR)/lint/typescript/Makefile
 # @example
 # make lint
 #/
-lint: lint-filenames lint-javascript lint-markdown lint-c lint-python lint-julia lint-r lint-shell lint-typescript lint-conf lint-pkg-json lint-repl-help lint-license-headers lint-editorconfig
+lint: lint-filenames lint-javascript lint-markdown lint-c lint-python lint-julia lint-r lint-shell lint-typescript lint-conf lint-pkg-json lint-manifest-json lint-manifest-json-deps lint-repl-help lint-license-headers lint-editorconfig
 
 .PHONY: lint
 

--- a/tools/make/lib/lint/manifest_json.mk
+++ b/tools/make/lib/lint/manifest_json.mk
@@ -1,0 +1,58 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+# Define the path of the manifest.json linter executable:
+MANIFEST_JSON_LINTER ?= $(TOOLS_PKGS_DIR)/lint/manifest-json/bin/cli
+
+# Define the command-line options to be used when invoking the executable:
+MANIFEST_JSON_LINTER_FLAGS ?=
+
+# Define the path of the manifest.json dependency linter executable:
+MANIFEST_JSON_DEPS_LINTER ?= $(TOOLS_PKGS_DIR)/lint/manifest-json-deps/bin/cli
+
+# Define the command-line options to be used when invoking the executable:
+MANIFEST_JSON_DEPS_LINTER_FLAGS ?=
+
+
+# RULES #
+
+#/
+# Lints `manifest.json` files.
+#
+# @example
+# make lint-manifest-json
+#/
+lint-manifest-json: $(NODE_MODULES)
+	$(QUIET) echo 'Linting manifest.json files...'
+	$(QUIET) NODE_PATH="$(NODE_PATH)" $(NODE) "$(MANIFEST_JSON_LINTER)" $(MANIFEST_JSON_LINTER_FLAGS) "$(ROOT_DIR)"
+
+.PHONY: lint-manifest-json
+
+#/
+# Lints `manifest.json` dependencies.
+#
+# @example
+# make lint-manifest-json-deps
+#/
+lint-manifest-json-deps: $(NODE_MODULES)
+	$(QUIET) echo 'Linting manifest.json dependencies...'
+	$(QUIET) NODE_PATH="$(NODE_PATH)" $(NODE) "$(MANIFEST_JSON_DEPS_LINTER)" $(MANIFEST_JSON_DEPS_LINTER_FLAGS) "$(ROOT_DIR)"
+
+.PHONY: lint-manifest-json-deps


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds `tools/make/lib/lint/manifest_json.mk` with `make lint-manifest-json` and `make lint-manifest-json-deps` targets.
-   Integrates both targets into the main `make lint` rule.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11169

## Questions

> Any questions for reviewers of this pull request?

This PR depends on the lint tool packages being merged first (PRs #11169 and the validate/lint PR).

## Other

> Any other information relevant to this pull request?

Part 4 of the manifest.json tooling series. Should be merged after the tool packages land.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code with direction and review from the author.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md