### PR TITLE
bench: refactor to use string interpolation in `iter`

### DIFF
--- a/lib/node_modules/@stdlib/iter/advance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/advance/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterAdvance = require( './../lib' );
 
@@ -83,7 +84,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var v;

--- a/lib/node_modules/@stdlib/iter/any-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/any-by/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterAnyBy = require( './../lib' );
 
@@ -91,7 +92,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var bool;
 	var arr;

--- a/lib/node_modules/@stdlib/iter/any/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/any/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterAny = require( './../lib' );
 
@@ -86,7 +87,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var bool;
 	var arr;

--- a/lib/node_modules/@stdlib/iter/concat/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/concat/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterConcat = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/constant/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/constant/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterConstant = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/iter/counter/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/counter/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCounter = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/cuany-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cuany-by/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var iterConstant = require( '@stdlib/iter/constant' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCuAnyBy = require( './../lib' );
 
@@ -66,7 +67,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/iter/cuany/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cuany/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var iterConstant = require( '@stdlib/iter/constant' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCuAny = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/iter/cuevery-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cuevery-by/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var iterConstant = require( '@stdlib/iter/constant' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCuEveryBy = require( './../lib' );
 
@@ -66,7 +67,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/iter/cuevery/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cuevery/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var iterConstant = require( '@stdlib/iter/constant' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCuEvery = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/iter/cunone-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var iterConstant = require( '@stdlib/iter/constant' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCuNoneBy = require( './../lib' );
 
@@ -66,7 +67,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/iter/cunone/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cunone/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var iterConstant = require( '@stdlib/iter/constant' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCuNone = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/iter/cusome-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cusome-by/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var iterConstant = require( '@stdlib/iter/constant' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCuSomeBy = require( './../lib' );
 
@@ -66,7 +67,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/iter/cusome/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cusome/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
 var iterConstant = require( '@stdlib/iter/constant' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterCuSome = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/iter/datespace/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/datespace/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterDatespace = require( './../lib' );
 
@@ -47,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/iter/dedupe-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/dedupe-by/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterDedupeBy = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/dedupe/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/dedupe/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterDedupe = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/do-until-each/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/do-until-each/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterator = require( './../lib' );
 
@@ -62,7 +63,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/do-while-each/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/do-while-each/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterDoWhileEach = require( './../lib' );
 
@@ -62,7 +63,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/empty/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/empty/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterEmpty = require( './../lib' );
 
@@ -47,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/iter/every-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/every-by/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterEveryBy = require( './../lib' );
 
@@ -91,7 +92,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var bool;
 	var arr;

--- a/lib/node_modules/@stdlib/iter/every/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/every/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterEvery = require( './../lib' );
 
@@ -87,7 +88,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var bool;
 	var arr;

--- a/lib/node_modules/@stdlib/iter/fill/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/fill/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterFill = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/filter-map/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/filter-map/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterFilterMap = require( './../lib' );
 
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/filter/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/filter/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterFilter = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/first/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/first/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterFirst = require( './../lib' );
 
@@ -87,7 +88,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var v;

--- a/lib/node_modules/@stdlib/iter/flow/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/flow/benchmark/benchmark.js
@@ -28,6 +28,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/iter/randu' );
 var iterHead = require( '@stdlib/iter/head' );
 var iterSomeBy = require( '@stdlib/iter/some-by' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterFlow = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::constructor,new', function benchmark( b ) {
+bench( format( '%s::constructor,new', pkg ), function benchmark( b ) {
 	var FluentIterator;
 	var src;
 	var it;
@@ -86,7 +87,7 @@ bench( pkg+'::constructor,new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::constructor,no_new', function benchmark( b ) {
+bench( format( '%s::constructor,no_new', pkg ), function benchmark( b ) {
 	var fluentIterator;
 	var src;
 	var it;
@@ -113,7 +114,7 @@ bench( pkg+'::constructor,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var FluentIterator;
 	var src;
 	var it;
@@ -143,7 +144,7 @@ bench( pkg+'::iteration', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::pipeline_throughput', function benchmark( b ) {
+bench( format( '%s::pipeline_throughput', pkg ), function benchmark( b ) {
 	var FluentIterator;
 	var bool;
 	var src;

--- a/lib/node_modules/@stdlib/iter/for-each/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/for-each/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterator = require( './../lib' );
 
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/head/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/head/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterHead = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/incrspace/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/incrspace/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterIncrspace = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/iter/intersection-by-hash/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/intersection-by-hash/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/iter/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterIntersectionByHash = require( './../lib' );
 
@@ -58,7 +59,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand1;
 	var rand2;
 	var iter;

--- a/lib/node_modules/@stdlib/iter/intersection/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/intersection/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/iter/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterIntersection = require( './../lib' );
 
@@ -54,7 +55,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand1;
 	var rand2;
 	var iter;

--- a/lib/node_modules/@stdlib/iter/last/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/last/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterLast = require( './../lib' );
 
@@ -87,7 +88,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var v;

--- a/lib/node_modules/@stdlib/iter/length/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/length/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterLength = require( './../lib' );
 
@@ -87,7 +88,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var count;
 	var arr;

--- a/lib/node_modules/@stdlib/iter/linspace/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/linspace/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterLinspace = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/iter/logspace/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/logspace/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterLogspace = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/iter/map/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/map/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterMap = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/mapn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/mapn/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterMapN = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/none-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/none-by/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterNoneBy = require( './../lib' );
 
@@ -91,7 +92,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var bool;
 	var arr;

--- a/lib/node_modules/@stdlib/iter/none/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/none/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterNone = require( './../lib' );
 
@@ -87,7 +88,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var bool;
 	var arr;

--- a/lib/node_modules/@stdlib/iter/nth/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/nth/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterNth = require( './../lib' );
 
@@ -87,7 +88,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var arr;
 	var v;

--- a/lib/node_modules/@stdlib/iter/pipeline/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/pipeline/benchmark/benchmark.js
@@ -27,13 +27,14 @@ var randu = require( '@stdlib/random/iter/randu' );
 var iterHead = require( '@stdlib/iter/head' );
 var iterSomeBy = require( '@stdlib/iter/some-by' );
 var iterThunk = require( '@stdlib/iter/pipeline-thunk' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterPipeline = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::arguments', function benchmark( b ) {
+bench( format( '%s::arguments', pkg ), function benchmark( b ) {
 	var fcn;
 	var it1;
 	var it2;
@@ -61,7 +62,7 @@ bench( pkg+'::arguments', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array', function benchmark( b ) {
+bench( format( '%s::array', pkg ), function benchmark( b ) {
 	var args;
 	var fcn;
 	var it1;
@@ -91,7 +92,7 @@ bench( pkg+'::array', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::pipeline_throughput', function benchmark( b ) {
+bench( format( '%s::pipeline_throughput', pkg ), function benchmark( b ) {
 	var bool;
 	var fcn;
 	var it0;

--- a/lib/node_modules/@stdlib/iter/pop/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/pop/benchmark/benchmark.js
@@ -25,6 +25,7 @@ var randu = require( '@stdlib/random/iter/randu' );
 var iterEmpty = require( '@stdlib/iter/empty' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterPop = require( './../lib' );
 
@@ -53,7 +54,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var it;
 	var z;

--- a/lib/node_modules/@stdlib/iter/reject/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/reject/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterReject = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/replicate-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/replicate-by/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterReplicateBy = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/replicate/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/replicate/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterReplicate = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/shift/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/shift/benchmark/benchmark.js
@@ -25,6 +25,7 @@ var randu = require( '@stdlib/random/iter/randu' );
 var iterEmpty = require( '@stdlib/iter/empty' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterShift = require( './../lib' );
 
@@ -53,7 +54,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var it;
 	var z;

--- a/lib/node_modules/@stdlib/iter/slice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/slice/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterSlice = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/some-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/some-by/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterSomeBy = require( './../lib' );
 
@@ -91,7 +92,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var count;
 	var bool;

--- a/lib/node_modules/@stdlib/iter/some/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/some/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterSome = require( './../lib' );
 
@@ -87,7 +88,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
 	var values;
 	var total;
 	var count;

--- a/lib/node_modules/@stdlib/iter/step/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/step/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterStep = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/iter/strided-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/strided-by/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterStridedBy = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/strided/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/strided/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterStrided = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/to-array-view-right/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/to-array-view-right/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var randu = require( '@stdlib/random/iter/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterator2arrayviewRight = require( './../lib' );
 
@@ -54,7 +55,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::map', function benchmark( b ) {
+bench( format( '%s::map', pkg ), function benchmark( b ) {
 	var out;
 	var arr;
 	var it;

--- a/lib/node_modules/@stdlib/iter/to-array-view/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/to-array-view/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var randu = require( '@stdlib/random/iter/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterator2arrayview = require( './../lib' );
 
@@ -54,7 +55,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::map', function benchmark( b ) {
+bench( format( '%s::map', pkg ), function benchmark( b ) {
 	var out;
 	var arr;
 	var it;

--- a/lib/node_modules/@stdlib/iter/union/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/union/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/iter/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterUnion = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/unique-by-hash/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/unique-by-hash/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/iter/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterUniqueByHash = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/unique-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/unique-by/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/iter/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterUniqueBy = require( './../lib' );
 
@@ -56,7 +57,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/unique/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/unique/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/iter/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterUnique = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/unitspace/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/unitspace/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterUnitspace = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var iter;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/iter/unshift/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/unshift/benchmark/benchmark.js
@@ -25,6 +25,7 @@ var randu = require( '@stdlib/random/iter/randu' );
 var iterEmpty = require( '@stdlib/iter/empty' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterUnshift = require( './../lib' );
 
@@ -53,7 +54,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var args;
 	var iter;
 	var it;

--- a/lib/node_modules/@stdlib/iter/until-each/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/until-each/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterator = require( './../lib' );
 
@@ -62,7 +63,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;

--- a/lib/node_modules/@stdlib/iter/while-each/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/while-each/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/iter/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var iterator = require( './../lib' );
 
@@ -62,7 +63,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iteration', function benchmark( b ) {
+bench( format( '%s::iteration', pkg ), function benchmark( b ) {
 	var rand;
 	var iter;
 	var z;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#454

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/iter`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/iter stdlib-js/metr-issue-tracker#454

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers