### PR TITLE
bench: refactor to use string interpolation in `dstructs`

### DIFF
--- a/lib/node_modules/@stdlib/dstructs/doubly-linked-list/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/dstructs/doubly-linked-list/benchmark/benchmark.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var DoublyLinkedList = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation,new', function benchmark( b ) {
+bench( format( '%s::instantiation,new', pkg ), function benchmark( b ) {
 	var list;
 	var i;
 
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation,new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var linkedList;
 	var list;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':first', function benchmark( b ) {
+bench( format( '%s:first', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -97,7 +98,7 @@ bench( pkg+':first', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':insert,pop', function benchmark( b ) {
+bench( format( '%s:insert,pop', pkg ), function benchmark( b ) {
 	var list;
 	var n;
 	var v;
@@ -127,7 +128,7 @@ bench( pkg+':insert,pop', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':insert,pop:location=after', function benchmark( b ) {
+bench( format( '%s:insert,pop:location=after', pkg ), function benchmark( b ) {
 	var list;
 	var n;
 	var v;
@@ -157,7 +158,7 @@ bench( pkg+':insert,pop:location=after', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':insert,shift:location=before', function benchmark( b ) {
+bench( format( '%s:insert,shift:location=before', pkg ), function benchmark( b ) {
 	var list;
 	var n;
 	var v;
@@ -187,7 +188,7 @@ bench( pkg+':insert,shift:location=before', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':iterator', function benchmark( b ) {
+bench( format( '%s:iterator', pkg ), function benchmark( b ) {
 	var iter;
 	var list;
 	var i;
@@ -213,7 +214,7 @@ bench( pkg+':iterator', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':iterator:direction=forward', function benchmark( b ) {
+bench( format( '%s:iterator:direction=forward', pkg ), function benchmark( b ) {
 	var iter;
 	var list;
 	var i;
@@ -239,7 +240,7 @@ bench( pkg+':iterator:direction=forward', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':iterator:direction=reverse', function benchmark( b ) {
+bench( format( '%s:iterator:direction=reverse', pkg ), function benchmark( b ) {
 	var iter;
 	var list;
 	var i;
@@ -265,7 +266,7 @@ bench( pkg+':iterator:direction=reverse', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':last', function benchmark( b ) {
+bench( format( '%s:last', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -292,7 +293,7 @@ bench( pkg+':last', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':length', function benchmark( b ) {
+bench( format( '%s:length', pkg ), function benchmark( b ) {
 	var list;
 	var len;
 	var i;
@@ -319,7 +320,7 @@ bench( pkg+':length', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':push,pop', function benchmark( b ) {
+bench( format( '%s:push,pop', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -346,7 +347,7 @@ bench( pkg+':push,pop', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':push,remove', function benchmark( b ) {
+bench( format( '%s:push,remove', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -373,7 +374,7 @@ bench( pkg+':push,remove', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':push,shift', function benchmark( b ) {
+bench( format( '%s:push,shift', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -400,7 +401,7 @@ bench( pkg+':push,shift', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toArray', function benchmark( b ) {
+bench( format( '%s:toArray', pkg ), function benchmark( b ) {
 	var list;
 	var arr;
 	var i;
@@ -427,7 +428,7 @@ bench( pkg+':toArray', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON', function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var list;
 	var o;
 	var i;
@@ -454,7 +455,7 @@ bench( pkg+':toJSON', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':unshift,pop', function benchmark( b ) {
+bench( format( '%s:unshift,pop', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/dstructs/fifo/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/dstructs/fifo/benchmark/benchmark.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var FIFO = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation,new', function benchmark( b ) {
+bench( format( '%s::instantiation,new', pkg ), function benchmark( b ) {
 	var q;
 	var i;
 
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation,new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var fifo;
 	var q;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':first', function benchmark( b ) {
+bench( format( '%s:first', pkg ), function benchmark( b ) {
 	var v;
 	var q;
 	var i;
@@ -97,7 +98,7 @@ bench( pkg+':first', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':iterator', function benchmark( b ) {
+bench( format( '%s:iterator', pkg ), function benchmark( b ) {
 	var iter;
 	var q;
 	var i;
@@ -123,7 +124,7 @@ bench( pkg+':iterator', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':last', function benchmark( b ) {
+bench( format( '%s:last', pkg ), function benchmark( b ) {
 	var v;
 	var q;
 	var i;
@@ -150,7 +151,7 @@ bench( pkg+':last', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':length', function benchmark( b ) {
+bench( format( '%s:length', pkg ), function benchmark( b ) {
 	var len;
 	var q;
 	var i;
@@ -177,7 +178,7 @@ bench( pkg+':length', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':push,pop', function benchmark( b ) {
+bench( format( '%s:push,pop', pkg ), function benchmark( b ) {
 	var v;
 	var q;
 	var i;
@@ -204,7 +205,7 @@ bench( pkg+':push,pop', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toArray', function benchmark( b ) {
+bench( format( '%s:toArray', pkg ), function benchmark( b ) {
 	var arr;
 	var q;
 	var i;
@@ -231,7 +232,7 @@ bench( pkg+':toArray', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON', function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var o;
 	var q;
 	var i;

--- a/lib/node_modules/@stdlib/dstructs/linked-list/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/dstructs/linked-list/benchmark/benchmark.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var LinkedList = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation,new', function benchmark( b ) {
+bench( format( '%s::instantiation,new', pkg ), function benchmark( b ) {
 	var list;
 	var i;
 
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation,new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var linkedList;
 	var list;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':first', function benchmark( b ) {
+bench( format( '%s:first', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -97,7 +98,7 @@ bench( pkg+':first', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':insert,pop', function benchmark( b ) {
+bench( format( '%s:insert,pop', pkg ), function benchmark( b ) {
 	var list;
 	var n;
 	var v;
@@ -127,7 +128,7 @@ bench( pkg+':insert,pop', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':iterator', function benchmark( b ) {
+bench( format( '%s:iterator', pkg ), function benchmark( b ) {
 	var iter;
 	var list;
 	var i;
@@ -153,7 +154,7 @@ bench( pkg+':iterator', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':last', function benchmark( b ) {
+bench( format( '%s:last', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -180,7 +181,7 @@ bench( pkg+':last', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':length', function benchmark( b ) {
+bench( format( '%s:length', pkg ), function benchmark( b ) {
 	var list;
 	var len;
 	var i;
@@ -207,7 +208,7 @@ bench( pkg+':length', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':push,pop', function benchmark( b ) {
+bench( format( '%s:push,pop', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -234,7 +235,7 @@ bench( pkg+':push,pop', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':push,remove', function benchmark( b ) {
+bench( format( '%s:push,remove', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -261,7 +262,7 @@ bench( pkg+':push,remove', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':push,shift', function benchmark( b ) {
+bench( format( '%s:push,shift', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;
@@ -288,7 +289,7 @@ bench( pkg+':push,shift', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toArray', function benchmark( b ) {
+bench( format( '%s:toArray', pkg ), function benchmark( b ) {
 	var list;
 	var arr;
 	var i;
@@ -315,7 +316,7 @@ bench( pkg+':toArray', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON', function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var list;
 	var o;
 	var i;
@@ -342,7 +343,7 @@ bench( pkg+':toJSON', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':unshift,pop', function benchmark( b ) {
+bench( format( '%s:unshift,pop', pkg ), function benchmark( b ) {
 	var list;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.copy_within.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.copy_within.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':copyWithin', function benchmark( b ) {
+bench( format( '%s:copyWithin', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var i;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.copy_within.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.copy_within.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':copyWithin:len='+len, f );
+		bench( format( '%s:copyWithin:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.data.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.data.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::tuple,get,index', function benchmark( b ) {
+bench( format( '%s::tuple,get,index', pkg ), function benchmark( b ) {
 	var Point;
 	var N;
 	var p;
@@ -54,7 +55,7 @@ bench( pkg+'::tuple,get,index', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::tuple,get,property_name', function benchmark( b ) {
+bench( format( '%s::tuple,get,property_name', pkg ), function benchmark( b ) {
 	var fields;
 	var Point;
 	var N;
@@ -83,7 +84,7 @@ bench( pkg+'::tuple,get,property_name', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::tuple,set,index', function benchmark( b ) {
+bench( format( '%s::tuple,set,index', pkg ), function benchmark( b ) {
 	var Point;
 	var N;
 	var p;
@@ -109,7 +110,7 @@ bench( pkg+'::tuple,set,index', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::tuple,set,property_name', function benchmark( b ) {
+bench( format( '%s::tuple,set,property_name', pkg ), function benchmark( b ) {
 	var fields;
 	var Point;
 	var N;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.entries.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.entries.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':entries', function benchmark( b ) {
+bench( format( '%s:entries', pkg ), function benchmark( b ) {
 	var Point;
 	var iter;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.every.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.every.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':every', function benchmark( b ) {
+bench( format( '%s:every', pkg ), function benchmark( b ) {
 	var Point;
 	var bool;
 	var p;
@@ -56,7 +57,7 @@ bench( pkg+':every', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::this_context:every', function benchmark( b ) {
+bench( format( '%s::this_context:every', pkg ), function benchmark( b ) {
 	var Point;
 	var bool;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.every.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.every.length.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -109,7 +110,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':every:len='+len, f );
+		bench( format( '%s:every:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.field_of.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.field_of.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':fieldOf', function benchmark( b ) {
+bench( format( '%s:fieldOf', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.field_of.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.field_of.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':fieldOf:len='+len, f );
+		bench( format( '%s:fieldOf:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.fill.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.fill.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':fill', function benchmark( b ) {
+bench( format( '%s:fill', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var i;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.fill.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.fill.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -96,7 +97,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':fill:len='+len, f );
+		bench( format( '%s:fill:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.filter.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.filter.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':filter', function benchmark( b ) {
+bench( format( '%s:filter', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;
@@ -55,7 +56,7 @@ bench( pkg+':filter', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::this_context:filter', function benchmark( b ) {
+bench( format( '%s::this_context:filter', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.filter.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.filter.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -108,7 +109,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':filter:len='+len, f );
+		bench( format( '%s:filter:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':find', function benchmark( b ) {
+bench( format( '%s:find', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;
@@ -56,7 +57,7 @@ bench( pkg+':find', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::this_context:find', function benchmark( b ) {
+bench( format( '%s::this_context:find', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -108,7 +109,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':find:len='+len, f );
+		bench( format( '%s:find:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find_field.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find_field.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':findField', function benchmark( b ) {
+bench( format( '%s:findField', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;
@@ -56,7 +57,7 @@ bench( pkg+':findField', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::this_context:findField', function benchmark( b ) {
+bench( format( '%s::this_context:findField', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find_field.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find_field.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -108,7 +109,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':findField:len='+len, f );
+		bench( format( '%s:findField:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find_index.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find_index.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':findIndex', function benchmark( b ) {
+bench( format( '%s:findIndex', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;
@@ -56,7 +57,7 @@ bench( pkg+':findIndex', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::this_context:findIndex', function benchmark( b ) {
+bench( format( '%s::this_context:findIndex', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find_index.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.find_index.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -108,7 +109,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':findIndex:len='+len, f );
+		bench( format( '%s:findIndex:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.for_each.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.for_each.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':forEach', function benchmark( b ) {
+bench( format( '%s:forEach', pkg ), function benchmark( b ) {
 	var count;
 	var Point;
 	var N;
@@ -59,7 +60,7 @@ bench( pkg+':forEach', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::this_context:forEach', function benchmark( b ) {
+bench( format( '%s::this_context:forEach', pkg ), function benchmark( b ) {
 	var count;
 	var Point;
 	var N;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.for_each.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.for_each.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -107,7 +108,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':forEach:len='+len, f );
+		bench( format( '%s:forEach:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.from.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.from.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
@@ -36,7 +37,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::typed_array:from', function benchmark( b ) {
+bench( format( '%s::typed_array:from', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -60,7 +61,7 @@ bench( pkg+'::typed_array:from', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array,clbk:from', function benchmark( b ) {
+bench( format( '%s::typed_array,clbk:from', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -88,7 +89,7 @@ bench( pkg+'::typed_array,clbk:from', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array:from', function benchmark( b ) {
+bench( format( '%s::array:from', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -112,7 +113,7 @@ bench( pkg+'::array:from', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array,clbk:from', function benchmark( b ) {
+bench( format( '%s::array,clbk:from', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -140,7 +141,7 @@ bench( pkg+'::array,clbk:from', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iterable:from', opts, function benchmark( b ) {
+bench( format( '%s::iterable:from', pkg ), opts, function benchmark( b ) {
 	var Point;
 	var p;
 	var i;
@@ -193,7 +194,7 @@ bench( pkg+'::iterable:from', opts, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iterable,clbk:from:', opts, function benchmark( b ) {
+bench( format( '%s::iterable,clbk:from:', pkg ), opts, function benchmark( b ) {
 	var Point;
 	var p;
 	var i;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.from_object.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.from_object.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':fromObject', function benchmark( b ) {
+bench( format( '%s:fromObject', pkg ), function benchmark( b ) {
 	var Point;
 	var obj;
 	var p;
@@ -54,7 +55,7 @@ bench( pkg+':fromObject', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::clbk:fromObject', function benchmark( b ) {
+bench( format( '%s::clbk:fromObject', pkg ), function benchmark( b ) {
 	var Point;
 	var obj;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.includes.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.includes.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':includes', function benchmark( b ) {
+bench( format( '%s:includes', pkg ), function benchmark( b ) {
 	var Point;
 	var bool;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.includes.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.includes.length.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -98,7 +99,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':includes:len='+len, f );
+		bench( format( '%s:includes:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.ind2key.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.ind2key.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':ind2key', function benchmark( b ) {
+bench( format( '%s:ind2key', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var N;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.ind2key.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.ind2key.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -99,7 +100,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':ind2key:len='+len, f );
+		bench( format( '%s:ind2key:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.index_of.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.index_of.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':indexOf', function benchmark( b ) {
+bench( format( '%s:indexOf', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.index_of.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.index_of.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':indexOf:len='+len, f );
+		bench( format( '%s:indexOf:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.join.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.join.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':join', function benchmark( b ) {
+bench( format( '%s:join', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.join.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.join.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -98,7 +99,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':join:len='+len, f );
+		bench( format( '%s:join:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isFunction = require( '@stdlib/assert/is-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -47,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::options', function benchmark( b ) {
+bench( format( '%s::options', pkg ), function benchmark( b ) {
 	var Point;
 	var i;
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.key2ind.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.key2ind.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':key2ind', function benchmark( b ) {
+bench( format( '%s:key2ind', pkg ), function benchmark( b ) {
 	var fields;
 	var Point;
 	var out;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.key2ind.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.key2ind.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -101,7 +102,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':key2ind:len='+len, f );
+		bench( format( '%s:key2ind:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.keys.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.keys.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':keys', function benchmark( b ) {
+bench( format( '%s:keys', pkg ), function benchmark( b ) {
 	var Point;
 	var iter;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.last_field_of.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.last_field_of.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':lastFieldOf', function benchmark( b ) {
+bench( format( '%s:lastFieldOf', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.last_field_of.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.last_field_of.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':lastFieldOf:len='+len, f );
+		bench( format( '%s:lastFieldOf:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.last_index_of.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.last_index_of.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':lastIndexOf', function benchmark( b ) {
+bench( format( '%s:lastIndexOf', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.last_index_of.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.last_index_of.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':lastIndexOf:len='+len, f );
+		bench( format( '%s:lastIndexOf:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -95,7 +96,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.map.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.map.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':map', function benchmark( b ) {
+bench( format( '%s:map', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;
@@ -55,7 +56,7 @@ bench( pkg+':map', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::this_context:map', function benchmark( b ) {
+bench( format( '%s::this_context:map', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.map.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -108,7 +109,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':map:len='+len, f );
+		bench( format( '%s:map:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.of.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.of.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtyple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':of', function benchmark( b ) {
+bench( format( '%s:of', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var i;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.properties.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.properties.js
@@ -25,13 +25,14 @@ var isArrayBuffer = require( '@stdlib/assert/is-arraybuffer' );
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::tuple,get:buffer', function benchmark( b ) {
+bench( format( '%s::tuple,get:buffer', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var v;
@@ -56,7 +57,7 @@ bench( pkg+'::tuple,get:buffer', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::tuple,get:byteLength', function benchmark( b ) {
+bench( format( '%s::tuple,get:byteLength', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var v;
@@ -81,7 +82,7 @@ bench( pkg+'::tuple,get:byteLength', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::tuple,get:byteOffset', function benchmark( b ) {
+bench( format( '%s::tuple,get:byteOffset', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var v;
@@ -106,7 +107,7 @@ bench( pkg+'::tuple,get:byteOffset', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::tuple,get:length', function benchmark( b ) {
+bench( format( '%s::tuple,get:length', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var v;
@@ -131,7 +132,7 @@ bench( pkg+'::tuple,get:length', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::tuple,get:name', function benchmark( b ) {
+bench( format( '%s::tuple,get:name', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var v;
@@ -156,7 +157,7 @@ bench( pkg+'::tuple,get:name', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::tuple,get:fields', function benchmark( b ) {
+bench( format( '%s::tuple,get:fields', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var v;
@@ -180,7 +181,7 @@ bench( pkg+'::tuple,get:fields', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::tuple,get:orderedFields', function benchmark( b ) {
+bench( format( '%s::tuple,get:orderedFields', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var v;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reduce.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reduce.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':reduce', function benchmark( b ) {
+bench( format( '%s:reduce', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;
@@ -55,7 +56,7 @@ bench( pkg+':reduce', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::initial_value:reduce', function benchmark( b ) {
+bench( format( '%s::initial_value:reduce', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reduce.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reduce.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -109,7 +110,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':reduce:len='+len, f );
+		bench( format( '%s:reduce:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reduce_right.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reduce_right.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':reduceRight', function benchmark( b ) {
+bench( format( '%s:reduceRight', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;
@@ -55,7 +56,7 @@ bench( pkg+':reduceRight', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::initial_value:reduceRight', function benchmark( b ) {
+bench( format( '%s::initial_value:reduceRight', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reduce_right.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reduce_right.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -109,7 +110,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':reduceRight:len='+len, f );
+		bench( format( '%s:reduceRight:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reverse.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reverse.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':reverse', function benchmark( b ) {
+bench( format( '%s:reverse', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reverse.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.reverse.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':reverse:len='+len, f );
+		bench( format( '%s:reverse:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.set.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.set.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::array:set', function benchmark( b ) {
+bench( format( '%s::array:set', pkg ), function benchmark( b ) {
 	var values;
 	var Point;
 	var buf;
@@ -64,7 +65,7 @@ bench( pkg+'::array:set', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array:set', function benchmark( b ) {
+bench( format( '%s::typed_array:set', pkg ), function benchmark( b ) {
 	var values;
 	var Point;
 	var buf;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.set.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.set.length.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -112,7 +113,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':set:len='+len, f );
+		bench( format( '%s:set:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.slice.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.slice.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':slice', function benchmark( b ) {
+bench( format( '%s:slice', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.slice.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.slice.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':slice:len='+len, f );
+		bench( format( '%s:slice:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.some.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.some.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':some', function benchmark( b ) {
+bench( format( '%s:some', pkg ), function benchmark( b ) {
 	var Point;
 	var bool;
 	var p;
@@ -56,7 +57,7 @@ bench( pkg+':some', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::this_context:some', function benchmark( b ) {
+bench( format( '%s::this_context:some', pkg ), function benchmark( b ) {
 	var Point;
 	var bool;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.some.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.some.length.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -109,7 +110,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':some:len='+len, f );
+		bench( format( '%s:some:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.sort.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.sort.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':sort', function benchmark( b ) {
+bench( format( '%s:sort', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.sort.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.sort.length.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -104,7 +105,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':sort:len='+len, f );
+		bench( format( '%s:sort:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.subarray.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.subarray.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':subarray', function benchmark( b ) {
+bench( format( '%s:subarray', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.subarray.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.subarray.length.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -98,7 +99,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':subarray:len='+len, f );
+		bench( format( '%s:subarray:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.subtuple.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.subtuple.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':subtuple', function benchmark( b ) {
+bench( format( '%s:subtuple', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.subtuple.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.subtuple.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':subtuple:len='+len, f );
+		bench( format( '%s:subtuple:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_json.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_json.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':toJSON', function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_json.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_json.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':toJSON:len='+len, f );
+		bench( format( '%s:toJSON:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_locale_string.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_locale_string.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':toLocaleString', function benchmark( b ) {
+bench( format( '%s:toLocaleString', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_locale_string.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_locale_string.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':toLocaleString:len='+len, f );
+		bench( format( '%s:toLocaleString:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_string.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_string.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':toString', function benchmark( b ) {
+bench( format( '%s:toString', pkg ), function benchmark( b ) {
 	var Point;
 	var out;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_string.length.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.to_string.length.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
@@ -97,7 +98,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':toString:len='+len, f );
+		bench( format( '%s:toString:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.tuple_instantiation.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.tuple_instantiation.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var ArrayBuffer = require( '@stdlib/array/buffer' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
@@ -37,7 +38,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::instantiation,new', function benchmark( b ) {
+bench( format( '%s::instantiation,new', pkg ), function benchmark( b ) {
 	var Point;
 	var p;
 	var i;
@@ -59,7 +60,7 @@ bench( pkg+'::instantiation,new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var point;
 	var p;
 	var i;
@@ -81,7 +82,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,typed_array', function benchmark( b ) {
+bench( format( '%s::instantiation,typed_array', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -105,7 +106,7 @@ bench( pkg+'::instantiation,typed_array', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,typed_array,dtype', function benchmark( b ) {
+bench( format( '%s::instantiation,typed_array,dtype', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -129,7 +130,7 @@ bench( pkg+'::instantiation,typed_array,dtype', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,array', function benchmark( b ) {
+bench( format( '%s::instantiation,array', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -153,7 +154,7 @@ bench( pkg+'::instantiation,array', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,array,dtype', function benchmark( b ) {
+bench( format( '%s::instantiation,array,dtype', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -177,7 +178,7 @@ bench( pkg+'::instantiation,array,dtype', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,iterable', opts, function benchmark( b ) {
+bench( format( '%s::instantiation,iterable', pkg ), opts, function benchmark( b ) {
 	var Point;
 	var p;
 	var i;
@@ -229,7 +230,7 @@ bench( pkg+'::instantiation,iterable', opts, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::instantiation,iterable,dtype', opts, function benchmark( b ) {
+bench( format( '%s::instantiation,iterable,dtype', pkg ), opts, function benchmark( b ) {
 	var Point;
 	var p;
 	var i;
@@ -281,7 +282,7 @@ bench( pkg+'::instantiation,iterable,dtype', opts, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::instantiation,arraybuffer', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -305,7 +306,7 @@ bench( pkg+'::instantiation,arraybuffer', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,dtype', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,dtype', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -329,7 +330,7 @@ bench( pkg+'::instantiation,arraybuffer,dtype', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;
@@ -353,7 +354,7 @@ bench( pkg+'::instantiation,arraybuffer,byte_offset', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset,dtype', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset,dtype', pkg ), function benchmark( b ) {
 	var Point;
 	var buf;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.values.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/benchmark/benchmark.values.js
@@ -21,13 +21,14 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var namedtypedtuple = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+':values', function benchmark( b ) {
+bench( format( '%s:values', pkg ), function benchmark( b ) {
 	var Point;
 	var iter;
 	var p;

--- a/lib/node_modules/@stdlib/dstructs/stack/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/dstructs/stack/benchmark/benchmark.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Stack = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation,new', function benchmark( b ) {
+bench( format( '%s::instantiation,new', pkg ), function benchmark( b ) {
 	var s;
 	var i;
 
@@ -48,7 +49,7 @@ bench( pkg+'::instantiation,new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var stack;
 	var s;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':first', function benchmark( b ) {
+bench( format( '%s:first', pkg ), function benchmark( b ) {
 	var v;
 	var s;
 	var i;
@@ -97,7 +98,7 @@ bench( pkg+':first', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':iterator', function benchmark( b ) {
+bench( format( '%s:iterator', pkg ), function benchmark( b ) {
 	var iter;
 	var s;
 	var i;
@@ -123,7 +124,7 @@ bench( pkg+':iterator', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':last', function benchmark( b ) {
+bench( format( '%s:last', pkg ), function benchmark( b ) {
 	var v;
 	var s;
 	var i;
@@ -150,7 +151,7 @@ bench( pkg+':last', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':length', function benchmark( b ) {
+bench( format( '%s:length', pkg ), function benchmark( b ) {
 	var len;
 	var s;
 	var i;
@@ -177,7 +178,7 @@ bench( pkg+':length', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':push,pop', function benchmark( b ) {
+bench( format( '%s:push,pop', pkg ), function benchmark( b ) {
 	var v;
 	var s;
 	var i;
@@ -204,7 +205,7 @@ bench( pkg+':push,pop', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toArray', function benchmark( b ) {
+bench( format( '%s:toArray', pkg ), function benchmark( b ) {
 	var arr;
 	var s;
 	var i;
@@ -231,7 +232,7 @@ bench( pkg+':toArray', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON', function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var o;
 	var s;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#458

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/dstructs`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/dstructs stdlib-js/metr-issue-tracker#458

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers