### PR TITLE
docs: capitalize `Pearson` and close backtick in `stats/strided/dpcorrwd`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dpcorrwd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/dpcorrwd/docs/types/index.d.ts
@@ -72,7 +72,7 @@ interface Routine {
 *
 * @param N - number of indexed elements
 * @param x - first input array
-* @param strideX - stride length of `x
+* @param strideX - stride length of `x`
 * @param y - second input array
 * @param strideY - stride length of `y`
 * @returns sample correlation coefficient

--- a/lib/node_modules/@stdlib/stats/strided/dpcorrwd/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/dpcorrwd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/strided/dpcorrwd",
   "version": "0.0.0",
-  "description": "Calculate the pearson correlation coefficient of two double-precision floating-point strided arrays using Welford's algorithm.",
+  "description": "Calculate the Pearson correlation coefficient of two double-precision floating-point strided arrays using Welford's algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Capitalizes the proper noun "Pearson" in the `@stdlib/stats/strided/dpcorrwd` `package.json` description so that it matches the capitalization already used throughout the README (e.g., "sample Pearson product-moment correlation coefficient").
-   Closes an unterminated backtick in the JSDoc `@param strideX` description in `docs/types/index.d.ts`. Previously the line read `* @param strideX - stride length of \`x` (no closing backtick), which would cause IDE/TSDoc renderers to treat the remainder of the comment block as inline code.

Both issues were surfaced during a review of the packages touched by the last commits on `develop`. A codebase-wide scan (JSDoc/comment lines and markdown outside fenced code blocks) found no other instances of unbalanced backticks.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Diff is two characters across two files — pure docs fix, no behavior change.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

Both typos were identified and fixed by Claude Code during a review of recent `develop` commits, and Claude Code also ran the codebase-wide backtick-balance scan that confirmed no other instances. I reviewed and approved the diff manually before committing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md