### PR TITLE
chore: fix JavaScript lint errors (issue #11235)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dgemv/test/test.dgemv.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/test/test.dgemv.native.js
@@ -39,7 +39,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );


### PR DESCRIPTION
Description

This pull request fixes a JavaScript linting error (stdlib/no-empty-lines-between-requires) by removing an unexpected empty line between require statements in the dgemv native test file.

Fixed linting error in lib/node_modules/@stdlib/blas/base/dgemv/test/test.dgemv.native.js

Related Issues

resolves #11235

Questions

No.

Other

No.

Checklist

[x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

AI Assistance

[x] Yes

If you answered "yes" above, how did you use AI assistance?

[x] Research and understanding

Disclosure

I consulted Gemini to understand the specific linting error and the project's contribution requirements, but the proposed changes were fully authored manually by myself.

@stdlib-js/reviewers