### PR TITLE
feat: add C implementation for `stats/base/dists/erlang/cdf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/README.md
@@ -164,6 +164,105 @@ logEachMap( 'x: %0.4f, k: %d, λ: %0.4f, F(x;k,λ): %0.4f', x, k, lambda, cdf );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/erlang/cdf.h"
+```
+
+#### stdlib_base_dists_erlang_cdf( x, k, lambda )
+
+Evaluates the [cumulative distribution function][cdf] (CDF) for an [Erlang][erlang-distribution] distribution with parameters `k` (shape parameter) and `lambda` (rate parameter).
+
+```c
+double y = stdlib_base_dists_erlang_cdf( 2.0, 1, 1.0 );
+// returns ~0.865
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **k**: `[in] double` shape parameter.
+-   **lambda**: `[in] double` rate parameter.
+
+```c
+double stdlib_base_dists_erlang_cdf( const double x, const double k, const double lambda );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/erlang/cdf.h"
+#include "stdlib/math/base/special/round.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
+int main( void ) {
+    double lambda;
+    double k;
+    double x;
+    double y;
+    int i;
+
+    for ( i = 0; i < 25; i++ ) {
+        k = stdlib_base_round( random_uniform( 1.0, 10.0 ) );
+        lambda = random_uniform( 0.0, 10.0 );
+        x = random_uniform( 0.0, 20.0 );
+        y = stdlib_base_dists_erlang_cdf( x, k, lambda );
+        printf( "x: %lf, k: %lf, λ: %lf, F(x;k,λ): %lf\n", x, k, lambda, y );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/benchmark/benchmark.native.js
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var cdf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( cdf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
+	var lambda;
+	var len;
+	var k;
+	var x;
+	var y;
+	var i;
+
+	len = 100;
+	x = new Float64Array( len );
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 50.0 );
+		k[ i ] = discreteUniform( 1, 10 );
+		lambda[ i ] = uniform( EPS, 20.0 );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = cdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+} );

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/benchmark/c/benchmark.c
@@ -1,0 +1,145 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/erlang/cdf.h"
+#include "stdlib/math/base/special/round.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "erlang-cdf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
+*/
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double lambda[ 100 ];
+	double k[ 100 ];
+	double x[ 100 ];
+	double t;
+	double y;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		k[ i ] = stdlib_base_round( random_uniform( 1.0, 100.0 ) );
+		lambda[ i ] = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
+		x[ i ] = random_uniform( 0.0, 20.0 );
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		y = stdlib_base_dists_erlang_cdf( x[ i%100 ], k[ i%100 ], lambda[ i%100 ] );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/binding.gyp
@@ -1,0 +1,44 @@
+{
+  "variables": {
+    "addon_name": "addon"
+  },
+  "targets": [
+    {
+      "target_name": "<(addon_name)",
+      "type": "loadable_module",
+      "dependencies": [
+        "<(module_root_dir)/../../../../math/base/napi/ternary/binding.gyp:math_base_napi_ternary",
+        "<(module_root_dir)/../../gamma/cdf/binding.gyp:stats_base_dists_gamma_cdf"
+      ],
+      "include_dirs": [
+        "<(node_root_dir)/include/node",
+        "<(module_root_dir)/include"
+      ],
+      "sources": [
+        "src/addon.c",
+        "src/main.c"
+      ],
+      "cflags_c": [
+        "-std=c99",
+        "-O3",
+        "-Wall",
+        "-pedantic"
+      ],
+      "conditions": [
+        [
+          "OS==\"mac\"",
+          {
+            "xcode_settings": {
+              "GCC_C_LANGUAGE_STANDARD": "c99",
+              "OTHER_CFLAGS": [
+                "-O3",
+                "-Wall",
+                "-pedantic"
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/examples/c/example.c
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/erlang/cdf.h"
+#include "stdlib/math/base/special/round.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+int main( void ) {
+	double lambda;
+	double k;
+	double x;
+	double y;
+	int i;
+
+	for ( i = 0; i < 25; i++ ) {
+		k = stdlib_base_round( random_uniform( 1.0, 10.0 ) );
+		lambda = random_uniform( 0.0, 10.0 );
+		x = random_uniform( 0.0, 20.0 );
+		y = stdlib_base_dists_erlang_cdf( x, k, lambda );
+		printf( "x: %lf, k: %lf, λ: %lf, F(x;k,λ): %lf\n", x, k, lambda, y );
+	}
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/include/stdlib/stats/base/dists/erlang/cdf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/include/stdlib/stats/base/dists/erlang/cdf.h
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_DISTS_ERLANG_CDF_H
+#define STDLIB_STATS_BASE_DISTS_ERLANG_CDF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the cumulative distribution function (CDF) for an Erlang distribution with shape parameter `k` and rate parameter `lambda`.
+*/
+double stdlib_base_dists_erlang_cdf( const double x, const double k, const double lambda );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_ERLANG_CDF_H

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/lib/native.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Evaluates the cumulative distribution function (CDF) for an Erlang distribution with shape parameter `k` and rate parameter `lambda` at a value `x`.
+*
+* @private
+* @param {number} x - input value
+* @param {NonNegativeInteger} k - shape parameter
+* @param {PositiveNumber} lambda - rate parameter
+* @returns {Probability} evaluated CDF
+*
+* @example
+* var y = cdf( 2.0, 1, 1.0 );
+* // returns ~0.865
+*/
+function cdf( x, k, lambda ) {
+	return addon( x, k, lambda );
+}
+
+
+// EXPORTS //
+
+module.exports = cdf;

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/manifest.json
@@ -1,0 +1,82 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/ternary",
+        "@stdlib/math/base/assert/is-nonnegative-integer",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/stats/base/dists/gamma/cdf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nonnegative-integer",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/stats/base/dists/gamma/cdf"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nonnegative-integer",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/stats/base/dists/gamma/cdf"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stdlib/stats/base/dists/erlang/cdf",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Erlang distribution cumulative distribution function (CDF).",
   "license": "Apache-2.0",
   "author": {
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",
@@ -57,8 +60,8 @@
     "dist",
     "probability",
     "cdf",
-    "cumulative distribution",
-    "distribution function",
+    "cumulative",
+    "distribution",
     "erlang",
     "univariate",
     "continuous"

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/src/addon.c
@@ -1,0 +1,22 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/erlang/cdf.h"
+#include "stdlib/math/base/napi/ternary.h"
+
+STDLIB_MATH_BASE_NAPI_MODULE_DDD_D( stdlib_base_dists_erlang_cdf )

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/src/main.c
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/erlang/cdf.h"
+#include "stdlib/stats/base/dists/gamma/cdf.h"
+#include "stdlib/math/base/assert/is_nonnegative_integer.h"
+#include "stdlib/math/base/assert/is_nan.h"
+
+/**
+* Evaluates the cumulative distribution function (CDF) for an Erlang distribution with shape parameter `k` and rate parameter `lambda` at a value `x`.
+*
+* @param x       input value
+* @param k       shape parameter (must be a nonnegative integer)
+* @param lambda  rate parameter (must be positive)
+* @return        evaluated CDF
+*
+* @example
+* double y = stdlib_base_dists_erlang_cdf( 2.0, 1, 1.0 );
+* // returns ~0.865
+*/
+double stdlib_base_dists_erlang_cdf( const double x, const double k, const double lambda ) {
+	if (
+		stdlib_base_is_nan( x ) ||
+		!stdlib_base_is_nonnegative_integer( k ) ||
+		stdlib_base_is_nan( lambda ) ||
+		lambda <= 0.0
+	) {
+		return 0.0 / 0.0; // NaN
+	}
+	return stdlib_base_dists_gamma_cdf( x, k, lambda );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/test/test.native.js
@@ -1,0 +1,166 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+
+// VARIABLES //
+
+var cdf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( cdf instanceof Error )
+};
+
+// FIXTURES //
+
+var largeShape = require( './fixtures/julia/large_shape.json' );
+var largeRate = require( './fixtures/julia/large_rate.json' );
+var bothLarge = require( './fixtures/julia/both_large.json' );
+
+// MAIN //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof cdf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
+	var y = cdf( NaN, 1.0, 1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	y = cdf( 1.0, NaN, 1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	y = cdf( 1.0, 1.0, NaN );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'if provided a negative integer or non-integer for `k`, the function returns `NaN`', opts, function test( t ) {
+	var y = cdf( 2.0, -1, 1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = cdf( 2.0, 1.5, 1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'if provided a `lambda` which is not a positive number, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = cdf( 2.0, 1, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = cdf( 2.0, 1, -1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = cdf( 2.0, 1, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'evaluates the cdf (large shape)', opts, function test( t ) {
+	var expected;
+	var lambda;
+	var delta;
+	var tol;
+	var k;
+	var x;
+	var y;
+	var i;
+
+	expected = largeShape.expected;
+	x = largeShape.x;
+	k = largeShape.k;
+	lambda = largeShape.lambda;
+	for ( i = 0; i < x.length; i++ ) {
+		y = cdf( x[ i ], k[ i ], lambda[ i ] );
+		if ( y === expected[ i ] ) {
+			t.equal( y, expected[ i ], 'x: '+x[ i ]+', k: '+k[ i ]+', lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
+		} else {
+			delta = Math.abs( y - expected[ i ] );
+			tol = 1000.0 * EPS * Math.abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'evaluates the cdf (large rate)', opts, function test( t ) {
+	var expected;
+	var lambda;
+	var delta;
+	var tol;
+	var k;
+	var x;
+	var y;
+	var i;
+
+	expected = largeRate.expected;
+	x = largeRate.x;
+	k = largeRate.k;
+	lambda = largeRate.lambda;
+	for ( i = 0; i < x.length; i++ ) {
+		y = cdf( x[ i ], k[ i ], lambda[ i ] );
+		if ( y === expected[ i ] ) {
+			t.equal( y, expected[ i ], 'x: '+x[ i ]+', k: '+k[ i ]+', lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
+		} else {
+			delta = Math.abs( y - expected[ i ] );
+			tol = 1400.0 * EPS * Math.abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'evaluates the cdf (both large)', opts, function test( t ) {
+	var expected;
+	var lambda;
+	var delta;
+	var tol;
+	var k;
+	var x;
+	var y;
+	var i;
+
+	expected = bothLarge.expected;
+	x = bothLarge.x;
+	k = bothLarge.k;
+	lambda = bothLarge.lambda;
+	for ( i = 0; i < x.length; i++ ) {
+		y = cdf( x[ i ], k[ i ], lambda[ i ] );
+		if ( y === expected[ i ] ) {
+			t.equal( y, expected[ i ], 'x: '+x[ i ]+', k: '+k[ i ]+', lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[ i ] );
+		} else {
+			delta = Math.abs( y - expected[ i ] );
+			tol = 2400.0 * EPS * Math.abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[ i ]+'. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+	}
+	t.end();
+});
+


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds a C implementation for evaluating the cumulative distribution function (CDF) of an Erlang distribution (`@stdlib/stats/base/dists/erlang/cdf`). The implementation validates that the shape parameter `k` is a non-negative integer and delegates to the existing `stdlib_base_dists_gamma_cdf` function.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #3568

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

