### PR TITLE
feat: add `blas/ext/sort`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/sort/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/sort/README.md
@@ -1,0 +1,175 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# sort
+
+> Sort an input [ndarray][@stdlib/ndarray/ctor] along one or more [ndarray][@stdlib/ndarray/ctor] dimensions.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var sort = require( '@stdlib/blas/ext/sort' );
+```
+
+#### sort( x\[, sortOrder]\[, options] )
+
+Sorts an input [ndarray][@stdlib/ndarray/ctor] along one or more [ndarray][@stdlib/ndarray/ctor] dimensions.
+
+```javascript
+var array = require( '@stdlib/ndarray/array' );
+
+var x = array( [ -1.0, 2.0, -3.0 ] );
+
+var y = sort( x );
+// returns <ndarray>[ -3.0, -1.0, 2.0 ]
+
+var bool = ( x === y );
+// returns true
+```
+
+The function has the following parameters:
+
+-   **x**: input [ndarray][@stdlib/ndarray/ctor]. Must have a real-valued or "generic" [data type][@stdlib/ndarray/dtypes].
+-   **sortOrder**: sort order (_optional_). May be either a scalar value, string, or an [ndarray][@stdlib/ndarray/ctor] having a real-valued or "generic" [data type][@stdlib/ndarray/dtypes]. If provided an [ndarray][@stdlib/ndarray/ctor], the value must have a shape which is [broadcast-compatible][@stdlib/ndarray/base/broadcast-shapes] with the complement of the shape defined by `options.dims`. For example, given the input shape `[2, 3, 4]` and `options.dims=[0]`, an [ndarray][@stdlib/ndarray/ctor] sort order must have a shape which is [broadcast-compatible][@stdlib/ndarray/base/broadcast-shapes] with the shape `[3, 4]`. Similarly, when performing the operation over all elements in a provided input [ndarray][@stdlib/ndarray/ctor], an [ndarray][@stdlib/ndarray/ctor] sort order must be a zero-dimensional [ndarray][@stdlib/ndarray/ctor]. By default, the sort order is `1` (i.e., increasing order).
+-   **options**: function options (_optional_).
+
+The function accepts the following options:
+
+-   **dims**: list of dimensions over which to perform operation. If not provided, the function performs the operation over all elements in a provided input [ndarray][@stdlib/ndarray/ctor].
+
+By default, the function sorts elements in increasing order. To sort in a different order, provide a `sortOrder` argument.
+
+```javascript
+var array = require( '@stdlib/ndarray/array' );
+
+var x = array( [ -1.0, 2.0, -3.0 ] );
+
+var y = sort( x, -1.0 );
+// returns <ndarray>[ 2.0, -1.0, -3.0 ]
+```
+
+In addition to numeric values, one can specify the sort order via one of the following string literals: `'ascending'`, `'asc'`, `'descending'`, or `'desc'`. The first two literals indicate to sort in ascending (i.e., increasing) order. The last two literals indicate to sort in descending (i.e., decreasing) order.
+
+```javascript
+var array = require( '@stdlib/ndarray/array' );
+
+var x = array( [ -1.0, 2.0, -3.0 ] );
+
+// Sort in ascending order:
+var y = sort( x, 'asc' );
+// returns <ndarray>[ -3.0, -1.0, 2.0 ]
+
+// Sort in descending order:
+y = sort( x, 'descending' );
+// returns <ndarray>[ 2.0, -1.0, -3.0 ]
+```
+
+By default, the function performs the operation over all elements in a provided input [ndarray][@stdlib/ndarray/ctor]. To perform the operation over specific dimensions, provide a `dims` option.
+
+```javascript
+var array = require( '@stdlib/ndarray/array' );
+
+var x = array( [ -1.0, 2.0, -3.0, 4.0 ], {
+    'shape': [ 2, 2 ],
+    'order': 'row-major'
+});
+// returns <ndarray>[ [ -1.0, 2.0 ], [ -3.0, 4.0 ] ]
+
+var y = sort( x, {
+    'dims': [ 0 ]
+});
+// returns <ndarray>[ [ -3.0, 2.0 ], [ -1.0, 4.0 ] ]
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The input [ndarray][@stdlib/ndarray/ctor] is sorted **in-place** (i.e., the input [ndarray][@stdlib/ndarray/ctor] is **mutated**).
+-   If `sortOrder < 0.0` or is either `'desc'` or `'descending'`, the input [ndarray][@stdlib/ndarray/ctor] is sorted in **decreasing** order. If `sortOrder > 0.0` or is either `'asc'` or `'ascending'`, the input [ndarray][@stdlib/ndarray/ctor] is sorted in **increasing** order. If `sortOrder == 0.0`, the input [ndarray][@stdlib/ndarray/ctor] is left unchanged.
+-   The algorithm distinguishes between `-0` and `+0`. When sorted in increasing order, `-0` is sorted before `+0`. When sorted in decreasing order, `-0` is sorted after `+0`.
+-   The algorithm sorts `NaN` values to the end. When sorted in increasing order, `NaN` values are sorted last. When sorted in decreasing order, `NaN` values are sorted first.
+-   The function iterates over [ndarray][@stdlib/ndarray/ctor] elements according to the memory layout of the input [ndarray][@stdlib/ndarray/ctor]. Accordingly, performance degradation is possible when operating over multiple dimensions of a large non-contiguous multi-dimensional input [ndarray][@stdlib/ndarray/ctor]. In such scenarios, one may want to copy an input [ndarray][@stdlib/ndarray/ctor] to contiguous memory before sorting.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var sort = require( '@stdlib/blas/ext/sort' );
+
+// Generate an array of random numbers:
+var xbuf = discreteUniform( 25, -20, 20, {
+    'dtype': 'generic'
+});
+
+// Wrap in an ndarray:
+var x = new ndarray( 'generic', xbuf, [ 5, 5 ], [ 5, 1 ], 0, 'row-major' );
+console.log( ndarray2array( x ) );
+
+// Perform operation:
+sort( x, {
+    'dims': [ 0 ]
+});
+
+// Print the results:
+console.log( ndarray2array( x ) );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/ndarray/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/ctor
+
+[@stdlib/ndarray/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/dtypes
+
+[@stdlib/ndarray/base/broadcast-shapes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/base/broadcast-shapes
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/blas/ext/sort/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/sort/README.md
@@ -125,18 +125,14 @@ var y = sort( x, {
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/discrete-uniform' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
-var ndarray = require( '@stdlib/ndarray/ctor' );
 var sort = require( '@stdlib/blas/ext/sort' );
 
 // Generate an array of random numbers:
-var xbuf = discreteUniform( 25, -20, 20, {
+var x = discreteUniform( [ 5, 5 ], -20, 20, {
     'dtype': 'generic'
 });
-
-// Wrap in an ndarray:
-var x = new ndarray( 'generic', xbuf, [ 5, 5 ], [ 5, 1 ], 0, 'row-major' );
 console.log( ndarray2array( x ) );
 
 // Perform operation:

--- a/lib/node_modules/@stdlib/blas/ext/sort/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/sort/benchmark/benchmark.js
@@ -1,0 +1,106 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var sort = require( './../lib' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = uniform( len, -50.0, 50.0, options );
+	x = new ndarray( options.dtype, x, [ len ], [ 1 ], 0, 'row-major' );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var o;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			o = sort( x, ( i%2 ) ? 1 : -1 );
+			if ( typeof o !== 'object' ) {
+				b.fail( 'should return an ndarray' );
+			}
+		}
+		b.toc();
+		if ( isnan( o.get( i%len ) ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=%s,len=%d', pkg, options.dtype, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/blas/ext/sort/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/sort/docs/repl.txt
@@ -1,0 +1,60 @@
+
+{{alias}}( x[, sortOrder][, options] )
+    Sorts an input ndarray along one or more ndarray dimensions.
+
+    The algorithm distinguishes between `-0` and `+0`. When sorted in increasing
+    order, `-0` is sorted before `+0`. When sorted in decreasing order, `-0` is
+    sorted after `+0`.
+
+    The algorithm sorts `NaN` values to the end. When sorted in increasing
+    order, `NaN` values are sorted last. When sorted in decreasing order, `NaN`
+    values are sorted first.
+
+    The function sorts an input ndarray in-place and thus mutates an input
+    ndarray.
+
+    Parameters
+    ----------
+    x: ndarray
+        Input array. Must have a real-valued or "generic" data type.
+
+    sortOrder: ndarray|number|string (optional)
+        Sort order. May be either a scalar value, string, or an ndarray having a
+        real-valued or "generic" data type. If provided an ndarray, the value
+        must have a shape which is broadcast compatible with the complement of
+        the shape defined by `options.dims`. For example, given the input shape
+        `[2, 3, 4]` and `options.dims=[0]`, an ndarray sort order must have a
+        shape which is broadcast compatible with the shape `[3, 4]`. Similarly,
+        when performing the operation over all elements in a provided input
+        ndarray, an ndarray sort order must be a zero-dimensional ndarray.
+
+        If specified as a string, must be one of the following values:
+
+        - ascending: sort in increasing order.
+        - asc: sort in increasing order.
+        - descending: sort in decreasing order.
+        - desc: sort in decreasing order.
+
+        By default, the sort order is `1` (i.e., increasing order).
+
+    options: Object (optional)
+        Function options.
+
+    options.dims: Array<integer> (optional)
+        List of dimensions over which to perform operation. If not provided, the
+        function performs the operation over all elements in a provided input
+        ndarray.
+
+    Returns
+    -------
+    out: ndarray
+        Input array.
+
+    Examples
+    --------
+    > var x = {{alias:@stdlib/ndarray/array}}( [ -1.0, 2.0, -3.0, -4.0 ] );
+    > var y = {{alias}}( x )
+    <ndarray>[ -4.0, -3.0, -1.0, 2.0 ]
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/blas/ext/sort/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/sort/docs/types/index.d.ts
@@ -1,0 +1,137 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { ArrayLike } from '@stdlib/types/array';
+import { typedndarray, realndarray, genericndarray } from '@stdlib/types/ndarray';
+
+/**
+* Input array.
+*/
+type InputArray = realndarray | genericndarray<number|string>;
+
+/**
+* Sort order.
+*/
+type SortOrder = typedndarray<number> | genericndarray<number> | number | 'descending' | 'desc' | 'ascending' | 'asc';
+
+
+/**
+* Interface defining options.
+*/
+interface Options {
+	/**
+	* List of dimensions over which to perform operation.
+	*/
+	dims?: ArrayLike<number>;
+}
+
+/**
+* Interface for performing an operation on an ndarray.
+*/
+interface Sort {
+	/**
+	* Sorts an input ndarray along one or more ndarray dimensions.
+	*
+	* ## Notes
+	*
+	* -   The input ndarray is sorted **in-place** (i.e., the input ndarray is **mutated**).
+	* -   If `sortOrder < 0.0` or is either `'desc'` or `'descending'`, the input ndarray is sorted in **decreasing** order. If `sortOrder > 0.0` or is either `'asc'` or `'ascending'`, the input ndarray is sorted in **increasing** order. If `sortOrder == 0.0`, the input ndarray is left unchanged.
+	* -   The algorithm distinguishes between `-0` and `+0`. When sorted in increasing order, `-0` is sorted before `+0`. When sorted in decreasing order, `-0` is sorted after `+0`.
+	* -   The algorithm sorts `NaN` values to the end. When sorted in increasing order, `NaN` values are sorted last. When sorted in decreasing order, `NaN` values are sorted first.
+	*
+	* @param x - input ndarray
+	* @param options - function options
+	* @returns output ndarray
+	*
+	* @example
+	* var array = require( '@stdlib/ndarray/array' );
+	*
+	* var x = array( [ -1.0, 2.0, -3.0 ] );
+	*
+	* var y = sort( x );
+	* // returns <ndarray>[ -3.0, -1.0, 2.0 ]
+	*/
+	<T extends InputArray = InputArray>( x: T, options?: Options ): T;
+
+	/**
+	* Sorts an input ndarray along one or more ndarray dimensions.
+	*
+	* ## Notes
+	*
+	* -   The input ndarray is sorted **in-place** (i.e., the input ndarray is **mutated**).
+	* -   If `sortOrder < 0.0` or is either `'desc'` or `'descending'`, the input ndarray is sorted in **decreasing** order. If `sortOrder > 0.0` or is either `'asc'` or `'ascending'`, the input ndarray is sorted in **increasing** order. If `sortOrder == 0.0`, the input ndarray is left unchanged.
+	* -   The algorithm distinguishes between `-0` and `+0`. When sorted in increasing order, `-0` is sorted before `+0`. When sorted in decreasing order, `-0` is sorted after `+0`.
+	* -   The algorithm sorts `NaN` values to the end. When sorted in increasing order, `NaN` values are sorted last. When sorted in decreasing order, `NaN` values are sorted first.
+	*
+	* @param x - input ndarray
+	* @param sortOrder - sort order
+	* @param options - function options
+	* @returns output ndarray
+	*
+	* @example
+	* var array = require( '@stdlib/ndarray/array' );
+	*
+	* var x = array( [ -1.0, 2.0, -3.0 ] );
+	*
+	* var y = sort( x, 1.0 );
+	* // returns <ndarray>[ -3.0, -1.0, 2.0 ]
+	*/
+	<T extends InputArray = InputArray>( x: T, sortOrder: SortOrder, options?: Options ): T;
+}
+
+/**
+* Sorts an input ndarray along one or more ndarray dimensions.
+*
+* ## Notes
+*
+* -   The input ndarray is sorted **in-place** (i.e., the input ndarray is **mutated**).
+* -   If `sortOrder < 0.0` or is either `'desc'` or `'descending'`, the input ndarray is sorted in **decreasing** order. If `sortOrder > 0.0` or is either `'asc'` or `'ascending'`, the input ndarray is sorted in **increasing** order. If `sortOrder == 0.0`, the input ndarray is left unchanged.
+* -   The algorithm distinguishes between `-0` and `+0`. When sorted in increasing order, `-0` is sorted before `+0`. When sorted in decreasing order, `-0` is sorted after `+0`.
+* -   The algorithm sorts `NaN` values to the end. When sorted in increasing order, `NaN` values are sorted last. When sorted in decreasing order, `NaN` values are sorted first.
+*
+* @param x - input ndarray
+* @param sortOrder - sort order
+* @param options - function options
+* @returns output ndarray
+*
+* @example
+* var array = require( '@stdlib/ndarray/array' );
+*
+* var x = array( [ -1.0, 2.0, -3.0 ] );
+*
+* var y = sort( x, 1.0 );
+* // returns <ndarray>[ -3.0, -1.0, 2.0 ]
+*
+* @example
+* var array = require( '@stdlib/ndarray/array' );
+*
+* var x = array( [ -1.0, 2.0, -3.0 ] );
+*
+* var y = sort( x, 1.0 );
+* // returns <ndarray>[ -3.0, -1.0, 2.0 ]
+*/
+declare const sort: Sort;
+
+
+// EXPORTS //
+
+export = sort;

--- a/lib/node_modules/@stdlib/blas/ext/sort/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/sort/docs/types/test.ts
@@ -1,0 +1,151 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable space-in-parens */
+
+/// <reference types="@stdlib/types"/>
+
+import zeros = require( '@stdlib/ndarray/zeros' );
+import sort = require( './index' );
+
+
+// TESTS //
+
+// The function returns an ndarray...
+{
+	const x = zeros( [ 2, 2 ], {
+		'dtype': 'float64'
+	});
+
+	sort( x ); // $ExpectType float64ndarray
+	sort( x, 1.0 ); // $ExpectType float64ndarray
+	sort( x, {} ); // $ExpectType float64ndarray
+	sort( x, 1.0, {} ); // $ExpectType float64ndarray
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an ndarray...
+{
+	sort( '5' ); // $ExpectError
+	sort( 5 ); // $ExpectError
+	sort( true ); // $ExpectError
+	sort( false ); // $ExpectError
+	sort( null ); // $ExpectError
+	sort( void 0 ); // $ExpectError
+	sort( {} ); // $ExpectError
+	sort( ( x: number ): number => x ); // $ExpectError
+
+	sort( '5', 1.0 ); // $ExpectError
+	sort( 5, 1.0 ); // $ExpectError
+	sort( true, 1.0 ); // $ExpectError
+	sort( false, 1.0 ); // $ExpectError
+	sort( null, 1.0 ); // $ExpectError
+	sort( void 0, 1.0 ); // $ExpectError
+	sort( {}, 1.0 ); // $ExpectError
+	sort( ( x: number ): number => x, 1.0 ); // $ExpectError
+
+	sort( '5', {} ); // $ExpectError
+	sort( 5, {} ); // $ExpectError
+	sort( true, {} ); // $ExpectError
+	sort( false, {} ); // $ExpectError
+	sort( null, {} ); // $ExpectError
+	sort( void 0, {} ); // $ExpectError
+	sort( {}, {} ); // $ExpectError
+	sort( ( x: number ): number => x, {} ); // $ExpectError
+
+	sort( '5', 1.0, {} ); // $ExpectError
+	sort( 5, 1.0, {} ); // $ExpectError
+	sort( true, 1.0, {} ); // $ExpectError
+	sort( false, 1.0, {} ); // $ExpectError
+	sort( null, 1.0, {} ); // $ExpectError
+	sort( void 0, 1.0, {} ); // $ExpectError
+	sort( {}, 1.0, {} ); // $ExpectError
+	sort( ( x: number ): number => x, 1.0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sort order argument which is not an ndarray, supported string literal, or scalar value...
+{
+	const x = zeros( [ 2, 2 ], {
+		'dtype': 'float64'
+	});
+
+	sort( x, true ); // $ExpectError
+	sort( x, false ); // $ExpectError
+	sort( x, [] ); // $ExpectError
+	sort( x, ( x: number ): number => x ); // $ExpectError
+
+	sort( x, 'foo', {} ); // $ExpectError
+	sort( x, true, {} ); // $ExpectError
+	sort( x, false, {} ); // $ExpectError
+	sort( x, null, {} ); // $ExpectError
+	sort( x, void 0, {} ); // $ExpectError
+	sort( x, [], {} ); // $ExpectError
+	sort( x, {}, {} ); // $ExpectError
+	sort( x, ( x: number ): number => x, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a options argument which is not an object...
+{
+	const x = zeros( [ 2, 2 ], {
+		'dtype': 'float64'
+	});
+
+	sort( x, true ); // $ExpectError
+	sort( x, false ); // $ExpectError
+	sort( x, [] ); // $ExpectError
+	sort( x, ( x: number ): number => x ); // $ExpectError
+
+	sort( x, 1.0, '5' ); // $ExpectError
+	sort( x, 1.0, true ); // $ExpectError
+	sort( x, 1.0, false ); // $ExpectError
+	sort( x, 1.0, null ); // $ExpectError
+	sort( x, 1.0, [] ); // $ExpectError
+	sort( x, 1.0, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an invalid `dims` option...
+{
+	const x = zeros( [ 2, 2 ], {
+		'dtype': 'float64'
+	});
+
+	sort( x, { 'dims': '5' } ); // $ExpectError
+	sort( x, { 'dims': 5 } ); // $ExpectError
+	sort( x, { 'dims': true } ); // $ExpectError
+	sort( x, { 'dims': false } ); // $ExpectError
+	sort( x, { 'dims': null } ); // $ExpectError
+	sort( x, { 'dims': {} } ); // $ExpectError
+	sort( x, { 'dims': ( x: number ): number => x } ); // $ExpectError
+
+	sort( x, 1.0, { 'dims': '5' } ); // $ExpectError
+	sort( x, 1.0, { 'dims': 5 } ); // $ExpectError
+	sort( x, 1.0, { 'dims': true } ); // $ExpectError
+	sort( x, 1.0, { 'dims': false } ); // $ExpectError
+	sort( x, 1.0, { 'dims': null } ); // $ExpectError
+	sort( x, 1.0, { 'dims': {} } ); // $ExpectError
+	sort( x, 1.0, { 'dims': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = zeros( [ 2, 2 ], {
+		'dtype': 'float64'
+	});
+
+	sort(); // $ExpectError
+	sort( x, 10.0, {}, {} ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/blas/ext/sort/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/sort/examples/index.js
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var sort = require( './../lib' );
+
+// Generate an array of random numbers:
+var xbuf = discreteUniform( 25, -20, 20, {
+	'dtype': 'generic'
+});
+
+// Wrap in an ndarray:
+var x = new ndarray( 'generic', xbuf, [ 5, 5 ], [ 5, 1 ], 0, 'row-major' );
+console.log( ndarray2array( x ) );
+
+// Perform operation:
+sort( x, {
+	'dims': [ 0 ]
+});
+
+// Print the results:
+console.log( ndarray2array( x ) );

--- a/lib/node_modules/@stdlib/blas/ext/sort/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/sort/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/discrete-uniform' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
-var ndarray = require( '@stdlib/ndarray/ctor' );
 var sort = require( './../lib' );
 
 // Generate an array of random numbers:
-var xbuf = discreteUniform( 25, -20, 20, {
+var x = discreteUniform( [ 5, 5 ], -20, 20, {
 	'dtype': 'generic'
 });
-
-// Wrap in an ndarray:
-var x = new ndarray( 'generic', xbuf, [ 5, 5 ], [ 5, 1 ], 0, 'row-major' );
 console.log( ndarray2array( x ) );
 
 // Perform operation:

--- a/lib/node_modules/@stdlib/blas/ext/sort/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/ext/sort/lib/base.js
@@ -1,0 +1,104 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var dtypes = require( '@stdlib/ndarray/dtypes' );
+var gsort = require( '@stdlib/blas/ext/base/ndarray/gsort' );
+var dsort = require( '@stdlib/blas/ext/base/ndarray/dsort' );
+var ssort = require( '@stdlib/blas/ext/base/ndarray/ssort' );
+var factory = require( '@stdlib/ndarray/base/nullary-strided1d-dispatch-factory' );
+
+
+// VARIABLES //
+
+var idtypes0 = dtypes( 'real_and_generic' ); // sortOrder ndarray
+var odtypes = dtypes( 'real_and_generic' );
+var table = {
+	'types': [
+		'float64', // input/output
+		'float32'  // input/output
+	],
+	'fcns': [
+		dsort,
+		ssort
+	],
+	'default': gsort
+};
+var options = {
+	'strictTraversalOrder': true
+};
+
+
+// MAIN //
+
+/**
+* Sorts an input ndarray along one or more ndarray dimensions.
+*
+* @private
+* @name sort
+* @type {Function}
+* @param {ndarray} x - input ndarray
+* @param {ndarray} sortOrder - ndarray containing the sort order
+* @param {Options} [options] - function options
+* @param {IntegerArray} [options.dims] - list of dimensions over which to perform operation
+* @throws {TypeError} first argument must be an ndarray-like object
+* @throws {TypeError} second argument must be an ndarray-like object
+* @throws {TypeError} options argument must be an object
+* @throws {RangeError} dimension indices must not exceed input ndarray bounds
+* @throws {RangeError} number of dimension indices must not exceed the number of input ndarray dimensions
+* @throws {Error} must provide valid options
+* @returns {ndarray} output ndarray
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+* var ndarray = require( '@stdlib/ndarray/ctor' );
+*
+* // Create a data buffer:
+* var xbuf = new Float64Array( [ 1.0, 2.0, -3.0, 4.0, -5.0, 6.0 ] );
+*
+* // Define the shape of the input array:
+* var sh = [ 3, 1, 2 ];
+*
+* // Define the array strides:
+* var sx = [ 2, 2, 1 ];
+*
+* // Define the index offset:
+* var ox = 0;
+*
+* // Create an input ndarray:
+* var x = new ndarray( 'float64', xbuf, sh, sx, ox, 'row-major' );
+*
+* // Create an ndarray containing the sort order:
+* var sortOrder = scalar2ndarray( 1.0, {
+*     'dtype': 'float64'
+* });
+*
+* // Perform operation:
+* var out = sort( x, sortOrder );
+* // returns <ndarray>[ [ [ -5.0, -3.0 ] ], [ [ 1.0, 2.0 ] ], [ [ 4.0, 6.0 ] ] ]
+*/
+var sort = factory( table, [ idtypes0 ], odtypes, options );
+
+
+// EXPORTS //
+
+module.exports = sort;

--- a/lib/node_modules/@stdlib/blas/ext/sort/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/sort/lib/index.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Sort an input ndarray along one or more ndarray dimensions.
+*
+* @module @stdlib/blas/ext/sort
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var ndarray = require( '@stdlib/ndarray/ctor' );
+* var sort = require( '@stdlib/blas/ext/sort' );
+*
+* // Create a data buffer:
+* var xbuf = new Float64Array( [ 1.0, 2.0, -3.0, 4.0, -5.0, 6.0 ] );
+*
+* // Define the shape of the input array:
+* var sh = [ 3, 1, 2 ];
+*
+* // Define the array strides:
+* var sx = [ 2, 2, 1 ];
+*
+* // Define the index offset:
+* var ox = 0;
+*
+* // Create an input ndarray:
+* var x = new ndarray( 'float64', xbuf, sh, sx, ox, 'row-major' );
+*
+* // Perform operation:
+* var out = sort( x );
+* // returns <ndarray>[ [ [ -5.0, -3.0 ] ], [ [ 1.0, 2.0 ] ], [ [ 4.0, 6.0 ] ] ]
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/blas/ext/sort/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/sort/lib/main.js
@@ -1,0 +1,217 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable max-len */
+
+'use strict';
+
+// MODULES //
+
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var isRealFloatingDataType = require( '@stdlib/ndarray/base/assert/is-real-floating-point-data-type' );
+var isSignedIntegerDataType = require( '@stdlib/ndarray/base/assert/is-signed-integer-data-type' );
+var broadcastScalar = require( '@stdlib/ndarray/base/broadcast-scalar' );
+var maybeBroadcastArray = require( '@stdlib/ndarray/base/maybe-broadcast-array' );
+var nonCoreShape = require( '@stdlib/ndarray/base/complement-shape' );
+var getDType = require( '@stdlib/ndarray/dtype' );
+var getShape = require( '@stdlib/ndarray/shape' );
+var getOrder = require( '@stdlib/ndarray/order' );
+var format = require( '@stdlib/string/format' );
+var base = require( './base.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns a boolean indicating if a value is a string literal specifying ascending sort order.
+*
+* @private
+* @param {*} value - input value
+* @returns {boolean} boolean result
+*/
+function isAscending( value ) {
+	return ( value === 'asc' || value === 'ascending' );
+}
+
+/**
+* Returns a boolean indicating if a value is a string literal specifying descending sort order.
+*
+* @private
+* @param {*} value - input value
+* @returns {boolean} boolean result
+*/
+function isDescending( value ) {
+	return ( value === 'desc' || value === 'descending' );
+}
+
+/**
+* Converts a string literal to a numeric sort order value.
+*
+* @private
+* @param {string} value - input value
+* @throws {TypeError} must provide a supported string
+* @returns {number} sort order
+*/
+function string2order( value ) {
+	if ( isAscending( value ) ) {
+		return 1;
+	}
+	if ( isDescending( value ) ) {
+		return -1;
+	}
+	throw new TypeError( format( 'invalid argument. Second argument must be a valid sort order. Value: `%s`.', value ) );
+}
+
+/**
+* Normalize a numeric sort order value.
+*
+* ## Notes
+*
+* -   Normalizing numeric sort order values to canonical values `-1`, `+1`, and `0` ensures that we can avoid truncation rounding errors when casting a provided sort order to the data type of the input ndarray.
+*
+* @private
+* @param {number} value - input value
+* @returns {number} normalized value
+*/
+function normalizeOrder( value ) {
+	if ( value < 0 ) {
+		return -1;
+	}
+	if ( value > 0 ) {
+		return 1;
+	}
+	return value;
+}
+
+
+// MAIN //
+
+/**
+* Sorts an input ndarray along one or more ndarray dimensions.
+*
+* @param {ndarrayLike} x - input ndarray
+* @param {(ndarrayLike|number|string)} [sortOrder=1.0] - sort order
+* @param {Options} [options] - function options
+* @param {IntegerArray} [options.dims] - list of dimensions over which to perform operation
+* @throws {TypeError} first argument must be an ndarray-like object
+* @throws {TypeError} sort order argument must be either an ndarray-like object, a numeric value, or a supported string
+* @throws {TypeError} options argument must be an object
+* @throws {RangeError} dimension indices must not exceed input ndarray bounds
+* @throws {RangeError} number of dimension indices must not exceed the number of input ndarray dimensions
+* @throws {Error} must provide valid options
+* @returns {ndarray} output ndarray
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var ndarray = require( '@stdlib/ndarray/ctor' );
+*
+* // Create a data buffer:
+* var xbuf = new Float64Array( [ 1.0, 2.0, -3.0, 4.0, -5.0, 6.0 ] );
+*
+* // Define the shape of the input array:
+* var sh = [ 3, 1, 2 ];
+*
+* // Define the array strides:
+* var sx = [ 2, 2, 1 ];
+*
+* // Define the index offset:
+* var ox = 0;
+*
+* // Create an input ndarray:
+* var x = new ndarray( 'float64', xbuf, sh, sx, ox, 'row-major' );
+*
+* // Perform operation:
+* var out = sort( x );
+* // returns <ndarray>[ [ [ -5.0, -3.0 ] ], [ [ 1.0, 2.0 ] ], [ [ 4.0, 6.0 ] ] ]
+*/
+function sort( x ) {
+	var nargs;
+	var isStr;
+	var opts;
+	var ord;
+	var dt;
+	var sh;
+	var o;
+
+	nargs = arguments.length;
+
+	// Resolve input ndarray meta data:
+	dt = getDType( x );
+	if ( !isRealFloatingDataType( dt ) && !isSignedIntegerDataType( dt ) ) {
+		// Fallback to "generic" only if we cannot safely cast `-1` to the data type of the input ndarray:
+		dt = 'generic';
+	}
+	ord = getOrder( x );
+
+	// Case: sort( x )
+	if ( nargs < 2 ) {
+		return base( x, broadcastScalar( 1, dt, [], ord ) );
+	}
+	o = arguments[ 1 ];
+
+	// Case: sort( x, ??? )
+	if ( nargs === 2 ) {
+		// Case: sort( x, sortOrder_scalar || sortOrder_string )
+		isStr = isString( o );
+		if ( isStr || isNumber( o ) ) {
+			return base( x, broadcastScalar( ( isStr ) ? string2order( o ) : normalizeOrder( o ), dt, [], ord ) );
+		}
+		// Case: sort( x, sortOrder_ndarray )
+		if ( isndarrayLike( o ) ) {
+			// As the operation is performed across all dimensions, `o` is assumed to be a zero-dimensional ndarray...
+			return base( x, o );
+		}
+		// Case: sort( x, opts )
+		opts = o;
+		o = 1;
+
+		// Intentionally fall through...
+	}
+	// Case: sort( x, sortOrder, opts )
+	else { // nargs > 2
+		opts = arguments[ 2 ];
+	}
+	// Case: sort( x, sortOrder_scalar || sortOrder_string, opts )
+	isStr = isString( o );
+	if ( isStr || isNumber( o ) ) {
+		if ( hasOwnProp( opts, 'dims' ) ) {
+			sh = nonCoreShape( getShape( x ), opts.dims );
+		} else {
+			sh = [];
+		}
+		o = broadcastScalar( ( isStr ) ? string2order( o ) : normalizeOrder( o ), dt, sh, getOrder( x ) );
+	}
+	// Case: sort( x, sortOrder_ndarray, opts )
+	else if ( isndarrayLike( o ) ) {
+		// When not provided `dims`, the operation is performed across all dimensions and `o` is assumed to be a zero-dimensional ndarray; when `dims` is provided, we need to broadcast `o` to match the shape of the non-core dimensions...
+		if ( hasOwnProp( opts, 'dims' ) ) {
+			o = maybeBroadcastArray( o, nonCoreShape( getShape( x ), opts.dims ) );
+		}
+	} else {
+		throw new TypeError( format( 'invalid argument. Second argument must be either an ndarray, a numeric scalar value, or a supported string. Value: `%s`.', o ) );
+	}
+	return base( x, o, opts );
+}
+
+
+// EXPORTS //
+
+module.exports = sort;

--- a/lib/node_modules/@stdlib/blas/ext/sort/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/sort/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@stdlib/blas/ext/sort",
+  "version": "0.0.0",
+  "description": "Sort an input ndarray along one or more ndarray dimensions.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "arrange",
+    "sort",
+    "ndarray"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/blas/ext/sort/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/sort/test/test.js
@@ -1,0 +1,1559 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isSameArray = require( '@stdlib/assert/is-same-array' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+var empty = require( '@stdlib/ndarray/empty' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var getDType = require( '@stdlib/ndarray/dtype' );
+var getShape = require( '@stdlib/ndarray/shape' );
+var getOrder = require( '@stdlib/ndarray/order' );
+var getData = require( '@stdlib/ndarray/data-buffer' );
+var sort = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof sort, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object (scalar sort order)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, 1.0 );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object (ndarray sort order)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, scalar2ndarray( 1.0 ) );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object (options)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object (scalar sort order, options)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, 1.0, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object (ndarray sort order, options)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, scalar2ndarray( 1.0 ), {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object having a supported data type', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		empty( [ 2, 2 ], {
+			'dtype': 'bool'
+		})
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object having a supported data type (scalar sort order)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		empty( [ 2, 2 ], {
+			'dtype': 'bool'
+		})
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, 1.0 );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object having a supported data type (ndarray sort order)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		empty( [ 2, 2 ], {
+			'dtype': 'bool'
+		})
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, scalar2ndarray( 1.0 ) );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object having a supported data type (options)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		empty( [ 2, 2 ], {
+			'dtype': 'bool'
+		})
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object having a supported data type (scalar sort order, options)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		empty( [ 2, 2 ], {
+			'dtype': 'bool'
+		})
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, 1.0, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument which is not an ndarray-like object having a supported data type (ndarray sort order, options)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		empty( [ 2, 2 ], {
+			'dtype': 'bool'
+		})
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( value, scalar2ndarray( 1.0 ), {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `sortOrder` argument which is not an ndarray-like object, a numeric scalar, or a supported string', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		'invalid',
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `sortOrder` argument which is not an ndarray-like object, a numeric scalar, or a supported string (options)', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		'invalid',
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, value, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `sortOrder` argument which is not broadcast-compatible', function test( t ) {
+	var values;
+	var opts;
+	var x;
+	var i;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	x = zeros( [ 2, 2 ], opts );
+
+	values = [
+		zeros( [ 4 ], opts ),
+		zeros( [ 2, 2, 2 ], opts ),
+		zeros( [ 0 ], opts )
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `sortOrder` argument which is not broadcast-compatible (options)', function test( t ) {
+	var values;
+	var opts;
+	var x;
+	var i;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	x = zeros( [ 2, 2 ], opts );
+
+	values = [
+		zeros( [ 4 ], opts ),
+		zeros( [ 2, 2, 2 ], opts ),
+		zeros( [ 0 ], opts )
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, value, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an options argument which is not an object', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		'5',
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an options argument which is not an object (scalar sort order)', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, 1.0, value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an options argument which is not an object (ndarray sort order)', function test( t ) {
+	var values;
+	var opts;
+	var x;
+	var i;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	x = zeros( [ 2, 2 ], opts );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, scalar2ndarray( 1.0, opts ), value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which is not an array-like object of integers', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[ 'a' ],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which is not an array-like object of integers (scalar sort order)', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[ 'a' ],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, 1.0, {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which is not an array-like object of integers (ndarray sort order)', function test( t ) {
+	var values;
+	var opts;
+	var x;
+	var i;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	x = zeros( [ 2, 2 ], opts );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[ 'a' ],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, scalar2ndarray( 1.0, opts ), {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which contains out-of-bounds indices', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		[ -10 ],
+		[ 0, 20 ],
+		[ 20 ]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which contains out-of-bounds indices (scalar sort order)', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		[ -10 ],
+		[ 0, 20 ],
+		[ 20 ]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, 1.0, {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which contains out-of-bounds indices (ndarray sort order)', function test( t ) {
+	var values;
+	var opts;
+	var x;
+	var i;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	x = zeros( [ 2, 2 ], opts );
+
+	values = [
+		[ -10 ],
+		[ 0, 20 ],
+		[ 20 ]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, scalar2ndarray( 1.0, opts ), {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which contains too many indices', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		[ 0, 1, 2 ],
+		[ 0, 1, 2, 3 ]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which contains too many indices (scalar sort order)', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		[ 0, 1, 2 ],
+		[ 0, 1, 2, 3 ]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, 1.0, {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which contains too many indices (ndarray sort order)', function test( t ) {
+	var values;
+	var opts;
+	var x;
+	var i;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	x = zeros( [ 2, 2 ], opts );
+
+	values = [
+		[ 0, 1, 2 ],
+		[ 0, 1, 2, 3 ]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, scalar2ndarray( 1.0, opts ), {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which contains duplicate indices', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		[ 0, 0 ],
+		[ 1, 1 ],
+		[ 0, 1, 0 ],
+		[ 1, 0, 1 ]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which contains duplicate indices (scalar sort order)', function test( t ) {
+	var values;
+	var x;
+	var i;
+
+	x = zeros( [ 2, 2 ], {
+		'dtype': 'generic'
+	});
+
+	values = [
+		[ 0, 0 ],
+		[ 1, 1 ],
+		[ 0, 1, 0 ],
+		[ 1, 0, 1 ]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, 1.0, {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dims` option which contains duplicate indices (ndarray sort order)', function test( t ) {
+	var values;
+	var opts;
+	var x;
+	var i;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	x = zeros( [ 2, 2 ], opts );
+
+	values = [
+		[ 0, 0 ],
+		[ 1, 1 ],
+		[ 0, 1, 0 ],
+		[ 1, 0, 1 ]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			sort( x, scalar2ndarray( 1.0, opts ), {
+				'dims': value
+			});
+		};
+	}
+});
+
+tape( 'the function sorts elements in an input ndarray (default, row-major)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x );
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function sorts elements in an input ndarray (default, column-major)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	actual = sort( x );
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function sorts elements in an input ndarray (all dimensions, row-major)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, {
+		'dims': [ 0, 1 ]
+	});
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function sorts elements in an input ndarray (all dimensions, column-major)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	actual = sort( x, {
+		'dims': [ 0, 1 ]
+	});
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function sorts elements in an input ndarray (no dimensions, row-major)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, {
+		'dims': []
+	});
+	expected = [ [ -1.0, 2.0 ], [ -3.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function sorts elements in an input ndarray (no dimensions, column-major)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	actual = sort( x, {
+		'dims': []
+	});
+	expected = [ [ -1.0, -3.0 ], [ 2.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying operation dimensions (row-major)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, {
+		'dims': [ 0 ]
+	});
+	expected = [ [ -3.0, 2.0 ], [ -1.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, {
+		'dims': [ 1 ]
+	});
+	expected = [ [ -1.0, 2.0 ], [ -3.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying operation dimensions (column-major)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	actual = sort( x, {
+		'dims': [ 0 ]
+	});
+	expected = [ [ -1.0, -3.0 ], [ 2.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	actual = sort( x, {
+		'dims': [ 1 ]
+	});
+	expected = [ [ -3.0, -1.0 ], [ 2.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a `sortOrder` argument (scalar)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 1.0 );
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'column-major' );
+
+	actual = sort( x, -1.0 );
+	expected = [ 4.0, 2.0, -1.0, -3.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a `sortOrder` argument (scalar, options)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 1.0, {} );
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'column-major' );
+
+	actual = sort( x, -1.0, {} );
+	expected = [ 4.0, 2.0, -1.0, -3.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 0.0, {} );
+	expected = [ -1.0, 2.0, -3.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a `sortOrder` argument (0d ndarray)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var opts;
+	var x;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, scalar2ndarray( 1.0, opts ) );
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'column-major' );
+
+	actual = sort( x, scalar2ndarray( -1.0, opts ) );
+	expected = [ 4.0, 2.0, -1.0, -3.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'column-major' );
+
+	actual = sort( x, scalar2ndarray( 0.0, opts ) );
+	expected = [ -1.0, 2.0, -3.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a `sortOrder` argument (0d ndarray, options)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var opts;
+	var x;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, scalar2ndarray( 1.0, opts ), {} );
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'column-major' );
+
+	actual = sort( x, scalar2ndarray( -1.0, opts ), {} );
+	expected = [ 4.0, 2.0, -1.0, -3.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'column-major' );
+
+	actual = sort( x, scalar2ndarray( 0.0, opts ), {} );
+	expected = [ -1.0, 2.0, -3.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a `sortOrder` argument (scalar, broadcasted)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 1.0, {
+		'dims': [ 0 ]
+	});
+	expected = [ [ -3.0, 2.0 ], [ -1.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	actual = sort( x, -1.0, {
+		'dims': [ 0 ]
+	});
+	expected = [ [ 2.0, 4.0 ], [ -1.0, -3.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	actual = sort( x, 0.0, {
+		'dims': [ 0 ]
+	});
+	expected = [ [ -1.0, -3.0 ], [ 2.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a `sortOrder` argument (0d ndarray, broadcasted)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var opts;
+	var x;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, scalar2ndarray( 1.0, opts ), {
+		'dims': [ 0 ]
+	});
+	expected = [ [ -3.0, 2.0 ], [ -1.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	actual = sort( x, scalar2ndarray( -1.0, opts ), {
+		'dims': [ 0 ]
+	});
+	expected = [ [ 2.0, 4.0 ], [ -1.0, -3.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	actual = sort( x, scalar2ndarray( 0.0, opts ), {
+		'dims': [ 0 ]
+	});
+	expected = [ [ -1.0, -3.0 ], [ 2.0, 4.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a `sortOrder` argument (string literals)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 'asc' );
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 'ascending' );
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 'desc' );
+	expected = [ 4.0, 2.0, -1.0, -3.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 'descending' );
+	expected = [ 4.0, 2.0, -1.0, -3.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a `sortOrder` argument (string literals, options)', function test( t ) {
+	var expected;
+	var actual;
+	var xbuf;
+	var x;
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 'asc', {} );
+	expected = [ -3.0, -1.0, 2.0, 4.0 ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( 'generic', xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	actual = sort( x, 'descending', {
+		'dims': [ 0 ]
+	});
+	expected = [ [ -1.0, 4.0 ], [ -3.0, 2.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing a `sortOrder` argument (ndarray)', function test( t ) {
+	var sortOrder;
+	var expected;
+	var actual;
+	var xbuf;
+	var obuf;
+	var opts;
+	var x;
+
+	opts = {
+		'dtype': 'generic'
+	};
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	obuf = [ 1.0, -1.0 ];
+	sortOrder = new ndarray( opts.dtype, obuf, [ 2 ], [ 1 ], 0, 'row-major' );
+	actual = sort( x, sortOrder, {
+		'dims': [ 0 ]
+	});
+	expected = [ [ -3.0, 4.0 ], [ -1.0, 2.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	xbuf = [ -1.0, 2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 1, 2 ], 0, 'column-major' );
+
+	obuf = [ 1.0, -1.0 ];
+	sortOrder = new ndarray( opts.dtype, obuf, [ 2 ], [ 1 ], 0, 'row-major' );
+	actual = sort( x, sortOrder, {
+		'dims': [ 0 ]
+	});
+	expected = [ [ -1.0, 4.0 ], [ 2.0, -3.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	xbuf = [ 1.0, -2.0, -3.0, 4.0 ];
+	x = new ndarray( opts.dtype, xbuf, [ 2, 2 ], [ 2, 1 ], 0, 'row-major' );
+
+	obuf = [ 0.0, -1.0 ];
+	sortOrder = new ndarray( opts.dtype, obuf, [ 2 ], [ 1 ], 0, 'row-major' );
+	actual = sort( x, sortOrder, {
+		'dims': [ 1 ]
+	});
+	expected = [ [ 1.0, -2.0 ], [ 4.0, -3.0 ] ];
+
+	t.strictEqual( actual, x, 'returns expected value' );
+	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
+	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
+	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/blas/ext/sort/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/sort/test/test.js
@@ -926,7 +926,7 @@ tape( 'the function sorts elements in an input ndarray (default, row-major)', fu
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -947,7 +947,7 @@ tape( 'the function sorts elements in an input ndarray (default, column-major)',
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -970,7 +970,7 @@ tape( 'the function sorts elements in an input ndarray (all dimensions, row-majo
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -993,7 +993,7 @@ tape( 'the function sorts elements in an input ndarray (all dimensions, column-m
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1016,7 +1016,7 @@ tape( 'the function sorts elements in an input ndarray (no dimensions, row-major
 	expected = [ [ -1.0, 2.0 ], [ -3.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1039,7 +1039,7 @@ tape( 'the function sorts elements in an input ndarray (no dimensions, column-ma
 	expected = [ [ -1.0, -3.0 ], [ 2.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1062,7 +1062,7 @@ tape( 'the function supports specifying operation dimensions (row-major)', funct
 	expected = [ [ -3.0, 2.0 ], [ -1.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1076,7 +1076,7 @@ tape( 'the function supports specifying operation dimensions (row-major)', funct
 	expected = [ [ -1.0, 2.0 ], [ -3.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1099,7 +1099,7 @@ tape( 'the function supports specifying operation dimensions (column-major)', fu
 	expected = [ [ -1.0, -3.0 ], [ 2.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1113,7 +1113,7 @@ tape( 'the function supports specifying operation dimensions (column-major)', fu
 	expected = [ [ -3.0, -1.0 ], [ 2.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1134,7 +1134,7 @@ tape( 'the function supports providing a `sortOrder` argument (scalar)', functio
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1146,7 +1146,7 @@ tape( 'the function supports providing a `sortOrder` argument (scalar)', functio
 	expected = [ 4.0, 2.0, -1.0, -3.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1167,7 +1167,7 @@ tape( 'the function supports providing a `sortOrder` argument (scalar, options)'
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1179,7 +1179,7 @@ tape( 'the function supports providing a `sortOrder` argument (scalar, options)'
 	expected = [ 4.0, 2.0, -1.0, -3.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1191,7 +1191,7 @@ tape( 'the function supports providing a `sortOrder` argument (scalar, options)'
 	expected = [ -1.0, 2.0, -3.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1216,7 +1216,7 @@ tape( 'the function supports providing a `sortOrder` argument (0d ndarray)', fun
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1228,7 +1228,7 @@ tape( 'the function supports providing a `sortOrder` argument (0d ndarray)', fun
 	expected = [ 4.0, 2.0, -1.0, -3.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1240,7 +1240,7 @@ tape( 'the function supports providing a `sortOrder` argument (0d ndarray)', fun
 	expected = [ -1.0, 2.0, -3.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1265,7 +1265,7 @@ tape( 'the function supports providing a `sortOrder` argument (0d ndarray, optio
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1277,7 +1277,7 @@ tape( 'the function supports providing a `sortOrder` argument (0d ndarray, optio
 	expected = [ 4.0, 2.0, -1.0, -3.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1289,7 +1289,7 @@ tape( 'the function supports providing a `sortOrder` argument (0d ndarray, optio
 	expected = [ -1.0, 2.0, -3.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1312,7 +1312,7 @@ tape( 'the function supports providing a `sortOrder` argument (scalar, broadcast
 	expected = [ [ -3.0, 2.0 ], [ -1.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1326,7 +1326,7 @@ tape( 'the function supports providing a `sortOrder` argument (scalar, broadcast
 	expected = [ [ 2.0, 4.0 ], [ -1.0, -3.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1340,7 +1340,7 @@ tape( 'the function supports providing a `sortOrder` argument (scalar, broadcast
 	expected = [ [ -1.0, -3.0 ], [ 2.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1367,7 +1367,7 @@ tape( 'the function supports providing a `sortOrder` argument (0d ndarray, broad
 	expected = [ [ -3.0, 2.0 ], [ -1.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1381,7 +1381,7 @@ tape( 'the function supports providing a `sortOrder` argument (0d ndarray, broad
 	expected = [ [ 2.0, 4.0 ], [ -1.0, -3.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1395,7 +1395,7 @@ tape( 'the function supports providing a `sortOrder` argument (0d ndarray, broad
 	expected = [ [ -1.0, -3.0 ], [ 2.0, 4.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1416,7 +1416,7 @@ tape( 'the function supports providing a `sortOrder` argument (string literals)'
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1428,7 +1428,7 @@ tape( 'the function supports providing a `sortOrder` argument (string literals)'
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1440,7 +1440,7 @@ tape( 'the function supports providing a `sortOrder` argument (string literals)'
 	expected = [ 4.0, 2.0, -1.0, -3.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1452,7 +1452,7 @@ tape( 'the function supports providing a `sortOrder` argument (string literals)'
 	expected = [ 4.0, 2.0, -1.0, -3.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1473,7 +1473,7 @@ tape( 'the function supports providing a `sortOrder` argument (string literals, 
 	expected = [ -3.0, -1.0, 2.0, 4.0 ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.strictEqual( isSameArray( getData( actual ), expected ), true, 'returns expected value' );
@@ -1487,7 +1487,7 @@ tape( 'the function supports providing a `sortOrder` argument (string literals, 
 	expected = [ [ -1.0, 4.0 ], [ -3.0, 2.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), 'generic', 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1518,7 +1518,7 @@ tape( 'the function supports providing a `sortOrder` argument (ndarray)', functi
 	expected = [ [ -3.0, 4.0 ], [ -1.0, 2.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1534,7 +1534,7 @@ tape( 'the function supports providing a `sortOrder` argument (ndarray)', functi
 	expected = [ [ -1.0, 4.0 ], [ 2.0, -3.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );
@@ -1550,7 +1550,7 @@ tape( 'the function supports providing a `sortOrder` argument (ndarray)', functi
 	expected = [ [ 1.0, -2.0 ], [ 4.0, -3.0 ] ];
 
 	t.strictEqual( actual, x, 'returns expected value' );
-	t.strictEqual( getDType( actual ), opts.dtype, 'returns expected value' );
+	t.strictEqual( String( getDType( actual ) ), opts.dtype, 'returns expected value' );
 	t.deepEqual( getShape( actual ), getShape( x ), 'returns expected value' );
 	t.strictEqual( getOrder( actual ), getOrder( x ), 'returns expected value' );
 	t.deepEqual( ndarray2array( actual ), expected, 'returns expected value' );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: passed
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/120.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `blas/ext/sort`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/120

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
