### PR TITLE
docs: remove unused `ndarray2array` requires from README usage examples

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsort/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsort/README.md
@@ -42,7 +42,6 @@ Sorts a one-dimensional ndarray.
 
 ```javascript
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var array = require( '@stdlib/ndarray/array' );
 
 var x = array( [ 1.0, -2.0, 3.0, -4.0 ], {

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/scircshift/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/scircshift/README.md
@@ -43,7 +43,6 @@ Circularly shifts the elements of a one-dimensional single-precision floating-po
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 
 var xbuf = new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );

--- a/lib/node_modules/@stdlib/blas/ext/find-index/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/find-index/README.md
@@ -170,7 +170,6 @@ var idx = ndarray2array( out );
 By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having a [data type][@stdlib/ndarray/dtypes] determined by the function's output data type [policy][@stdlib/ndarray/output-dtype-policies]. To override the default behavior, set the `dtype` option.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var dtype = require( '@stdlib/ndarray/dtype' );
 var array = require( '@stdlib/ndarray/array' );
 

--- a/lib/node_modules/@stdlib/blas/ext/find-last-index/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/find-last-index/README.md
@@ -170,7 +170,6 @@ var idx = ndarray2array( out );
 By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having a [data type][@stdlib/ndarray/dtypes] determined by the function's output data type [policy][@stdlib/ndarray/output-dtype-policies]. To override the default behavior, set the `dtype` option.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var dtype = require( '@stdlib/ndarray/dtype' );
 var array = require( '@stdlib/ndarray/array' );
 

--- a/lib/node_modules/@stdlib/blas/ext/index-of/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/index-of/README.md
@@ -136,7 +136,6 @@ var idx = ndarray2array( out );
 By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having a [data type][@stdlib/ndarray/dtypes] determined by the function's output data type [policy][@stdlib/ndarray/output-dtype-policies]. To override the default behavior, set the `dtype` option.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var dtype = require( '@stdlib/ndarray/dtype' );
 var array = require( '@stdlib/ndarray/array' );
 

--- a/lib/node_modules/@stdlib/blas/ext/last-index-of/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/last-index-of/README.md
@@ -136,7 +136,6 @@ var idx = ndarray2array( out );
 By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having a [data type][@stdlib/ndarray/dtypes] determined by the function's output data type [policy][@stdlib/ndarray/output-dtype-policies]. To override the default behavior, set the `dtype` option.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var dtype = require( '@stdlib/ndarray/dtype' );
 var array = require( '@stdlib/ndarray/array' );
 

--- a/lib/node_modules/@stdlib/ndarray/base/fliplr/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/fliplr/README.md
@@ -47,7 +47,6 @@ Returns a view of an input ndarray in which the order of elements along the last
 ```javascript
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var getShape = require( '@stdlib/ndarray/shape' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 var buffer = [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ];
 var shape = [ 3, 2 ];

--- a/lib/node_modules/@stdlib/ndarray/base/unary-strided1d-dispatch-factory/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-strided1d-dispatch-factory/README.md
@@ -129,7 +129,6 @@ By default, the function returns an ndarray having a data type determined by the
 <!-- eslint-disable id-length -->
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var base = require( '@stdlib/stats/base/ndarray/cumax' );
 var getDType = require( '@stdlib/ndarray/dtype' );

--- a/lib/node_modules/@stdlib/ndarray/base/unary-strided1d-dispatch/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-strided1d-dispatch/README.md
@@ -128,7 +128,6 @@ By default, the method returns an ndarray having a data type determined by the o
 
 ```javascript
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var base = require( '@stdlib/stats/base/ndarray/cumax' );
 var getDType = require( '@stdlib/ndarray/dtype' );
 

--- a/lib/node_modules/@stdlib/ndarray/spread-dimensions/README.md
+++ b/lib/node_modules/@stdlib/ndarray/spread-dimensions/README.md
@@ -45,7 +45,6 @@ var spreadDimensions = require( '@stdlib/ndarray/spread-dimensions' );
 Returns a read-only view of an input [ndarray][@stdlib/ndarray/ctor] where the dimensions of the input [ndarray][@stdlib/ndarray/ctor] are expanded to a specified dimensionality by spreading dimensions to specified dimension indices and inserting dimensions of size one for the remaining dimensions.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var array = require( '@stdlib/ndarray/array' );
 
 // Create a 2x2 ndarray:

--- a/lib/node_modules/@stdlib/stats/cumax/README.md
+++ b/lib/node_modules/@stdlib/stats/cumax/README.md
@@ -99,7 +99,6 @@ v = ndarray2array( y );
 By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having a [data type][@stdlib/ndarray/dtypes] determined by the function's output data type [policy][@stdlib/ndarray/output-dtype-policies]. To override the default behavior, set the `dtype` option.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var getDType = require( '@stdlib/ndarray/dtype' );
 var array = require( '@stdlib/ndarray/array' );
 

--- a/lib/node_modules/@stdlib/stats/cumin/README.md
+++ b/lib/node_modules/@stdlib/stats/cumin/README.md
@@ -99,7 +99,6 @@ v = ndarray2array( y );
 By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having a [data type][@stdlib/ndarray/dtypes] determined by the function's output data type [policy][@stdlib/ndarray/output-dtype-policies]. To override the default behavior, set the `dtype` option.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var getDType = require( '@stdlib/ndarray/dtype' );
 var array = require( '@stdlib/ndarray/array' );
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Removes unused `ndarray2array` requires from usage example code blocks in 12 README files. In each case, `ndarray2array` was imported but never called within the usage code block.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Claude Code identified the unused imports during a codebase-wide review and performed the removals.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md