### PR TITLE
bench: refactor to use string interpolation in `regexp`

### DIFF
--- a/lib/node_modules/@stdlib/regexp/basename/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/basename/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var fromCodePoint = require( '@stdlib/string/from-code-point' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reBasename = require( './../lib' );
 
@@ -64,7 +65,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':posix', function benchmark( b ) {
+bench( format( '%s:posix', pkg ), function benchmark( b ) {
 	var out;
 	var str;
 	var i;
@@ -86,7 +87,7 @@ bench( pkg+':posix', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':win32', function benchmark( b ) {
+bench( format( '%s:win32', pkg ), function benchmark( b ) {
 	var out;
 	var str;
 	var i;

--- a/lib/node_modules/@stdlib/regexp/color-hexadecimal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/color-hexadecimal/benchmark/benchmark.js
@@ -51,7 +51,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%sshorthand', pkg ), function benchmark( b ) {
+bench( format( '%s:shorthand', pkg ), function benchmark( b ) {
 	var bool;
 	var str;
 	var i;

--- a/lib/node_modules/@stdlib/regexp/color-hexadecimal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/color-hexadecimal/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var fromCodePoint = require( '@stdlib/string/from-code-point' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reColorHexadecimal = require( './../lib' );
 
@@ -50,7 +51,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'shorthand', function benchmark( b ) {
+bench( format( '%sshorthand', pkg ), function benchmark( b ) {
 	var bool;
 	var str;
 	var i;
@@ -71,7 +72,7 @@ bench( pkg+'shorthand', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':either', function benchmark( b ) {
+bench( format( '%s:either', pkg ), function benchmark( b ) {
 	var bool;
 	var str;
 	var i;

--- a/lib/node_modules/@stdlib/regexp/dirname/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/dirname/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var fromCodePoint = require( '@stdlib/string/from-code-point' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reDirname = require( './../lib' );
 
@@ -63,7 +64,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':posix', function benchmark( b ) {
+bench( format( '%s:posix', pkg ), function benchmark( b ) {
 	var out;
 	var str;
 	var i;
@@ -84,7 +85,7 @@ bench( pkg+':posix', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':win32', function benchmark( b ) {
+bench( format( '%s:win32', pkg ), function benchmark( b ) {
 	var out;
 	var str;
 	var i;

--- a/lib/node_modules/@stdlib/regexp/extname/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/extname/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var fromCodePoint = require( '@stdlib/string/from-code-point' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reExtname = require( './../lib' );
 
@@ -63,7 +64,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':posix', function benchmark( b ) {
+bench( format( '%s:posix', pkg ), function benchmark( b ) {
 	var out;
 	var str;
 	var i;
@@ -84,7 +85,7 @@ bench( pkg+':posix', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':win32', function benchmark( b ) {
+bench( format( '%s:win32', pkg ), function benchmark( b ) {
 	var out;
 	var str;
 	var i;

--- a/lib/node_modules/@stdlib/regexp/filename/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/filename/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
 var fromCodePoint = require( '@stdlib/string/from-code-point' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reFilename = require( './../lib' );
 
@@ -62,7 +63,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':posix', function benchmark( b ) {
+bench( format( '%s:posix', pkg ), function benchmark( b ) {
 	var out;
 	var str;
 	var i;
@@ -83,7 +84,7 @@ bench( pkg+':posix', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':win32', function benchmark( b ) {
+bench( format( '%s:win32', pkg ), function benchmark( b ) {
 	var out;
 	var str;
 	var i;

--- a/lib/node_modules/@stdlib/regexp/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var parseJSON = require( '@stdlib/utils/parse-json' );
 var regexp2json = require( '@stdlib/regexp/to-json' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reviver = require( './../lib' );
 
@@ -39,7 +40,7 @@ var VALUES = [
 
 // MAIN //
 
-bench( pkg+'::parse', function benchmark( b ) {
+bench( format( '%s::parse', pkg ), function benchmark( b ) {
 	var o;
 	var i;
 
@@ -58,7 +59,7 @@ bench( pkg+'::parse', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::parse,no_reviver', function benchmark( b ) {
+bench( format( '%s::parse,no_reviver', pkg ), function benchmark( b ) {
 	var o;
 	var i;
 


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#444

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/regexp`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/regexp stdlib-js/metr-issue-tracker#444

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers