### PR TITLE
bench: refactor to use string interpolation in `error`

### DIFF
--- a/lib/node_modules/@stdlib/error/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/error/reviver/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var parseJSON = require( '@stdlib/utils/parse-json' );
 var err2json = require( '@stdlib/error/to-json' );
+var format = require( '@stdlib/string/format' );
+var parseJSON = require( '@stdlib/utils/parse-json' );
 var pkg = require( './../package.json' ).name;
 var reviver = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver', function benchmark( b ) {
+bench( format( '%s::no_reviver', pkg ), function benchmark( b ) {
 	var errs;
 	var o;
 	var i;
@@ -89,7 +90,7 @@ bench( pkg+'::no_reviver', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver,built-in', function benchmark( b ) {
+bench( format( '%s::no_reviver,built-in', pkg ), function benchmark( b ) {
 	var errs;
 	var o;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#457

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/error`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/error stdlib-js/metr-issue-tracker#457

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers