### PR TITLE
build: use exact ref lookup in `tools/git/hooks/pre-push`

### DIFF
--- a/tools/git/hooks/pre-push
+++ b/tools/git/hooks/pre-push
@@ -168,8 +168,8 @@ amend_commit() {
 
 # Checks if commits exist to push, as `git push` will execute regardless of whether commits exist to push or not.
 has_commits() {
-	local commits
 	local remote_ref="${remote}/${GIT_CURRENT_BRANCH}"
+	local commits
 
 	echo 'Checking if remote branch exists...' >&2
 	# We use rev-parse to test the actual ref.

--- a/tools/git/hooks/pre-push
+++ b/tools/git/hooks/pre-push
@@ -172,6 +172,7 @@ has_commits() {
 	local commits
 
 	echo 'Checking if remote branch exists...' >&2
+
 	# We use rev-parse to test the actual ref. Directing to /dev/null makes it silent on failure; the exit code is what matters...
 	if git rev-parse --verify "refs/remotes/${remote_ref}" > /dev/null 2>&1; then
 		echo 'Remote branch exists.' >&2

--- a/tools/git/hooks/pre-push
+++ b/tools/git/hooks/pre-push
@@ -183,7 +183,6 @@ has_commits() {
 		echo 'Checking for commits to push...' >&2
 		commits=$(git log "${GIT_CURRENT_BRANCH}" --oneline --)
 	fi
-
 	if [[ -z "${commits}" ]]; then
 		echo 'No commits to push.'
 		return 1

--- a/tools/git/hooks/pre-push
+++ b/tools/git/hooks/pre-push
@@ -172,8 +172,7 @@ has_commits() {
 	local commits
 
 	echo 'Checking if remote branch exists...' >&2
-	# We use rev-parse to test the actual ref.
-	# 2>/dev/null makes it silent on failure; the exit code is what matters.
+	# We use rev-parse to test the actual ref. Directing to /dev/null makes it silent on failure; the exit code is what matters...
 	if git rev-parse --verify "refs/remotes/${remote_ref}" > /dev/null 2>&1; then
 		echo 'Remote branch exists.' >&2
 		echo 'Checking for commits to push...' >&2

--- a/tools/git/hooks/pre-push
+++ b/tools/git/hooks/pre-push
@@ -168,28 +168,28 @@ amend_commit() {
 
 # Checks if commits exist to push, as `git push` will execute regardless of whether commits exist to push or not.
 has_commits() {
-    local commits
-    local remote_ref="${remote}/${GIT_CURRENT_BRANCH}"
+	local commits
+	local remote_ref="${remote}/${GIT_CURRENT_BRANCH}"
 
-    echo 'Checking if remote branch exists...' >&2
-    # We use rev-parse to test the actual ref.
-    # 2>/dev/null makes it silent on failure; the exit code is what matters.
-    if git rev-parse --verify "refs/remotes/${remote_ref}" > /dev/null 2>&1; then
-        echo 'Remote branch exists.' >&2
-        echo 'Checking for commits to push...' >&2
-        commits=$(git log "${remote_ref}..${GIT_CURRENT_BRANCH}" --oneline --)
-    else
-        echo 'Remote branch does not exist.' >&2
-        echo 'Checking for commits to push...' >&2
-        commits=$(git log "${GIT_CURRENT_BRANCH}" --oneline --)
-    fi
+	echo 'Checking if remote branch exists...' >&2
+	# We use rev-parse to test the actual ref.
+	# 2>/dev/null makes it silent on failure; the exit code is what matters.
+	if git rev-parse --verify "refs/remotes/${remote_ref}" > /dev/null 2>&1; then
+		echo 'Remote branch exists.' >&2
+		echo 'Checking for commits to push...' >&2
+		commits=$(git log "${remote_ref}..${GIT_CURRENT_BRANCH}" --oneline --)
+	else
+		echo 'Remote branch does not exist.' >&2
+		echo 'Checking for commits to push...' >&2
+		commits=$(git log "${GIT_CURRENT_BRANCH}" --oneline --)
+	fi
 
-    if [[ -z "${commits}" ]]; then
-        echo 'No commits to push.'
-        return 1
-    fi
-    echo 'Found commits to push.'
-    return 0
+	if [[ -z "${commits}" ]]; then
+		echo 'No commits to push.'
+		return 1
+	fi
+	echo 'Found commits to push.'
+	return 0
 }
 
 # Checks licenses.

--- a/tools/git/hooks/pre-push
+++ b/tools/git/hooks/pre-push
@@ -168,24 +168,28 @@ amend_commit() {
 
 # Checks if commits exist to push, as `git push` will execute regardless of whether commits exist to push or not.
 has_commits() {
-	local commits
+    local commits
+    local remote_ref="${remote}/${GIT_CURRENT_BRANCH}"
 
-	echo 'Checking if remote branch exists...' >&2
-	if git branch -r | grep "${GIT_CURRENT_BRANCH}" > /dev/null; then
-		echo 'Remote branch exists.' >&2
-		echo 'Checking for commits to push...' >&2
-		commits=$(git log "${remote}/${GIT_CURRENT_BRANCH}..${GIT_CURRENT_BRANCH}" --oneline --)
-	else
-		echo 'Remote branch does not exist.' >&2
-		echo 'Checking for commits to push...' >&2
-		commits=$(git log "${GIT_CURRENT_BRANCH}" --oneline --)
-	fi
-	if [[ -z "${commits}" ]]; then
-		echo 'No commits to push.'
-		return 1
-	fi
-	echo 'Found commits to push.'
-	return 0
+    echo 'Checking if remote branch exists...' >&2
+    # We use rev-parse to test the actual ref.
+    # 2>/dev/null makes it silent on failure; the exit code is what matters.
+    if git rev-parse --verify "refs/remotes/${remote_ref}" > /dev/null 2>&1; then
+        echo 'Remote branch exists.' >&2
+        echo 'Checking for commits to push...' >&2
+        commits=$(git log "${remote_ref}..${GIT_CURRENT_BRANCH}" --oneline --)
+    else
+        echo 'Remote branch does not exist.' >&2
+        echo 'Checking for commits to push...' >&2
+        commits=$(git log "${GIT_CURRENT_BRANCH}" --oneline --)
+    fi
+
+    if [[ -z "${commits}" ]]; then
+        echo 'No commits to push.'
+        return 1
+    fi
+    echo 'Found commits to push.'
+    return 0
 }
 
 # Checks licenses.


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: missing_dependencies
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed
   ---
Resolves #11372.

## Description

> What is the purpose of this pull request?

This pull request fixes incorrect remote branch detection in the pre-push hook by replacing substring-based matching with an exact Git reference lookup.

Previously, the hook used:

```bash
git branch -r | grep "${GIT_CURRENT_BRANCH}"
```

which could lead to false positives when branch names share prefixes or substrings (e.g., `refactor/stats-base-dists` matching `refactor/stats-base-dists-chi`). This resulted in failures when attempting to compare against a non-existent remote ref.

This PR updates the logic to use an exact ref check via `git rev-parse --verify`, ensuring correct detection of remote branch existence.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11372

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md