### PR TITLE
bench: refactor to use string interpolation in `nlp`

### DIFF
--- a/lib/node_modules/@stdlib/nlp/expand-acronyms/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/nlp/expand-acronyms/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var mobyDick = require( '@stdlib/datasets/moby-dick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var expandAcronyms = require( './../lib' );
 var ACRONYMS = require( './../lib/acronyms.json' );
@@ -51,7 +52,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::long_text', function benchmark( b ) {
+bench( format( '%s::long_text', pkg ), function benchmark( b ) {
 	var text;
 	var str;
 	var out;

--- a/lib/node_modules/@stdlib/nlp/expand-contractions/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/nlp/expand-contractions/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var mobyDick = require( '@stdlib/datasets/moby-dick' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var expandContractions = require( './../lib' );
 var CONTRACTIONS = require( './../lib/contractions.json' );
@@ -51,7 +52,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::long_text', function benchmark( b ) {
+bench( format( '%s::long_text', pkg ), function benchmark( b ) {
 	var text;
 	var str;
 	var out;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#450

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/nlp`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/nlp stdlib-js/metr-issue-tracker#450

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers