### PR TITLE
bench: refactor to use string interpolation in `simulate`

### DIFF
--- a/lib/node_modules/@stdlib/simulate/iter/awgn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/awgn/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var randu = require( '@stdlib/random/iter/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterawgn = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var rand;
 	var v;

--- a/lib/node_modules/@stdlib/simulate/iter/awln/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/awln/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var randu = require( '@stdlib/random/iter/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterawln = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var rand;
 	var v;

--- a/lib/node_modules/@stdlib/simulate/iter/awun/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/awun/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var randu = require( '@stdlib/random/iter/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterawun = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var rand;
 	var v;

--- a/lib/node_modules/@stdlib/simulate/iter/bartlett-hann-pulse/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/bartlett-hann-pulse/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterBartlettHannPulse = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/bartlett-pulse/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/bartlett-pulse/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterBartlettPulse = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/cosine-wave/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/cosine-wave/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCosineWave = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/dirac-comb/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/dirac-comb/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterDiracComb = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/flat-top-pulse/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/flat-top-pulse/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterFlatTopPulse = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/hann-pulse/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/hann-pulse/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterHannPulse = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/lanczos-pulse/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/lanczos-pulse/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterLanczosPulse = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/periodic-sinc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/periodic-sinc/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterPeriodicSinc = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration,odd_N', function benchmark( b ) {
+bench( format( '%s::iteration,odd_N', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::iteration,odd_N', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration,even_N', function benchmark( b ) {
+bench( format( '%s::iteration,even_N', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/pulse/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/pulse/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterPulse = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/sawtooth-wave/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/sawtooth-wave/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterSawtoothWave = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/sine-wave/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/sine-wave/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterSineWave = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/square-wave/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/square-wave/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterSquareWave = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/simulate/iter/triangle-wave/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/simulate/iter/triangle-wave/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterTriangleWave = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#442

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/simulate`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/simulate stdlib-js/metr-issue-tracker#442

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers