### PR TITLE
bench: fix swapped dtypes in size benchmarks

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.size.float32.js
+++ b/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.size.float32.js
@@ -52,7 +52,7 @@ function createBenchmark( len ) {
 		var i;
 
 		opts = {
-			'dtype': 'float64'
+			'dtype': 'float32'
 		};
 
 		b.tic();

--- a/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.size.float64.js
+++ b/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.size.float64.js
@@ -52,7 +52,7 @@ function createBenchmark( len ) {
 		var i;
 
 		opts = {
-			'dtype': 'float32'
+			'dtype': 'float64'
 		};
 
 		b.tic();

--- a/lib/node_modules/@stdlib/ndarray/ones/benchmark/benchmark.size.float32.js
+++ b/lib/node_modules/@stdlib/ndarray/ones/benchmark/benchmark.size.float32.js
@@ -52,7 +52,7 @@ function createBenchmark( len ) {
 		var i;
 
 		opts = {
-			'dtype': 'float64'
+			'dtype': 'float32'
 		};
 
 		b.tic();

--- a/lib/node_modules/@stdlib/ndarray/ones/benchmark/benchmark.size.float64.js
+++ b/lib/node_modules/@stdlib/ndarray/ones/benchmark/benchmark.size.float64.js
@@ -52,7 +52,7 @@ function createBenchmark( len ) {
 		var i;
 
 		opts = {
-			'dtype': 'float32'
+			'dtype': 'float64'
 		};
 
 		b.tic();

--- a/lib/node_modules/@stdlib/ndarray/zeros/benchmark/benchmark.size.float32.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros/benchmark/benchmark.size.float32.js
@@ -52,7 +52,7 @@ function createBenchmark( len ) {
 		var i;
 
 		opts = {
-			'dtype': 'float64'
+			'dtype': 'float32'
 		};
 
 		b.tic();

--- a/lib/node_modules/@stdlib/ndarray/zeros/benchmark/benchmark.size.float64.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros/benchmark/benchmark.size.float64.js
@@ -52,7 +52,7 @@ function createBenchmark( len ) {
 		var i;
 
 		opts = {
-			'dtype': 'float32'
+			'dtype': 'float64'
 		};
 
 		b.tic();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes the `opts.dtype` values in the per-size `float32` and `float64` benchmark files for `@stdlib/ndarray/ones`, `@stdlib/ndarray/zeros`, and `@stdlib/ndarray/empty`. The values were swapped between the two files in each package, so each file benchmarked the opposite dtype from the one its filename and bench label advertised.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Scope verified across all ndarray benchmark files: only the three packages above use the `opts.dtype` pattern. The `*-like` and `ndarray/base/*` size benchmarks pass the dtype positionally (e.g., \`zeros( 'float32', [len], 'row-major' )\`) and were already correct.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Claude Code identified the swapped dtypes while reviewing `@stdlib/ndarray/ones` and applied the fix to all affected packages per my instructions.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md