### PR TITLE
bench: refactor to use string interpolation in `plot`

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/annotations/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/annotations/benchmark/benchmark.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Annotations = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var node;
 	var i;
 	b.tic();
@@ -45,7 +46,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var node;
 	var i;
@@ -67,7 +68,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':render', function benchmark( b ) {
+bench( format( '%s:render', pkg ), function benchmark( b ) {
 	var vtree;
 	var node;
 	var i;

--- a/lib/node_modules/@stdlib/plot/components/svg/defs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/defs/benchmark/benchmark.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Defs = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var node;
 	var i;
 	b.tic();
@@ -45,7 +46,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var node;
 	var i;
@@ -67,7 +68,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':render', function benchmark( b ) {
+bench( format( '%s:render', pkg ), function benchmark( b ) {
 	var vtree;
 	var node;
 	var i;

--- a/lib/node_modules/@stdlib/plot/components/svg/rug/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/rug/benchmark/benchmark.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var noop = require( '@stdlib/utils/noop' );
 var randu = require( '@stdlib/random/base/randu' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Rug = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var node;
 	var i;
 	b.tic();
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var node;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,options', function benchmark( b ) {
+bench( format( '%s::instantiation,options', pkg ), function benchmark( b ) {
 	var node;
 	var opts;
 	var i;
@@ -101,7 +102,7 @@ bench( pkg+'::instantiation,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:autoRender', function benchmark( b ) {
+bench( format( '%s::set,get:autoRender', pkg ), function benchmark( b ) {
 	var node;
 	var bool;
 	var i;
@@ -123,7 +124,7 @@ bench( pkg+'::set,get:autoRender', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:color', function benchmark( b ) {
+bench( format( '%s::set,get:color', pkg ), function benchmark( b ) {
 	var values;
 	var node;
 	var i;
@@ -149,7 +150,7 @@ bench( pkg+'::set,get:color', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:data', function benchmark( b ) {
+bench( format( '%s::set,get:data', pkg ), function benchmark( b ) {
 	var node;
 	var i;
 
@@ -170,7 +171,7 @@ bench( pkg+'::set,get:data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:isDefined', function benchmark( b ) {
+bench( format( '%s::set,get:isDefined', pkg ), function benchmark( b ) {
 	var node;
 	var i;
 
@@ -198,7 +199,7 @@ bench( pkg+'::set,get:isDefined', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::set,get:label', function benchmark( b ) {
+bench( format( '%s::set,get:label', pkg ), function benchmark( b ) {
 	var values;
 	var node;
 	var i;
@@ -224,7 +225,7 @@ bench( pkg+'::set,get:label', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:opacity', function benchmark( b ) {
+bench( format( '%s::set,get:opacity', pkg ), function benchmark( b ) {
 	var node;
 	var i;
 
@@ -245,7 +246,7 @@ bench( pkg+'::set,get:opacity', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:orientation', function benchmark( b ) {
+bench( format( '%s::set,get:orientation', pkg ), function benchmark( b ) {
 	var values;
 	var node;
 	var v;
@@ -275,7 +276,7 @@ bench( pkg+'::set,get:orientation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:scale', function benchmark( b ) {
+bench( format( '%s::set,get:scale', pkg ), function benchmark( b ) {
 	var node;
 	var i;
 
@@ -303,7 +304,7 @@ bench( pkg+'::set,get:scale', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::set,get:size', function benchmark( b ) {
+bench( format( '%s::set,get:size', pkg ), function benchmark( b ) {
 	var values;
 	var node;
 	var v;

--- a/lib/node_modules/@stdlib/plot/components/svg/rug/benchmark/benchmark.render.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/rug/benchmark/benchmark.render.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Rug = require( './../lib' );
 
@@ -99,7 +100,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':render:len='+len, f );
+		bench( format( '%s:render:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/plot/sparklines/base/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/base/ctor/benchmark/benchmark.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var noop = require( '@stdlib/utils/noop' );
 var randu = require( '@stdlib/random/base/randu' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Sparkline = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 	b.tic();
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var v;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,options', function benchmark( b ) {
+bench( format( '%s::instantiation,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -98,7 +99,7 @@ bench( pkg+'::instantiation,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data', function benchmark( b ) {
+bench( format( '%s::instantiation,data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -117,7 +118,7 @@ bench( pkg+'::instantiation,data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data,options', function benchmark( b ) {
+bench( format( '%s::instantiation,data,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -144,7 +145,7 @@ bench( pkg+'::instantiation,data,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:autoRender', function benchmark( b ) {
+bench( format( '%s::set,get:autoRender', pkg ), function benchmark( b ) {
 	var bool;
 	var v;
 	var i;
@@ -167,7 +168,7 @@ bench( pkg+'::set,get:autoRender', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
+bench( format( '%s::set,get:bufferSize', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -195,7 +196,7 @@ bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:data', function benchmark( b ) {
+bench( format( '%s::set,get:data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -217,7 +218,7 @@ bench( pkg+'::set,get:data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:description', function benchmark( b ) {
+bench( format( '%s::set,get:description', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -244,7 +245,7 @@ bench( pkg+'::set,get:description', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:isDefined', function benchmark( b ) {
+bench( format( '%s::set,get:isDefined', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -273,7 +274,7 @@ bench( pkg+'::set,get:isDefined', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::set,get:label', function benchmark( b ) {
+bench( format( '%s::set,get:label', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/benchmark/benchmark.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var noop = require( '@stdlib/utils/noop' );
 var randu = require( '@stdlib/random/base/randu' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var UnicodeSparkline = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 	b.tic();
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var v;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,options', function benchmark( b ) {
+bench( format( '%s::instantiation,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -102,7 +103,7 @@ bench( pkg+'::instantiation,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data', function benchmark( b ) {
+bench( format( '%s::instantiation,data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -121,7 +122,7 @@ bench( pkg+'::instantiation,data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data,options', function benchmark( b ) {
+bench( format( '%s::instantiation,data,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -152,7 +153,7 @@ bench( pkg+'::instantiation,data,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:autoRender', function benchmark( b ) {
+bench( format( '%s::set,get:autoRender', pkg ), function benchmark( b ) {
 	var bool;
 	var v;
 	var i;
@@ -174,7 +175,7 @@ bench( pkg+'::set,get:autoRender', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
+bench( format( '%s::set,get:bufferSize', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -201,7 +202,7 @@ bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:data', function benchmark( b ) {
+bench( format( '%s::set,get:data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -222,7 +223,7 @@ bench( pkg+'::set,get:data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:description', function benchmark( b ) {
+bench( format( '%s::set,get:description', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -248,7 +249,7 @@ bench( pkg+'::set,get:description', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:infinities', function benchmark( b ) {
+bench( format( '%s::set,get:infinities', pkg ), function benchmark( b ) {
 	var bool;
 	var v;
 	var i;
@@ -270,7 +271,7 @@ bench( pkg+'::set,get:infinities', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:isDefined', function benchmark( b ) {
+bench( format( '%s::set,get:isDefined', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -298,7 +299,7 @@ bench( pkg+'::set,get:isDefined', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::set,get:label', function benchmark( b ) {
+bench( format( '%s::set,get:label', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -324,7 +325,7 @@ bench( pkg+'::set,get:label', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:type', function benchmark( b ) {
+bench( format( '%s::set,get:type', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -353,7 +354,7 @@ bench( pkg+'::set,get:type', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:yMax', function benchmark( b ) {
+bench( format( '%s::set,get:yMax', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -374,7 +375,7 @@ bench( pkg+'::set,get:yMax', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:yMin', function benchmark( b ) {
+bench( format( '%s::set,get:yMin', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/benchmark/benchmark.render.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/benchmark/benchmark.render.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var UnicodeSparkline = require( './../lib' );
 
@@ -162,7 +163,7 @@ function main() {
 			'bufferSize': len
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:type=default,len='+len, f );
+		bench( format( '%s:render:type=default,len=%d', pkg, len ), f );
 
 		chart = new UnicodeSparkline({
 			'bufferSize': len,
@@ -170,14 +171,14 @@ function main() {
 			'yMax': 1.0
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+'::ymin,ymax:render:type=default,len='+len, f );
+		bench( format( '%s::ymin,ymax:render:type=default,len=%d', pkg, len ), f );
 
 		chart = new UnicodeSparkline({
 			'bufferSize': len,
 			'type': 'column'
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:type=column,len='+len, f );
+		bench( format( '%s:render:type=column,len=%d', pkg, len ), f );
 
 		chart = new UnicodeSparkline({
 			'bufferSize': len,
@@ -186,14 +187,14 @@ function main() {
 			'yMax': 1.0
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+'::ymin,ymax:render:type=column,len='+len, f );
+		bench( format( '%s::ymin,ymax:render:type=column,len=%d', pkg, len ), f );
 
 		chart = new UnicodeSparkline({
 			'bufferSize': len,
 			'type': 'line'
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:type=line,len='+len, f );
+		bench( format( '%s:render:type=line,len=%d', pkg, len ), f );
 
 		chart = new UnicodeSparkline({
 			'bufferSize': len,
@@ -202,28 +203,28 @@ function main() {
 			'yMax': 1.0
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+'::ymin,ymax:render:type=line,len='+len, f );
+		bench( format( '%s::ymin,ymax:render:type=line,len=%d', pkg, len ), f );
 
 		chart = new UnicodeSparkline({
 			'bufferSize': len,
 			'type': 'tristate'
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:type=tristate,len='+len, f );
+		bench( format( '%s:render:type=tristate,len=%d', pkg, len ), f );
 
 		chart = new UnicodeSparkline({
 			'bufferSize': len,
 			'type': 'up-down'
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:type=up-down,len='+len, f );
+		bench( format( '%s:render:type=up-down,len=%d', pkg, len ), f );
 
 		chart = new UnicodeSparkline({
 			'bufferSize': len,
 			'type': 'win-loss'
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:type=win-loss,len='+len, f );
+		bench( format( '%s:render:type=win-loss,len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/column/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/column/benchmark/benchmark.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var noop = require( '@stdlib/utils/noop' );
 var randu = require( '@stdlib/random/base/randu' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var ColumnChart = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 	b.tic();
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var v;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,options', function benchmark( b ) {
+bench( format( '%s::instantiation,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -101,7 +102,7 @@ bench( pkg+'::instantiation,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data', function benchmark( b ) {
+bench( format( '%s::instantiation,data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -120,7 +121,7 @@ bench( pkg+'::instantiation,data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data,options', function benchmark( b ) {
+bench( format( '%s::instantiation,data,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -150,7 +151,7 @@ bench( pkg+'::instantiation,data,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:autoRender', function benchmark( b ) {
+bench( format( '%s::set,get:autoRender', pkg ), function benchmark( b ) {
 	var bool;
 	var v;
 	var i;
@@ -172,7 +173,7 @@ bench( pkg+'::set,get:autoRender', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
+bench( format( '%s::set,get:bufferSize', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -199,7 +200,7 @@ bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:data', function benchmark( b ) {
+bench( format( '%s::set,get:data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -220,7 +221,7 @@ bench( pkg+'::set,get:data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:description', function benchmark( b ) {
+bench( format( '%s::set,get:description', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -246,7 +247,7 @@ bench( pkg+'::set,get:description', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:infinities', function benchmark( b ) {
+bench( format( '%s::set,get:infinities', pkg ), function benchmark( b ) {
 	var bool;
 	var v;
 	var i;
@@ -268,7 +269,7 @@ bench( pkg+'::set,get:infinities', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:isDefined', function benchmark( b ) {
+bench( format( '%s::set,get:isDefined', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -296,7 +297,7 @@ bench( pkg+'::set,get:isDefined', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::set,get:label', function benchmark( b ) {
+bench( format( '%s::set,get:label', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -322,7 +323,7 @@ bench( pkg+'::set,get:label', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:yMax', function benchmark( b ) {
+bench( format( '%s::set,get:yMax', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -343,7 +344,7 @@ bench( pkg+'::set,get:yMax', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:yMin', function benchmark( b ) {
+bench( format( '%s::set,get:yMin', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/column/benchmark/benchmark.render.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/column/benchmark/benchmark.render.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var ColumnChart = require( './../lib' );
 
@@ -101,7 +102,7 @@ function main() {
 			'bufferSize': len
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:len='+len, f );
+		bench( format( '%s:render:len=%d', pkg, len ), f );
 
 		chart = new ColumnChart({
 			'bufferSize': len,
@@ -109,7 +110,7 @@ function main() {
 			'yMax': 1.0
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+'::ymin,ymax:render:len='+len, f );
+		bench( format( '%s::ymin,ymax:render:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/tristate/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/tristate/benchmark/benchmark.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var noop = require( '@stdlib/utils/noop' );
 var randu = require( '@stdlib/random/base/randu' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var TristateChart = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 	b.tic();
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var v;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,options', function benchmark( b ) {
+bench( format( '%s::instantiation,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -98,7 +99,7 @@ bench( pkg+'::instantiation,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data', function benchmark( b ) {
+bench( format( '%s::instantiation,data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -117,7 +118,7 @@ bench( pkg+'::instantiation,data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data,options', function benchmark( b ) {
+bench( format( '%s::instantiation,data,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -144,7 +145,7 @@ bench( pkg+'::instantiation,data,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:autoRender', function benchmark( b ) {
+bench( format( '%s::set,get:autoRender', pkg ), function benchmark( b ) {
 	var bool;
 	var v;
 	var i;
@@ -166,7 +167,7 @@ bench( pkg+'::set,get:autoRender', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
+bench( format( '%s::set,get:bufferSize', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -193,7 +194,7 @@ bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:data', function benchmark( b ) {
+bench( format( '%s::set,get:data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -214,7 +215,7 @@ bench( pkg+'::set,get:data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:description', function benchmark( b ) {
+bench( format( '%s::set,get:description', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -240,7 +241,7 @@ bench( pkg+'::set,get:description', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:isDefined', function benchmark( b ) {
+bench( format( '%s::set,get:isDefined', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -268,7 +269,7 @@ bench( pkg+'::set,get:isDefined', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::set,get:label', function benchmark( b ) {
+bench( format( '%s::set,get:label', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/tristate/benchmark/benchmark.render.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/tristate/benchmark/benchmark.render.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Int8Array = require( '@stdlib/array/int8' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var TristateChart = require( './../lib' );
 
@@ -109,7 +110,7 @@ function main() {
 			'bufferSize': len
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:len='+len, f );
+		bench( format( '%s:render:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/up-down/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/up-down/benchmark/benchmark.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var noop = require( '@stdlib/utils/noop' );
 var randu = require( '@stdlib/random/base/randu' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var UpDownChart = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 	b.tic();
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var v;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,options', function benchmark( b ) {
+bench( format( '%s::instantiation,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -98,7 +99,7 @@ bench( pkg+'::instantiation,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data', function benchmark( b ) {
+bench( format( '%s::instantiation,data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -117,7 +118,7 @@ bench( pkg+'::instantiation,data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data,options', function benchmark( b ) {
+bench( format( '%s::instantiation,data,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -144,7 +145,7 @@ bench( pkg+'::instantiation,data,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:autoRender', function benchmark( b ) {
+bench( format( '%s::set,get:autoRender', pkg ), function benchmark( b ) {
 	var bool;
 	var v;
 	var i;
@@ -166,7 +167,7 @@ bench( pkg+'::set,get:autoRender', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
+bench( format( '%s::set,get:bufferSize', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -193,7 +194,7 @@ bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:data', function benchmark( b ) {
+bench( format( '%s::set,get:data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -214,7 +215,7 @@ bench( pkg+'::set,get:data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:description', function benchmark( b ) {
+bench( format( '%s::set,get:description', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -240,7 +241,7 @@ bench( pkg+'::set,get:description', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:isDefined', function benchmark( b ) {
+bench( format( '%s::set,get:isDefined', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -268,7 +269,7 @@ bench( pkg+'::set,get:isDefined', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::set,get:label', function benchmark( b ) {
+bench( format( '%s::set,get:label', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/up-down/benchmark/benchmark.render.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/up-down/benchmark/benchmark.render.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Int8Array = require( '@stdlib/array/int8' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var UpDownChart = require( './../lib' );
 
@@ -107,7 +108,7 @@ function main() {
 			'bufferSize': len
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:len='+len, f );
+		bench( format( '%s:render:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/win-loss/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/win-loss/benchmark/benchmark.js
@@ -24,13 +24,14 @@ var bench = require( '@stdlib/bench' );
 var noop = require( '@stdlib/utils/noop' );
 var randu = require( '@stdlib/random/base/randu' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var WinLossChart = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 	b.tic();
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var v;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,options', function benchmark( b ) {
+bench( format( '%s::instantiation,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -98,7 +99,7 @@ bench( pkg+'::instantiation,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data', function benchmark( b ) {
+bench( format( '%s::instantiation,data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -117,7 +118,7 @@ bench( pkg+'::instantiation,data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,data,options', function benchmark( b ) {
+bench( format( '%s::instantiation,data,options', pkg ), function benchmark( b ) {
 	var opts;
 	var v;
 	var i;
@@ -144,7 +145,7 @@ bench( pkg+'::instantiation,data,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:autoRender', function benchmark( b ) {
+bench( format( '%s::set,get:autoRender', pkg ), function benchmark( b ) {
 	var bool;
 	var v;
 	var i;
@@ -166,7 +167,7 @@ bench( pkg+'::set,get:autoRender', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
+bench( format( '%s::set,get:bufferSize', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -193,7 +194,7 @@ bench( pkg+'::set,get:bufferSize', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:data', function benchmark( b ) {
+bench( format( '%s::set,get:data', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -214,7 +215,7 @@ bench( pkg+'::set,get:data', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:description', function benchmark( b ) {
+bench( format( '%s::set,get:description', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -240,7 +241,7 @@ bench( pkg+'::set,get:description', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::set,get:isDefined', function benchmark( b ) {
+bench( format( '%s::set,get:isDefined', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 
@@ -268,7 +269,7 @@ bench( pkg+'::set,get:isDefined', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::set,get:label', function benchmark( b ) {
+bench( format( '%s::set,get:label', pkg ), function benchmark( b ) {
 	var values;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/win-loss/benchmark/benchmark.render.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/win-loss/benchmark/benchmark.render.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Int8Array = require( '@stdlib/array/int8' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var WinLossChart = require( './../lib' );
 
@@ -111,7 +112,7 @@ function main() {
 			'bufferSize': len
 		});
 		f = createBenchmark( len, chart );
-		bench( pkg+':render:len='+len, f );
+		bench( format( '%s:render:len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#447

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/plot`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/plot stdlib-js/metr-issue-tracker#447

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers