### PR TITLE
bench: refactor to use string interpolation in `console`

### DIFF
--- a/lib/node_modules/@stdlib/console/log-each-map/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/console/log-each-map/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var proxyquire = require( 'proxyquire' );
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ function clbk( x ) {
 
 // MAIN //
 
-bench( pkg+'::no_collections', function benchmark( b ) {
+bench( format( '%s::no_collections', pkg ), function benchmark( b ) {
 	var logEachMap;
 	var i;
 
@@ -64,7 +65,7 @@ bench( pkg+'::no_collections', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::collections:len=1', function benchmark( b ) {
+bench( format( '%s::collections:len=1', pkg ), function benchmark( b ) {
 	var logEachMap;
 	var i;
 
@@ -87,7 +88,7 @@ bench( pkg+'::collections:len=1', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::collections:len=2', function benchmark( b ) {
+bench( format( '%s::collections:len=2', pkg ), function benchmark( b ) {
 	var logEachMap;
 	var i;
 

--- a/lib/node_modules/@stdlib/console/log-each-map/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/console/log-each-map/benchmark/benchmark.length.js
@@ -24,6 +24,7 @@ var proxyquire = require( 'proxyquire' );
 var bench = require( '@stdlib/bench' );
 var zeros = require( '@stdlib/array/zeros' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -102,7 +103,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::collections:len='+len, f );
+		bench( format( '%s::collections:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/console/log-each/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/console/log-each/benchmark/benchmark.js
@@ -22,12 +22,13 @@
 
 var proxyquire = require( 'proxyquire' );
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
 // MAIN //
 
-bench( pkg+'::no_collections', function benchmark( b ) {
+bench( format( '%s::no_collections', pkg ), function benchmark( b ) {
 	var logEach;
 	var i;
 
@@ -50,7 +51,7 @@ bench( pkg+'::no_collections', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::collections:len=1', function benchmark( b ) {
+bench( format( '%s::collections:len=1', pkg ), function benchmark( b ) {
 	var logEach;
 	var i;
 

--- a/lib/node_modules/@stdlib/console/log-each/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/console/log-each/benchmark/benchmark.length.js
@@ -24,6 +24,7 @@ var proxyquire = require( 'proxyquire' );
 var bench = require( '@stdlib/bench' );
 var zeros = require( '@stdlib/array/zeros' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -91,7 +92,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+'::collections:len='+len, f );
+		bench( format( '%s::collections:len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#460

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/console`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/console stdlib-js/metr-issue-tracker#460

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers