### PR TITLE
bench: refactor to use string interpolation in `blas/base/diagonal-type-resolve-enum`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/diagonal-type-resolve-enum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/diagonal-type-resolve-enum/benchmark/benchmark.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var str2enum = require( '@stdlib/blas/base/diagonal-type-str2enum' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var resolve = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::string', function benchmark( b ) {
+bench( format( '%s::string', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -54,7 +55,7 @@ bench( pkg+'::string', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::integer', function benchmark( b ) {
+bench( format( '%s::integer', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;


### PR DESCRIPTION
Ref: #8647.

## Description
This pull request:
- Refactors the JavaScript benchmarks in @stdlib/blas/base/diagonal-type-resolve-enum to use string interpolation (@stdlib/string/format) for generating benchmark names instead of string concatenation, as outlined in the tracking issue #8647.

## Related Issues
This pull request has the following related issues:
- #8647

## Questions
No.

## Other
No.

## Checklist
- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance
- [] Yes
- [x] No

* * *
@stdlib-js/reviewers
[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
