### PR TITLE
fix: fortran benchmark build of `blas/base/dger`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dger/benchmark/fortran/Makefile
+++ b/lib/node_modules/@stdlib/blas/base/dger/benchmark/fortran/Makefile
@@ -78,7 +78,7 @@ endif
 INCLUDE ?=
 
 # List of Fortran source files:
-SOURCE_FILES ?= ../../src/dger.f
+SOURCE_FILES ?= ../../src/dger.f ../../../xerbla/src/xerbla.f
 
 # List of Fortran targets:
 f_targets := benchmark.length.out


### PR DESCRIPTION
Progresses #2039.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes Fortran benchmark build error by adding dependency location in the Makefile. 

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #2039 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
