### PR TITLE
chore: fix EditorConfig lint errors (issue #11471)

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/graph/lib/defaults.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/graph/lib/defaults.json
@@ -1,5 +1,5 @@
 {
-	"translateX": 0,
-	"translateY": 0,
-	"autoRender": false
+  "translateX": 0,
+  "translateY": 0,
+  "autoRender": false
 }


### PR DESCRIPTION
## Description

I noticed the automated EditorConfig lint workflow was failing in CI because three `defaults.json` files under `lib/node_modules/@stdlib/plot/components/svg/` used tabs for indentation, while the project's `.editorconfig` specifies `indent_style = space` and `indent_size = 2` for JSON files.

This PR fixes the indentation in the following files:
- `lib/node_modules/@stdlib/plot/components/svg/annotations/line/properties/render-annotation/defaults.json`
- `lib/node_modules/@stdlib/plot/components/svg/graph/properties/render/defaults.json`
- `lib/node_modules/@stdlib/plot/components/svg/marks/line/properties/render-marks/defaults.json`

Each file had tabs replaced with 2-space indentation to match the EditorConfig rules.

## Contributing Guidelines

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).