### PR TITLE
docs: add missing private annotation in `blas/ext/base/ndarray/ssum`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssum/lib/native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssum/lib/native.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var serialize = require( '@stdlib/ndarray/base/serialize-meta-data' );
-var dataBuffer = require( '@stdlib/ndarray/base/data-buffer' );
+var getData = require( '@stdlib/ndarray/base/data-buffer' );
 var addon = require( './../src/addon.node' );
 
 
@@ -30,6 +30,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Computes the sum of all elements in a one-dimensional single-precision floating-point ndarray.
 *
+* @private
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing an input ndarray
 * @returns {number} sum
 *
@@ -45,7 +46,7 @@ var addon = require( './../src/addon.node' );
 */
 function ssum( arrays ) {
 	var x = arrays[ 0 ];
-	return addon( dataBuffer( x ), serialize( x ) );
+	return addon( getData( x ), serialize( x ) );
 }
 
 


### PR DESCRIPTION
Resolves #{{TODO: add issue number}}.

## Description

> What is the purpose of this pull request?

This pull request:

-  refactor: Add missing JsDoc annotation in `blas/ext/base/ndarray/ssum`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{{TODO: add related issue number}}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
