### PR TITLE
build: fix resolve cache path in worktrees and submodules

### DIFF
--- a/tools/git/hooks/commit-msg
+++ b/tools/git/hooks/commit-msg
@@ -33,7 +33,7 @@ skip_lint="${SKIP_LINT_COMMIT}"
 # Get the path to a file containing the commit message:
 commit_message="$1"
 
-# Determine git directory (resolves where `${root}/.git` is file OR directory):
+# Resolve the location of the Git directory:
 git_dir=$(git rev-parse --absolute-git-dir)
 
 # Define the path to a report generated during the pre-commit hook:

--- a/tools/git/hooks/commit-msg
+++ b/tools/git/hooks/commit-msg
@@ -36,8 +36,11 @@ commit_message="$1"
 # Determine root directory:
 root=$(git rev-parse --show-toplevel)
 
+# Determine git directory (resolves where `${root}/.git` is file OR directory):
+git_dir=$(git rev-parse --absolute-git-dir)
+
 # Define the path to a report generated during the pre-commit hook:
-pre_commit_report="${root}/.git/hooks-cache/pre_commit_report.yml"
+pre_commit_report="${git_dir}/hooks-cache/pre_commit_report.yml"
 
 
 # FUNCTIONS #

--- a/tools/git/hooks/commit-msg
+++ b/tools/git/hooks/commit-msg
@@ -33,9 +33,6 @@ skip_lint="${SKIP_LINT_COMMIT}"
 # Get the path to a file containing the commit message:
 commit_message="$1"
 
-# Determine root directory:
-root=$(git rev-parse --show-toplevel)
-
 # Determine git directory (resolves where `${root}/.git` is file OR directory):
 git_dir=$(git rev-parse --absolute-git-dir)
 

--- a/tools/git/hooks/pre-commit
+++ b/tools/git/hooks/pre-commit
@@ -50,6 +50,9 @@ skip_editorconfig="${SKIP_LINT_EDITORCONFIG}"
 # Determine root directory:
 root=$(git rev-parse --show-toplevel)
 
+# Determine git directory (resolves where `${root}/.git` is file OR directory):
+git_dir=$(git rev-parse --absolute-git-dir)
+
 # Define the path to a utility for linting filenames:
 lint_filenames="${root}/lib/node_modules/@stdlib/_tools/lint/filenames/bin/cli"
 
@@ -81,7 +84,7 @@ cppcheck_tests_fixtures_suppressions_list="${root}/etc/cppcheck/suppressions.tes
 cppcheck_benchmarks_suppressions_list="${root}/etc/cppcheck/suppressions.benchmarks.txt"
 
 # Define the path to a directory for caching hook results:
-cache_dir="${root}/.git/hooks-cache"
+cache_dir="${git_dir}/hooks-cache"
 
 # Define the path to a file for storing hook results:
 cache_file="${cache_dir}/pre_commit_report.yml"

--- a/tools/git/hooks/pre-commit
+++ b/tools/git/hooks/pre-commit
@@ -50,7 +50,7 @@ skip_editorconfig="${SKIP_LINT_EDITORCONFIG}"
 # Determine root directory:
 root=$(git rev-parse --show-toplevel)
 
-# Determine git directory (resolves where `${root}/.git` is file OR directory):
+# Resolve the location of the Git directory:
 git_dir=$(git rev-parse --absolute-git-dir)
 
 # Define the path to a utility for linting filenames:

--- a/tools/git/hooks/pre-push
+++ b/tools/git/hooks/pre-push
@@ -59,7 +59,7 @@ GIT_CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 # Determine root directory:
 root=$(git rev-parse --show-toplevel)
 
-# Determine git directory (resolves where `${root}/.git` is file OR directory):
+# Resolve the location of the Git directory:
 git_dir=$(git rev-parse --absolute-git-dir)
 
 # Define the path to a directory for caching hook results:

--- a/tools/git/hooks/pre-push
+++ b/tools/git/hooks/pre-push
@@ -59,8 +59,11 @@ GIT_CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 # Determine root directory:
 root=$(git rev-parse --show-toplevel)
 
+# Determine git directory (resolves where `${root}/.git` is file OR directory):
+git_dir=$(git rev-parse --absolute-git-dir)
+
 # Define the path to a directory for caching hook results:
-cache_dir="${root}/.git/hooks-cache"
+cache_dir="${git_dir}/hooks-cache"
 
 # Define the path to a file for storing hook results:
 cache_file="${cache_dir}/pre_push_report.yml"


### PR DESCRIPTION
Fix `pre-commit`, `pre-push`, and `commit-msg` hooks assumption that `${root}/.git` is a directory (not true for worktrees and submodules).

Use `git rev-parse` to resolve the git directory rather than path-joining onto `${root}/.git`, so the hooks work in any repo layout git supports — linked worktrees and submodules both put a gitfile at `${root}/.git` and fail under the old assumption.

Fixes: https://github.com/stdlib-js/stdlib/issues/11500
Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>

Resolves #11500 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes the `pre-commit`, `pre-push`, and `commit-msg` git hooks so they work in repository layouts where `${root}/.git` is a file rather than a directory — specifically **linked worktrees** (`git worktree add ...`) and **submodules**. Under the previous implementation, every run of these hooks in such layouts emitted dozens of `Not a directory` errors, and the `pre_commit_report.yml` that `pre-commit` writes (and `commit-msg` reads) was never produced.
-   Resolves the git directory via `git rev-parse --absolute-git-dir` in each affected hook's prologue, alongside the existing `root=$(git rev-parse --show-toplevel)` line, and uses `${git_dir}` in place of `${root}/.git` at the three cache-path sites.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11500 

## Questions

> Any questions for reviewers of this pull request?

1. Each hook now has a local `git_dir=$(git rev-parse --absolute-git-dir)` in its prologue. An alternative would be to inline `$(git rev-parse --absolute-git-dir)` at each call site — smaller diff, but runs the subshell on every use and doesn't mirror the existing `root=` pattern. Easy for me to refactor if you'd prefer that style.

2. The `GIT_HOOKS_OUT ?= $(ROOT_DIR)/.git/hooks` line on `git_hooks.mk:` 

https://github.com/stdlib-js/stdlib/blob/d3427df39ee3407e76b32095ec622edf1c7d084e/tools/make/lib/init/git_hooks.mk#L27-L28

has the same `${root}/.git` assumption and will fail under `make init-git-hooks` in a worktree or submodule. I scoped this PR to what was proposed in #11500, but can add it to this or submit as its own PR.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   `make lint-commit-message` passes cleanly on the commit message (0 problems, 0 warnings).
-   Ran `git rev-parse --absolute-git-dir` in the worktree where #11500 was originally reproduced and confirmed the resolved path points to an existing directory, whereas `${root}/.git` points to a gitfile.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Claude Opus 4.7 (via Claude Code) assisted with drafting the three-file patch, analyzing side effects (the `--git-dir` vs `--absolute-git-dir` vs `--git-common-dir` trade-off, the per-worktree-vs-shared-cache question, the CWD-safety check), and drafting the commit message and this PR description. All changes were reviewed and edited by me before committing. The `Assisted-by:` trailer on the commit records the same.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
