### PR TITLE
chore: fix JavaScript lint errors (issue #11319)

### DIFF
--- a/lib/node_modules/@stdlib/datasets/us-states-names-capitals/README.md
+++ b/lib/node_modules/@stdlib/datasets/us-states-names-capitals/README.md
@@ -103,6 +103,7 @@ var t = table();
 <!-- eslint no-undef: "error" -->
 
 ```javascript
+var format = require( '@stdlib/string/format' );
 var capitalize = require( '@stdlib/string/capitalize' );
 var table = require( '@stdlib/datasets/us-states-names-capitals' );
 
@@ -123,7 +124,7 @@ function getCapital( state ) {
 
     // Ensure a valid state name was provided...
     if ( capital === void 0 ) {
-        throw new Error( 'unrecognized state name. Value: `' + state + '`.' );
+        throw new Error( format( 'unrecognized state name. Value: `%s`.', state ) );
     }
     return capital;
 }

--- a/lib/node_modules/@stdlib/datasets/us-states-names-capitals/examples/index.js
+++ b/lib/node_modules/@stdlib/datasets/us-states-names-capitals/examples/index.js
@@ -18,6 +18,7 @@
 
 'use strict';
 
+var format = require( '@stdlib/string/format' );
 var capitalize = require( '@stdlib/string/capitalize' );
 var table = require( './../lib' );
 
@@ -38,7 +39,7 @@ function getCapital( state ) {
 
 	// Ensure a valid state name was provided...
 	if ( capital === void 0 ) {
-		throw new Error( 'unrecognized state name. Value: `' + state + '`.' );
+		throw new Error( format( 'unrecognized state name. Value: `%s`.', state ) );
 	}
 	return capital;
 }


### PR DESCRIPTION

Resolves #11319 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Replaced string concatenation with `string/format` to resolve the linting error.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11319 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
