### PR TITLE
revert: build: enable signed commits in automated PR workflows

### DIFF
--- a/.github/workflows/lint_random_files.yml
+++ b/.github/workflows/lint_random_files.yml
@@ -604,4 +604,3 @@ jobs:
             reviewers
           branch: 'fix-lint-errors'
           delete-branch: true
-          sign-commits: true

--- a/.github/workflows/markdown_equations.yml
+++ b/.github/workflows/markdown_equations.yml
@@ -188,7 +188,6 @@ jobs:
             reviewers
           branch: markdown-insert-equations
           delete-branch: true
-          sign-commits: true
 
       # Create Markdown summary of the pull request:
       - name: 'Create summary'

--- a/.github/workflows/markdown_pkg_urls.yml
+++ b/.github/workflows/markdown_pkg_urls.yml
@@ -162,4 +162,3 @@ jobs:
             reviewers
           branch: markdown-pkg-urls
           delete-branch: true
-          sign-commits: true

--- a/.github/workflows/markdown_related_packages.yml
+++ b/.github/workflows/markdown_related_packages.yml
@@ -174,4 +174,3 @@ jobs:
             reviewers
           branch: markdown-related-packages
           delete-branch: true
-          sign-commits: true

--- a/.github/workflows/markdown_tocs.yml
+++ b/.github/workflows/markdown_tocs.yml
@@ -140,7 +140,6 @@ jobs:
             reviewers
           branch: update-namespace-tocs
           delete-branch: true
-          sign-commits: true
 
       # Create Markdown summary of the pull request:
       - name: 'Create summary'

--- a/.github/workflows/namespace_exports.yml
+++ b/.github/workflows/namespace_exports.yml
@@ -146,4 +146,3 @@ jobs:
             reviewers
           branch: update-namespace-exports
           delete-branch: true
-          sign-commits: true

--- a/.github/workflows/update_cli_permissions.yml
+++ b/.github/workflows/update_cli_permissions.yml
@@ -112,4 +112,3 @@ jobs:
             reviewers
           branch: update-cli-permissions
           delete-branch: true
-          sign-commits: true

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -131,7 +131,6 @@ jobs:
             reviewers
           branch: update-contributors
           delete-branch: true
-          sign-commits: true
 
       # Create a pull request summary:
       - name: 'Create summary'

--- a/.github/workflows/update_error_databases.yml
+++ b/.github/workflows/update_error_databases.yml
@@ -174,4 +174,3 @@ jobs:
             reviewers
           branch: update-error-databases
           delete-branch: true
-          sign-commits: true

--- a/.github/workflows/update_math_scaffold_databases.yml
+++ b/.github/workflows/update_math_scaffold_databases.yml
@@ -142,7 +142,6 @@ jobs:
             reviewers
           branch: update-math-scaffold-databases
           delete-branch: true
-          sign-commits: true
 
       # Create a pull request summary:
       - name: 'Create summary'

--- a/.github/workflows/update_package_meta_data.yml
+++ b/.github/workflows/update_package_meta_data.yml
@@ -126,7 +126,6 @@ jobs:
             reviewers
           branch: update-package-meta-data
           delete-branch: true
-          sign-commits: true
 
       # Create a pull request summary:
       - name: 'Create summary'

--- a/.github/workflows/update_repl_docs.yml
+++ b/.github/workflows/update_repl_docs.yml
@@ -132,7 +132,6 @@ jobs:
             reviewers
           branch: update-repl-docs
           delete-branch: true
-          sign-commits: true
 
       # Create a pull request summary:
       - name: 'Create summary'


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   reverts #11195, which added `sign-commits: true` to all 12 `peter-evans/create-pull-request` workflow steps

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   Reverts #11195

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was created by Claude Code to revert #11195.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md