### PR TITLE
bench: refactor to use string interpolation in `_tools`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/incr/lloc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/incr/lloc/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isFunction = require( '@stdlib/assert/is-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var incrlloc = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::accumulate', function benchmark( b ) {
+bench( format( '%s::accumulate', pkg ), function benchmark( b ) {
 	var values;
 	var acc;
 	var o;

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/incr/program-summary/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/incr/program-summary/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isFunction = require( '@stdlib/assert/is-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var incrsummary = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::accumulate', function benchmark( b ) {
+bench( format( '%s::accumulate', pkg ), function benchmark( b ) {
 	var values;
 	var acc;
 	var o;

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/incr/sloc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/incr/sloc/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isFunction = require( '@stdlib/assert/is-function' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var incrsloc = require( './../lib' );
 
@@ -48,7 +49,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::accumulate', function benchmark( b ) {
+bench( format( '%s::accumulate', pkg ), function benchmark( b ) {
 	var values;
 	var acc;
 	var o;

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/lloc-file-list/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/lloc-file-list/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isNonNegativeIntegerArray = require( '@stdlib/assert/is-nonnegative-integer-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var analyze = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=true', function benchmark( b ) {
+bench( format( '%s:cumulative=true', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var i;
@@ -93,7 +94,7 @@ bench( pkg+':cumulative=true', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=false', function benchmark( b ) {
+bench( format( '%s:cumulative=false', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var i;
@@ -127,7 +128,7 @@ bench( pkg+':cumulative=false', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var files;
 	var o;
 	var i;
@@ -151,7 +152,7 @@ bench( pkg+':sync', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=true', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=true', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var o;
@@ -179,7 +180,7 @@ bench( pkg+':sync:cumulative=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=false', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=false', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var o;

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/lloc-glob/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/lloc-glob/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isArrayArray = require( '@stdlib/assert/is-array-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var analyze = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=true', function benchmark( b ) {
+bench( format( '%s:cumulative=true', pkg ), function benchmark( b ) {
 	var opts;
 	var i;
 
@@ -90,7 +91,7 @@ bench( pkg+':cumulative=true', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=false', function benchmark( b ) {
+bench( format( '%s:cumulative=false', pkg ), function benchmark( b ) {
 	var opts;
 	var i;
 
@@ -121,7 +122,7 @@ bench( pkg+':cumulative=false', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var opts;
 	var o;
 	var i;
@@ -145,7 +146,7 @@ bench( pkg+':sync', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=true', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=true', pkg ), function benchmark( b ) {
 	var opts;
 	var o;
 	var i;
@@ -170,7 +171,7 @@ bench( pkg+':sync:cumulative=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=false', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=false', pkg ), function benchmark( b ) {
 	var opts;
 	var o;
 	var i;

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/sloc-file-list/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/sloc-file-list/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isNonNegativeIntegerArray = require( '@stdlib/assert/is-nonnegative-integer-array' ).primitives;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var analyze = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=true', function benchmark( b ) {
+bench( format( '%s:cumulative=true', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var i;
@@ -93,7 +94,7 @@ bench( pkg+':cumulative=true', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=false', function benchmark( b ) {
+bench( format( '%s:cumulative=false', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var i;
@@ -127,7 +128,7 @@ bench( pkg+':cumulative=false', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var files;
 	var o;
 	var i;
@@ -151,7 +152,7 @@ bench( pkg+':sync', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=true', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=true', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var o;
@@ -179,7 +180,7 @@ bench( pkg+':sync:cumulative=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=false', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=false', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var o;

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/sloc-glob/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/sloc-glob/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isArrayArray = require( '@stdlib/assert/is-array-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var analyze = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=true', function benchmark( b ) {
+bench( format( '%s:cumulative=true', pkg ), function benchmark( b ) {
 	var opts;
 	var i;
 
@@ -90,7 +91,7 @@ bench( pkg+':cumulative=true', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=false', function benchmark( b ) {
+bench( format( '%s:cumulative=false', pkg ), function benchmark( b ) {
 	var opts;
 	var i;
 
@@ -121,7 +122,7 @@ bench( pkg+':cumulative=false', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var opts;
 	var o;
 	var i;
@@ -145,7 +146,7 @@ bench( pkg+':sync', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=true', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=true', pkg ), function benchmark( b ) {
 	var opts;
 	var o;
 	var i;
@@ -170,7 +171,7 @@ bench( pkg+':sync:cumulative=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=false', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=false', pkg ), function benchmark( b ) {
 	var opts;
 	var o;
 	var i;

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/summarize-file-list/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/summarize-file-list/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isPlainObjectArray = require( '@stdlib/assert/is-plain-object-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var analyze = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=true', function benchmark( b ) {
+bench( format( '%s:cumulative=true', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var i;
@@ -93,7 +94,7 @@ bench( pkg+':cumulative=true', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=false', function benchmark( b ) {
+bench( format( '%s:cumulative=false', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var i;
@@ -127,7 +128,7 @@ bench( pkg+':cumulative=false', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var files;
 	var o;
 	var i;
@@ -151,7 +152,7 @@ bench( pkg+':sync', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=true', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=true', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var o;
@@ -179,7 +180,7 @@ bench( pkg+':sync:cumulative=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=false', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=false', pkg ), function benchmark( b ) {
 	var files;
 	var opts;
 	var o;

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/summarize-glob/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/summarize-glob/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isPlainObjectArray = require( '@stdlib/assert/is-plain-object-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var analyze = require( './../lib' );
 
@@ -59,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=true', function benchmark( b ) {
+bench( format( '%s:cumulative=true', pkg ), function benchmark( b ) {
 	var opts;
 	var i;
 
@@ -90,7 +91,7 @@ bench( pkg+':cumulative=true', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':cumulative=false', function benchmark( b ) {
+bench( format( '%s:cumulative=false', pkg ), function benchmark( b ) {
 	var opts;
 	var i;
 
@@ -121,7 +122,7 @@ bench( pkg+':cumulative=false', function benchmark( b ) {
 	}
 });
 
-bench( pkg+':sync', function benchmark( b ) {
+bench( format( '%s:sync', pkg ), function benchmark( b ) {
 	var opts;
 	var o;
 	var i;
@@ -145,7 +146,7 @@ bench( pkg+':sync', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=true', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=true', pkg ), function benchmark( b ) {
 	var opts;
 	var o;
 	var i;
@@ -170,7 +171,7 @@ bench( pkg+':sync:cumulative=true', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':sync:cumulative=false', function benchmark( b ) {
+bench( format( '%s:sync:cumulative=false', pkg ), function benchmark( b ) {
 	var opts;
 	var o;
 	var i;


### PR DESCRIPTION
Progresses #8647
Resolves stdlib-js/metr-issue-tracker#465

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors to use string interpolation in `@stdlib/_tools`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647
-   [RFC]: use string interpolation in JavaScript benchmarks for @stdlib/_tools stdlib-js/metr-issue-tracker#465

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

---

@stdlib-js/reviewers