### PR TITLE
chore: fix JavaScript lint errors (issue #11247)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/sync.js
@@ -55,7 +55,7 @@ var debug = logger( 'entry-points:sync' );
 * var pkgs = [ '/foo/bar/baz' ];
 *
 * var entries = entryPoints( pkgs );
-* // returns [{...}]
+* // throws <Error>
 */
 function entryPoints( pkgs, options ) {
 	var results;


### PR DESCRIPTION
Resolves #11247.

## Description

> What is the purpose of this pull request?

This pull request:

-   Replaces the incorrect \`// returns [{...}]\` doctest annotation with \`// throws <Error>\` in the \`@example\` block of \`_tools/pkgs/entry-points/lib/sync.js\`. The example passes \`/foo/bar/baz\` (a non-existent path) to \`entryPoints()\`, which causes the function to throw synchronously while resolving the package path, so the \`// returns [{...}]\` annotation fails the \`stdlib/jsdoc-doctest\` check. The linter itself suggested the \`// throws <Error>\` annotation in the failure message captured in the issue.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11247

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The companion \`async.js\` in the same directory uses a similarly non-existent path (\`./some/nonexistent/path\`) but has no \`// returns\` / \`// throws\` annotation because results are delivered via callback, so doctest does not flag that variant and no change is needed there.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored with Claude Code. I reviewed the \`stdlib/jsdoc-doctest\` failure in the issue, confirmed the behavior manually (non-existent path causes \`entryPoints()\` to throw), and the model's suggested swap matches the linter's own hint.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md