### PR TITLE
bench: refactor to use string interpolation in `function`

### DIFF
--- a/lib/node_modules/@stdlib/function/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/function/ctor/benchmark/benchmark.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Fcn = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var f;
 	var i;
 
@@ -46,7 +47,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::evaluation', function benchmark( b ) {
+bench( format( '%s::evaluation', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -68,7 +69,7 @@ bench( pkg+'::evaluation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::inline', function benchmark( b ) {
+bench( format( '%s::inline', pkg ), function benchmark( b ) {
 	var v;
 	var i;
 

--- a/lib/node_modules/@stdlib/function/thunk/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/function/thunk/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var thunk = require( './../lib' );
 
@@ -49,7 +50,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::thunk', function benchmark( b ) {
+bench( format( '%s::thunk', pkg ), function benchmark( b ) {
 	var fcn;
 	var out;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#455

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/function`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/function stdlib-js/metr-issue-tracker#455

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers