### PR TITLE
fix: replace new Array() constructor in utils/async/try-then

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/try-then/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/async/try-then/lib/main.js
@@ -96,7 +96,8 @@ function trythenAsync( x, y, done ) {
 			return y( error, clbk2 );
 		}
 		nargs = arguments.length;
-		args = new Array( nargs );
+		args = [];
+		args.length = nargs;
 		args[ 0 ] = null;
 		for ( i = 1; i < nargs; i++ ) {
 			args[ i ] = arguments[ i ];
@@ -120,7 +121,8 @@ function trythenAsync( x, y, done ) {
 			return done( error );
 		}
 		nargs = arguments.length;
-		args = new Array( nargs );
+		args = [];
+		args.length = nargs;
 		args[ 0 ] = null;
 		for ( i = 1; i < nargs; i++ ) {
 			args[ i ] = arguments[ i ];


### PR DESCRIPTION
Resolves #11183.

## Description

This pull request:

-   Replaces `new Array()` constructor with array literal approach in `@stdlib/utils/async/try-then` to fix `stdlib/no-new-array` lint errors at lines 99 and 123 in `main.js`

## Related Issues

This pull request has the following related issues:

-   #11183

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md