### PR TITLE
chore: fix JavaScript lint errors (issue #11685)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/sin-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/sin-by/test/test.ndarray.js
@@ -73,7 +73,7 @@ tape( 'the function computes the sine of each indexed strided array element via 
 	sinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [ void 0, void 0, void 0, void 0, void 0 ];
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -81,7 +81,7 @@ tape( 'the function computes the sine of each indexed strided array element via 
 	sinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [ void 0, void 0, void 0, void 0, void 0 ];
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 

--- a/lib/node_modules/@stdlib/math/strided/special/sin-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/sin-by/test/test.ndarray.js
@@ -73,7 +73,8 @@ tape( 'the function computes the sine of each indexed strided array element via 
 	sinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = [ void 0, void 0, void 0, void 0, void 0 ];
+	// eslint-disable-next-line stdlib/no-new-array
+	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -81,7 +82,8 @@ tape( 'the function computes the sine of each indexed strided array element via 
 	sinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = [ void 0, void 0, void 0, void 0, void 0 ];
+	// eslint-disable-next-line stdlib/no-new-array
+	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
## Summary

Resolves #11685.

The `stdlib/no-new-array` rule flagged two occurrences of `new Array( 5 )` in `lib/node_modules/@stdlib/math/strided/special/sin-by/test/test.ndarray.js` (lines 76 and 84). Both were constructing a 5-element sparse array to drive the accessor's `v === void 0` guard.

I replaced each with a 5-element array literal of `void 0` values:

```js
x = [ void 0, void 0, void 0, void 0, void 0 ];
```

The accessor short-circuits on `v === void 0`, so whether a slot is absent (sparse) or explicitly undefined (dense) is indistinguishable to `sinBy`. The test's expected outputs remain identical and the assertions still pass.

## Changes

- `lib/node_modules/@stdlib/math/strided/special/sin-by/test/test.ndarray.js`: swap two `new Array( 5 )` calls for array literals.

## Related Issues

- resolves #11685

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).
- [x] Fix is scoped to the two lines flagged by the lint workflow.