### PR TITLE
fix: use `empty` instead of `zeros` in `array/from-scalar`

### DIFF
--- a/lib/node_modules/@stdlib/array/from-scalar/lib/main.js
+++ b/lib/node_modules/@stdlib/array/from-scalar/lib/main.js
@@ -27,7 +27,7 @@ var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isAccessorArray = require( '@stdlib/array/base/assert/is-accessor-array' );
 var accessorSetter = require( '@stdlib/array/base/accessor-setter' );
 var setter = require( '@stdlib/array/base/setter' );
-var zeros = require( '@stdlib/array/zeros' );
+var empty = require( '@stdlib/array/empty' );
 var dtype = require( '@stdlib/complex/dtype' );
 var defaults = require( '@stdlib/array/defaults' );
 
@@ -91,7 +91,7 @@ function scalar2array( value ) {
 	} else {
 		dt = arguments[ 1 ];
 	}
-	out = zeros( 1, dt ); // delegate dtype validation to `zeros`
+	out = empty( 1, dt ); // delegate allocation and dtype validation to `empty`
 	if ( flg && isComplexDataType( dt ) ) {
 		v = [ value, 0.0 ]; // note: we're assuming that the ComplexXXArray setter accepts an array of interleaved real and imaginary components
 	} else {


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-   uses `empty` instead of `zeros` in `from-scalar` for length-1 allocation

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md