### PR TITLE
chore: propagate recent doctest and lint fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/docs/types/index.d.ts
@@ -188,10 +188,7 @@ interface Namespace {
 	* var y = array( new Float32Array( [ 2.0, 6.0, -1.0, -4.0, 8.0 ] ) );
 	*
 	* var z = ns.sdot( x, y );
-	* // returns <ndarray>
-	*
-	* var v = z.get();
-	* // returns -5.0
+	* // returns <ndarray>[ -5.0 ]
 	*/
 	sdot: typeof sdot;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/docs/repl.txt
@@ -30,9 +30,8 @@
     > var x = new {{alias:@stdlib/ndarray/ctor}}( dt, xbuf, sh, st, oo, ord );
     > var y = new {{alias:@stdlib/ndarray/ctor}}( dt, ybuf, sh, st, oo, ord );
     > var s = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, { 'dtype': dt } );
-    > {{alias}}( [ x, y, s ] );
-    > {{alias:@stdlib/ndarray/to-array}}( y )
-    [ 1.0, -1.0, 1.0 ]
+    > {{alias}}( [ x, y, s ] )
+    <ndarray>[ 1.0, -1.0, 1.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumkbn/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumkbn/docs/repl.txt
@@ -30,9 +30,8 @@
     > var x = new {{alias:@stdlib/ndarray/ctor}}( dt, xbuf, sh, st, oo, ord );
     > var y = new {{alias:@stdlib/ndarray/ctor}}( dt, ybuf, sh, st, oo, ord );
     > var s = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, { 'dtype': dt } );
-    > {{alias}}( [ x, y, s ] );
-    > {{alias:@stdlib/ndarray/to-array}}( y )
-    [ 1.0, -1.0, 1.0 ]
+    > {{alias}}( [ x, y, s ] )
+    <ndarray>[ 1.0, -1.0, 1.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumkbn2/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumkbn2/docs/repl.txt
@@ -30,9 +30,8 @@
     > var x = new {{alias:@stdlib/ndarray/ctor}}( dt, xbuf, sh, st, oo, ord );
     > var y = new {{alias:@stdlib/ndarray/ctor}}( dt, ybuf, sh, st, oo, ord );
     > var s = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, { 'dtype': dt } );
-    > {{alias}}( [ x, y, s ] );
-    > {{alias:@stdlib/ndarray/to-array}}( y )
-    [ 1.0, -1.0, 1.0 ]
+    > {{alias}}( [ x, y, s ] )
+    <ndarray>[ 1.0, -1.0, 1.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumors/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumors/docs/repl.txt
@@ -30,9 +30,8 @@
     > var x = new {{alias:@stdlib/ndarray/ctor}}( dt, xbuf, sh, st, oo, ord );
     > var y = new {{alias:@stdlib/ndarray/ctor}}( dt, ybuf, sh, st, oo, ord );
     > var s = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, { 'dtype': dt } );
-    > {{alias}}( [ x, y, s ] );
-    > {{alias:@stdlib/ndarray/to-array}}( y )
-    [ 1.0, -1.0, 1.0 ]
+    > {{alias}}( [ x, y, s ] )
+    <ndarray>[ 1.0, -1.0, 1.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumpw/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumpw/docs/repl.txt
@@ -30,9 +30,8 @@
     > var x = new {{alias:@stdlib/ndarray/ctor}}( dt, xbuf, sh, st, oo, ord );
     > var y = new {{alias:@stdlib/ndarray/ctor}}( dt, ybuf, sh, st, oo, ord );
     > var s = {{alias:@stdlib/ndarray/from-scalar}}( 0.0, { 'dtype': dt } );
-    > {{alias}}( [ x, y, s ] );
-    > {{alias:@stdlib/ndarray/to-array}}( y )
-    [ 1.0, -1.0, 1.0 ]
+    > {{alias}}( [ x, y, s ] )
+    <ndarray>[ 1.0, -1.0, 1.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/datasets/us-states-capitals-names/README.md
+++ b/lib/node_modules/@stdlib/datasets/us-states-capitals-names/README.md
@@ -104,6 +104,7 @@ var t = table();
 
 ```javascript
 var capitalize = require( '@stdlib/string/capitalize' );
+var format = require( '@stdlib/string/format' );
 var table = require( '@stdlib/datasets/us-states-capitals-names' );
 
 var tbl = table();
@@ -123,7 +124,7 @@ function getState( capital ) {
 
     // Ensure a valid capital name was provided...
     if ( state === void 0 ) {
-        throw new Error( 'unrecognized capital. Value: `' + capital + '`.' );
+        throw new Error( format( 'unrecognized capital. Value: `%s`.', capital ) );
     }
     return state;
 }

--- a/lib/node_modules/@stdlib/datasets/us-states-capitals-names/examples/index.js
+++ b/lib/node_modules/@stdlib/datasets/us-states-capitals-names/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var capitalize = require( '@stdlib/string/capitalize' );
+var format = require( '@stdlib/string/format' );
 var table = require( './../lib' );
 
 var tbl = table();
@@ -38,7 +39,7 @@ function getState( capital ) {
 
 	// Ensure a valid capital name was provided...
 	if ( state === void 0 ) {
-		throw new Error( 'unrecognized capital. Value: `' + capital + '`.' );
+		throw new Error( format( 'unrecognized capital. Value: `%s`.', capital ) );
 	}
 	return state;
 }

--- a/lib/node_modules/@stdlib/stats/base/ndarray/cumin/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/cumin/lib/main.js
@@ -36,7 +36,6 @@ var strided = require( '@stdlib/stats/base/cumin' ).ndarray;
 * @returns {ndarrayLike} output ndarray
 *
 * @example
-* var ndarray2array = require( '@stdlib/ndarray/to-array' );
 * var ndarray = require( '@stdlib/ndarray/base/ctor' );
 *
 * var xbuf = [ 1.0, 3.0, 4.0, 2.0 ];

--- a/lib/node_modules/@stdlib/utils/async/for-each/README.md
+++ b/lib/node_modules/@stdlib/utils/async/for-each/README.md
@@ -280,6 +280,7 @@ The function accepts the same `options` as `forEachAsync()`.
 ```javascript
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' );
+var format = require( '@stdlib/string/format' );
 var forEachAsync = require( '@stdlib/utils/async/for-each' );
 
 var files = [
@@ -302,7 +303,7 @@ function read( file, next ) {
 
     function onFile( error ) {
         if ( error ) {
-            error = new Error( 'unable to read file: '+file );
+            error = new Error( format( 'unable to read file: %s', file ) );
             return next( error );
         }
         console.log( 'Successfully read file: %s', file );

--- a/lib/node_modules/@stdlib/utils/async/for-each/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/async/for-each/examples/index.js
@@ -20,6 +20,7 @@
 
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' );
+var format = require( '@stdlib/string/format' );
 var forEachAsync = require( './../lib' );
 
 var files = [
@@ -42,7 +43,7 @@ function read( file, next ) {
 
 	function onFile( error ) {
 		if ( error ) {
-			error = new Error( 'unable to read file: '+file );
+			error = new Error( format( 'unable to read file: %s', file ) );
 			return next( error );
 		}
 		console.log( 'Successfully read file: %s', file );

--- a/lib/node_modules/@stdlib/utils/async/inmap-right/README.md
+++ b/lib/node_modules/@stdlib/utils/async/inmap-right/README.md
@@ -366,6 +366,7 @@ The function accepts the same `options` as `inmapRightAsync()`.
 ```javascript
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' );
+var format = require( '@stdlib/string/format' );
 var inmapRightAsync = require( '@stdlib/utils/async/inmap-right' );
 
 var files = [
@@ -388,7 +389,7 @@ function read( file, next ) {
 
     function onFile( error, data ) {
         if ( error ) {
-            error = new Error( 'unable to read file: '+file );
+            error = new Error( format( 'unable to read file: %s', file ) );
             return next( error );
         }
         next( null, data );

--- a/lib/node_modules/@stdlib/utils/async/inmap-right/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/async/inmap-right/examples/index.js
@@ -20,6 +20,7 @@
 
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' );
+var format = require( '@stdlib/string/format' );
 var inmapRightAsync = require( './../lib' );
 
 var files = [
@@ -42,7 +43,7 @@ function read( file, next ) {
 
 	function onFile( error, data ) {
 		if ( error ) {
-			error = new Error( 'unable to read file: '+file );
+			error = new Error( format( 'unable to read file: %s', file ) );
 			return next( error );
 		}
 		next( null, data );

--- a/lib/node_modules/@stdlib/utils/async/inmap/README.md
+++ b/lib/node_modules/@stdlib/utils/async/inmap/README.md
@@ -367,6 +367,7 @@ The function accepts the same `options` as `inmapAsync()`.
 ```javascript
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' );
+var format = require( '@stdlib/string/format' );
 var inmapAsync = require( '@stdlib/utils/async/inmap' );
 
 var files = [
@@ -389,7 +390,7 @@ function read( file, next ) {
 
     function onFile( error, data ) {
         if ( error ) {
-            error = new Error( 'unable to read file: '+file );
+            error = new Error( format( 'unable to read file: %s', file ) );
             return next( error );
         }
         next( null, data );

--- a/lib/node_modules/@stdlib/utils/async/inmap/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/async/inmap/examples/index.js
@@ -20,6 +20,7 @@
 
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' );
+var format = require( '@stdlib/string/format' );
 var inmapAsync = require( './../lib' );
 
 var files = [
@@ -42,7 +43,7 @@ function read( file, next ) {
 
 	function onFile( error, data ) {
 		if ( error ) {
-			error = new Error( 'unable to read file: '+file );
+			error = new Error( format( 'unable to read file: %s', file ) );
 			return next( error );
 		}
 		next( null, data );


### PR DESCRIPTION
## Description

Propagates four recent `develop` fixes to sibling packages with the same defect. One commit per source.

### `blas/ext/base/ndarray/dcusum*/docs/repl.txt` — source 638fdf01

Collapse the two-step `> {{alias}}( ... );` + `> {{alias:@stdlib/ndarray/to-array}}( y )` REPL doctest into the inline `<ndarray>[ ... ]` form across the five `dcusum*` siblings (`dcusum`, `dcusumkbn`, `dcusumkbn2`, `dcusumors`, `dcusumpw`).

### `blas/docs/types/index.d.ts` — source 97d6f49c

Inline the `sdot` `@example` scalar return the same way the adjacent `ddot` entry already is: drop `var v = z.get();` + `// returns -5.0` and fold the value into `// returns <ndarray>[ -5.0 ]`.

### `stats/base/ndarray/cumin/lib/main.js` — source 0873811a

Remove the orphan `require( '@stdlib/ndarray/to-array' )` left behind in the `@example` block (the output is already inlined).

### `utils/async/{inmap,inmap-right,for-each}` + `datasets/us-states-capitals-names` — source 650bf8ac

Replace `new Error( 'text: ' + value )` with `new Error( format( 'text: %s', value ) )` and add the `@stdlib/string/format` import.

## Questions

No.

## Other

No related-issue keywords on purpose — `random/iter` (49fc2415) and `napi/create-*` (e08ef82b, b946af96) had no remaining candidates after their source commits.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

Authored by Claude Code running a fix-propagation routine: enumerated commits merged to `develop` in the last 24h, extracted generalizable patterns, searched for sibling sites, validated with independent reviewer agents, and applied only the high-signal propagations. Draft until a maintainer audits.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md