### PR TITLE
chore: fix typos and incorrect test values

### DIFF
--- a/lib/node_modules/@stdlib/array/base/falses/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/falses/docs/types/test.ts
@@ -29,9 +29,9 @@ import falses = require( './index' );
 // The compiler throws an error if the function is provided an argument which is not a number...
 {
 	falses( 'abc' ); // $ExpectError
+	falses( true ); // $ExpectError
 	falses( false ); // $ExpectError
-	falses( false ); // $ExpectError
-	falses( false ); // $ExpectError
+	falses( null ); // $ExpectError
 	falses( [] ); // $ExpectError
 	falses( {} ); // $ExpectError
 	falses( ( x: number ): number => x ); // $ExpectError

--- a/lib/node_modules/@stdlib/array/base/trues/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/trues/docs/types/test.ts
@@ -31,7 +31,7 @@ import trues = require( './index' );
 	trues( 'abc' ); // $ExpectError
 	trues( true ); // $ExpectError
 	trues( false ); // $ExpectError
-	trues( true ); // $ExpectError
+	trues( null ); // $ExpectError
 	trues( [] ); // $ExpectError
 	trues( {} ); // $ExpectError
 	trues( ( x: number ): number => x ); // $ExpectError

--- a/lib/node_modules/@stdlib/array/nulls/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/nulls/benchmark/benchmark.js
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 	}
 	b.toc();
 	if ( !isCollection( arr ) ) {
-		b.fail( 'should return a typed array' );
+		b.fail( 'should return an array' );
 	}
 	b.pass( 'benchmark finished' );
 	b.end();

--- a/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-arrays/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-arrays/lib/main.js
@@ -28,7 +28,7 @@ var getShape = require( '@stdlib/ndarray/base/shape' );
 // MAIN //
 
 /**
-* Broadcasts an ndarrays to a common shape.
+* Broadcasts ndarrays to a common shape.
 *
 * ## Notes
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes duplicate `false` test cases in `array/base/falses` type tests to use distinct invalid types (`true`, `false`, `null`)
-   Fixes duplicate `true` test case in `array/base/trues` type tests replacing it with `null`
-   Fixes incorrect error message in `array/nulls` benchmark ("should return a typed array" → "should return an array")
-   Fixes grammar typo in `ndarray/base/maybe-broadcast-arrays` JSDoc ("an ndarrays" → "ndarrays")

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored with assistance from Claude Code, which identified the typos and incorrect test values.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md