### PR TITLE
bench: refactor to use string interpolation in `complex`

### DIFF
--- a/lib/node_modules/@stdlib/complex/base/cast-return/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/base/cast-return/benchmark/benchmark.js
@@ -26,6 +26,7 @@ var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isFunction = require( '@stdlib/assert/is-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cast = require( './../lib' );
 
@@ -76,7 +77,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_nullary', function benchmark( b ) {
+bench( format( '%s::wrapped_nullary', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -98,7 +99,7 @@ bench( pkg+'::wrapped_nullary', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_unary,real', function benchmark( b ) {
+bench( format( '%s::wrapped_unary,real', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -120,7 +121,7 @@ bench( pkg+'::wrapped_unary,real', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_unary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_unary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -142,7 +143,7 @@ bench( pkg+'::wrapped_unary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_binary,real', function benchmark( b ) {
+bench( format( '%s::wrapped_binary,real', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -164,7 +165,7 @@ bench( pkg+'::wrapped_binary,real', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_binary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_binary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -186,7 +187,7 @@ bench( pkg+'::wrapped_binary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_ternary,real', function benchmark( b ) {
+bench( format( '%s::wrapped_ternary,real', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -208,7 +209,7 @@ bench( pkg+'::wrapped_ternary,real', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_ternary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_ternary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -230,7 +231,7 @@ bench( pkg+'::wrapped_ternary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_quaternary,real', function benchmark( b ) {
+bench( format( '%s::wrapped_quaternary,real', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -252,7 +253,7 @@ bench( pkg+'::wrapped_quaternary,real', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_quaternary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_quaternary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -274,7 +275,7 @@ bench( pkg+'::wrapped_quaternary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_quinary,real', function benchmark( b ) {
+bench( format( '%s::wrapped_quinary,real', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -296,7 +297,7 @@ bench( pkg+'::wrapped_quinary,real', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_quinary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_quinary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -318,7 +319,7 @@ bench( pkg+'::wrapped_quinary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_nary,real', function benchmark( b ) {
+bench( format( '%s::wrapped_nary,real', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -340,7 +341,7 @@ bench( pkg+'::wrapped_nary,real', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_nary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_nary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/complex/base/wrap-function/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/base/wrap-function/benchmark/benchmark.js
@@ -26,6 +26,7 @@ var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isFunction = require( '@stdlib/assert/is-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var wrap = require( './../lib' );
 
@@ -70,7 +71,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_nullary', function benchmark( b ) {
+bench( format( '%s::wrapped_nullary', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -92,7 +93,7 @@ bench( pkg+'::wrapped_nullary', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_unary,reals', function benchmark( b ) {
+bench( format( '%s::wrapped_unary,reals', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -114,7 +115,7 @@ bench( pkg+'::wrapped_unary,reals', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_unary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_unary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var z;
@@ -138,7 +139,7 @@ bench( pkg+'::wrapped_unary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_binary,reals', function benchmark( b ) {
+bench( format( '%s::wrapped_binary,reals', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -160,7 +161,7 @@ bench( pkg+'::wrapped_binary,reals', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_binary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_binary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var z;
@@ -184,7 +185,7 @@ bench( pkg+'::wrapped_binary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_ternary,reals', function benchmark( b ) {
+bench( format( '%s::wrapped_ternary,reals', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -206,7 +207,7 @@ bench( pkg+'::wrapped_ternary,reals', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_ternary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_ternary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var z;
@@ -230,7 +231,7 @@ bench( pkg+'::wrapped_ternary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_quaternary,reals', function benchmark( b ) {
+bench( format( '%s::wrapped_quaternary,reals', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -252,7 +253,7 @@ bench( pkg+'::wrapped_quaternary,reals', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_quaternary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_quaternary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var z;
@@ -276,7 +277,7 @@ bench( pkg+'::wrapped_quaternary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_quinary,reals', function benchmark( b ) {
+bench( format( '%s::wrapped_quinary,reals', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -298,7 +299,7 @@ bench( pkg+'::wrapped_quinary,reals', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_quinary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_quinary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var z;
@@ -322,7 +323,7 @@ bench( pkg+'::wrapped_quinary,complex', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_nary,reals', function benchmark( b ) {
+bench( format( '%s::wrapped_nary,reals', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var i;
@@ -344,7 +345,7 @@ bench( pkg+'::wrapped_nary,reals', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::wrapped_nary,complex', function benchmark( b ) {
+bench( format( '%s::wrapped_nary,complex', pkg ), function benchmark( b ) {
 	var f;
 	var v;
 	var z;

--- a/lib/node_modules/@stdlib/complex/cmplx/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/cmplx/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var complex = require( './../lib' );
 
@@ -46,7 +47,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=float64', function benchmark( b ) {
+bench( format( '%s:dtype=float64', pkg ), function benchmark( b ) {
 	var z;
 	var i;
 	b.tic();
@@ -64,7 +65,7 @@ bench( pkg+':dtype=float64', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=float32', function benchmark( b ) {
+bench( format( '%s:dtype=float32', pkg ), function benchmark( b ) {
 	var z;
 	var i;
 	b.tic();

--- a/lib/node_modules/@stdlib/complex/float32/base/add/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/add/benchmark/benchmark.assign.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var add = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':assign', function benchmark( b ) {
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var re;
 	var im;

--- a/lib/node_modules/@stdlib/complex/float32/base/add/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/add/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float32/base/add/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/add/benchmark/benchmark.strided.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var add = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':strided', function benchmark( b ) {
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
 	var out;
 	var z1;
 	var z2;

--- a/lib/node_modules/@stdlib/complex/float32/base/identity/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/identity/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var real = require( '@stdlib/complex/float32/real' );
 var imag = require( '@stdlib/complex/float32/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/complex/float32/base/mul-add/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/mul-add/benchmark/benchmark.assign.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var muladd = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':assign', function benchmark( b ) {
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var re;
 	var im;

--- a/lib/node_modules/@stdlib/complex/float32/base/mul-add/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/mul-add/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float32/base/mul-add/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/mul-add/benchmark/benchmark.strided.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var muladd = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':strided', function benchmark( b ) {
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
 	var out;
 	var z1;
 	var z2;

--- a/lib/node_modules/@stdlib/complex/float32/base/mul/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/mul/benchmark/benchmark.assign.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var mul = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':assign', function benchmark( b ) {
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var re;
 	var im;

--- a/lib/node_modules/@stdlib/complex/float32/base/mul/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/mul/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float32/base/mul/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/mul/benchmark/benchmark.strided.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var mul = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':strided', function benchmark( b ) {
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
 	var out;
 	var z1;
 	var z2;

--- a/lib/node_modules/@stdlib/complex/float32/base/neg/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/neg/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float32/base/scale/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/scale/benchmark/benchmark.assign.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var scale = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':assign', function benchmark( b ) {
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var re;
 	var im;

--- a/lib/node_modules/@stdlib/complex/float32/base/scale/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/scale/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float32/base/scale/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/scale/benchmark/benchmark.strided.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Float32Array = require( '@stdlib/array/float32' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var scale = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':strided', function benchmark( b ) {
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
 	var out;
 	var z1;
 	var N;

--- a/lib/node_modules/@stdlib/complex/float32/base/sub/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/sub/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float32/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/float32/ctor/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Complex64 = require( './../lib' );
 
@@ -47,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:real', function benchmark( b ) {
+bench( format( '%s::get:real', pkg ), function benchmark( b ) {
 	var re;
 	var z;
 	var i;
@@ -69,7 +70,7 @@ bench( pkg+'::get:real', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:imag', function benchmark( b ) {
+bench( format( '%s::get:imag', pkg ), function benchmark( b ) {
 	var im;
 	var z;
 	var i;
@@ -91,7 +92,7 @@ bench( pkg+'::get:imag', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toString', function benchmark( b ) {
+bench( format( '%s:toString', pkg ), function benchmark( b ) {
 	var o;
 	var z;
 	var i;
@@ -113,7 +114,7 @@ bench( pkg+':toString', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON', function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var o;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/complex/float32/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/float32/reviver/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var parseJSON = require( '@stdlib/utils/parse-json' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reviver = require( './../lib' );
 
@@ -49,7 +50,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver', function benchmark( b ) {
+bench( format( '%s::no_reviver', pkg ), function benchmark( b ) {
 	var str;
 	var o;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::no_reviver', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver,built-in', function benchmark( b ) {
+bench( format( '%s::no_reviver,built-in', pkg ), function benchmark( b ) {
 	var str;
 	var o;
 	var i;

--- a/lib/node_modules/@stdlib/complex/float64/base/div/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/div/benchmark/benchmark.assign.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cdiv = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':assign', function benchmark( b ) {
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var re;
 	var im;

--- a/lib/node_modules/@stdlib/complex/float64/base/div/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/div/benchmark/benchmark.js
@@ -27,6 +27,7 @@ var uniform = require( '@stdlib/random/base/uniform' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
 var abs = require( '@stdlib/math/base/special/abs' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cdiv = require( './../lib' );
 
@@ -60,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::smiths_algorithm', function benchmark( b ) {
+bench( format( '%s::smiths_algorithm', pkg ), function benchmark( b ) {
 	var values;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/complex/float64/base/div/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/div/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float64/base/div/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/div/benchmark/benchmark.strided.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var cdiv = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':strided', function benchmark( b ) {
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
 	var out;
 	var z1;
 	var z2;

--- a/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/benchmark.native.js
@@ -27,6 +27,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -40,7 +41,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/complex/float64/base/mul-add/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/mul-add/benchmark/benchmark.assign.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var muladd = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':assign', function benchmark( b ) {
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var re;
 	var im;

--- a/lib/node_modules/@stdlib/complex/float64/base/mul-add/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/mul-add/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float64/base/mul-add/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/mul-add/benchmark/benchmark.strided.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var muladd = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':strided', function benchmark( b ) {
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
 	var out;
 	var z1;
 	var z2;

--- a/lib/node_modules/@stdlib/complex/float64/base/mul/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/mul/benchmark/benchmark.assign.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var mul = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':assign', function benchmark( b ) {
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var re;
 	var im;

--- a/lib/node_modules/@stdlib/complex/float64/base/mul/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/mul/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float64/base/mul/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/mul/benchmark/benchmark.strided.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var mul = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':strided', function benchmark( b ) {
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
 	var out;
 	var z1;
 	var z2;

--- a/lib/node_modules/@stdlib/complex/float64/base/neg/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/neg/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float64/base/scale/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/scale/benchmark/benchmark.assign.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var scale = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':assign', function benchmark( b ) {
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var re;
 	var im;

--- a/lib/node_modules/@stdlib/complex/float64/base/scale/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/scale/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float64/base/scale/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/scale/benchmark/benchmark.strided.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var scale = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':strided', function benchmark( b ) {
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
 	var out;
 	var z1;
 	var N;

--- a/lib/node_modules/@stdlib/complex/float64/base/sub/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/sub/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float64/conj/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float64/conj/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float64/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/float64/ctor/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var Complex128 = require( './../lib' );
 
@@ -47,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:real', function benchmark( b ) {
+bench( format( '%s::get:real', pkg ), function benchmark( b ) {
 	var re;
 	var z;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::get:real', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:imag', function benchmark( b ) {
+bench( format( '%s::get:imag', pkg ), function benchmark( b ) {
 	var im;
 	var z;
 	var i;
@@ -93,7 +94,7 @@ bench( pkg+'::get:imag', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toString', function benchmark( b ) {
+bench( format( '%s:toString', pkg ), function benchmark( b ) {
 	var o;
 	var z;
 	var i;
@@ -115,7 +116,7 @@ bench( pkg+':toString', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':toJSON', function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var o;
 	var z;
 	var i;

--- a/lib/node_modules/@stdlib/complex/float64/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/float64/reviver/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var parseJSON = require( '@stdlib/utils/parse-json' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reviver = require( './../lib' );
 
@@ -49,7 +50,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver', function benchmark( b ) {
+bench( format( '%s::no_reviver', pkg ), function benchmark( b ) {
 	var str;
 	var o;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::no_reviver', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver,built-in', function benchmark( b ) {
+bench( format( '%s::no_reviver,built-in', pkg ), function benchmark( b ) {
 	var str;
 	var o;
 	var i;

--- a/lib/node_modules/@stdlib/complex/promotion-rules/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/promotion-rules/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var dtypes = require( '@stdlib/complex/dtypes' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var promotionRules = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::dtypes', function benchmark( b ) {
+bench( format( '%s::dtypes', pkg ), function benchmark( b ) {
 	var out;
 	var dt;
 	var N;

--- a/lib/node_modules/@stdlib/complex/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/complex/reviver/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var parseJSON = require( '@stdlib/utils/parse-json' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reviver = require( './../lib' );
 
@@ -49,7 +50,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver', function benchmark( b ) {
+bench( format( '%s::no_reviver', pkg ), function benchmark( b ) {
 	var str;
 	var o;
 	var i;
@@ -70,7 +71,7 @@ bench( pkg+'::no_reviver', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver,built-in', function benchmark( b ) {
+bench( format( '%s::no_reviver,built-in', pkg ), function benchmark( b ) {
 	var str;
 	var o;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#461

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/complex`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/complex stdlib-js/metr-issue-tracker#461

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers