### PR TITLE
bench: refactor to use string interpolation in `object`

### DIFF
--- a/lib/node_modules/@stdlib/object/any-in-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/any-in-by/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var anyInBy = require( './../lib' );
 
@@ -61,7 +62,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::built-in', function benchmark( b ) {
+bench( format( '%s::built-in', pkg ), function benchmark( b ) {
 	var bool;
 	var keys;
 	var obj;
@@ -98,7 +99,7 @@ bench( pkg+'::built-in', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var bool;
 	var keys;
 	var obj;

--- a/lib/node_modules/@stdlib/object/bifurcate-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/bifurcate-in/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var bifurcateIn = require( './../lib' );
 
@@ -61,7 +62,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::values', function benchmark( b ) {
+bench( format( '%s::values', pkg ), function benchmark( b ) {
 	var opts;
 	var key;
 	var obj;
@@ -97,7 +98,7 @@ bench( pkg+'::values', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::keys', function benchmark( b ) {
+bench( format( '%s::keys', pkg ), function benchmark( b ) {
 	var opts;
 	var key;
 	var obj;
@@ -133,7 +134,7 @@ bench( pkg+'::keys', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::pairs', function benchmark( b ) {
+bench( format( '%s::pairs', pkg ), function benchmark( b ) {
 	var opts;
 	var key;
 	var obj;
@@ -169,7 +170,7 @@ bench( pkg+'::pairs', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::this_context', function benchmark( b ) {
+bench( format( '%s::this_context', pkg ), function benchmark( b ) {
 	var opts;
 	var key;
 	var obj;

--- a/lib/node_modules/@stdlib/object/bifurcate-own/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/bifurcate-own/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var bifurcateOwn = require( './../lib' );
 
@@ -61,7 +62,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::values', function benchmark( b ) {
+bench( format( '%s::values', pkg ), function benchmark( b ) {
 	var opts;
 	var key;
 	var obj;
@@ -97,7 +98,7 @@ bench( pkg+'::values', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::keys', function benchmark( b ) {
+bench( format( '%s::keys', pkg ), function benchmark( b ) {
 	var opts;
 	var key;
 	var obj;
@@ -133,7 +134,7 @@ bench( pkg+'::keys', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::pairs', function benchmark( b ) {
+bench( format( '%s::pairs', pkg ), function benchmark( b ) {
 	var opts;
 	var key;
 	var obj;
@@ -169,7 +170,7 @@ bench( pkg+'::pairs', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::this_context', function benchmark( b ) {
+bench( format( '%s::this_context', pkg ), function benchmark( b ) {
 	var opts;
 	var key;
 	var obj;

--- a/lib/node_modules/@stdlib/object/common-keys-in/benchmark/benchmark.num_arguments.js
+++ b/lib/node_modules/@stdlib/object/common-keys-in/benchmark/benchmark.num_arguments.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
 var isEmptyArray = require( '@stdlib/assert/is-empty-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var commonKeysIn = require( './../lib' );
 
@@ -100,7 +101,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 2, i );
 		f = createBenchmark( len );
-		bench( pkg+':num_args='+len+',num_properties=10', f );
+		bench( format( '%s:num_args=%d,num_properties=10', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/object/common-keys-in/benchmark/benchmark.num_properties.js
+++ b/lib/node_modules/@stdlib/object/common-keys-in/benchmark/benchmark.num_properties.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
 var isEmptyArray = require( '@stdlib/assert/is-empty-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var commonKeysIn = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':num_properties='+len, f );
+		bench( format( '%s:num_properties=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/object/common-keys/benchmark/benchmark.num_arguments.js
+++ b/lib/node_modules/@stdlib/object/common-keys/benchmark/benchmark.num_arguments.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
 var isEmptyArray = require( '@stdlib/assert/is-empty-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var commonKeys = require( './../lib' );
 
@@ -100,7 +101,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 2, i );
 		f = createBenchmark( len );
-		bench( pkg+':num_args='+len+',num_properties=10', f );
+		bench( format( '%s:num_args=%d,num_properties=10', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/object/common-keys/benchmark/benchmark.num_properties.js
+++ b/lib/node_modules/@stdlib/object/common-keys/benchmark/benchmark.num_properties.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
 var isEmptyArray = require( '@stdlib/assert/is-empty-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var commonKeys = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':num_properties='+len, f );
+		bench( format( '%s:num_properties=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/object/deep-get/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/deep-get/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var deepGet = require( './../lib' );
 
@@ -61,7 +62,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::paths_array', function benchmark( b ) {
+bench( format( '%s::paths_array', pkg ), function benchmark( b ) {
 	var paths;
 	var arr;
 	var obj;
@@ -95,7 +96,7 @@ bench( pkg+'::paths_array', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var dget;
 	var arr;
 	var obj;

--- a/lib/node_modules/@stdlib/object/deep-set/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/deep-set/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var deepSet = require( './../lib' );
 
@@ -73,7 +74,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::setter', function benchmark( b ) {
+bench( format( '%s::setter', pkg ), function benchmark( b ) {
 	var bool;
 	var obj;
 	var i;
@@ -105,7 +106,7 @@ bench( pkg+'::setter', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':factory', function benchmark( b ) {
+bench( format( '%s:factory', pkg ), function benchmark( b ) {
 	var bool;
 	var dset;
 	var obj;

--- a/lib/node_modules/@stdlib/object/every-own-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/every-own-by/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var everyOwnBy = require( './../lib' );
 
@@ -60,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var bool;
 	var keys;
 	var obj;

--- a/lib/node_modules/@stdlib/object/for-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/for-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var forIn = require( './../lib' );
 
@@ -60,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var obj;
 	var key;
 	var i;

--- a/lib/node_modules/@stdlib/object/for-own/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/for-own/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var forOwn = require( './../lib' );
 
@@ -60,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var keys;
 	var obj;
 	var i;

--- a/lib/node_modules/@stdlib/object/inverse-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/inverse-by/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var invertBy = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':duplicates=true', function benchmark( b ) {
+bench( format( '%s:duplicates=true', pkg ), function benchmark( b ) {
 	var opts;
 	var obj;
 	var out;
@@ -94,7 +95,7 @@ bench( pkg+':duplicates=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':duplicates=false', function benchmark( b ) {
+bench( format( '%s:duplicates=false', pkg ), function benchmark( b ) {
 	var opts;
 	var obj;
 	var out;

--- a/lib/node_modules/@stdlib/object/inverse/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/inverse/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var invert = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':duplicates=true', function benchmark( b ) {
+bench( format( '%s:duplicates=true', pkg ), function benchmark( b ) {
 	var opts;
 	var obj;
 	var out;
@@ -88,7 +89,7 @@ bench( pkg+':duplicates=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':duplicates=false', function benchmark( b ) {
+bench( format( '%s:duplicates=false', pkg ), function benchmark( b ) {
 	var opts;
 	var obj;
 	var out;

--- a/lib/node_modules/@stdlib/object/none-in-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/none-in-by/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var noneInBy = require( './../lib' );
 
@@ -60,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::for-in-loop', function benchmark( b ) {
+bench( format( '%s::for-in-loop', pkg ), function benchmark( b ) {
 	var bool;
 	var obj;
 	var key;

--- a/lib/node_modules/@stdlib/object/some-in-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/some-in-by/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var someInBy = require( './../lib' );
 
@@ -61,7 +62,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg + '::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var total;
 	var count;
 	var bool;

--- a/lib/node_modules/@stdlib/object/some-own-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/some-own-by/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var someOwnBy = require( './../lib' );
 
@@ -61,7 +62,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var total;
 	var count;
 	var bool;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#448

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/object`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/object stdlib-js/metr-issue-tracker#448

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers