### PR TITLE
test: add tests for Scale constructor and properties

### DIFF
--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain.js
@@ -1,0 +1,152 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isUndefined = require( '@stdlib/assert/is-undefined' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isCollection = require( '@stdlib/assert/is-collection' );
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `domain` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'domain' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'domain' ), true, 'returns expected value' );
+	t.strictEqual( isUndefined( v.domain ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'domain': [ 0, 10 ]
+	});
+	t.strictEqual( isCollection( v.domain ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domain` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.domain = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `domain` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( isUndefined( scale.domain ), true, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domain': [ 0, 10 ]
+	});
+	t.deepEqual( scale.domain, [ 0, 10 ], 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domain': [ 0, 20 ]
+	});
+	t.deepEqual( scale.domain, [ 0, 20 ], 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domain` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.domain = [ 0, 10 ];
+	t.deepEqual( scale.domain, [ 0, 10 ], 'returns expected value' );
+
+	scale.domain = [ 0, 20 ];
+	t.deepEqual( scale.domain, [ 0, 20 ], 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `domain` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.domain = [ 0, 10 ];
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.domain = [ 0, 20 ];
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.domain = [ 0, 20 ];
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain_max.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain_max.js
@@ -1,0 +1,153 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isUndefined = require( '@stdlib/assert/is-undefined' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `domainMax` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'domainMax' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'domainMax' ), true, 'returns expected value' );
+	t.strictEqual( isUndefined( v.domainMax ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'domainMax': 10
+	});
+	t.strictEqual( isNumber( v.domainMax ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domainMax` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		'5',
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.domainMax = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `domainMax` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( isUndefined( scale.domainMax ), true, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domainMax': 10
+	});
+	t.strictEqual( scale.domainMax, 10, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domainMax': 20
+	});
+	t.strictEqual( scale.domainMax, 20, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domainMax` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.domainMax = 10;
+	t.strictEqual( scale.domainMax, 10, 'returns expected value' );
+
+	scale.domainMax = 20;
+	t.strictEqual( scale.domainMax, 20, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `domainMax` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.domainMax = 10;
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.domainMax = 20;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.domainMax = 20;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain_mid.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain_mid.js
@@ -1,0 +1,153 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isUndefined = require( '@stdlib/assert/is-undefined' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `domainMid` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'domainMid' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'domainMid' ), true, 'returns expected value' );
+	t.strictEqual( isUndefined( v.domainMid ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'domainMid': 10
+	});
+	t.strictEqual( isNumber( v.domainMid ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domainMid` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		'5',
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.domainMid = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `domainMid` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( isUndefined( scale.domainMid ), true, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domainMid': 10
+	});
+	t.strictEqual( scale.domainMid, 10, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domainMid': 20
+	});
+	t.strictEqual( scale.domainMid, 20, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domainMid` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.domainMid = 10;
+	t.strictEqual( scale.domainMid, 10, 'returns expected value' );
+
+	scale.domainMid = 20;
+	t.strictEqual( scale.domainMid, 20, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `domainMid` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.domainMid = 10;
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.domainMid = 20;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.domainMid = 20;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain_min.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain_min.js
@@ -1,0 +1,153 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isUndefined = require( '@stdlib/assert/is-undefined' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `domainMin` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'domainMin' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'domainMin' ), true, 'returns expected value' );
+	t.strictEqual( isUndefined( v.domainMin ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'domainMin': 10
+	});
+	t.strictEqual( isNumber( v.domainMin ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domainMin` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		'5',
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.domainMin = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `domainMin` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( isUndefined( scale.domainMin ), true, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domainMin': 10
+	});
+	t.strictEqual( scale.domainMin, 10, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domainMin': 20
+	});
+	t.strictEqual( scale.domainMin, 20, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domainMin` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.domainMin = 10;
+	t.strictEqual( scale.domainMin, 10, 'returns expected value' );
+
+	scale.domainMin = 20;
+	t.strictEqual( scale.domainMin, 20, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `domainMin` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.domainMin = 10;
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.domainMin = 20;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.domainMin = 20;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain_raw.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.domain_raw.js
@@ -1,0 +1,154 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isUndefined = require( '@stdlib/assert/is-undefined' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isCollection = require( '@stdlib/assert/is-collection' );
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `domainRaw` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'domainRaw' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'domainRaw' ), true, 'returns expected value' );
+	t.strictEqual( isUndefined( v.domainRaw ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'domainRaw': [ 0, 10 ]
+	});
+	t.strictEqual( isCollection( v.domainRaw ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domainRaw` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.domainRaw = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `domainRaw` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( isUndefined( scale.domainRaw ), true, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domainRaw': [ 0, 10 ]
+	});
+	t.deepEqual( scale.domainRaw, [ 0, 10 ], 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'domainRaw': [ 0, 20 ]
+	});
+	t.deepEqual( scale.domainRaw, [ 0, 20 ], 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `domainRaw` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.domainRaw = [ 0, 10 ];
+	t.deepEqual( scale.domainRaw, [ 0, 10 ], 'returns expected value' );
+
+	scale.domainRaw = [ 0, 20 ];
+	t.deepEqual( scale.domainRaw, [ 0, 20 ], 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `domainRaw` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.domainRaw = [ 0, 10 ];
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.domainRaw = [ 0, 20 ];
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.domainRaw = [ 0, 20 ];
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.interpolate.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.interpolate.js
@@ -1,0 +1,153 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isUndefined = require( '@stdlib/assert/is-undefined' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `interpolate` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'interpolate' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'interpolate' ), true, 'returns expected value' );
+	t.strictEqual( isUndefined( v.interpolate ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'interpolate': 'cubehelix'
+	});
+	t.strictEqual( isString( v.interpolate ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `interpolate` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.interpolate = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `interpolate` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( isUndefined( scale.interpolate ), true, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'interpolate': 'cubehelix'
+	});
+	t.strictEqual( scale.interpolate, 'cubehelix', 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'interpolate': 'rgb'
+	});
+	t.strictEqual( scale.interpolate, 'rgb', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `interpolate` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.interpolate = 'cubehelix';
+	t.strictEqual( scale.interpolate, 'cubehelix', 'returns expected value' );
+
+	scale.interpolate = 'rgb';
+	t.strictEqual( scale.interpolate, 'rgb', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `interpolate` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.interpolate = 'cubehelix';
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.interpolate = 'rgb';
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.interpolate = 'rgb';
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.js
@@ -1,0 +1,510 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var EventEmitter = require( 'events' ).EventEmitter;
+var tape = require( 'tape' );
+var instanceOf = require( '@stdlib/assert/instance-of' );
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function is a constructor', function test( t ) {
+	var scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( instanceOf( scale, Scale ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the constructor does not require the `new` keyword', function test( t ) {
+	var scale;
+	var fcn;
+
+	fcn = Scale;
+	scale = fcn({
+		'name': 'xScale'
+	});
+	t.strictEqual( instanceOf( scale, Scale ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the constructor does not require the `new` keyword (options)', function test( t ) {
+	var scale;
+	var fcn;
+
+	fcn = Scale;
+	scale = fcn({
+		'name': 'xScale',
+		'type': 'log'
+	});
+	t.strictEqual( instanceOf( scale, Scale ), true, 'returns expected value' );
+	t.strictEqual( scale.type, 'log', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the constructor throws an error if provided an options argument which is not an object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		void 0,
+		true,
+		false,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale( value ); // eslint-disable-line no-unused-vars
+		};
+	}
+});
+
+tape( 'the constructor throws an error if not provided a `name` option', function test( t ) {
+	t.throws( foo, TypeError, 'throws an error' );
+	t.end();
+
+	function foo() {
+		var scale = new Scale({}); // eslint-disable-line no-unused-vars
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `domain` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'domain': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `domainMax` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'domainMax': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `domainMin` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'domainMin': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `domainMid` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'domainMid': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `domainRaw` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'domainRaw': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `interpolate` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'interpolate': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `name` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `range` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'range': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `reverse` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'reverse': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `round` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'round': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor throws an error if provided an invalid `type` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'beep',
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var scale = new Scale({ // eslint-disable-line no-unused-vars
+				'name': 'xScale',
+				'type': value
+			});
+		};
+	}
+});
+
+tape( 'the constructor has a read-only `name` property', function test( t ) {
+	t.strictEqual( Scale.name, 'Scale', 'returns expected value' );
+	t.throws( foo, TypeError, 'throws an error' );
+	t.end();
+
+	function foo() {
+		Scale.name = 'beep';
+	}
+});
+
+tape( 'the constructor returns an instance having a `toJSON` method for serializing an instance to JSON', function test( t ) {
+	var expected;
+	var scale;
+	var json;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	json = scale.toJSON();
+
+	expected = {
+		'name': 'xScale',
+		'reverse': false,
+		'round': false,
+		'type': 'linear'
+	};
+	t.deepEqual( json, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `toJSON` method for serializing an instance to JSON (options)', function test( t ) {
+	var expected;
+	var scale;
+	var json;
+
+	scale = new Scale({
+		'name': 'xScale',
+		'type': 'log',
+		'round': true,
+		'reverse': true
+	});
+	json = scale.toJSON();
+
+	expected = {
+		'name': 'xScale',
+		'reverse': true,
+		'round': true,
+		'type': 'log'
+	};
+	t.deepEqual( json, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the `toJSON` method is implicitly invoked by `JSON.stringify`', function test( t ) {
+	var expected;
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	expected = {
+		'name': 'xScale',
+		'reverse': false,
+		'round': false,
+		'type': 'linear'
+	};
+	t.strictEqual( JSON.stringify( scale ), JSON.stringify( expected ), 'returns expected value' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which is an EventEmitter', function test( t ) {
+	var scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( instanceOf( scale, EventEmitter ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the constructor ignores unrecognized options', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale',
+		'beep': 'boop',
+		'foo': 'bar'
+	});
+
+	t.strictEqual( scale.name, 'xScale', 'returns expected value' );
+	t.strictEqual( scale.beep, void 0, 'returns expected value' );
+	t.strictEqual( scale.foo, void 0, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.js
@@ -101,7 +101,7 @@ tape( 'the constructor throws an error if not provided a `name` option', functio
 	t.end();
 
 	function foo() {
-		var scale = new Scale({}); // eslint-disable-line no-unused-vars
+		var scale = new Scale( {} ); // eslint-disable-line no-unused-vars
 	}
 });
 

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.name.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.name.js
@@ -1,0 +1,145 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `name` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'name' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'name' ), true, 'returns expected value' );
+	t.strictEqual( isString( v.name ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'yScale'
+	});
+	t.strictEqual( isString( v.name ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `name` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.name = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `name` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( scale.name, 'xScale', 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'yScale'
+	});
+	t.strictEqual( scale.name, 'yScale', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `name` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.name = 'yScale';
+	t.strictEqual( scale.name, 'yScale', 'returns expected value' );
+
+	scale.name = 'zScale';
+	t.strictEqual( scale.name, 'zScale', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `name` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.name = 'yScale';
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.name = 'zScale';
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.name = 'zScale';
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.properties.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.properties.js
@@ -59,7 +59,7 @@ tape( 'the constructor returns an instance having a `properties` property which 
 
 	t.strictEqual( isArray( props ), true, 'returns expected value' );
 
-	expected = [ 'domain', 'domainMax', 'domainMid', 'domainMin', 'domainRaw', 'interpolate', 'name', 'range', 'reverse', 'round', 'type' ];
+	expected = [ 'domain', 'domainMax', 'domainMin', 'domainMid', 'domainRaw', 'interpolate', 'name', 'range', 'reverse', 'round', 'type' ];
 	t.deepEqual( props, expected, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.properties.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.properties.js
@@ -59,7 +59,19 @@ tape( 'the constructor returns an instance having a `properties` property which 
 
 	t.strictEqual( isArray( props ), true, 'returns expected value' );
 
-	expected = [ 'domain', 'domainMax', 'domainMin', 'domainMid', 'domainRaw', 'interpolate', 'name', 'range', 'reverse', 'round', 'type' ];
+	expected = [
+		'domain',
+		'domainMax',
+		'domainMin',
+		'domainMid',
+		'domainRaw',
+		'interpolate',
+		'name',
+		'range',
+		'reverse',
+		'round',
+		'type'
+	];
 	t.deepEqual( props, expected, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.properties.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.properties.js
@@ -1,0 +1,83 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isArray = require( '@stdlib/assert/is-array' );
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `properties` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'properties' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'properties' ), true, 'returns expected value' );
+	t.strictEqual( isArray( v.properties ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `properties` property which returns a list of enumerable properties', function test( t ) {
+	var expected;
+	var scale;
+	var props;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	props = scale.properties;
+
+	t.strictEqual( isArray( props ), true, 'returns expected value' );
+
+	expected = [ 'domain', 'domainMax', 'domainMid', 'domainMin', 'domainRaw', 'interpolate', 'name', 'range', 'reverse', 'round', 'type' ];
+	t.deepEqual( props, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `properties` property which returns a new array on each access', function test( t ) {
+	var props1;
+	var props2;
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	props1 = scale.properties;
+	props2 = scale.properties;
+
+	t.notEqual( props1, props2, 'returns expected value' );
+	t.deepEqual( props1, props2, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.range.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.range.js
@@ -1,0 +1,155 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isUndefined = require( '@stdlib/assert/is-undefined' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isCollection = require( '@stdlib/assert/is-collection' );
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `range` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'range' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'range' ), true, 'returns expected value' );
+	t.strictEqual( isUndefined( v.range ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'range': [ 0, 100 ]
+	});
+	t.strictEqual( isCollection( v.range ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `range` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.range = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `range` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( isUndefined( scale.range ), true, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'range': [ 0, 10 ]
+	});
+	t.deepEqual( scale.range, [ 0, 10 ], 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'range': [ 0, 20 ]
+	});
+	t.deepEqual( scale.range, [ 0, 20 ], 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `range` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.range = [ 0, 10 ];
+	t.deepEqual( scale.range, [ 0, 10 ], 'returns expected value' );
+
+	scale.range = [ 0, 20 ];
+	t.deepEqual( scale.range, [ 0, 20 ], 'returns expected value' );
+
+	scale.range = 'width';
+	t.strictEqual( scale.range, 'width', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `range` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.range = [ 0, 10 ];
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.range = [ 0, 20 ];
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.range = [ 0, 20 ];
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.reverse.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.reverse.js
@@ -1,0 +1,152 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `reverse` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'reverse' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'reverse' ), true, 'returns expected value' );
+	t.strictEqual( isBoolean( v.reverse ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'reverse': true
+	});
+	t.strictEqual( isBoolean( v.reverse ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `reverse` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.reverse = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `reverse` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( scale.reverse, false, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'reverse': true
+	});
+	t.strictEqual( scale.reverse, true, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'reverse': false
+	});
+	t.strictEqual( scale.reverse, false, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `reverse` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.reverse = true;
+	t.strictEqual( scale.reverse, true, 'returns expected value' );
+
+	scale.reverse = false;
+	t.strictEqual( scale.reverse, false, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `reverse` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.reverse = true;
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.reverse = false;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.reverse = false;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.round.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.round.js
@@ -1,0 +1,152 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `round` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'round' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'round' ), true, 'returns expected value' );
+	t.strictEqual( isBoolean( v.round ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'round': true
+	});
+	t.strictEqual( isBoolean( v.round ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `round` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.round = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `round` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( scale.round, false, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'round': true
+	});
+	t.strictEqual( scale.round, true, 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'round': false
+	});
+	t.strictEqual( scale.round, false, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `round` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.round = true;
+	t.strictEqual( scale.round, true, 'returns expected value' );
+
+	scale.round = false;
+	t.strictEqual( scale.round, false, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `round` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.round = true;
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.round = false;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.round = false;
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});

--- a/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.type.js
+++ b/lib/node_modules/@stdlib/plot/vega/scale/base/ctor/test/test.type.js
@@ -1,0 +1,154 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var hasProp = require( '@stdlib/assert/has-property' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var Scale = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Scale, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the constructor returns an instance which has a `type` property', function test( t ) {
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( hasOwnProp( v, 'type' ), false, 'returns expected value' );
+	t.strictEqual( hasProp( v, 'type' ), true, 'returns expected value' );
+	t.strictEqual( isString( v.type ), true, 'returns expected value' );
+
+	v = new Scale({
+		'name': 'xScale',
+		'type': 'linear'
+	});
+	t.strictEqual( isString( v.type ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `type` property which throws an error if set to an invalid value', function test( t ) {
+	var values;
+	var i;
+	var v;
+
+	v = new Scale({
+		'name': 'xScale'
+	});
+
+	values = [
+		'beep',
+		5,
+		NaN,
+		null,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			v.type = value;
+		};
+	}
+});
+
+tape( 'the constructor returns an instance having a `type` property', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	t.strictEqual( scale.type, 'linear', 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'type': 'ordinal'
+	});
+	t.strictEqual( scale.type, 'ordinal', 'returns expected value' );
+
+	scale = new Scale({
+		'name': 'xScale',
+		'type': 'band'
+	});
+	t.strictEqual( scale.type, 'band', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance having a `type` property which can be set to a valid value', function test( t ) {
+	var scale;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+
+	scale.type = 'ordinal';
+	t.strictEqual( scale.type, 'ordinal', 'returns expected value' );
+
+	scale.type = 'band';
+	t.strictEqual( scale.type, 'band', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the constructor returns an instance which emits an event when the `type` property is set to a new value', function test( t ) {
+	var scale;
+	var count;
+
+	scale = new Scale({
+		'name': 'xScale'
+	});
+	count = 0;
+
+	scale.on( 'change', onChange );
+
+	scale.type = 'ordinal';
+	t.strictEqual( count, 1, 'returns expected value' );
+
+	scale.type = 'band';
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	// Setting to the same value should not emit an event:
+	scale.type = 'band';
+	t.strictEqual( count, 2, 'returns expected value' );
+
+	t.end();
+
+	function onChange() {
+		count += 1;
+	}
+});


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   test: add tests for Scale constructor and properties

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-  This would be required #11188 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [X] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [X] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
