### PR TITLE
build: tolerate trailing inline comment in `_tools/eslint/rules/jsdoc-doctest`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest/lib/main.js
@@ -48,7 +48,7 @@ var windowShim = require( './window.js' );
 
 var debug = logger( 'jsdoc-doctest' );
 var ROOT_DIR = rootDir();
-var RE_ANNOTATION = /(?:\n|^)(?!function\s|class\s)(?:var|let|const)? ?([a-zA-Z0-9._]+) ?=?[^;]*;\n\/\/ ?(returns|([A-Za-z][A-Za-z_0-9]*)? ?=>|throws) {0,1}([\s\S]*?)(\n|$)/g;
+var RE_ANNOTATION = /(?:\n|^)(?!function\s|class\s)(?:var|let|const)? ?([a-zA-Z0-9._]+) ?=?[^;]*;[ \t]*(?:\/\/[^\n]*)?\n\/\/ ?(returns|([A-Za-z][A-Za-z_0-9]*)? ?=>|throws) {0,1}([\s\S]*?)(\n|$)/g;
 var RE_CONSOLE = /console\.(?:dir|error|log)/;
 var RE_MODULE_TAG = /\* @module[^\n]*\n/g;
 var NODE_SHEBANG = /#!\/usr\/bin\/env node/;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest/test/fixtures/invalid.js
@@ -1021,6 +1021,140 @@ test = {
 };
 invalid.push( test );
 
+test = {
+	'code': [
+		'\'use strict\'',
+		'',
+		'/**',
+		'* Squares a number.',
+		'*',
+		'* @param {number} x - input value',
+		'* @returns {number} x*x',
+		'* @example',
+		'* var y = square( 3.0 ); // x squared',
+		'* // returns 12.0',
+		'*',
+		'* y = square( 2.0 ); // x squared',
+		'* // returns 4.0',
+		'*/',
+		'function square( x ) {',
+		'  return x*x;',
+		'}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Displayed return value is `12.0`, but expected `9` instead',
+			'type': null
+		}
+	],
+	'output': [
+		'\'use strict\'',
+		'',
+		'/**',
+		'* Squares a number.',
+		'*',
+		'* @param {number} x - input value',
+		'* @returns {number} x*x',
+		'* @example',
+		'* var y = square( 3.0 ); // x squared',
+		'* // returns 9',
+		'*',
+		'* y = square( 2.0 ); // x squared',
+		'* // returns 4.0',
+		'*/',
+		'function square( x ) {',
+		'  return x*x;',
+		'}'
+	].join( '\n' )
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Squares a number.',
+		'*',
+		'* @param {number} x - input value',
+		'* @returns {number} x*x',
+		'* @example',
+		'* console.log( square( 3.0 ) ); // x squared',
+		'* // => 12.0',
+		'*',
+		'* console.log( square( 2.0 ) ); // x squared',
+		'* // => 4.0',
+		'*/',
+		'function square( x ) {',
+		'  return x*x;',
+		'}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Displayed return value is `12.0`, but expected `9` instead',
+			'type': null
+		}
+	],
+	'output': [
+		'/**',
+		'* Squares a number.',
+		'*',
+		'* @param {number} x - input value',
+		'* @returns {number} x*x',
+		'* @example',
+		'* console.log( square( 3.0 ) ); // x squared',
+		'* // => 9',
+		'*',
+		'* console.log( square( 2.0 ) ); // x squared',
+		'* // => 4.0',
+		'*/',
+		'function square( x ) {',
+		'  return x*x;',
+		'}'
+	].join( '\n' )
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'\'use strict\'',
+		'',
+		'/**',
+		'* Squares a number.',
+		'*',
+		'* @param {number} x - input value',
+		'* @returns {number} x*x',
+		'* @example',
+		'* var y = square( 3.0 ); // oh; interesting',
+		'* // returns 12.0',
+		'*/',
+		'function square( x ) {',
+		'  return x*x;',
+		'}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Displayed return value is `12.0`, but expected `9` instead',
+			'type': null
+		}
+	],
+	'output': [
+		'\'use strict\'',
+		'',
+		'/**',
+		'* Squares a number.',
+		'*',
+		'* @param {number} x - input value',
+		'* @returns {number} x*x',
+		'* @example',
+		'* var y = square( 3.0 ); // oh; interesting',
+		'* // returns 9',
+		'*/',
+		'function square( x ) {',
+		'  return x*x;',
+		'}'
+	].join( '\n' )
+};
+invalid.push( test );
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest/test/fixtures/valid.js
@@ -1551,6 +1551,48 @@ test = {
 };
 valid.push( test );
 
