### PR TITLE
test: migrate `math/base/special/acosd` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acosd/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosd/test/test.js
@@ -22,7 +22,7 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
@@ -51,8 +51,6 @@ tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 
 tape( 'the function computes the arccosine in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -62,21 +60,13 @@ tape( 'the function computes the arccosine in degrees (negative values)', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosd( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosine in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -86,13 +76,7 @@ tape( 'the function computes the arccosine in degrees (positive values)', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosd( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosd/test/test.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
@@ -60,8 +60,6 @@ tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 
 tape( 'the function computes the arccosine in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -71,21 +69,13 @@ tape( 'the function computes the arccosine in degrees (negative values)', opts, 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosd( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosine in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,13 +85,7 @@ tape( 'the function computes the arccosine in degrees (positive values)', opts, 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosd( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Progresses #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-  Migrates test cases from relative error-based tolerance checks to ULP-based comparisons using `@stdlib/assert/is-almost-same-value` for `math/base/special/acosd`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- I had to set `maxULP` to 2 because the tests were failing with 1.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

NA

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
