### PR TITLE
fix: rename pow.h to pow_int.h to match package name

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
@@ -161,7 +161,7 @@ for ( y = 0; y < 309; y++ ) {
 ### Usage
 
 ```c
-#include "stdlib/math/base/special/fast/pow.h"
+#include "stdlib/math/base/special/fast/pow_int.h"
 ```
 
 #### stdlib_base_fast_pow( x, y )
@@ -204,7 +204,7 @@ double stdlib_base_fast_pow( const double x, const int32_t y );
 ### Examples
 
 ```c
-#include "stdlib/math/base/special/fast/pow.h"
+#include "stdlib/math/base/special/fast/pow_int.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/c/native/benchmark.c
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-#include "stdlib/math/base/special/fast/pow.h"
+#include "stdlib/math/base/special/fast/pow_int.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/example.c
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-#include "stdlib/math/base/special/fast/pow.h"
+#include "stdlib/math/base/special/fast/pow_int.h"
 #include <stdio.h>
 #include <stdint.h>
 

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/include/stdlib/math/base/special/fast/pow_int.h
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/include/stdlib/math/base/special/fast/pow_int.h
@@ -16,8 +16,8 @@
 * limitations under the License.
 */
 
-#ifndef STDLIB_MATH_BASE_SPECIAL_FAST_POW_H
-#define STDLIB_MATH_BASE_SPECIAL_FAST_POW_H
+#ifndef STDLIB_MATH_BASE_SPECIAL_FAST_POW_INT_H
+#define STDLIB_MATH_BASE_SPECIAL_FAST_POW_INT_H
 
 #include <stdint.h>
 
@@ -37,4 +37,4 @@ double stdlib_base_fast_pow( const double x, const int32_t y );
 }
 #endif
 
-#endif // !STDLIB_MATH_BASE_SPECIAL_FAST_POW_H
+#endif // !STDLIB_MATH_BASE_SPECIAL_FAST_POW_INT_H

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/addon.c
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-#include "stdlib/math/base/special/fast/pow.h"
+#include "stdlib/math/base/special/fast/pow_int.h"
 #include "stdlib/math/base/napi/binary.h"
 
 STDLIB_MATH_BASE_NAPI_MODULE_DI_D( stdlib_base_fast_pow )

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-#include "stdlib/math/base/special/fast/pow.h"
+#include "stdlib/math/base/special/fast/pow_int.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/constants/float64/pinf.h"
 


### PR DESCRIPTION
Resolves #11230.

## Description
> What is the purpose of this pull request?

This pull request:
- Renames `pow.h` to `pow_int.h` to match the package name (`pow-int`) in snake_case, as required by the naming convention.

## Related Issues
> Does this pull request have any related issues?

This pull request has the following related issues:
- #11230

## Questions
> Any questions for reviewers of this pull request?

No.

## Other
> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist
> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance
> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] No

* * *
@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md