+test = {
+	'code': [
+		'/**',
+		'* Squares a number.',
+		'*',
+		'* @param {number} x - input value',
+		'* @returns {number} x*x',
+		'* @example',
+		'* var y = square( 3.0 ); // x squared',
+		'* // returns 9.0',
+		'*',
+		'* y = square( 2.0 ); // x squared',
+		'* // returns 4.0',
+		'*/',
+		'function square( x ) {',
+		'  return x*x;',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Squares a number.',
+		'*',
+		'* @param {number} x - input value',
+		'* @returns {number} x*x',
+		'* @example',
+		'* console.log( square( 3.0 ) ); // x squared',
+		'* // => 9.0',
+		'*',
+		'* console.log( square( 2.0 ) ); // x squared',
+		'* // => 4.0',
+		'*/',
+		'function square( x ) {',
+		'  return x*x;',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
 
 // EXPORTS //
 


### PR DESCRIPTION
## Description

This pull request:

-   **`_tools/eslint/rules/jsdoc-doctest`** — Relaxes the `RE_ANNOTATION` matcher in `lib/main.js` so that an optional trailing inline `// ...` comment between the statement-terminating `;` and the newline preceding a `// returns X` (or `// => X`, `// throws X`) annotation no longer disables the doctest. Previously the regex required `;\n//` literally, which meant any statement carrying a math-narration / explanatory trailing comment caused the rule to silently skip the assertion. Adds five fixture-driven test cases (two valid, three invalid) covering both `var`-annotated and `console.log`-annotated forms, the autofix output (which preserves the trailing comment and only rewrites the `// returns` annotation), and the edge case where the trailing inline comment itself contains a `;`.

## Related Issues

This pull request surfaced from review of #11584, where a stale `// returns 0.5` annotation in `chebyshev-seriesf`'s JSDoc example slipped past the doctest rule because of this exact gap. With this fix in place, the rule would have flagged that bug at lint time, and will now also catch the same pattern still present in the sibling `chebyshev-series` package.

No.

## Questions

No.

## Other

**Verification.**

-   `node test/test.js` (from the rule's package directory): all 5 tape tests pass, including the 5 newly added fixtures.
-   Direct microtest of the old vs. new regex against the exact `chebyshev-seriesf` example confirms the old regex returned **0** matches (silently skipping both annotations), while the new regex returns **2** matches and correctly surfaces the stale `// returns 0.5`.

**Why the old regex missed it.** The chebyshev example reads:

```js
v = polyval( 0.0 ); // 1*T_0(0) + 0.5*T_1(0)
// returns 0.5
```

The old `;\n\/\/` literal in `RE_ANNOTATION` required the semicolon to be followed *immediately* by a newline. The space + `// 1*T_0(0) + 0.5*T_1(0)` between `;` and `\n` broke the match, so the assertion was never executed and the wrong return value was never compared.

**Risk surface.**

-   The added group `[ \t]*(?:\/\/[^\n]*)?` is non-capturing; existing capture indices (`arr[1]` variable name, `arr[2]` annotation kind, `arr[3]` arrow-fn name, `arr[4]` expected value) are unchanged.
-   `arr[0]` is fed back to `vm.runInContext` at line 300 — appended trailing line comments are stripped at JS parse time, so execution is unaffected.
-   The autofix path (`replace( tag.description, arr[ 0 ], str )` at line 318) still works because the enlarged `arr[0]` remains a verbatim substring of the JSDoc description; the trailing inline comment is preserved verbatim in the autofix output, as covered by the new invalid fixtures' `output` assertions.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude (Opus 4.7) under my review. The bug was identified during follow-up review of PR #11584; Claude traced it to the exact regex literal, drafted the one-character-region regex change, added paired valid/invalid fixtures, and verified with both the existing tape suite and a direct microtest against the real-world chebyshev snippet that previously slipped through.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md