### PR TITLE
chore: fix JavaScript lint errors (issue #11193)

### DIFF
--- a/lib/node_modules/@stdlib/stats/ztest2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/ztest2/benchmark/benchmark.js
@@ -39,14 +39,14 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	sigma = stdev( 1.0, 51.0 );
-	x = new Array( 100 );
-	for ( i = 0; i < x.length; i++ ) {
-		x[ i ] = ( randu()*50.0 ) + 1.0;
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
+		x.push( ( randu()*50.0 ) + 1.0 );
 	}
 
-	y = new Array( 120 );
-	for ( i = 0; i < y.length; i++ ) {
-		y[ i ] = ( randu()*50.0 ) + 1.0;
+	y = [];
+	for ( i = 0; i < 120; i++ ) {
+		y.push( ( randu()*50.0 ) + 1.0 );
 	}
 
 	b.tic();
@@ -74,13 +74,13 @@ bench( pkg+'::one-sided', function benchmark( b ) {
 	var i;
 
 	sigma = stdev( 1.0, 51.0 );
-	x = new Array( 100 );
-	for ( i = 0; i < x.length; i++ ) {
-		x[ i ] = ( randu()*50.0 ) + 1.0;
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
+		x.push( ( randu()*50.0 ) + 1.0 );
 	}
-	y = new Array( 120 );
-	for ( i = 0; i < y.length; i++ ) {
-		y[ i ] = ( randu()*50.0 ) + 1.0;
+	y = [];
+	for ( i = 0; i < 120; i++ ) {
+		y.push( ( randu()*50.0 ) + 1.0 );
 	}
 	opts = {
 		'alternative': 'less'
@@ -112,13 +112,13 @@ bench( pkg+':print', function benchmark( b ) {
 	var i;
 
 	sigma = stdev( 1.0, 51.0 );
-	x = new Array( 100 );
-	for ( i = 0; i < x.length; i++ ) {
-		x[ i ] = ( randu()*50.0 ) + 1.0;
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
+		x.push( ( randu()*50.0 ) + 1.0 );
 	}
-	y = new Array( 120 );
-	for ( i = 0; i < y.length; i++ ) {
-		y[ i ] = ( randu()*50.0 ) + 1.0;
+	y = [];
+	for ( i = 0; i < 120; i++ ) {
+		y.push( ( randu()*50.0 ) + 1.0 );
 	}
 	result = ztest2( x, y, sigma, sigma );
 


### PR DESCRIPTION
Resolves #11193.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes JavaScript lint errors in the ztest2 benchmark by replacing disallowed `new Array(...)` usage with array literals and `push(...)`
-   keeps benchmark behavior unchanged (same generated sample sizes and value initialization flow)

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #5377

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] File locating
-   [x] PR Documentation 
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I used ChatGPT only to locate the relevant file. I completed the refactor and all subsequent changes manually, and reviewed and validated the final code before submission

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md