### PR TITLE
bench: refactor to use string interpolation in `proxy`

### DIFF
--- a/lib/node_modules/@stdlib/proxy/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/proxy/ctor/benchmark/benchmark.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Proxy = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var handlers;
 	var p;
 	var i;
@@ -57,7 +58,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array,proxy,get', function benchmark( b ) {
+bench( format( '%s::array,proxy,get', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -95,7 +96,7 @@ bench( pkg+'::array,proxy,get', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::typed_array,proxy,get', function benchmark( b ) {
+bench( format( '%s::typed_array,proxy,get', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -130,7 +131,7 @@ bench( pkg+'::typed_array,proxy,get', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array,proxy,no_handlers,get', function benchmark( b ) {
+bench( format( '%s::array,proxy,no_handlers,get', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -162,7 +163,7 @@ bench( pkg+'::array,proxy,no_handlers,get', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array,proxy,no_handlers,get', function benchmark( b ) {
+bench( format( '%s::typed_array,proxy,no_handlers,get', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -192,7 +193,7 @@ bench( pkg+'::typed_array,proxy,no_handlers,get', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array,no_proxy,get', function benchmark( b ) {
+bench( format( '%s::array,no_proxy,get', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -220,7 +221,7 @@ bench( pkg+'::array,no_proxy,get', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array,no_proxy,get', function benchmark( b ) {
+bench( format( '%s::typed_array,no_proxy,get', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -245,7 +246,7 @@ bench( pkg+'::typed_array,no_proxy,get', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array,no_proxy,getter', function benchmark( b ) {
+bench( format( '%s::array,no_proxy,getter', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -279,7 +280,7 @@ bench( pkg+'::array,no_proxy,getter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::typed_array,no_proxy,getter', function benchmark( b ) {
+bench( format( '%s::typed_array,no_proxy,getter', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -309,7 +310,7 @@ bench( pkg+'::typed_array,no_proxy,getter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array,proxy,no_handlers,getter', function benchmark( b ) {
+bench( format( '%s::array,proxy,no_handlers,getter', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -348,7 +349,7 @@ bench( pkg+'::array,proxy,no_handlers,getter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::typed_array,proxy,no_handlers,getter', function benchmark( b ) {
+bench( format( '%s::typed_array,proxy,no_handlers,getter', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -383,7 +384,7 @@ bench( pkg+'::typed_array,proxy,no_handlers,getter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array,proxy,getter', function benchmark( b ) {
+bench( format( '%s::array,proxy,getter', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -428,7 +429,7 @@ bench( pkg+'::array,proxy,getter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::typed_array,proxy,getter', function benchmark( b ) {
+bench( format( '%s::typed_array,proxy,getter', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -469,7 +470,7 @@ bench( pkg+'::typed_array,proxy,getter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array,proxy,set', function benchmark( b ) {
+bench( format( '%s::array,proxy,set', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -508,7 +509,7 @@ bench( pkg+'::array,proxy,set', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::typed_array,proxy,set', function benchmark( b ) {
+bench( format( '%s::typed_array,proxy,set', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -545,7 +546,7 @@ bench( pkg+'::typed_array,proxy,set', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array,proxy,no_handlers,set', function benchmark( b ) {
+bench( format( '%s::array,proxy,no_handlers,set', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -578,7 +579,7 @@ bench( pkg+'::array,proxy,no_handlers,set', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array,proxy,no_handlers,set', function benchmark( b ) {
+bench( format( '%s::typed_array,proxy,no_handlers,set', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -608,7 +609,7 @@ bench( pkg+'::typed_array,proxy,no_handlers,set', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array,no_proxy,set', function benchmark( b ) {
+bench( format( '%s::array,no_proxy,set', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -636,7 +637,7 @@ bench( pkg+'::array,no_proxy,set', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array,no_proxy,set', function benchmark( b ) {
+bench( format( '%s::typed_array,no_proxy,set', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -661,7 +662,7 @@ bench( pkg+'::typed_array,no_proxy,set', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array,no_proxy,setter', function benchmark( b ) {
+bench( format( '%s::array,no_proxy,setter', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -695,7 +696,7 @@ bench( pkg+'::array,no_proxy,setter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::typed_array,no_proxy,setter', function benchmark( b ) {
+bench( format( '%s::typed_array,no_proxy,setter', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -725,7 +726,7 @@ bench( pkg+'::typed_array,no_proxy,setter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array,proxy,no_handlers,setter', function benchmark( b ) {
+bench( format( '%s::array,proxy,no_handlers,setter', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -764,7 +765,7 @@ bench( pkg+'::array,proxy,no_handlers,setter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::typed_array,proxy,no_handlers,setter', function benchmark( b ) {
+bench( format( '%s::typed_array,proxy,no_handlers,setter', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -799,7 +800,7 @@ bench( pkg+'::typed_array,proxy,no_handlers,setter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array,proxy,setter', function benchmark( b ) {
+bench( format( '%s::array,proxy,setter', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;
@@ -845,7 +846,7 @@ bench( pkg+'::array,proxy,setter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::typed_array,proxy,setter', function benchmark( b ) {
+bench( format( '%s::typed_array,proxy,setter', pkg ), function benchmark( b ) {
 	var handlers;
 	var arr;
 	var N;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#445

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/proxy`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/proxy stdlib-js/metr-issue-tracker#445

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers