### PR TITLE
feat: add C implementation for `stats/base/dists/chi/kurtosis`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/benchmark/c/benchmark.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/binding.gyp
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/examples/c/example.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include.gypi
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include/stdlib/stats/base/dists/chi/kurtosis.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/include/stdlib/stats/base/dists/chi/kurtosis.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/index.js
@@ -35,7 +35,14 @@
 
 // MODULES //
 
-var main = require( './main.js' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var polyfill = require( './main.js' );
+
+
+// VARIABLES //
+
+var kurtosis = tryRequire( require.resolve( './native.js' ) );
+var main = ( kurtosis instanceof Error ) ? polyfill : kurtosis;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2025 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/addon.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/src/main.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -82,4 +83,22 @@ tape( 'the function returns the excess kurtosis of a chi distribution', function
 		}
 	}
 	t.end();
+});
+
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', function test( t ) {
+	var kurtosis;
+	var main;
+
+	main = require( './../lib/main.js' );
+
+	kurtosis = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( kurtosis, main, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/kurtosis/test/test.main.js
@@ -20,11 +20,10 @@
 
 // MODULES //
 
-var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
 
 
 // FIXTURES //
@@ -34,39 +33,39 @@ var data = require( './fixtures/julia/data.json' );
 
 // VARIABLES //
 
-var kurtosis = tryRequire( resolve( __dirname, './../lib/native.js' ) );
-var opts = {
-	'skip': ( kurtosis instanceof Error )
-};
+var kurtosis = require( './../lib/main.js' );
 
 
 // TESTS //
 
-tape( 'main export is a function', opts, function test( t ) {
+tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
 	t.strictEqual( typeof kurtosis, 'function', 'main export is a function' );
 	t.end();
 });
 
-tape( 'if provided `NaN` for the parameter, the function returns `NaN`', opts, function test( t ) {
-	var y = kurtosis( NaN );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
+tape( 'if provided `NaN` for `k`, the function returns `NaN`', function test( t ) {
+	var v = kurtosis( NaN );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
-tape( 'if provided a non-positive `k`, the function returns `NaN`', opts, function test( t ) {
-	var y;
+tape( 'if provided a degrees of freedom parameter `k` that is not a positive number, the function returns `NaN`', function test( t ) {
+	var v;
 
-	y = kurtosis( -1.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
+	v = kurtosis( -1.0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
-	y = kurtosis( 0.0 );
-	t.strictEqual( isnan( y ), true, 'returns expected value' );
+	v = kurtosis( 0.0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = kurtosis( NINF );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'the function returns the excess kurtosis of a chi distribution', opts, function test( t ) {
+tape( 'the function returns the excess kurtosis of a chi distribution', function test( t ) {
 	var expected;
 	var delta;
 	var tol;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds a C implementation for evaluating the excess kurtosis of a chi distribution (`@stdlib/stats/base/dists/chi/kurtosis`). This re-establishes a cleanly rebased version of the previously closed PR #10837 without the unrelated branch differences.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #3754
-   #10837

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

