### PR TITLE
bench: refactor random number generation in `number/int32/base/mul`

### DIFF
--- a/lib/node_modules/@stdlib/number/int32/base/mul/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/int32/base/mul/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var minstd = require( '@stdlib/random/base/minstd' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var pkg = require( './../package.json' ).name;
 var imul = require( './../lib' );
 var polyfill = require( './../lib/polyfill.js' );
@@ -35,17 +34,20 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = discreteUniform( 100, 0, 10, {
+		'dtype': 'int32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = minstd();
-		y = imul( x|0, x|0 );
-		if ( isnan( y ) ) {
-			b.fail( 'should not return NaN' );
+		y = imul( x[ i%x.length ], 10 );
+		if ( y > 100 ) {
+			b.fail( 'unexpected result' );
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
-		b.fail( 'should not return NaN' );
+	if ( y > 100 ) {
+		b.fail( 'unexpected result' );
 	}
 	b.pass( 'benchmark finished' );
 	b.end();
@@ -56,38 +58,44 @@ bench( pkg+'::polyfill', function benchmark( b ) {
 	var y;
 	var i;
 
+	x = discreteUniform( 100, 0, 10, {
+		'dtype': 'int32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = minstd();
-		y = polyfill( x|0, x|0 );
-		if ( isnan( y ) ) {
-			b.fail( 'should not return NaN' );
+		y = polyfill( x[ i%x.length ], 10 );
+		if ( y > 100 ) {
+			b.fail( 'unexpected result' );
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
-		b.fail( 'should not return NaN' );
+	if ( y > 100 ) {
+		b.fail( 'unexpected result' );
 	}
 	b.pass( 'benchmark finished' );
 	b.end();
 });
 
-bench( pkg+'::naive_multiplication', function benchmark( b ) {
+bench( pkg+'::inline', function benchmark( b ) {
 	var x;
 	var y;
 	var i;
 
+	x = discreteUniform( 100, 0, 10, {
+		'dtype': 'int32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = minstd();
-		y = ( x|0 ) * ( x|0 );
-		if ( isnan( y ) ) {
-			b.fail( 'should not return NaN' );
+		y = ( ( x[ i%x.length ] ) * 5 ) | 0;
+		if ( y > 100 ) {
+			b.fail( 'unexpected result' );
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
-		b.fail( 'should not return NaN' );
+	if ( y > 100 ) {
+		b.fail( 'unexpected result' );
 	}
 	b.pass( 'benchmark finished' );
 	b.end();

--- a/lib/node_modules/@stdlib/number/int32/base/mul/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/int32/base/mul/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var imul = require( './../lib' );
 var polyfill = require( './../lib/polyfill.js' );
@@ -53,7 +54,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::polyfill', function benchmark( b ) {
+bench( format( '%s::polyfill', pkg ), function benchmark( b ) {
 	var x;
 	var y;
 	var i;
@@ -77,7 +78,7 @@ bench( pkg+'::polyfill', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::inline', function benchmark( b ) {
+bench( format( '%s::inline', pkg ), function benchmark( b ) {
 	var x;
 	var y;
 	var i;


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `number/int32/base/mul`
- Moves the random number generation outside the benchmarking loops
- Replaces `minstd()` usage with `discreteUniform()`
- Replaces `isnan()` checks with range based checks for integer focused code path

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
