### PR TITLE
docs: correct JSDoc return value in `math/base/tools/chebyshev-seriesf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/tools/chebyshev-seriesf/lib/factory.js
+++ b/lib/node_modules/@stdlib/math/base/tools/chebyshev-seriesf/lib/factory.js
@@ -49,7 +49,7 @@ var chebyshevSeriesf = require( './main.js' );
 * // returns 0.75
 *
 * v = polyval( 0.0 ); // 1*T_0(0) + 0.5*T_1(0)
-* // returns 0.5
+* // returns 0.25
 */
 function factory( c ) {
 	var f;

--- a/lib/node_modules/@stdlib/math/base/tools/chebyshev-seriesf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/tools/chebyshev-seriesf/lib/index.js
@@ -38,7 +38,7 @@
 * // returns 0.75
 *
 * v = polyval( 0.0 ); // 1*T_0(0) + 0.5*T_1(0)
-* // returns 0.5
+* // returns 0.25
 */
 
 // MODULES //


### PR DESCRIPTION
## Description

Follow-up fix for commits merged to `develop` between `dcba41a4` (2026-04-19 01:48 UTC) and `aaa6e064` (2026-04-19 12:05 UTC) — 66 first-parent commits reviewed.

This pull request:

-   **`math/base/tools/chebyshev-seriesf`** — Fixes the `// returns 0.5` annotation on the `polyval( 0.0 )` example in `lib/factory.js` and `lib/index.js` (introduced in `2d1c3d6`); with `c = [1.0, 0.5]`, the Clenshaw recurrence yields `0.5 * (b0 - b2) = 0.25`. The doctest harness missed this because its extractor regex doesn't tolerate a trailing inline comment between the `;` and the newline (the example carries `// 1*T_0(0) + 0.5*T_1(0)` after the `;`), so the example is skipped rather than executed.

## Related Issues

No.

## Questions

No.

## Other

**Validation.** Four reviewer agents (two style, two bugs) audited the 66-commit diff:

-   Code-style compliance vs. sibling reference packages (`chebyshev-series`, `dnancount`, `snancount`, `svariance`, `scopy`, etc.).
-   Bug scan limited to the introduced code; each finding cross-checked by re-reading the diff.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude (Opus 4.7) under my review: automated reviewers audited the 24h `develop` window, I triaged their findings for high signal (dropping anything subjective or requiring out-of-window scope), and applied the surviving documentation-only fix. I also manually verified the actual return value.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
