### PR TITLE
refactor: remove unneeded `isnan` checks

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mean/lib/main.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var isNonNegativeInteger = require( '@stdlib/math/base/assert/is-nonnegative-integer' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 
 
@@ -72,13 +71,6 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 * // returns NaN
 */
 function mean( N, K, n ) {
-	if (
-		isnan( N ) ||
-		isnan( K ) ||
-		isnan( n )
-	) {
-		return NaN;
-	}
 	if (
 		!isNonNegativeInteger( N ) ||
 		!isNonNegativeInteger( K ) ||


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request

-   removes a redundant `isnan(N)||isnan(K)||isnan(n)` guard and the associated `@stdlib/math/base/assert/is-nan` require from `stats/base/dists/hypergeometric/mean`. All other packages in the distribution namespace rely solely on the `!isNonNegativeInteger` predicate to reject NaN inputs — `!isNonNegativeInteger(NaN)` is `true`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Output of a cross-package drift-detection routine over a randomly selected stdlib namespace (`stats/base/dists/hypergeometric`, seed `1776774012099`). See the local drift report for the full per-feature tally, excluded findings, and agent verdicts. Draft PR: a maintainer should audit before promoting to ready-for-review.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Claude Code executed a cross-package drift-detection routine that randomly selected the `stats/base/dists/hypergeometric` namespace (seed `1776774012099`), extracted structural and semantic features across the 11 sibling packages, computed majority patterns, and identified outliers. Three validation agents (opus × 2, sonnet × 1) independently verified each drift candidate; only findings classified as `confirmed-drift` by all relevant agents were applied as mechanical, behavior-preserving patches. A maintainer must audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
