### PR TITLE
bench: refactor to use string interpolation in `cli`

### DIFF
--- a/lib/node_modules/@stdlib/cli/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/cli/ctor/benchmark/benchmark.js
@@ -22,13 +22,14 @@
 
 var bench = require( '@stdlib/bench' );
 var isArray = require( '@stdlib/assert/is-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var CLI = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::instantiation', function benchmark( b ) {
+bench( format( '%s::instantiation', pkg ), function benchmark( b ) {
 	var cli;
 	var i;
 	b.tic();
@@ -46,7 +47,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
 	var ctor;
 	var cli;
 	var i;
@@ -68,7 +69,7 @@ bench( pkg+'::instantiation,no_new', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::instantiation,options', function benchmark( b ) {
+bench( format( '%s::instantiation,options', pkg ), function benchmark( b ) {
 	var opts;
 	var cli;
 	var i;
@@ -100,7 +101,7 @@ bench( pkg+'::instantiation,options', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':args', function benchmark( b ) {
+bench( format( '%s:args', pkg ), function benchmark( b ) {
 	var out;
 	var cli;
 	var i;
@@ -122,7 +123,7 @@ bench( pkg+':args', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':flags', function benchmark( b ) {
+bench( format( '%s:flags', pkg ), function benchmark( b ) {
 	var out;
 	var cli;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#462

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/cli`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/cli stdlib-js/metr-issue-tracker#462

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers