### PR TITLE
bench: refactor to use string interpolation in `repl`

### DIFF
--- a/lib/node_modules/@stdlib/repl/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/repl/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var inspectSinkStream = require( '@stdlib/streams/node/inspect-sink' );
 var randu = require( '@stdlib/random/streams/randu' );
+var format = require( '@stdlib/string/format' );
 var noop = require( '@stdlib/utils/noop' );
 var pkg = require( './../package.json' ).name;
 var REPL = require( './../lib' );
@@ -30,7 +31,7 @@ var REPL = require( './../lib' );
 
 // MAIN //
 
-bench( pkg+'::new', function benchmark( b ) {
+bench( format( '%s::new', pkg ), function benchmark( b ) {
 	var sopts;
 	var opts;
 	var r;
@@ -60,7 +61,7 @@ bench( pkg+'::new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_new', function benchmark( b ) {
+bench( format( '%s::no_new', pkg ), function benchmark( b ) {
 	var sopts;
 	var repl;
 	var opts;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#443

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/repl`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/repl stdlib-js/metr-issue-tracker#443

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers