### PR TITLE
bench: refactor to use string interpolation in `blas/base/diagonal-type-resolve-str`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/diagonal-type-resolve-str/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/diagonal-type-resolve-str/benchmark/benchmark.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var str2enum = require( '@stdlib/blas/base/diagonal-type-str2enum' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var resolve = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::string', function benchmark( b ) {
+bench( format( '%s::string', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -54,7 +55,7 @@ bench( pkg+'::string', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::integer', function benchmark( b ) {
+bench( format( '%s::integer', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;


### PR DESCRIPTION
Ref: #8647.

## Description

### What is the purpose of this pull request?

This pull request:

- Refactors the JavaScript benchmarks in `@stdlib/blas/base/diagonal-type-resolve-str` to use string interpolation (`@stdlib/string/format`) for generating benchmark names instead of string concatenation, as outlined in the tracking issue [#8647](https://github.com/stdlib-js/stdlib/issues/8647).

## Related Issues

Does this pull request have any related issues?

This pull request has the following related issues:

- [#8647](https://github.com/stdlib-js/stdlib/issues/8647)

## Questions

Any questions for reviewers of this pull request?

No.

## Other

Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No