### PR TITLE
bench: refactor to use string interpolation in `slice`

### DIFF
--- a/lib/node_modules/@stdlib/slice/base/args2multislice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/base/args2multislice/benchmark/benchmark.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var isMultiSlice = require( '@stdlib/assert/is-multi-slice' );
 var S = require( '@stdlib/slice/ctor' );
 var M = require( '@stdlib/slice/multi' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var args2multislice = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':ndims=0', function benchmark( b ) {
+bench( format( '%s:ndims=0', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -54,7 +55,7 @@ bench( pkg+':ndims=0', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::baseline:ndims=0', function benchmark( b ) {
+bench( format( '%s::baseline:ndims=0', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -78,7 +79,7 @@ bench( pkg+'::baseline:ndims=0', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=1', function benchmark( b ) {
+bench( format( '%s:ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -106,7 +107,7 @@ bench( pkg+':ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::baseline:ndims=1', function benchmark( b ) {
+bench( format( '%s::baseline:ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -134,7 +135,7 @@ bench( pkg+'::baseline:ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=2', function benchmark( b ) {
+bench( format( '%s:ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -163,7 +164,7 @@ bench( pkg+':ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::baseline:ndims=2', function benchmark( b ) {
+bench( format( '%s::baseline:ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -192,7 +193,7 @@ bench( pkg+'::baseline:ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=3', function benchmark( b ) {
+bench( format( '%s:ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -221,7 +222,7 @@ bench( pkg+':ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::baseline:ndims=3', function benchmark( b ) {
+bench( format( '%s::baseline:ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -250,7 +251,7 @@ bench( pkg+'::baseline:ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=4', function benchmark( b ) {
+bench( format( '%s:ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -280,7 +281,7 @@ bench( pkg+':ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::baseline:ndims=4', function benchmark( b ) {
+bench( format( '%s::baseline:ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -310,7 +311,7 @@ bench( pkg+'::baseline:ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=5', function benchmark( b ) {
+bench( format( '%s:ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -340,7 +341,7 @@ bench( pkg+':ndims=5', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::baseline:ndims=5', function benchmark( b ) {
+bench( format( '%s::baseline:ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;

--- a/lib/node_modules/@stdlib/slice/base/nonreduced-dimensions/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/base/nonreduced-dimensions/benchmark/benchmark.js
@@ -26,13 +26,14 @@ var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
 var S = require( '@stdlib/slice/ctor' );
 var MultiSlice = require( '@stdlib/slice/multi' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var nonreducedDimensions = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::ndims=1', function benchmark( b ) {
+bench( format( '%s::ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -72,7 +73,7 @@ bench( pkg+'::ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=2', function benchmark( b ) {
+bench( format( '%s::ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -112,7 +113,7 @@ bench( pkg+'::ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=3', function benchmark( b ) {
+bench( format( '%s::ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -152,7 +153,7 @@ bench( pkg+'::ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=4', function benchmark( b ) {
+bench( format( '%s::ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -192,7 +193,7 @@ bench( pkg+'::ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=5', function benchmark( b ) {
+bench( format( '%s::ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;

--- a/lib/node_modules/@stdlib/slice/base/normalize-multi-slice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/base/normalize-multi-slice/benchmark/benchmark.js
@@ -26,13 +26,14 @@ var bench = require( '@stdlib/bench' );
 var isMultiSlice = require( '@stdlib/assert/is-multi-slice' );
 var S = require( '@stdlib/slice/ctor' );
 var MultiSlice = require( '@stdlib/slice/multi' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var normalizeMultiSlice = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::ndims=1', function benchmark( b ) {
+bench( format( '%s::ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -74,7 +75,7 @@ bench( pkg+'::ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=2', function benchmark( b ) {
+bench( format( '%s::ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -116,7 +117,7 @@ bench( pkg+'::ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=3', function benchmark( b ) {
+bench( format( '%s::ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -158,7 +159,7 @@ bench( pkg+'::ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=4', function benchmark( b ) {
+bench( format( '%s::ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -200,7 +201,7 @@ bench( pkg+'::ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=5', function benchmark( b ) {
+bench( format( '%s::ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;

--- a/lib/node_modules/@stdlib/slice/base/reduced-dimensions/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/base/reduced-dimensions/benchmark/benchmark.js
@@ -26,13 +26,14 @@ var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
 var S = require( '@stdlib/slice/ctor' );
 var MultiSlice = require( '@stdlib/slice/multi' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reducedDimensions = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::ndims=1', function benchmark( b ) {
+bench( format( '%s::ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -72,7 +73,7 @@ bench( pkg+'::ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=2', function benchmark( b ) {
+bench( format( '%s::ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -112,7 +113,7 @@ bench( pkg+'::ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=3', function benchmark( b ) {
+bench( format( '%s::ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -152,7 +153,7 @@ bench( pkg+'::ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=4', function benchmark( b ) {
+bench( format( '%s::ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -192,7 +193,7 @@ bench( pkg+'::ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::ndims=5', function benchmark( b ) {
+bench( format( '%s::ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;

--- a/lib/node_modules/@stdlib/slice/base/sargs2multislice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/base/sargs2multislice/benchmark/benchmark.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isMultiSlice = require( '@stdlib/assert/is-multi-slice' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var sargs2multislice = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':ndims=0', function benchmark( b ) {
+bench( format( '%s:ndims=0', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -52,7 +53,7 @@ bench( pkg+':ndims=0', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=1', function benchmark( b ) {
+bench( format( '%s:ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -80,7 +81,7 @@ bench( pkg+':ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=2', function benchmark( b ) {
+bench( format( '%s:ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -110,7 +111,7 @@ bench( pkg+':ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=3', function benchmark( b ) {
+bench( format( '%s:ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -140,7 +141,7 @@ bench( pkg+':ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=4', function benchmark( b ) {
+bench( format( '%s:ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -171,7 +172,7 @@ bench( pkg+':ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=5', function benchmark( b ) {
+bench( format( '%s:ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;

--- a/lib/node_modules/@stdlib/slice/base/seq2multislice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/base/seq2multislice/benchmark/benchmark.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isMultiSlice = require( '@stdlib/assert/is-multi-slice' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var seq2multislice = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::1d', function benchmark( b ) {
+bench( format( '%s::1d', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -86,7 +87,7 @@ bench( pkg+'::1d', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::2d', function benchmark( b ) {
+bench( format( '%s::2d', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -120,7 +121,7 @@ bench( pkg+'::2d', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::3d', function benchmark( b ) {
+bench( format( '%s::3d', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -155,7 +156,7 @@ bench( pkg+'::3d', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::4d', function benchmark( b ) {
+bench( format( '%s::4d', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -190,7 +191,7 @@ bench( pkg+'::4d', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::5d', function benchmark( b ) {
+bench( format( '%s::5d', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;

--- a/lib/node_modules/@stdlib/slice/base/seq2slice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/base/seq2slice/benchmark/benchmark.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isSlice = require( '@stdlib/assert/is-slice' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var seq2slice = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::defaults', function benchmark( b ) {
+bench( format( '%s::defaults', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -53,7 +54,7 @@ bench( pkg+'::defaults', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::positive_integers', function benchmark( b ) {
+bench( format( '%s::positive_integers', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -83,7 +84,7 @@ bench( pkg+'::positive_integers', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::negative_integers', function benchmark( b ) {
+bench( format( '%s::negative_integers', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -113,7 +114,7 @@ bench( pkg+'::negative_integers', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::end,defaults', function benchmark( b ) {
+bench( format( '%s::end,defaults', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -139,7 +140,7 @@ bench( pkg+'::end,defaults', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::end,subtraction', function benchmark( b ) {
+bench( format( '%s::end,subtraction', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -167,7 +168,7 @@ bench( pkg+'::end,subtraction', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::end,division', function benchmark( b ) {
+bench( format( '%s::end,division', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;

--- a/lib/node_modules/@stdlib/slice/base/shape/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/base/shape/benchmark/benchmark.js
@@ -27,6 +27,7 @@ var isNonNegativeIntegerArray = require( '@stdlib/assert/is-nonnegative-integer-
 var S = require( '@stdlib/slice/ctor' );
 var MultiSlice = require( '@stdlib/slice/multi' );
 var normalizeMultiSlice = require( '@stdlib/slice/base/normalize-multi-slice' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var sliceShape = require( './../lib' );
 
@@ -55,7 +56,7 @@ var SLICES = [
 
 // MAIN //
 
-bench( pkg+':ndims=1', function benchmark( b ) {
+bench( format( '%s:ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -93,7 +94,7 @@ bench( pkg+':ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=2', function benchmark( b ) {
+bench( format( '%s:ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -133,7 +134,7 @@ bench( pkg+':ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=3', function benchmark( b ) {
+bench( format( '%s:ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -173,7 +174,7 @@ bench( pkg+':ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=4', function benchmark( b ) {
+bench( format( '%s:ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;
@@ -213,7 +214,7 @@ bench( pkg+':ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=5', function benchmark( b ) {
+bench( format( '%s:ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var shape;
 	var out;

--- a/lib/node_modules/@stdlib/slice/base/str2multislice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/base/str2multislice/benchmark/benchmark.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isMultiSlice = require( '@stdlib/assert/is-multi-slice' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var str2multislice = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':ndims=0', function benchmark( b ) {
+bench( format( '%s:ndims=0', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -53,7 +54,7 @@ bench( pkg+':ndims=0', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=1', function benchmark( b ) {
+bench( format( '%s:ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -80,7 +81,7 @@ bench( pkg+':ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=2', function benchmark( b ) {
+bench( format( '%s:ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -108,7 +109,7 @@ bench( pkg+':ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=3', function benchmark( b ) {
+bench( format( '%s:ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -136,7 +137,7 @@ bench( pkg+':ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=4', function benchmark( b ) {
+bench( format( '%s:ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -165,7 +166,7 @@ bench( pkg+':ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':ndims=5', function benchmark( b ) {
+bench( format( '%s:ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;

--- a/lib/node_modules/@stdlib/slice/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/ctor/benchmark/benchmark.js
@@ -25,13 +25,14 @@ var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isNull = require( '@stdlib/assert/is-null' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Slice = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation:nargs=1', function benchmark( b ) {
+bench( format( '%s::instantiation:nargs=1', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -50,7 +51,7 @@ bench( pkg+'::instantiation:nargs=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:nargs=1', function benchmark( b ) {
+bench( format( '%s::instantiation,new:nargs=1', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -69,7 +70,7 @@ bench( pkg+'::instantiation,new:nargs=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation:nargs=2', function benchmark( b ) {
+bench( format( '%s::instantiation:nargs=2', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -88,7 +89,7 @@ bench( pkg+'::instantiation:nargs=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:nargs=2', function benchmark( b ) {
+bench( format( '%s::instantiation,new:nargs=2', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -107,7 +108,7 @@ bench( pkg+'::instantiation,new:nargs=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation:nargs=3', function benchmark( b ) {
+bench( format( '%s::instantiation:nargs=3', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -126,7 +127,7 @@ bench( pkg+'::instantiation:nargs=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:nargs=3', function benchmark( b ) {
+bench( format( '%s::instantiation,new:nargs=3', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -145,7 +146,7 @@ bench( pkg+'::instantiation,new:nargs=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:start', function benchmark( b ) {
+bench( format( '%s::get:start', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -174,7 +175,7 @@ bench( pkg+'::get:start', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:stop', function benchmark( b ) {
+bench( format( '%s::get:stop', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -203,7 +204,7 @@ bench( pkg+'::get:stop', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:step', function benchmark( b ) {
+bench( format( '%s::get:step', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -232,7 +233,7 @@ bench( pkg+'::get:step', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toString', function benchmark( b ) {
+bench( format( '%s:toString', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -261,7 +262,7 @@ bench( pkg+':toString', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON', function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;

--- a/lib/node_modules/@stdlib/slice/multi/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/multi/benchmark/benchmark.js
@@ -26,13 +26,14 @@ var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isArray = require( '@stdlib/assert/is-array' );
 var Slice = require( '@stdlib/slice/ctor' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var MultiSlice = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation:nargs=1', function benchmark( b ) {
+bench( format( '%s::instantiation:nargs=1', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -51,7 +52,7 @@ bench( pkg+'::instantiation:nargs=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:nargs=1', function benchmark( b ) {
+bench( format( '%s::instantiation,new:nargs=1', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,new:nargs=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation:nargs=2', function benchmark( b ) {
+bench( format( '%s::instantiation:nargs=2', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -89,7 +90,7 @@ bench( pkg+'::instantiation:nargs=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:nargs=2', function benchmark( b ) {
+bench( format( '%s::instantiation,new:nargs=2', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -108,7 +109,7 @@ bench( pkg+'::instantiation,new:nargs=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation:nargs=3', function benchmark( b ) {
+bench( format( '%s::instantiation:nargs=3', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -127,7 +128,7 @@ bench( pkg+'::instantiation:nargs=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:nargs=3', function benchmark( b ) {
+bench( format( '%s::instantiation,new:nargs=3', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -146,7 +147,7 @@ bench( pkg+'::instantiation,new:nargs=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation:nargs=4', function benchmark( b ) {
+bench( format( '%s::instantiation:nargs=4', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -165,7 +166,7 @@ bench( pkg+'::instantiation:nargs=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:nargs=4', function benchmark( b ) {
+bench( format( '%s::instantiation,new:nargs=4', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -184,7 +185,7 @@ bench( pkg+'::instantiation,new:nargs=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation:nargs=5', function benchmark( b ) {
+bench( format( '%s::instantiation:nargs=5', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -203,7 +204,7 @@ bench( pkg+'::instantiation:nargs=5', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:nargs=5', function benchmark( b ) {
+bench( format( '%s::instantiation,new:nargs=5', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -222,7 +223,7 @@ bench( pkg+'::instantiation,new:nargs=5', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation:nargs=6', function benchmark( b ) {
+bench( format( '%s::instantiation:nargs=6', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -241,7 +242,7 @@ bench( pkg+'::instantiation:nargs=6', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:nargs=6', function benchmark( b ) {
+bench( format( '%s::instantiation,new:nargs=6', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 
@@ -260,7 +261,7 @@ bench( pkg+'::instantiation,new:nargs=6', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:ndims', function benchmark( b ) {
+bench( format( '%s::get:ndims', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -289,7 +290,7 @@ bench( pkg+'::get:ndims', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:data', function benchmark( b ) {
+bench( format( '%s::get:data', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -318,7 +319,7 @@ bench( pkg+'::get:data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toString:ndims=1', function benchmark( b ) {
+bench( format( '%s:toString:ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;
@@ -354,7 +355,7 @@ bench( pkg+':toString:ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toString:ndims=2', function benchmark( b ) {
+bench( format( '%s:toString:ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;
@@ -390,7 +391,7 @@ bench( pkg+':toString:ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toString:ndims=3', function benchmark( b ) {
+bench( format( '%s:toString:ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;
@@ -426,7 +427,7 @@ bench( pkg+':toString:ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toString:ndims=4', function benchmark( b ) {
+bench( format( '%s:toString:ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;
@@ -462,7 +463,7 @@ bench( pkg+':toString:ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toString:ndims=5', function benchmark( b ) {
+bench( format( '%s:toString:ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;
@@ -498,7 +499,7 @@ bench( pkg+':toString:ndims=5', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON:ndims=1', function benchmark( b ) {
+bench( format( '%s:toJSON:ndims=1', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;
@@ -534,7 +535,7 @@ bench( pkg+':toJSON:ndims=1', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON:ndims=2', function benchmark( b ) {
+bench( format( '%s:toJSON:ndims=2', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;
@@ -570,7 +571,7 @@ bench( pkg+':toJSON:ndims=2', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON:ndims=3', function benchmark( b ) {
+bench( format( '%s:toJSON:ndims=3', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;
@@ -606,7 +607,7 @@ bench( pkg+':toJSON:ndims=3', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON:ndims=4', function benchmark( b ) {
+bench( format( '%s:toJSON:ndims=4', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;
@@ -642,7 +643,7 @@ bench( pkg+':toJSON:ndims=4', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON:ndims=5', function benchmark( b ) {
+bench( format( '%s:toJSON:ndims=5', pkg ), function benchmark( b ) {
 	var values;
 	var slices;
 	var out;

--- a/lib/node_modules/@stdlib/slice/seq2slice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/slice/seq2slice/benchmark/benchmark.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isSlice = require( '@stdlib/assert/is-slice' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var seq2slice = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::defaults', function benchmark( b ) {
+bench( format( '%s::defaults', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -53,7 +54,7 @@ bench( pkg+'::defaults', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::positive_integers', function benchmark( b ) {
+bench( format( '%s::positive_integers', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -83,7 +84,7 @@ bench( pkg+'::positive_integers', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::negative_integers', function benchmark( b ) {
+bench( format( '%s::negative_integers', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -113,7 +114,7 @@ bench( pkg+'::negative_integers', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::end,defaults', function benchmark( b ) {
+bench( format( '%s::end,defaults', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -139,7 +140,7 @@ bench( pkg+'::end,defaults', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::end,subtraction', function benchmark( b ) {
+bench( format( '%s::end,subtraction', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;
@@ -167,7 +168,7 @@ bench( pkg+'::end,subtraction', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::end,division', function benchmark( b ) {
+bench( format( '%s::end,division', pkg ), function benchmark( b ) {
 	var values;
 	var out;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#441

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/slice`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/slice stdlib-js/metr-issue-tracker#441

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers