### PR TITLE
docs: propagate recent fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/napi/argv-bool/README.md
+++ b/lib/node_modules/@stdlib/napi/argv-bool/README.md
@@ -137,7 +137,7 @@ The function accepts the following arguments:
 -   **value**: `[in] napi_value` Node-API value.
 -   **out**: `[out] bool*` destination for storing output value.
 -   **message**: `[in] char*` error message.
--   **err**: `[out] napi_value*` pointer for storing a JavaScript error. If not provided a number, the function sets `err` with a JavaScript error; otherwise, `err` is set to `NULL`.
+-   **err**: `[out] napi_value*` pointer for storing a JavaScript error. If not provided a boolean, the function sets `err` with a JavaScript error; otherwise, `err` is set to `NULL`.
 
 ```c
 napi_status stdlib_napi_argv_bool( const napi_env env, const napi_value value, bool *out, const char *message, napi_value *err );

--- a/lib/node_modules/@stdlib/ndarray/base/rotl90/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/rotl90/README.md
@@ -74,7 +74,7 @@ The function accepts the following arguments:
 -   If `k > 0`, the function rotates the matrix counterclockwise.
 -   If `k < 0`, the function rotates the matrix clockwise.
 -   The returned ndarray is a **view** of the input ndarray. Accordingly, writing to the original ndarray will **mutate** the returned ndarray and vice versa.
--   If provided an ndarray with fewer than two dimensions, the function does not perform rotation and simply returns a new view of the input ndarray.
+-   If provided an ndarray with fewer than two dimensions, the function does not perform a rotation and simply returns a new view of the input ndarray.
 
 </section>
 

--- a/lib/node_modules/@stdlib/ndarray/base/rotr90/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/rotr90/README.md
@@ -74,7 +74,7 @@ The function accepts the following arguments:
 -   If `k > 0`, the function rotates the matrix clockwise.
 -   If `k < 0`, the function rotates the matrix counterclockwise.
 -   The returned ndarray is a **view** of the input ndarray. Accordingly, writing to the original ndarray will **mutate** the returned ndarray and vice versa.
--   If provided an ndarray with fewer than two dimensions, the function does not perform rotation and simply returns a new view of the input ndarray.
+-   If provided an ndarray with fewer than two dimensions, the function does not perform a rotation and simply returns a new view of the input ndarray.
 
 </section>
 


### PR DESCRIPTION
Propagating fixes merged to `develop` between 2026-04-19 and 2026-04-20 to sibling packages that carried the same copy-paste defects.

## Description

> What is the purpose of this pull request?

This pull request:

-   **`napi/argv-bool` — propagates `f3dfe11` ("docs: update descriptions").** Commit `f3dfe11` swept 33 `napi/argv-*` README files to correct a copy-paste error in the `**err**` parameter description, replacing the wrong validated type ("a number") with the correct one for each package. For `napi/argv-bool`, which validates a JavaScript `boolean` and stores into `bool *out`, the phrase now correctly reads "a boolean" in `lib/node_modules/@stdlib/napi/argv-bool/README.md` (line 140).

-   **`ndarray/base/rot{l,r}90` — propagates `f756fa1` + `c2c401e` ("docs: update note").** Commits `f756fa1` (README) and `c2c401e` (repl.txt) fixed a missing article in `ndarray/rotr90`, changing "perform rotation" to "perform a rotation". The same defect was present in the base package siblings; this propagation applies the identical one-word fix to `lib/node_modules/@stdlib/ndarray/base/rotl90/README.md` and `lib/node_modules/@stdlib/ndarray/base/rotr90/README.md` (both at line 77).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Candidate sites were found by searching the full repository for the defect signatures in scope:

-   Pattern search scope: `lib/node_modules/@stdlib/**/benchmark/benchmark.size.{float32,float64}.js` for `869c9da` (swapped dtypes — 0 sites beyond those already fixed); `lib/node_modules/@stdlib/blas/**/benchmark/*.js` for `cd1a4d3` (wrong `b.fail` message — see exclusions); `lib/node_modules/@stdlib/napi/argv-*/README.md` for `f3dfe11`; `rg "perform rotation"` repo-wide for `f756fa1`/`c2c401e`.
-   Two independent validation agents read each candidate file in full; an adaptation agent produced the per-site wording for the adaptive `f3dfe11` fix; a style-consistency pass confirmed spacing and primitive-vs-typed-array wording conventions matched the source commits.

**Deliberately excluded.** The `cd1a4d3` pattern (`'should not return NaN'` → `'should return an ndarray'`) surfaced 24 candidate benchmark files across `blas/{s,d}{dot,swap}`, `blas/tools/swap-factory`, and `blas/ext/*`. Every one was rejected: the remaining `b.fail( 'should not return NaN' );` calls in those files guard genuine scalar `isnan(...)` checks (the ndarray-type guards in those same files already use the correct `'should return an ndarray'` message). The `869c9da` pattern had no propagation sites — sibling `benchmark.size.float{32,64}.js` files pass `dtype` as a positional argument rather than an options-object literal, so the filename/dtype mismatch does not occur. No `needs-human` sites remained after filtering.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running a fix-propagation routine over the last 24 hours of `develop`. Candidate source commits were classified into patterns; sibling sites were enumerated with `rg`, then independently validated (two validation agents), adapted, and style-checked before any patch was applied. Only sites confirmed by both validation passes and the style agent are included.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md