### PR TITLE
chore: fix JavaScript lint errors (issue #11183)

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/try-then/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/async/try-then/lib/main.js
@@ -96,10 +96,10 @@ function trythenAsync( x, y, done ) {
 			return y( error, clbk2 );
 		}
 		nargs = arguments.length;
-		args = new Array( nargs );
-		args[ 0 ] = null;
+		args = [];
+		args.push( null );
 		for ( i = 1; i < nargs; i++ ) {
-			args[ i ] = arguments[ i ];
+			args.push( arguments[ i ] );
 		}
 		return done.apply( null, args );
 	}
@@ -120,10 +120,10 @@ function trythenAsync( x, y, done ) {
 			return done( error );
 		}
 		nargs = arguments.length;
-		args = new Array( nargs );
-		args[ 0 ] = null;
+		args = [];
+		args.push( null );
 		for ( i = 1; i < nargs; i++ ) {
-			args[ i ] = arguments[ i ];
+			args.push( arguments[ i ] );
 		}
 		return done.apply( null, args );
 	}


### PR DESCRIPTION
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

## Summary

Fix two `stdlib/no-new-array` lint violations in `@stdlib/utils/async/try-then/lib/main.js`.

## Changes

Replace `new Array(nargs)` with `[]` and indexed assignment with `args.push()` equivalents.

```diff
-  args = new Array( nargs );
-  args[ 0 ] = null;
-  for ( i = 1; i < nargs; i++ ) { args[ i ] = arguments[ i ]; }
+  args = [];
+  args.push( null );
+  for ( i = 1; i < nargs; i++ ) { args.push( arguments[ i ] ); }
```

Closes #11183