### PR TITLE
chore: add missing `npm` engine constraint to `stats/base/dists/*/ctor`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/f/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/t/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/ctor/package.json
@@ -34,7 +34,8 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
   "os": [
     "aix",


### PR DESCRIPTION
## Description

Adds the missing `"npm": ">2.7.0"` entry to the `engines` field in the `package.json` of every distribution-constructor package under `@stdlib/stats/base/dists/*/ctor`. All 34 ctor packages specified only `"node": ">=0.10.0"` while 5,418 of 5,469 (99.07%) `@stdlib/*` packages specify both `node` and `npm` engines. Root cause is template-copy drift in the distribution-constructor scaffold.

### Changes

Applied a uniform edit to 34 files — one package.json per distribution constructor:

```diff
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
   },
```

Packages updated (34):

`arcsine`, `bernoulli`, `beta`, `betaprime`, `binomial`, `cauchy`, `chi`, `chisquare`, `cosine`, `degenerate`, `discrete-uniform`, `erlang`, `exponential`, `f`, `frechet`, `gamma`, `geometric`, `gumbel`, `hypergeometric`, `invgamma`, `kumaraswamy`, `laplace`, `levy`, `logistic`, `lognormal`, `negative-binomial`, `normal`, `pareto-type1`, `poisson`, `rayleigh`, `t`, `triangular`, `uniform`, `weibull`.

No behavior, signatures, tests, or docs are affected. The diff on every file is identical (+2 / -1).

### How this was found

A majority-vote drift pass over the 14 members of `@stdlib/stats/base/dists/uniform` flagged `uniform/ctor` as missing the `npm` engine constraint (13/14 = 93% conformance within the namespace). A follow-up codebase-wide audit over 5,469 `@stdlib/*` packages revealed the same drift across every `stats/base/dists/*/ctor` package — a template-copy pattern:

| `engines` shape | Count |
|---|---|
| `{"node": ">=0.10.0", "npm": ">2.7.0"}` | 5,418 |
| `{"node": ">=0.10.0"}` ← drift | 34 |
| Other (non-standard `node` constraint, all include `npm`) | 18 |

All 34 offenders are `stats/base/dists/*/ctor` packages; no other namespace exhibits the drift.

## Related Issues

None.

## Questions

None.

## Other

The `uniform` namespace drift routine also surfaced `uniform/mgf` as missing the `"probability"` keyword (13/14 siblings within the namespace). A cross-distribution check revealed only 2 of 21 other `stats/base/dists/*/mgf` packages (cosine, degenerate) include `"probability"` — the `uniform` namespace convention appears to be a local template-copy, not a cross-distribution norm. That correction was dropped from this PR.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

Used AI assistance for:

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code running a cross-package API drift detection routine, extended with a codebase-wide audit of the `engines` field. The scope expanded from one package (`uniform/ctor`) to 34 after discovery that the drift pattern covered every `stats/base/dists/*/ctor` package. All changes are identical, mechanical `package.json` edits with no behavioral impact; maintainer audit still recommended before promoting out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md