### PR TITLE
bench: refactor to use string interpolation in `fs`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/links/create/test/test.cli.js
+++ b/lib/node_modules/@stdlib/_tools/links/create/test/test.cli.js
@@ -153,7 +153,7 @@ tape( 'the command-line interface tries to insert an entry for the provided URI 
 
 	exec( cmd.join( ' ' ), done );
 
-	expected = 'Error: duplicate entry. Database already contains an entry for the provided URI: https://stdlib.io/.\n';
+	expected = 'Error: invalid argument. Database already contains an entry for the provided URI. Value: `https://stdlib.io/`.\n';
 
 	function done( error, stdout, stderr ) {
 		t.strictEqual( error instanceof Error, true, 'returns expected value' );
@@ -180,7 +180,7 @@ tape( 'the command-line interface tries to insert an entry for the provided URI 
 	child.stdin.write( 'A standard library for JavaScript and Node.js\n' );
 	child.stdin.end();
 
-	expected = 'Error: duplicate entry. Database already contains an entry for the provided URI: https://stdlib.io/.\n';
+	expected = 'Error: invalid argument. Database already contains an entry for the provided URI. Value: `https://stdlib.io/`.\n';
 
 	function done( error, stdout, stderr ) {
 		stdout = stdout.toString();

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var join = require( 'path' ).join;
 var bench = require( '@stdlib/bench' );
 var unlink = require( '@stdlib/fs/unlink' ).sync;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var appendFile = require( './../lib' );
 
@@ -62,7 +63,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/close/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/close/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var openSync = require( '@stdlib/fs/open' ).sync;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var close = require( './../lib' ); // eslint-disable-line stdlib/no-redeclare
 
@@ -55,7 +56,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var fd;
 	var i;

--- a/lib/node_modules/@stdlib/fs/exists/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/exists/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var exists = require( './../lib' );
 
@@ -57,7 +58,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var bool;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/open/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/open/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var closeSync = require( '@stdlib/fs/close' ).sync;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var open = require( './../lib' ); // eslint-disable-line stdlib/no-redeclare
 
@@ -55,7 +56,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var fd;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/read-dir/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/read-dir/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var readDir = require( './../lib' );
 
@@ -53,7 +54,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/read-file-list/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/read-file-list/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var readFileList = require( './../lib' );
 
@@ -62,7 +63,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/read-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/read-file/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var readFile = require( './../lib' );
 
@@ -53,7 +54,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/read-json/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/read-json/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var readJSON = require( './../lib' );
 
@@ -60,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/read-ndjson/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/read-ndjson/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var readNDJSON = require( './../lib' );
 
@@ -60,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/read-wasm/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/read-wasm/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var join = require( 'path' ).join;
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var readWASM = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/rename/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/rename/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var join = require( 'path' ).join;
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var rename = require( './../lib' );
 
@@ -81,7 +82,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var np;
 	var op;

--- a/lib/node_modules/@stdlib/fs/resolve-parent-path-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-path-by/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var resolveParentPathBy = require( './../lib' );
 
@@ -65,7 +66,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var opts;
 	var path;
 	var i;

--- a/lib/node_modules/@stdlib/fs/resolve-parent-path/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-path/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var resolveParentPath = require( './../lib' );
 
@@ -61,7 +62,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var opts;
 	var path;
 	var i;

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths/benchmark/benchmark.js
@@ -22,13 +22,14 @@
 
 var basename = require( 'path' ).basename;
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var resolveParentPaths = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':mode=first', function benchmark( b ) {
+bench( format( '%s:mode=first', pkg ), function benchmark( b ) {
 	var PATHS;
 	var opts;
 	var i;
@@ -69,7 +70,7 @@ bench( pkg+':mode=first', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':mode=some', function benchmark( b ) {
+bench( format( '%s:mode=some', pkg ), function benchmark( b ) {
 	var PATHS;
 	var opts;
 	var i;
@@ -110,7 +111,7 @@ bench( pkg+':mode=some', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':mode=all', function benchmark( b ) {
+bench( format( '%s:mode=all', pkg ), function benchmark( b ) {
 	var PATHS;
 	var opts;
 	var i;
@@ -150,7 +151,7 @@ bench( pkg+':mode=all', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':mode=each', function benchmark( b ) {
+bench( format( '%s:mode=each', pkg ), function benchmark( b ) {
 	var PATHS;
 	var opts;
 	var i;
@@ -192,7 +193,7 @@ bench( pkg+':mode=each', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync:mode=first', function benchmark( b ) {
+bench( format( '%s:sync:mode=first', pkg ), function benchmark( b ) {
 	var PATHS;
 	var paths;
 	var opts;
@@ -223,7 +224,7 @@ bench( pkg+':sync:mode=first', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:mode=some', function benchmark( b ) {
+bench( format( '%s:sync:mode=some', pkg ), function benchmark( b ) {
 	var PATHS;
 	var paths;
 	var opts;
@@ -254,7 +255,7 @@ bench( pkg+':sync:mode=some', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:mode=all', function benchmark( b ) {
+bench( format( '%s:sync:mode=all', pkg ), function benchmark( b ) {
 	var PATHS;
 	var paths;
 	var opts;
@@ -284,7 +285,7 @@ bench( pkg+':sync:mode=all', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:mode=each', function benchmark( b ) {
+bench( format( '%s:sync:mode=each', pkg ), function benchmark( b ) {
 	var PATHS;
 	var paths;
 	var opts;

--- a/lib/node_modules/@stdlib/fs/unlink/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/unlink/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var join = require( 'path' ).join;
 var bench = require( '@stdlib/bench' );
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var unlink = require( './../lib' );
 
@@ -75,7 +76,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 

--- a/lib/node_modules/@stdlib/fs/write-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/write-file/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var join = require( 'path' ).join;
 var bench = require( '@stdlib/bench' );
 var readFile = require( '@stdlib/fs/read-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var writeFile = require( './../lib' );
 
@@ -61,7 +62,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var out;
 	var i;
 


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#456

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/fs`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/fs stdlib-js/metr-issue-tracker#456

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers