### PR TITLE
bench: refactor to use string interpolation in `streams`

### DIFF
--- a/lib/node_modules/@stdlib/streams/node/debug-sink/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/debug-sink/benchmark/benchmark.throughput.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var noop = require( '@stdlib/utils/noop' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var debugSinkStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -55,7 +56,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput', function benchmark( b ) {
+bench( format( '%s::throughput', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -84,7 +85,7 @@ bench( pkg+'::throughput', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,noop_callback', function benchmark( b ) {
+bench( format( '%s::throughput,noop_callback', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -113,7 +114,7 @@ bench( pkg+'::throughput,noop_callback', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -143,7 +144,7 @@ bench( pkg+'::throughput,object_mode', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode,noop_callback', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode,noop_callback', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;

--- a/lib/node_modules/@stdlib/streams/node/debug/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/debug/benchmark/benchmark.throughput.js
@@ -25,13 +25,14 @@ var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var noop = require( '@stdlib/utils/noop' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var debugStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -57,7 +58,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput', function benchmark( b ) {
+bench( format( '%s::throughput', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -99,7 +100,7 @@ bench( pkg+'::throughput', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,noop_callback', function benchmark( b ) {
+bench( format( '%s::throughput,noop_callback', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -141,7 +142,7 @@ bench( pkg+'::throughput,noop_callback', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -184,7 +185,7 @@ bench( pkg+'::throughput,object_mode', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode,noop_callback', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode,noop_callback', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;

--- a/lib/node_modules/@stdlib/streams/node/empty/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/streams/node/empty/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var Readable = require( 'readable-stream' ).Readable;
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyStream = require( './../lib' );
 
@@ -47,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':objectMode', function benchmark( b ) {
+bench( format( '%s:objectMode', pkg ), function benchmark( b ) {
 	var s;
 	var i;
 
@@ -66,7 +67,7 @@ bench( pkg+':objectMode', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var createStream;
 	var s;
 	var i;

--- a/lib/node_modules/@stdlib/streams/node/from-array/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/streams/node/from-array/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var Readable = require( 'readable-stream' ).Readable;
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var arrayStream = require( './../lib' );
 
@@ -50,7 +51,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':objectMode', function benchmark( b ) {
+bench( format( '%s:objectMode', pkg ), function benchmark( b ) {
 	var arr;
 	var s;
 	var i;
@@ -72,7 +73,7 @@ bench( pkg+':objectMode', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var createStream;
 	var arr;
 	var s;

--- a/lib/node_modules/@stdlib/streams/node/from-array/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/from-array/benchmark/benchmark.throughput.js
@@ -24,13 +24,14 @@ var WritableStream = require( 'readable-stream' ).Writable; // eslint-disable-li
 var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var arrayStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -56,7 +57,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -107,7 +108,7 @@ bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -160,7 +161,7 @@ bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -213,7 +214,7 @@ bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmar
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;

--- a/lib/node_modules/@stdlib/streams/node/from-circular-array/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/streams/node/from-circular-array/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var Readable = require( 'readable-stream' ).Readable;
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var circularArrayStream = require( './../lib' );
 
@@ -50,7 +51,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':objectMode', function benchmark( b ) {
+bench( format( '%s:objectMode', pkg ), function benchmark( b ) {
 	var arr;
 	var s;
 	var i;
@@ -72,7 +73,7 @@ bench( pkg+':objectMode', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var createStream;
 	var arr;
 	var s;

--- a/lib/node_modules/@stdlib/streams/node/from-circular-array/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/from-circular-array/benchmark/benchmark.throughput.js
@@ -24,13 +24,14 @@ var WritableStream = require( 'readable-stream' ).Writable; // eslint-disable-li
 var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var circularArrayStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -56,7 +57,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -104,7 +105,7 @@ bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -154,7 +155,7 @@ bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -204,7 +205,7 @@ bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmar
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;

--- a/lib/node_modules/@stdlib/streams/node/from-constant/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/streams/node/from-constant/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var Readable = require( 'readable-stream' ).Readable;
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var constantStream = require( './../lib' );
 
@@ -47,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':objectMode', function benchmark( b ) {
+bench( format( '%s:objectMode', pkg ), function benchmark( b ) {
 	var s;
 	var i;
 
@@ -66,7 +67,7 @@ bench( pkg+':objectMode', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var createStream;
 	var s;
 	var i;

--- a/lib/node_modules/@stdlib/streams/node/from-constant/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/from-constant/benchmark/benchmark.throughput.js
@@ -24,13 +24,14 @@ var WritableStream = require( 'readable-stream' ).Writable; // eslint-disable-li
 var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var constantStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -56,7 +57,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -101,7 +102,7 @@ bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -148,7 +149,7 @@ bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -195,7 +196,7 @@ bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmar
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;

--- a/lib/node_modules/@stdlib/streams/node/from-iterator/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/streams/node/from-iterator/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var Readable = require( 'readable-stream' ).Readable;
 var randu = require( '@stdlib/random/iter/randu' );
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iteratorStream = require( './../lib' );
 
@@ -51,7 +52,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':objectMode', function benchmark( b ) {
+bench( format( '%s:objectMode', pkg ), function benchmark( b ) {
 	var it;
 	var s;
 	var i;
@@ -73,7 +74,7 @@ bench( pkg+':objectMode', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var createStream;
 	var it;
 	var s;

--- a/lib/node_modules/@stdlib/streams/node/from-iterator/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/from-iterator/benchmark/benchmark.throughput.js
@@ -25,13 +25,14 @@ var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var randu = require( '@stdlib/random/iter/randu' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iteratorStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -57,7 +58,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -102,7 +103,7 @@ bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -149,7 +150,7 @@ bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -196,7 +197,7 @@ bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmar
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;

--- a/lib/node_modules/@stdlib/streams/node/from-strided-array/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/streams/node/from-strided-array/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var Readable = require( 'readable-stream' ).Readable;
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stridedArrayStream = require( './../lib' );
 
@@ -50,7 +51,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':objectMode', function benchmark( b ) {
+bench( format( '%s:objectMode', pkg ), function benchmark( b ) {
 	var arr;
 	var s;
 	var i;
@@ -72,7 +73,7 @@ bench( pkg+':objectMode', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::factory', function benchmark( b ) {
+bench( format( '%s::factory', pkg ), function benchmark( b ) {
 	var createStream;
 	var arr;
 	var s;

--- a/lib/node_modules/@stdlib/streams/node/from-strided-array/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/from-strided-array/benchmark/benchmark.throughput.js
@@ -24,13 +24,14 @@ var WritableStream = require( 'readable-stream' ).Writable; // eslint-disable-li
 var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stridedArrayStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -56,7 +57,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -107,7 +108,7 @@ bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -160,7 +161,7 @@ bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;
@@ -213,7 +214,7 @@ bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmar
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=0', pkg ), function benchmark( b ) {
 	var rStream;
 	var wStream;
 	var opts;

--- a/lib/node_modules/@stdlib/streams/node/inspect-sink/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/inspect-sink/benchmark/benchmark.throughput.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var noop = require( '@stdlib/utils/noop' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var inspectSinkStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -55,7 +56,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput', function benchmark( b ) {
+bench( format( '%s::throughput', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -82,7 +83,7 @@ bench( pkg+'::throughput', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;

--- a/lib/node_modules/@stdlib/streams/node/inspect/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/inspect/benchmark/benchmark.throughput.js
@@ -25,13 +25,14 @@ var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var noop = require( '@stdlib/utils/noop' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var inspectStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -57,7 +58,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput', function benchmark( b ) {
+bench( format( '%s::throughput', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -97,7 +98,7 @@ bench( pkg+'::throughput', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;

--- a/lib/node_modules/@stdlib/streams/node/join/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/join/benchmark/benchmark.throughput.js
@@ -24,13 +24,14 @@ var WritableStream = require( 'readable-stream' ).Writable; // eslint-disable-li
 var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var joinStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -56,7 +57,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput', function benchmark( b ) {
+bench( format( '%s::throughput', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -96,7 +97,7 @@ bench( pkg+'::throughput', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;

--- a/lib/node_modules/@stdlib/streams/node/split/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/split/benchmark/benchmark.throughput.js
@@ -24,13 +24,14 @@ var WritableStream = require( 'readable-stream' ).Writable; // eslint-disable-li
 var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var splitStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -56,7 +57,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput', function benchmark( b ) {
+bench( format( '%s::throughput', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -96,7 +97,7 @@ bench( pkg+'::throughput', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;

--- a/lib/node_modules/@stdlib/streams/node/transform/benchmark/benchmark.throughput.js
+++ b/lib/node_modules/@stdlib/streams/node/transform/benchmark/benchmark.throughput.js
@@ -24,13 +24,14 @@ var WritableStream = require( 'readable-stream' ).Writable; // eslint-disable-li
 var bench = require( '@stdlib/bench' );
 var inherit = require( '@stdlib/utils/inherit' );
 var nextTick = require( '@stdlib/utils/next-tick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var transformStream = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::throughput,baseline', function benchmark( b ) {
+bench( format( '%s::throughput,baseline', pkg ), function benchmark( b ) {
 	var i;
 
 	i = 0;
@@ -56,7 +57,7 @@ bench( pkg+'::throughput,baseline', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -102,7 +103,7 @@ bench( pkg+'::throughput:highWaterMark=<default>', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput:highWaterMark=0', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -149,7 +150,7 @@ bench( pkg+'::throughput:highWaterMark=0', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=<default>', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;
@@ -200,7 +201,7 @@ bench( pkg+'::throughput,object_mode:highWaterMark=<default>', function benchmar
 	}
 });
 
-bench( pkg+'::throughput,object_mode:highWaterMark=0', function benchmark( b ) {
+bench( format( '%s::throughput,object_mode:highWaterMark=0', pkg ), function benchmark( b ) {
 	var stream;
 	var opts;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#440

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/streams`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/streams stdlib-js/metr-issue-tracker#440

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers