### PR TITLE
build: add manifest.json standardization and auto-fix scripts

### DIFF
--- a/lib/node_modules/@stdlib/_tools/manifest-json/scripts/remove_duplicate_dependencies
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/scripts/remove_duplicate_dependencies
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/*
+* Remove duplicate entries from the `dependencies` arrays in all `manifest.json` files.
+*
+* To enable verbose logging, set the `DEBUG` environment variable.
+*
+* ``` bash
+* $ DEBUG=* remove_duplicate_dependencies
+* ```
+*/
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var logger = require( 'debug' );
+var glob = require( 'glob' ).sync;
+var readJSON = require( '@stdlib/fs/read-json' ).sync;
+var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var rootDir = require( '@stdlib/_tools/utils/root-dir' );
+
+
+// VARIABLES //
+
+var debug = logger( 'manifest-json:remove-duplicate-dependencies' );
+var ROOT = resolve( rootDir(), 'lib', 'node_modules' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns an array with duplicate values removed.
+*
+* @private
+* @param {StringArray} arr - input array
+* @returns {StringArray} deduplicated array
+*/
+function unique( arr ) {
+	var seen = {};
+	var out = [];
+	var i;
+	for ( i = 0; i < arr.length; i++ ) {
+		if ( !seen[ arr[ i ] ] ) {
+			seen[ arr[ i ] ] = true;
+			out.push( arr[ i ] );
+		}
+	}
+	return out;
+}
+
+/**
+* Removes duplicate entries from the `dependencies` arrays in all `manifest.json` files.
+*
+* @private
+*/
+function main() {
+	var changed;
+	var files;
+	var opts;
+	var deps;
+	var conf;
+	var out;
+	var i;
+	var j;
+
+	debug( 'Searching for manifest.json files in %s.', ROOT );
+	opts = {
+		'cwd': ROOT,
+		'ignore': [
+			'node_modules/**',
+			'**/build/**',
+			'**/snippets/**'
+		],
+		'realpath': true
+	};
+	files = glob( '**/@stdlib/**/manifest.json', opts );
+	debug( 'Found %d files.', files.length );
+
+	for ( i = 0; i < files.length; i++ ) {
+		debug( 'Processing file: %s (%d of %d).', files[ i ], i+1, files.length );
+
+		out = readJSON( files[ i ] );
+		if ( out instanceof Error ) {
+			debug( 'Error reading file: %s. Skipping.', out.message );
+			continue;
+		}
+		changed = false;
+		for ( j = 0; j < out.confs.length; j++ ) {
+			conf = out.confs[ j ];
+			if ( conf.dependencies && conf.dependencies.length > 1 ) {
+				deps = unique( conf.dependencies );
+				if ( deps.length !== conf.dependencies.length ) {
+					debug( 'Found %d duplicate(s) in conf %d.', conf.dependencies.length - deps.length, j );
+					conf.dependencies = deps;
+					changed = true;
+				}
+			}
+		}
+		if ( changed ) {
+			debug( 'Duplicates removed. Writing file.' );
+			writeFile( files[ i ], JSON.stringify( out, null, 2 )+'\n', {
+				'encoding': 'utf8'
+			});
+		} else {
+			debug( 'No duplicates found. Skipping.' );
+		}
+	}
+	debug( 'Finished removing duplicate dependencies in all manifest.json files.' );
+}
+
+
+// MAIN //
+
+main();

--- a/lib/node_modules/@stdlib/_tools/manifest-json/scripts/sort_dependencies
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/scripts/sort_dependencies
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/*
+* Sort the `dependencies` arrays in all `manifest.json` files alphabetically.
+*
+* To enable verbose logging, set the `DEBUG` environment variable.
+*
+* ``` bash
+* $ DEBUG=* sort_dependencies
+* ```
+*/
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var logger = require( 'debug' );
+var glob = require( 'glob' ).sync;
+var readJSON = require( '@stdlib/fs/read-json' ).sync;
+var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var rootDir = require( '@stdlib/_tools/utils/root-dir' );
+
+
+// VARIABLES //
+
+var debug = logger( 'manifest-json:sort-dependencies' );
+var ROOT = resolve( rootDir(), 'lib', 'node_modules' );
+
+
+// FUNCTIONS //
+
+/**
+* Sorts the `dependencies` arrays in all `manifest.json` files alphabetically.
+*
+* @private
+*/
+function main() {
+	var changed;
+	var files;
+	var opts;
+	var deps;
+	var conf;
+	var out;
+	var i;
+	var j;
+
+	debug( 'Searching for manifest.json files in %s.', ROOT );
+	opts = {
+		'cwd': ROOT,
+		'ignore': [
+			'node_modules/**',
+			'**/build/**',
+			'**/snippets/**'
+		],
+		'realpath': true
+	};
+	files = glob( '**/@stdlib/**/manifest.json', opts );
+	debug( 'Found %d files.', files.length );
+
+	for ( i = 0; i < files.length; i++ ) {
+		debug( 'Processing file: %s (%d of %d).', files[ i ], i+1, files.length );
+
+		out = readJSON( files[ i ] );
+		if ( out instanceof Error ) {
+			debug( 'Error reading file: %s. Skipping.', out.message );
+			continue;
+		}
+		changed = false;
+		for ( j = 0; j < out.confs.length; j++ ) {
+			conf = out.confs[ j ];
+			if ( conf.dependencies && conf.dependencies.length > 1 ) {
+				deps = conf.dependencies.slice().sort();
+				if ( JSON.stringify( deps ) !== JSON.stringify( conf.dependencies ) ) {
+					conf.dependencies = deps;
+					changed = true;
+				}
+			}
+		}
+		if ( changed ) {
+			debug( 'Dependencies reordered. Writing file.' );
+			writeFile( files[ i ], JSON.stringify( out, null, 2 )+'\n', {
+				'encoding': 'utf8'
+			});
+		} else {
+			debug( 'Dependencies already sorted. Skipping.' );
+		}
+	}
+	debug( 'Finished sorting dependencies in all manifest.json files.' );
+}
+
+
+// MAIN //
+
+main();

--- a/lib/node_modules/@stdlib/_tools/manifest-json/scripts/standardize_all
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/scripts/standardize_all
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/*
+* Standardize all `manifest.json` files by enforcing consistent key ordering.
+*
+* To enable verbose logging, set the `DEBUG` environment variable.
+*
+* ``` bash
+* $ DEBUG=* standardize_all
+* ```
+*/
+
+// MODULES //
+
+var join = require( 'path' ).join;
+var resolve = require( 'path' ).resolve;
+var logger = require( 'debug' );
+var glob = require( 'glob' ).sync;
+var readJSON = require( '@stdlib/fs/read-json' ).sync;
+var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var rootDir = require( '@stdlib/_tools/utils/root-dir' );
+var standardize = require( './../standardize' );
+
+
+// VARIABLES //
+
+var debug = logger( 'manifest-json:standardize-all' );
+var ROOT = resolve( rootDir(), 'lib', 'node_modules' );
+
+
+// FUNCTIONS //
+
+/**
+* Standardizes all `manifest.json` files by enforcing consistent key ordering.
+*
+* @private
+*/
+function main() {
+	var files;
+	var opts;
+	var out;
+	var i;
+
+	debug( 'Searching for manifest.json files in %s.', ROOT );
+	opts = {
+		'cwd': ROOT,
+		'ignore': [
+			'node_modules/**',
+			'**/build/**',
+			'**/snippets/**'
+		],
+		'realpath': true
+	};
+	files = glob( '**/@stdlib/**/manifest.json', opts );
+	debug( 'Found %d files.', files.length );
+
+	for ( i = 0; i < files.length; i++ ) {
+		debug( 'Processing file: %s (%d of %d).', files[ i ], i+1, files.length );
+
+		out = readJSON( files[ i ] );
+		if ( out instanceof Error ) {
+			debug( 'Error reading file: %s. Skipping.', out.message );
+			continue;
+		}
+		out = standardize( out );
+
+		debug( 'Serializing manifest data.' );
+		out = JSON.stringify( out, null, 2 ); // 2-space indentation
+
+		debug( 'Writing manifest data to file.' );
+		writeFile( files[ i ], out+'\n', {
+			'encoding': 'utf8'
+		});
+	}
+	debug( 'Finished standardizing all manifest.json files.' );
+}
+
+
+// MAIN //
+
+main();

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/README.md
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/README.md
@@ -1,0 +1,213 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Standardize
+
+> Standardize a `manifest.json` object.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var standardize = require( '@stdlib/_tools/manifest-json/standardize' );
+```
+
+#### standardize( manifest )
+
+Standardizes a `manifest.json` object by enforcing consistent key ordering.
+
+```javascript
+var manifest = {
+    'confs': [],
+    'fields': [],
+    'options': {}
+};
+
+var out = standardize( manifest );
+// returns {'options':{},'fields':[],'confs':[]}
+```
+
+The function enforces the following key ordering rules:
+
+-   **Top-level:** `options`, `fields`, `confs`
+-   **Within each `fields` entry:** `field`, `resolve`, `relative`
+-   **Within each `confs` entry:** Option-matching keys first (keys that exist in `options`, in the order declared in `options`), then `src`, `include`, `libraries`, `libpath`, `dependencies`, then any remaining unknown keys
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   The implementation relies on engines using insertion order for key ordering. This is **not** specified by the ECMAScript specification; however, most engines order keys according to insertion order.
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var standardize = require( '@stdlib/_tools/manifest-json/standardize' );
+
+var manifest = {
+    'confs': [
+        {
+            'src': [ './src/foo.c' ],
+            'os': 'linux',
+            'include': [ './include' ],
+            'libraries': [],
+            'libpath': [],
+            'dependencies': []
+        }
+    ],
+    'fields': [
+        {
+            'resolve': true,
+            'field': 'src',
+            'relative': true
+        }
+    ],
+    'options': {
+        'os': 'linux'
+    }
+};
+
+var out = standardize( manifest );
+console.log( JSON.stringify( out, null, 2 ) );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for describing a command-line interface. -->
+
+* * *
+
+<section class="cli">
+
+## CLI
+
+<!-- CLI usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```bash
+Usage: standardize-manifest-json [options] [json]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- CLI usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- CLI usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ standardize-manifest-json '{"confs":[],"fields":[],"options":{}}'
+{
+  "options": {},
+  "fields": [],
+  "confs": []
+}
+```
+
+To use as a standard stream,
+
+```bash
+$ echo '{"confs":[],"fields":[],"options":{}}' | standardize-manifest-json
+{
+  "options": {},
+  "fields": [],
+  "confs": []
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/bin/cli
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/bin/cli
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var parseJSON = require( '@stdlib/utils/parse-json' );
+var stdin = require( '@stdlib/process/read-stdin' );
+var stdinStream = require( '@stdlib/streams/node/stdin' );
+var CLI = require( '@stdlib/cli/ctor' );
+var standardize = require( './../lib' );
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+* @returns {void}
+*/
+function main() {
+	var flags;
+	var args;
+	var cli;
+
+	// Create a command-line interface:
+	cli = new CLI({
+		'pkg': require( './../package.json' ),
+		'options': require( './../etc/cli_opts.json' ),
+		'help': readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			'encoding': 'utf8'
+		})
+	});
+
+	// Get any provided command-line options:
+	flags = cli.flags();
+	if ( flags.help || flags.version ) {
+		return;
+	}
+
+	// Get any provided command-line arguments:
+	args = cli.args();
+
+	// Check if we are receiving data from `stdin`...
+	if ( !stdinStream.isTTY ) {
+		return stdin( onRead );
+	}
+	return next( args[0] );
+
+	/**
+	* Callback invoked upon reading from `stdin`.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Buffer} data - data
+	* @returns {void}
+	*/
+	function onRead( error, data ) {
+		if ( error ) {
+			return cli.error( error );
+		}
+		next( data.toString() );
+	}
+
+	/**
+	* Standardizes a `manifest.json`.
+	*
+	* @private
+	* @param {string} json - stringified JSON object
+	* @returns {void}
+	*/
+	function next( json ) {
+		var out;
+
+		json = parseJSON( json );
+		if ( json instanceof Error ) {
+			return cli.error( json );
+		}
+		out = standardize( json );
+		console.log( JSON.stringify( out, null, 2 ) ); // eslint-disable-line no-console
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/docs/usage.txt
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/docs/usage.txt
@@ -1,0 +1,8 @@
+
+Usage: standardize-manifest-json [options] [json]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/etc/cli_opts.json
@@ -1,0 +1,14 @@
+{
+	"boolean": [
+		"help",
+		"version"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		]
+	}
+}

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/examples/index.js
@@ -1,0 +1,47 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var standardize = require( './../lib' );
+
+var manifest = {
+	'confs': [
+		{
+			'src': [ './src/foo.c' ],
+			'os': 'linux',
+			'include': [ './include' ],
+			'libraries': [],
+			'libpath': [],
+			'dependencies': []
+		}
+	],
+	'fields': [
+		{
+			'resolve': true,
+			'field': 'src',
+			'relative': true
+		}
+	],
+	'options': {
+		'os': 'linux'
+	}
+};
+
+var out = standardize( manifest );
+console.log( JSON.stringify( out, null, 2 ) );

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/conf_keys.json
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/conf_keys.json
@@ -1,0 +1,1 @@
+["src", "include", "libraries", "libpath", "dependencies"]

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/field_keys.json
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/field_keys.json
@@ -1,0 +1,1 @@
+["field", "resolve", "relative"]

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Standardize a `manifest.json` object.
+*
+* @module @stdlib/_tools/manifest-json/standardize
+*
+* @example
+* var standardize = require( '@stdlib/_tools/manifest-json/standardize' );
+*
+* var manifest = {
+*     'confs': [],
+*     'fields': [],
+*     'options': {}
+* };
+*
+* var out = standardize( manifest );
+* // returns {'options':{},'fields':[],'confs':[]}
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/keys.json
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/keys.json
@@ -1,0 +1,1 @@
+["options", "fields", "confs"]

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/lib/main.js
@@ -1,0 +1,180 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isObject = require( '@stdlib/assert/is-plain-object' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var objectKeys = require( '@stdlib/utils/keys' );
+var format = require( '@stdlib/string/format' );
+var KEYS = require( './keys.json' );
+var FIELD_KEYS = require( './field_keys.json' );
+var CONF_KEYS = require( './conf_keys.json' );
+
+
+// FUNCTIONS //
+
+/**
+* Reorders keys in a fields entry.
+*
+* @private
+* @param {Object} entry - fields entry
+* @returns {Object} reordered entry
+*/
+function reorderFieldEntry( entry ) {
+	var keys;
+	var out;
+	var key;
+	var i;
+
+	out = {};
+
+	// Insert known field keys in order:
+	for ( i = 0; i < FIELD_KEYS.length; i++ ) {
+		key = FIELD_KEYS[ i ];
+		if ( hasOwnProp( entry, key ) ) {
+			out[ key ] = entry[ key ];
+		}
+	}
+
+	// Insert any remaining unknown keys:
+	keys = objectKeys( entry );
+	for ( i = 0; i < keys.length; i++ ) {
+		key = keys[ i ];
+		if ( !hasOwnProp( out, key ) ) {
+			out[ key ] = entry[ key ];
+		}
+	}
+	return out;
+}
+
+/**
+* Reorders keys in a confs entry.
+*
+* @private
+* @param {Object} entry - confs entry
+* @param {Array} optionKeys - keys from the manifest options object
+* @returns {Object} reordered entry
+*/
+function reorderConfEntry( entry, optionKeys ) {
+	var keys;
+	var out;
+	var key;
+	var i;
+
+	out = {};
+
+	// First, insert option-matching keys (in the order declared in options):
+	for ( i = 0; i < optionKeys.length; i++ ) {
+		key = optionKeys[ i ];
+		if ( hasOwnProp( entry, key ) ) {
+			out[ key ] = entry[ key ];
+		}
+	}
+
+	// Next, insert fixed field keys in order:
+	for ( i = 0; i < CONF_KEYS.length; i++ ) {
+		key = CONF_KEYS[ i ];
+		if ( hasOwnProp( entry, key ) ) {
+			out[ key ] = entry[ key ];
+		}
+	}
+
+	// Finally, insert any remaining unknown keys:
+	keys = objectKeys( entry );
+	for ( i = 0; i < keys.length; i++ ) {
+		key = keys[ i ];
+		if ( !hasOwnProp( out, key ) ) {
+			out[ key ] = entry[ key ];
+		}
+	}
+	return out;
+}
+
+
+// MAIN //
+
+/**
+* Standardizes a `manifest.json` object.
+*
+* ## Notes
+*
+* -   The implementation relies on engines using insertion order for key ordering. This is **not** specified by the ECMAScript specification; however, most engines order keys according to insertion order.
+*
+* @param {Object} manifest - `manifest.json` object
+* @throws {TypeError} first argument must be an object
+* @returns {Object} standardized object
+*
+* @example
+* var manifest = {
+*     'confs': [],
+*     'fields': [],
+*     'options': {}
+* };
+*
+* var out = standardize( manifest );
+* // returns {'options':{},'fields':[],'confs':[]}
+*/
+function standardize( manifest ) {
+	var optionKeys;
+	var out;
+	var key;
+	var i;
+
+	if ( !isObject( manifest ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', manifest ) );
+	}
+	out = {};
+
+	// Insert top-level keys in the canonical order:
+	for ( i = 0; i < KEYS.length; i++ ) {
+		key = KEYS[ i ];
+		if ( hasOwnProp( manifest, key ) ) {
+			out[ key ] = manifest[ key ];
+		}
+	}
+
+	// Determine option keys for reordering confs entries:
+	if ( hasOwnProp( manifest, 'options' ) && isObject( manifest.options ) ) {
+		optionKeys = objectKeys( manifest.options );
+	} else {
+		optionKeys = [];
+	}
+
+	// Reorder keys within each fields entry:
+	if ( hasOwnProp( out, 'fields' ) ) {
+		for ( i = 0; i < out.fields.length; i++ ) {
+			out.fields[ i ] = reorderFieldEntry( out.fields[ i ] );
+		}
+	}
+
+	// Reorder keys within each confs entry:
+	if ( hasOwnProp( out, 'confs' ) ) {
+		for ( i = 0; i < out.confs.length; i++ ) {
+			out.confs[ i ] = reorderConfEntry( out.confs[ i ], optionKeys );
+		}
+	}
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = standardize;

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/package.json
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@stdlib/_tools/manifest-json/standardize",
+  "version": "0.0.0",
+  "description": "Standardize a manifest.json.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "standardize-manifest-json": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "keywords": [
+    "stdlib",
+    "tools",
+    "tool",
+    "standardize",
+    "json",
+    "manifest"
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/manifest-json/standardize/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/manifest-json/standardize/test/test.js
@@ -1,0 +1,215 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var standardize = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof standardize, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided an object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			standardize( value );
+		};
+	}
+});
+
+tape( 'the function reorders top-level keys to options, fields, confs', function test( t ) {
+	var expected;
+	var manifest;
+	var actual;
+
+	manifest = {
+		'confs': [],
+		'fields': [],
+		'options': {}
+	};
+	expected = '{"options":{},"fields":[],"confs":[]}';
+	actual = standardize( manifest );
+
+	t.notEqual( JSON.stringify( manifest ), expected, 'original manifest is not standardized' );
+	t.strictEqual( JSON.stringify( actual ), expected, 'returns a standardized manifest' );
+	t.end();
+});
+
+tape( 'the function reorders field entry keys to field, resolve, relative', function test( t ) {
+	var expected;
+	var manifest;
+	var actual;
+
+	manifest = {
+		'options': {},
+		'fields': [
+			{
+				'resolve': true,
+				'field': 'src',
+				'relative': true
+			}
+		],
+		'confs': []
+	};
+	actual = standardize( manifest );
+	expected = '{"options":{},"fields":[{"field":"src","resolve":true,"relative":true}],"confs":[]}';
+
+	t.strictEqual( JSON.stringify( actual ), expected, 'reorders field entry keys' );
+	t.end();
+});
+
+tape( 'the function reorders conf entry keys: option keys first (in order from options), then src, include, libraries, libpath, dependencies', function test( t ) {
+	var expected;
+	var manifest;
+	var actual;
+
+	manifest = {
+		'options': {
+			'os': 'linux',
+			'blas': ''
+		},
+		'fields': [],
+		'confs': [
+			{
+				'src': [ './src/foo.c' ],
+				'blas': 'openblas',
+				'include': [ './include' ],
+				'os': 'linux',
+				'libraries': [ '-lopenblas' ],
+				'libpath': [],
+				'dependencies': []
+			}
+		]
+	};
+	actual = standardize( manifest );
+	expected = '{"options":{"os":"linux","blas":""},"fields":[],"confs":[{"os":"linux","blas":"openblas","src":["./src/foo.c"],"include":["./include"],"libraries":["-lopenblas"],"libpath":[],"dependencies":[]}]}';
+
+	t.strictEqual( JSON.stringify( actual ), expected, 'reorders conf entry keys with option keys first' );
+	t.end();
+});
+
+tape( 'the function preserves unknown keys at the end of conf entries', function test( t ) {
+	var expected;
+	var manifest;
+	var actual;
+
+	manifest = {
+		'options': {
+			'os': 'linux'
+		},
+		'fields': [],
+		'confs': [
+			{
+				'unknown_key': 'value',
+				'src': [ './src/foo.c' ],
+				'os': 'linux',
+				'include': [],
+				'libraries': [],
+				'libpath': [],
+				'dependencies': []
+			}
+		]
+	};
+	actual = standardize( manifest );
+	expected = '{"options":{"os":"linux"},"fields":[],"confs":[{"os":"linux","src":["./src/foo.c"],"include":[],"libraries":[],"libpath":[],"dependencies":[],"unknown_key":"value"}]}';
+
+	t.strictEqual( JSON.stringify( actual ), expected, 'preserves unknown keys at the end' );
+	t.end();
+});
+
+tape( 'the function works with empty options (no option keys in confs)', function test( t ) {
+	var expected;
+	var manifest;
+	var actual;
+
+	manifest = {
+		'options': {},
+		'fields': [],
+		'confs': [
+			{
+				'libraries': [ '-lm' ],
+				'src': [ './src/foo.c' ],
+				'include': [ './include' ],
+				'libpath': [],
+				'dependencies': []
+			}
+		]
+	};
+	actual = standardize( manifest );
+	expected = '{"options":{},"fields":[],"confs":[{"src":["./src/foo.c"],"include":["./include"],"libraries":["-lm"],"libpath":[],"dependencies":[]}]}';
+
+	t.strictEqual( JSON.stringify( actual ), expected, 'works with empty options' );
+	t.end();
+});
+
+tape( 'the function returns an empty object if provided an empty object', function test( t ) {
+	var out = standardize( {} );
+	t.deepEqual( out, {}, 'returns an empty object' );
+	t.end();
+});
+
+tape( 'the function preserves unknown keys at the end of field entries', function test( t ) {
+	var expected;
+	var manifest;
+	var actual;
+
+	manifest = {
+		'options': {},
+		'fields': [
+			{
+				'custom': true,
+				'resolve': true,
+				'field': 'src',
+				'relative': false
+			}
+		],
+		'confs': []
+	};
+	actual = standardize( manifest );
+	expected = '{"options":{},"fields":[{"field":"src","resolve":true,"relative":false,"custom":true}],"confs":[]}';
+
+	t.strictEqual( JSON.stringify( actual ), expected, 'preserves unknown keys at end of field entries' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds `@stdlib/_tools/manifest-json/standardize` — enforces consistent key ordering in manifest.json files (top-level: `options`, `fields`, `confs`; within confs: option keys first, then `src`/`include`/`libraries`/`libpath`/`dependencies`).
-   Adds auto-fix scripts under `@stdlib/_tools/manifest-json/scripts/`: `standardize_all`, `sort_dependencies`, and `remove_duplicate_dependencies`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11169

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Part 3 of the manifest.json tooling series.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code with direction and review from the author.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md