### PR TITLE
fix: allow `bool` dtype in `zeros` via `typed_and_generic`

### DIFF
--- a/lib/node_modules/@stdlib/array/zeros/README.md
+++ b/lib/node_modules/@stdlib/array/zeros/README.md
@@ -62,6 +62,7 @@ The function recognizes the following data types:
 -   `int8`: 8-bit two's complement signed integers
 -   `uint8`: 8-bit unsigned integers
 -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
+-   `bool`: boolean values
 -   `generic`: generic JavaScript values
 
 By default, the output array data type is `float64` (i.e., a [typed array][mdn-typed-array]). To specify an alternative data type, provide a `dtype` argument.

--- a/lib/node_modules/@stdlib/array/zeros/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/zeros/docs/repl.txt
@@ -15,6 +15,7 @@
     - int8: 8-bit two's complement signed integers.
     - uint8: 8-bit unsigned integers.
     - uint8c: 8-bit unsigned integers clamped to 0-255.
+    - bool: boolean values.
     - generic: generic JavaScript values.
 
     The default array data type is `float64`.

--- a/lib/node_modules/@stdlib/array/zeros/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/zeros/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { NumericAndGenericDataTypeMap } from '@stdlib/types/array';
+import { DataTypeMap } from '@stdlib/types/array';
 
 /**
 * Creates a zero-filled array having a specified length.
@@ -38,6 +38,7 @@ import { NumericAndGenericDataTypeMap } from '@stdlib/types/array';
 * -   `int8`: 8-bit two's complement signed integers
 * -   `uint8`: 8-bit unsigned integers
 * -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
+* -   `bool`: boolean values
 * -   `generic`: generic JavaScript values
 *
 * @param length - array length
@@ -52,7 +53,7 @@ import { NumericAndGenericDataTypeMap } from '@stdlib/types/array';
 * var arr = zeros( 2, 'float32' );
 * // returns <Float32Array>[ 0.0, 0.0 ]
 */
-declare function zeros<T extends keyof NumericAndGenericDataTypeMap<number> = 'float64'>( length: number, dtype?: T ): NumericAndGenericDataTypeMap<number>[T];
+declare function zeros<U extends keyof DataTypeMap<number> = 'float64'>( length: number, dtype?: U ): DataTypeMap<number>[U];
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/zeros/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/zeros/docs/types/test.ts
@@ -35,6 +35,7 @@ import zeros = require( './index' );
 	zeros( 10, 'uint16' ); // $ExpectType Uint16Array
 	zeros( 10, 'uint8' ); // $ExpectType Uint8Array
 	zeros( 10, 'uint8c' ); // $ExpectType Uint8ClampedArray
+	zeros( 10, 'bool' ); // $ExpectType BooleanArray
 	zeros( 10, 'generic' ); // $ExpectType number[]
 }
 

--- a/lib/node_modules/@stdlib/array/zeros/lib/main.js
+++ b/lib/node_modules/@stdlib/array/zeros/lib/main.js
@@ -33,7 +33,7 @@ var format = require( '@stdlib/string/format' );
 // VARIABLES //
 
 var DEFAULT_DTYPE = defaults.get( 'dtypes.default' );
-var DTYPES = dtypes( 'numeric_and_generic' );
+var DTYPES = dtypes( 'typed_and_generic' );
 var isValidDType = contains( DTYPES );
 
 

--- a/lib/node_modules/@stdlib/array/zeros/test/test.js
+++ b/lib/node_modules/@stdlib/array/zeros/test/test.js
@@ -32,6 +32,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
@@ -303,6 +304,20 @@ tape( 'the function returns a zero-filled array (dtype=uint8c)', function test( 
 
 	arr = zeros( 5, 'uint8c' );
 	t.strictEqual( instanceOf( arr, Uint8ClampedArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, expected.length, 'returns expected value' );
+	t.deepEqual( arr, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool)', function test( t ) {
+	var expected;
+	var arr;
+
+	expected = new BooleanArray( [ false, false, false, false, false ] );
+
+	arr = zeros( 5, 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( arr.length, expected.length, 'returns expected value' );
 	t.deepEqual( arr, expected, 'returns expected value' );
 


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-   allows `bool` dtype in `zeros` via `typed_and_generic`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Normal bug identification and options to explore for fixing it.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
