### PR TITLE
bench: replace M_PI in `math/base/special/sincospi` C benchmark

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincospi/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/benchmark/c/benchmark.c
@@ -25,6 +25,7 @@
 #define NAME "sincospi"
 #define ITERATIONS 1000000
 #define REPEATS 3
+#define PI 3.14159265358979323846
 
 /**
 * Prints the TAP version.
@@ -102,8 +103,8 @@ static double benchmark( void ) {
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		y = sin( M_PI * x[ i%100 ] );
-		z = cos( M_PI * x[ i%100 ] );
+		y = sin( PI * x[ i%100 ] );
+		z = cos( PI * x[ i%100 ] );
 		if ( y != y || z != z ) {
 			printf( "should not return NaN\n" );
 			break;


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces `M_PI` with local constant in `math/base/special/sincospi` C benchmark

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
