### PR TITLE
chore: fix JavaScript lint errors (issue #11164)

### DIFF
--- a/lib/node_modules/@stdlib/assert/has-dataview-support/test/test.js
+++ b/lib/node_modules/@stdlib/assert/has-dataview-support/test/test.js
@@ -71,7 +71,7 @@ tape( 'if `DataView` is supported, detection result is `true`', function test( t
 		}
 		out = {};
 		out.buffer = buf;
-		out._buffer = new Array( byteLength ); // eslint-disable-line no-underscore-dangle
+		out._buffer = []; // eslint-disable-line no-underscore-dangle
 		for ( i = 0; i < byteLength; i++ ) {
 			out._buffer[ i ] = 0; // eslint-disable-line no-underscore-dangle
 		}


### PR DESCRIPTION
Resolves #11164 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a JavaScript lint error by removing usage of `new Array()` and updating the code to follow stdlib linting rules.
-   line 74 in @stdlib/assert/has-dataview-support/test/test.js 

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11164 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
