### PR TITLE
bench: refactor to use string interpolation in `process`

### DIFF
--- a/lib/node_modules/@stdlib/process/cwd/benchmark/benchmark.polyfill.js
+++ b/lib/node_modules/@stdlib/process/cwd/benchmark/benchmark.polyfill.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cwd = require( './../lib/polyfill.js' );
 
 
 // MAIN //
 
-bench( pkg+'::polyfill', function benchmark( b ) {
+bench( format( '%s::polyfill', pkg ), function benchmark( b ) {
 	var dir;
 	var i;
 

--- a/lib/node_modules/@stdlib/process/getegid/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/process/getegid/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isNull = require( '@stdlib/assert/is-null' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var getegid = require( './../lib/polyfill.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var uid;
 	var i;
 

--- a/lib/node_modules/@stdlib/process/geteuid/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/process/geteuid/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isNull = require( '@stdlib/assert/is-null' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var geteuid = require( './../lib/polyfill.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var uid;
 	var i;
 

--- a/lib/node_modules/@stdlib/process/getgid/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/process/getgid/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isNull = require( '@stdlib/assert/is-null' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var getgid = require( './../lib/polyfill.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var uid;
 	var i;
 

--- a/lib/node_modules/@stdlib/process/getuid/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/process/getuid/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isNull = require( '@stdlib/assert/is-null' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var getuid = require( './../lib/polyfill.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var uid;
 	var i;
 

--- a/lib/node_modules/@stdlib/process/umask/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/process/umask/benchmark/benchmark.browser.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var umask = require( './../lib/browser.js' );
 
@@ -46,7 +47,7 @@ function restore() {
 
 // MAIN //
 
-bench( pkg+'::browser,get', function benchmark( b ) {
+bench( format( '%s::browser,get', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -66,7 +67,7 @@ bench( pkg+'::browser,get', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,get,options', function benchmark( b ) {
+bench( format( '%s::browser,get,options', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -86,7 +87,7 @@ bench( pkg+'::browser,get,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,get:symbolic=true', function benchmark( b ) {
+bench( format( '%s::browser,get:symbolic=true', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -111,7 +112,7 @@ bench( pkg+'::browser,get:symbolic=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,get:symbolic=false', function benchmark( b ) {
+bench( format( '%s::browser,get:symbolic=false', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -136,7 +137,7 @@ bench( pkg+'::browser,get:symbolic=false', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set', function benchmark( b ) {
+bench( format( '%s::browser,set', pkg ), function benchmark( b ) {
 	var m;
 	var v;
 	var i;
@@ -161,7 +162,7 @@ bench( pkg+'::browser,set', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set,symbolic,=', function benchmark( b ) {
+bench( format( '%s::browser,set,symbolic,=', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -183,7 +184,7 @@ bench( pkg+'::browser,set,symbolic,=', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set,symbolic,+', function benchmark( b ) {
+bench( format( '%s::browser,set,symbolic,+', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -205,7 +206,7 @@ bench( pkg+'::browser,set,symbolic,+', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set,symbolic,-', function benchmark( b ) {
+bench( format( '%s::browser,set,symbolic,-', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -227,7 +228,7 @@ bench( pkg+'::browser,set,symbolic,-', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set:symbolic=false', function benchmark( b ) {
+bench( format( '%s::browser,set:symbolic=false', pkg ), function benchmark( b ) {
 	var opts;
 	var m;
 	var v;
@@ -256,7 +257,7 @@ bench( pkg+'::browser,set:symbolic=false', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set,symbolic,=:symbolic=false', function benchmark( b ) {
+bench( format( '%s::browser,set,symbolic,=:symbolic=false', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -283,7 +284,7 @@ bench( pkg+'::browser,set,symbolic,=:symbolic=false', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set,symbolic,+:symbolic=false', function benchmark( b ) {
+bench( format( '%s::browser,set,symbolic,+:symbolic=false', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -310,7 +311,7 @@ bench( pkg+'::browser,set,symbolic,+:symbolic=false', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set,symbolic,-:symbolic=false', function benchmark( b ) {
+bench( format( '%s::browser,set,symbolic,-:symbolic=false', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -337,7 +338,7 @@ bench( pkg+'::browser,set,symbolic,-:symbolic=false', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set:symbolic=true', function benchmark( b ) {
+bench( format( '%s::browser,set:symbolic=true', pkg ), function benchmark( b ) {
 	var opts;
 	var m;
 	var v;
@@ -366,7 +367,7 @@ bench( pkg+'::browser,set:symbolic=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set,symbolic,=:symbolic=true', function benchmark( b ) {
+bench( format( '%s::browser,set,symbolic,=:symbolic=true', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -393,7 +394,7 @@ bench( pkg+'::browser,set,symbolic,=:symbolic=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set,symbolic,+:symbolic=true', function benchmark( b ) {
+bench( format( '%s::browser,set,symbolic,+:symbolic=true', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -420,7 +421,7 @@ bench( pkg+'::browser,set,symbolic,+:symbolic=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,set,symbolic,-:symbolic=true', function benchmark( b ) {
+bench( format( '%s::browser,set,symbolic,-:symbolic=true', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/process/umask/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/process/umask/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var umask = require( './../lib/browser.js' );
 
@@ -50,7 +51,7 @@ function restore() {
 
 // MAIN //
 
-bench( pkg+'::get', opts, function benchmark( b ) {
+bench( format( '%s::get', pkg ), opts, function benchmark( b ) {
 	var v;
 	var i;
 
@@ -70,7 +71,7 @@ bench( pkg+'::get', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get,options', opts, function benchmark( b ) {
+bench( format( '%s::get,options', pkg ), opts, function benchmark( b ) {
 	var v;
 	var i;
 
@@ -90,7 +91,7 @@ bench( pkg+'::get,options', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:symbolic=true', opts, function benchmark( b ) {
+bench( format( '%s::get:symbolic=true', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -115,7 +116,7 @@ bench( pkg+'::get:symbolic=true', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:symbolic=false', opts, function benchmark( b ) {
+bench( format( '%s::get:symbolic=false', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -140,7 +141,7 @@ bench( pkg+'::get:symbolic=false', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set', opts, function benchmark( b ) {
+bench( format( '%s::set', pkg ), opts, function benchmark( b ) {
 	var m;
 	var v;
 	var i;
@@ -165,7 +166,7 @@ bench( pkg+'::set', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,symbolic,=', opts, function benchmark( b ) {
+bench( format( '%s::set,symbolic,=', pkg ), opts, function benchmark( b ) {
 	var v;
 	var i;
 
@@ -187,7 +188,7 @@ bench( pkg+'::set,symbolic,=', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,symbolic,+', opts, function benchmark( b ) {
+bench( format( '%s::set,symbolic,+', pkg ), opts, function benchmark( b ) {
 	var v;
 	var i;
 
@@ -209,7 +210,7 @@ bench( pkg+'::set,symbolic,+', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,symbolic,-', opts, function benchmark( b ) {
+bench( format( '%s::set,symbolic,-', pkg ), opts, function benchmark( b ) {
 	var v;
 	var i;
 
@@ -231,7 +232,7 @@ bench( pkg+'::set,symbolic,-', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set:symbolic=false', opts, function benchmark( b ) {
+bench( format( '%s::set:symbolic=false', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var m;
 	var v;
@@ -260,7 +261,7 @@ bench( pkg+'::set:symbolic=false', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,symbolic,=:symbolic=false', opts, function benchmark( b ) {
+bench( format( '%s::set,symbolic,=:symbolic=false', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -287,7 +288,7 @@ bench( pkg+'::set,symbolic,=:symbolic=false', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,symbolic,+:symbolic=false', opts, function benchmark( b ) {
+bench( format( '%s::set,symbolic,+:symbolic=false', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -314,7 +315,7 @@ bench( pkg+'::set,symbolic,+:symbolic=false', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,symbolic,-:symbolic=false', opts, function benchmark( b ) {
+bench( format( '%s::set,symbolic,-:symbolic=false', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -341,7 +342,7 @@ bench( pkg+'::set,symbolic,-:symbolic=false', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set:symbolic=true', opts, function benchmark( b ) {
+bench( format( '%s::set:symbolic=true', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var m;
 	var v;
@@ -370,7 +371,7 @@ bench( pkg+'::set:symbolic=true', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,symbolic,=:symbolic=true', opts, function benchmark( b ) {
+bench( format( '%s::set,symbolic,=:symbolic=true', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -397,7 +398,7 @@ bench( pkg+'::set,symbolic,=:symbolic=true', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,symbolic,+:symbolic=true', opts, function benchmark( b ) {
+bench( format( '%s::set,symbolic,+:symbolic=true', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -424,7 +425,7 @@ bench( pkg+'::set,symbolic,+:symbolic=true', opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,symbolic,-:symbolic=true', opts, function benchmark( b ) {
+bench( format( '%s::set,symbolic,-:symbolic=true', pkg ), opts, function benchmark( b ) {
 	var opts;
 	var v;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#446

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/process`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/process stdlib-js/metr-issue-tracker#446

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers