### PR TITLE
chore: use spaces for JSON indent in plot graph defaults

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/graph/lib/defaults.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/graph/lib/defaults.json
@@ -1,5 +1,5 @@
 {
-	"translateX": 0,
-	"translateY": 0,
-	"autoRender": false
+  "translateX": 0,
+  "translateY": 0,
+  "autoRender": false
 }


### PR DESCRIPTION
Resolves #11471

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes an EditorConfig lint failure on `lib/node_modules/@stdlib/plot/components/svg/graph/lib/defaults.json` where lines 2–4 used **tab** indentation. Per the repository `.editorconfig` section for `[*.{json,json.txt}]`, JSON must use **`indent_style = space`** and **`indent_size = 2`**. The file is updated so property lines use two-space indents only (no semantic change to the JSON values).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11471

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md