### PR TITLE
bench: refactor to use string interpolation in `buffer`

### DIFF
--- a/lib/node_modules/@stdlib/buffer/from-arraybuffer/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/buffer/from-arraybuffer/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isBuffer = require( '@stdlib/assert/is-buffer' );
 var ArrayBuffer = require( '@stdlib/array/buffer' );
 var Uint8Array = require( '@stdlib/array/uint8' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var arraybuffer2buffer = require( './../lib' );
 
@@ -55,7 +56,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::byteoffset', function benchmark( b ) {
+bench( format( '%s::byteoffset', pkg ), function benchmark( b ) {
 	var view;
 	var buf;
 	var out;
@@ -80,7 +81,7 @@ bench( pkg+'::byteoffset', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::byteoffset,length', function benchmark( b ) {
+bench( format( '%s::byteoffset,length', pkg ), function benchmark( b ) {
 	var view;
 	var buf;
 	var out;

--- a/lib/node_modules/@stdlib/buffer/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/buffer/reviver/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
 var parseJSON = require( '@stdlib/utils/parse-json' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var reviver = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver', function benchmark( b ) {
+bench( format( '%s::no_reviver', pkg ), function benchmark( b ) {
 	var str;
 	var v;
 	var o;
@@ -75,7 +76,7 @@ bench( pkg+'::no_reviver', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::no_reviver,built-in', function benchmark( b ) {
+bench( format( '%s::no_reviver,built-in', pkg ), function benchmark( b ) {
 	var str;
 	var v;
 	var o;

--- a/lib/node_modules/@stdlib/buffer/to-json/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/buffer/to-json/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var allocUnsafe = require( '@stdlib/buffer/alloc-unsafe' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var toJSON = require( './../lib' );
 
@@ -51,7 +52,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::built-in', function benchmark( b ) {
+bench( format( '%s::built-in', pkg ), function benchmark( b ) {
 	var buf;
 	var o;
 	var i;
@@ -74,7 +75,7 @@ bench( pkg+'::built-in', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::large', function benchmark( b ) {
+bench( format( '%s::large', pkg ), function benchmark( b ) {
 	var buf;
 	var o;
 	var i;
@@ -97,7 +98,7 @@ bench( pkg+'::large', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::built-in,large', function benchmark( b ) {
+bench( format( '%s::built-in,large', pkg ), function benchmark( b ) {
 	var buf;
 	var o;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#463

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/buffer`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/buffer stdlib-js/metr-issue-tracker#463

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers