### PR TITLE
bench: refactor to use string interpolation in `datasets`

### DIFF
--- a/lib/node_modules/@stdlib/datasets/afinn-111/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/afinn-111/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var afinn111 = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/afinn-96/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/afinn-96/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var afinn96 = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/anscombes-quartet/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/anscombes-quartet/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var data = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var d;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/berndt-cps-wages-1985/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/berndt-cps-wages-1985/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/cdc-nchs-us-births-1969-1988/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/cdc-nchs-us-births-1969-1988/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/cdc-nchs-us-births-1994-2003/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/cdc-nchs-us-births-1994-2003/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/cdc-nchs-us-infant-mortality-bw-1915-2013/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/cdc-nchs-us-infant-mortality-bw-1915-2013/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/cmudict/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/cmudict/benchmark/benchmark.browser.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cmudict = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();
@@ -47,7 +48,7 @@ bench( pkg+'::browser', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,subset', function benchmark( b ) {
+bench( format( '%s::browser,subset', pkg ), function benchmark( b ) {
 	var options;
 	var data;
 	var i;

--- a/lib/node_modules/@stdlib/datasets/cmudict/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/datasets/cmudict/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var isArray = require( '@stdlib/assert/is-array' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cmudict = require( './../lib' );
 
@@ -55,7 +56,7 @@ bench( pkg, opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::subset', opts, function benchmark( b ) {
+bench( format( '%s::subset', pkg ), opts, function benchmark( b ) {
 	var options;
 	var data;
 	var i;

--- a/lib/node_modules/@stdlib/datasets/dale-chall-new/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/dale-chall-new/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var words = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/emoji-code-picto/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/emoji-code-picto/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var table = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/emoji-picto-code/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/emoji-picto-code/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var table = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/emoji/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/emoji/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/female-first-names-en/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/female-first-names-en/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var names = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/fivethirtyeight-ffq/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/fivethirtyeight-ffq/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/frb-sf-wage-rigidity/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/frb-sf-wage-rigidity/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var wages = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/harrison-boston-house-prices-corrected/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/harrison-boston-house-prices-corrected/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/harrison-boston-house-prices/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/harrison-boston-house-prices/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/herndon-venus-semidiameters/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/herndon-venus-semidiameters/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var data = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var d;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-acanthus-mollis/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-acanthus-mollis/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-airplane-from-above/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-airplane-from-above/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-allium-oreophilum/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-allium-oreophilum/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-black-canyon/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-black-canyon/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-dust-bowl-home/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-dust-bowl-home/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-french-alpine-landscape/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-french-alpine-landscape/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-locomotion-house-cat/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-locomotion-house-cat/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-locomotion-nude-male/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-locomotion-nude-male/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-march-pastoral/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-march-pastoral/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/img-nagasaki-boats/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/img-nagasaki-boats/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var image = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/liu-negative-opinion-words-en/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/liu-negative-opinion-words-en/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var words = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/liu-positive-opinion-words-en/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/liu-positive-opinion-words-en/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var words = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/male-first-names-en/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/male-first-names-en/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var names = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/minard-napoleons-march/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/minard-napoleons-march/benchmark/benchmark.browser.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var minard = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();
@@ -47,7 +48,7 @@ bench( pkg+'::browser', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::browser,subset', function benchmark( b ) {
+bench( format( '%s::browser,subset', pkg ), function benchmark( b ) {
 	var options;
 	var data;
 	var i;

--- a/lib/node_modules/@stdlib/datasets/minard-napoleons-march/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/datasets/minard-napoleons-march/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var minard = require( './../lib' );
 
@@ -55,7 +56,7 @@ bench( pkg, opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::subset', opts, function benchmark( b ) {
+bench( format( '%s::subset', pkg ), opts, function benchmark( b ) {
 	var options;
 	var data;
 	var i;

--- a/lib/node_modules/@stdlib/datasets/moby-dick/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/moby-dick/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var text = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/month-names-en/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/month-names-en/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var months = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/nightingales-rose/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/nightingales-rose/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var rose = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/pace-boston-house-prices/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/pace-boston-house-prices/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/primes-100k/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/primes-100k/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isPositiveIntegerArray = require( '@stdlib/assert/is-positive-integer-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var primes = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/savoy-stopwords-fin/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/savoy-stopwords-fin/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stopwords = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/savoy-stopwords-fr/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/savoy-stopwords-fr/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stopwords = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/savoy-stopwords-ger/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/savoy-stopwords-ger/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stopwords = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/savoy-stopwords-it/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/savoy-stopwords-it/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stopwords = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/savoy-stopwords-por/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/savoy-stopwords-por/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stopwords = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/savoy-stopwords-sp/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/savoy-stopwords-sp/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stopwords = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/savoy-stopwords-swe/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/savoy-stopwords-swe/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stopwords = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/sotu/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/datasets/sotu/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var sotu = require( './../lib' );
 
@@ -54,7 +55,7 @@ bench( pkg, opts, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::subset', opts, function benchmark( b ) {
+bench( format( '%s::subset', pkg ), opts, function benchmark( b ) {
 	var options;
 	var data;
 	var i;

--- a/lib/node_modules/@stdlib/datasets/spache-revised/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/spache-revised/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var words = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/spam-assassin/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/spam-assassin/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var corpus = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/ssa-us-births-2000-2014/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/ssa-us-births-2000-2014/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var dataset = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/standard-card-deck/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/standard-card-deck/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cards = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/stopwords-en/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/stopwords-en/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var stopwords = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/suthaharan-multi-hop-sensor-network/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/suthaharan-multi-hop-sensor-network/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var data = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var d;
 	var i;
 

--- a/lib/node_modules/@stdlib/datasets/suthaharan-single-hop-sensor-network/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/suthaharan-single-hop-sensor-network/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isObjectArray = require( '@stdlib/assert/is-plain-object-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var data = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var d;
 	var i;
 

--- a/lib/node_modules/@stdlib/datasets/us-states-abbr/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/us-states-abbr/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var abbr = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/us-states-capitals-names/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/us-states-capitals-names/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var table = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/us-states-capitals/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/us-states-capitals/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var capitals = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/us-states-names-capitals/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/us-states-names-capitals/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var table = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/datasets/us-states-names/benchmark/benchmark.browser.js
+++ b/lib/node_modules/@stdlib/datasets/us-states-names/benchmark/benchmark.browser.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isStringArray = require( '@stdlib/assert/is-string-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var names = require( './../lib/browser.js' );
 
 
 // MAIN //
 
-bench( pkg+'::browser', function benchmark( b ) {
+bench( format( '%s::browser', pkg ), function benchmark( b ) {
 	var data;
 	var i;
 	b.tic();


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#459

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/datasets`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/datasets stdlib-js/metr-issue-tracker#459

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers