### PR TITLE
chore: fix JavaScript lint errors (issue #11517)

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/map-values/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/async/map-values/examples/index.js
@@ -20,6 +20,7 @@
 
 var resolve = require( 'path' ).resolve;
 var stats = require( 'fs' ).stat;
+var format = require( '@stdlib/string/format' );
 var mapValuesAsync = require( './../lib' );
 
 var files = {
@@ -32,7 +33,7 @@ function getStats( file, next ) {
 
 	function onStats( error, data ) {
 		if ( error ) {
-			error = new Error( 'unable to retrieve stats: '+file );
+			error = new Error( format( 'unable to retrieve stats: %s', file ) );
 			return next( error );
 		}
 		next( null, data );


### PR DESCRIPTION
## Description

Fixes a JavaScript linting error in the `@stdlib/utils/async/map-values` examples file by replacing string concatenation in an error message with `@stdlib/string/format`.

##  Issues

resolves #11517

## Changes

Added `var format = require( '@stdlib/string/format' );` import
 Replaced string concatenation with `format( 'unable to retrieve stats: %s', file )`
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)