### PR TITLE
docs(utils/async/for-each): add missing type parameters to FactoryFunction

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/for-each/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/async/for-each/docs/types/index.d.ts
@@ -111,7 +111,7 @@ type Fcn<T, V> = BinaryFcn<T, V> | TernaryFcn<T, V> | QuaternaryFcn<T, V>;
 * @param collection - input collection
 * @param done - function to invoke upon completion
 */
-type FactoryFunction = ( collection: Collection, done: Callback ) => void;
+type FactoryFunction<T> = ( collection: Collection<T>, done: Callback ) => void;
 
 /**
 * Interface for `forEachAsync`.
@@ -277,7 +277,7 @@ interface ForEachAsync {
 	* // Run `read` for each element in `files`:
 	* forEach( files, done );
 	*/
-	factory<T = unknown, V = unknown>( options: Options<T, V>, fcn: Fcn<T, V> ): FactoryFunction;
+	factory<T = unknown, V = unknown>( options: Options<T, V>, fcn: Fcn<T, V> ): FactoryFunction<T>;
 
 	/**
 	* Returns a function to invoke a function once for each element in a collection.
@@ -328,7 +328,7 @@ interface ForEachAsync {
 	* // Run `read` for each element in `files`:
 	* forEach( files, done );
 	*/
-	factory<T = unknown, V = unknown>( fcn: Fcn<T, V> ): FactoryFunction;
+	factory<T = unknown, V = unknown>( fcn: Fcn<T, V> ): FactoryFunction<T>;
 }
 
 /**


### PR DESCRIPTION
Fixes missing generic type parameter `<T>` on FactoryFunction in for-each.