### PR TITLE
chore: fix no-empty-lines-between-requires in test files

### DIFF
--- a/lib/node_modules/@stdlib/_tools/lint/pkg-json-names/test/test.lint.js
+++ b/lib/node_modules/@stdlib/_tools/lint/pkg-json-names/test/test.lint.js
@@ -25,6 +25,7 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isObjectArray = require( '@stdlib/assert/is-object-array' );
 var contains = require( '@stdlib/assert/contains' );
+var lint = require( './../lib/lint.js' );
 
 
 // FIXTURES //
@@ -34,8 +35,6 @@ var invalidJsonPath = join( __dirname, 'fixtures', 'invalid.json' );
 var missingNamePath = join( __dirname, 'fixtures', 'missing-name.json' );
 var wrongScopePath = join( __dirname, 'fixtures', 'wrong-scope.json' );
 var nameMismatchPath = join( __dirname, 'fixtures', 'name-mismatch.json' );
-
-var lint = require( './../lib/lint.js' );
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/blas/base/gsyr/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/gsyr/test/test.ndarray.js
@@ -41,7 +41,6 @@ var rsa1nsa2 = require( './fixtures/row_major_sa1n_sa2.json' );
 var rsa1sa2n = require( './fixtures/row_major_sa1_sa2n.json' );
 var rsa1nsa2n = require( './fixtures/row_major_sa1n_sa2n.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cxp = require( './fixtures/column_major_xp.json' );


### PR DESCRIPTION
Resolves #11472

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `stdlib/no-empty-lines-between-requires` ESLint errors reported by the JavaScript lint workflow for two test files.
-   In `lib/node_modules/@stdlib/_tools/lint/pkg-json-names/test/test.lint.js`, moves `var lint = require( './../lib/lint.js' );` into the `// MODULES //` section with the other top-level `require` declarations, so a later `require` is not separated from an earlier one by non-`require` statements (the rule treats consecutive module-level `require`s across intervening code as a violation when blank lines appear between them).
-   In `lib/node_modules/@stdlib/blas/base/gsyr/test/test.ndarray.js`, removes the empty line between the `rcap` and `cu` fixture `require` lines so adjacent `require`s are not split by a blank line.

This pull request has the following related issues:

-   #11472


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Changes were made using Cursor IDE: locating the failing rule. I reviewed the diff and ran local ESLint on the touched files where the environment allowed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

## Questions

The file `lib/node_modules/@stdlib/blas/base/gsyr/test/test.ndarray.js` may still report an ESLint **`max-lines` warning** when linted with the test config (file length over the configured limit). That predates / is separate from the `stdlib/no-empty-lines-between-requires` fixes here.

**Should I fix `max-lines` in this PR, or open a separate change?**
