### PR TITLE
chore: fix JavaScript lint errors (issue #11559)

### DIFF
--- a/lib/node_modules/@stdlib/assert/has-sharedarraybuffer-support/test/test.js
+++ b/lib/node_modules/@stdlib/assert/has-sharedarraybuffer-support/test/test.js
@@ -61,9 +61,9 @@ tape( 'if `SharedArrayBuffer` is supported, detection result is `true`', functio
 		var out;
 		var i;
 
-		out = new Array( len/8 ); // we assume evenly divisible
-		for ( i = 0; i < out.length; i++ ) {
-			out[ i ] = 0;
+		out = [];
+		for ( i = 0; i < len/8; i++ ) {
+			out.push( 0 );
 		}
 		out.byteLength = len;
 		out.slice = slice;
@@ -135,9 +135,9 @@ tape( 'if `SharedArrayBuffer` is not supported, detected result is `false` (no s
 		var out;
 		var i;
 
-		out = new Array( len/8 ); // we assume evenly divisible
-		for ( i = 0; i < out.length; i++ ) {
-			out[ i ] = 0;
+		out = [];
+		for ( i = 0; i < len/8; i++ ) {
+			out.push( 0 );
 		}
 		out.byteLength = len;
 		return out;
@@ -161,9 +161,9 @@ tape( 'if `SharedArrayBuffer` is not supported, detected result is `false` (no b
 		var out;
 		var i;
 
-		out = new Array( len/8 ); // we assume evenly divisible
-		for ( i = 0; i < out.length; i++ ) {
-			out[ i ] = 0;
+		out = [];
+		for ( i = 0; i < len/8; i++ ) {
+			out.push( 0 );
 		}
 		out.slice = slice;
 		return out;


### PR DESCRIPTION
Resolves #11559.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes the three `stdlib/no-new-array` lint errors that `stdlib-bot` flagged in the 2026-04-19 daily JavaScript lint workflow run: `lib/node_modules/@stdlib/assert/has-sharedarraybuffer-support/test/test.js:64,138,164`.
-   Replaces each `out = new Array( len/8 ); for (...) out[i] = 0;` pattern inside the `Mock( len )` helpers with `out = []; for (...) out.push( 0 );`. Same final array (zero-filled, length `len/8`), same downstream property assignments (`out.byteLength`, `out.slice`). Only the allocation strategy changes.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11559

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

`grep -n "new Array" lib/node_modules/@stdlib/assert/has-sharedarraybuffer-support/test/test.js` returns no matches after the change.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was generated with Claude Code, which applied the three identical `stdlib/no-new-array` refactors verbatim after the author confirmed each code section matched the pattern flagged by the bot-filed issue.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
