### PR TITLE
bench: refactor to use string interpolation in `lapack`

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/dladiv/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/dladiv/benchmark/benchmark.ndarray.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dladiv = require( './../lib/ndarray.js' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':ndarray', function benchmark( b ) {
+bench( format( '%s:ndarray', pkg ), function benchmark( b ) {
 	var re;
 	var im;
 	var N;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#453

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/lapack`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/lapack stdlib-js/metr-issue-tracker#453

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers