### PR TITLE
docs: improve doctests for ndarray instances in `blas/ext/base/ndarray/dsorthp`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/README.md
@@ -43,7 +43,6 @@ Sorts a one-dimensional double-precision floating-point ndarray using heapsort.
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 
 var xbuf = new Float64Array( [ 1.0, -2.0, 3.0, -4.0 ] );
@@ -54,10 +53,7 @@ var order = scalar2ndarray( 1.0, {
 });
 
 var out = dsorthp( [ x, order ] );
-// returns <ndarray>
-
-var arr = ndarray2array( out );
-// returns [ -4.0, -2.0, 1.0, 3.0 ]
+// returns <ndarray>[ -4.0, -2.0, 1.0, 3.0 ]
 ```
 
 The function has the following parameters:

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/docs/repl.txt
@@ -33,9 +33,7 @@
     > var x = new {{alias:@stdlib/ndarray/ctor}}( dt, xbuf, sh, sx, ox, ord );
     > var o = {{alias:@stdlib/ndarray/from-scalar}}( 1.0, { 'dtype': dt } );
     > {{alias}}( [ x, o ] )
-    <ndarray>
-    > var data = x.data
-    <Float64Array>[ -4.0, -2.0, 1.0, 3.0 ]
+    <ndarray>[ -4.0, -2.0, 1.0, 3.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/docs/types/index.d.ts
@@ -34,7 +34,6 @@ import { typedndarray, float64ndarray } from '@stdlib/types/ndarray';
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 * var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var ndarray = require( '@stdlib/ndarray/base/ctor' );
 *
@@ -46,10 +45,7 @@ import { typedndarray, float64ndarray } from '@stdlib/types/ndarray';
 * });
 *
 * var out = dsorthp( [ x, ord ] );
-* // returns <ndarray>
-*
-* var arr = ndarray2array( out );
-* // returns [ -4.0, -2.0, 1.0, 3.0 ]
+* // returns <ndarray>[ -4.0, -2.0, 1.0, 3.0 ]
 */
 declare function dsorthp( arrays: [ float64ndarray, typedndarray<number> ] ): float64ndarray;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/lib/index.js
@@ -26,7 +26,6 @@
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
 * var ndarray = require( '@stdlib/ndarray/base/ctor' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 * var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var dsorthp = require( '@stdlib/blas/ext/base/ndarray/dsorthp' );
 *
@@ -38,10 +37,7 @@
 * });
 *
 * var out = dsorthp( [ x, ord ] );
-* // returns <ndarray>
-*
-* var arr = ndarray2array( out );
-* // returns [ -4.0, -2.0, 1.0, 3.0 ]
+* // returns <ndarray>[ -4.0, -2.0, 1.0, 3.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/lib/main.js
@@ -42,7 +42,6 @@ var strided = require( '@stdlib/blas/ext/base/dsorthp' ).ndarray;
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 * var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 * var ndarray = require( '@stdlib/ndarray/base/ctor' );
 *
@@ -54,10 +53,7 @@ var strided = require( '@stdlib/blas/ext/base/dsorthp' ).ndarray;
 * });
 *
 * var out = dsorthp( [ x, ord ] );
-* // returns <ndarray>
-*
-* var arr = ndarray2array( out );
-* // returns [ -4.0, -2.0, 1.0, 3.0 ]
+* // returns <ndarray>[ -4.0, -2.0, 1.0, 3.0 ]
 */
 function dsorthp( arrays ) {
 	var ord;


### PR DESCRIPTION
Progresses #9329.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates documentation examples in `@stdlib/blas/ext/base/ndarray/dsorthp` to use ndarray instance notation (e.g., <ndarray>[ ... ]) instead of explicit element access or decomposition logic.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9329

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

NA

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
