### PR TITLE
chore: minor clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/cgemv/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/lib/base.js
@@ -23,6 +23,7 @@
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 var cfill = require( '@stdlib/blas/ext/base/cfill' ).ndarray;
 var cscal = require( '@stdlib/blas/base/cscal' ).ndarray;
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
@@ -143,7 +144,7 @@ function cgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, 
 
 	// y = beta*y
 	if ( rebeta === 0.0 && imbeta === 0.0 ) {
-		cfill( ylen, alpha, y, strideY, offsetY );
+		cfill( ylen, new Complex64( 0.0, 0.0 ), y, strideY, offsetY );
 	} else if ( rebeta !== 1.0 || imbeta !== 0.0 ) {
 		cscal( ylen, beta, y, strideY, offsetY );
 	}
@@ -160,8 +161,8 @@ function cgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, 
 		sign = 1;
 	}
 	oa = offsetA * 2;
-	sa1 = strideA1 *2;
-	sa2 = strideA2 *2;
+	sa1 = strideA1 * 2;
+	sa2 = strideA2 * 2;
 	ox = offsetX * 2;
 	oy = offsetY * 2;
 	sx = strideX * 2;

--- a/lib/node_modules/@stdlib/blas/base/cgemv/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/lib/base.js
@@ -23,7 +23,6 @@
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 var cfill = require( '@stdlib/blas/ext/base/cfill' ).ndarray;
 var cscal = require( '@stdlib/blas/base/cscal' ).ndarray;
-var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
@@ -144,7 +143,7 @@ function cgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, 
 
 	// y = beta*y
 	if ( rebeta === 0.0 && imbeta === 0.0 ) {
-		cfill( ylen, new Complex64( 0.0, 0.0 ), y, strideY, offsetY );
+		cfill( ylen, beta, y, strideY, offsetY );
 	} else if ( rebeta !== 1.0 || imbeta !== 0.0 ) {
 		cscal( ylen, beta, y, strideY, offsetY );
 	}

--- a/lib/node_modules/@stdlib/blas/base/cgemv/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/lib/ndarray.js
@@ -24,6 +24,9 @@ var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operatio
 var format = require( '@stdlib/string/format' );
 var base = require( './base.js' );
 
+
+// MAIN //
+
 /**
 * Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y` or `y = α*A^H*x + β*y`, where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
 *

--- a/lib/node_modules/@stdlib/blas/ext/base/ddiff/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ddiff/README.md
@@ -68,7 +68,7 @@ The function has the following parameters:
 -   **workspace**: workspace [`Float64Array`][@stdlib/array/float64]. Must have `N + N1 + N2 - 1` elements.
 -   **strideW**: stride length for `workspace`.
 
-The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to differences of every other element:
+The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to compute differences of every other element:
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );

--- a/lib/node_modules/@stdlib/napi/argv-booleanarray/lib/native.js
+++ b/lib/node_modules/@stdlib/napi/argv-booleanarray/lib/native.js
@@ -32,7 +32,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {BooleanArray} v - input array
-* @returns {Uint8Array} input array
+* @returns {BooleanArray} input array
 *
 * @example
 * var BooleanArray = require( '@stdlib/array/bool' );

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dmaxsorted/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dmaxsorted/README.md
@@ -189,8 +189,8 @@ double stdlib_stats_dmaxsorted( const struct ndarray *arrays[] );
 #include <stdio.h>
 
 int main( void ) {
-    // Create a sorted data buffer (ascending):
-    const double data[] = { -8.0, -6.0, -4.0, -2.0, 1.0, 3.0, 5.0, 7.0 };
+   // Create a sorted data buffer (ascending):
+   const double data[] = { -8.0, -6.0, -4.0, -2.0, 1.0, 3.0, 5.0, 7.0 };
 
    // Specify the number of array dimensions:
    const int64_t ndims = 1;

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dmaxsorted/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dmaxsorted/README.md
@@ -189,49 +189,49 @@ double stdlib_stats_dmaxsorted( const struct ndarray *arrays[] );
 #include <stdio.h>
 
 int main( void ) {
-   // Create a sorted data buffer (ascending):
-   const double data[] = { -8.0, -6.0, -4.0, -2.0, 1.0, 3.0, 5.0, 7.0 };
-
-   // Specify the number of array dimensions:
-   const int64_t ndims = 1;
-
-   // Specify the array shape:
-   int64_t shape[] = { 4 };
-
-   // Specify the array strides:
-   int64_t strides[] = { 2*STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
-
-   // Specify the byte offset:
-   const int64_t offset = 0;
-
-   // Specify the array order:
-   const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
-
-   // Specify the index mode:
-   const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
-
-   // Specify the subscript index modes:
-   int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
-   const int64_t nsubmodes = 1;
-
-   // Create an ndarray:
-   struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)data, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
-   if ( x == NULL ) {
-      fprintf( stderr, "Error allocating memory.\n" );
-      exit( 1 );
-   }
-
-   // Define a list of ndarrays:
-   const struct ndarray *arrays[] = { x };
-
-   // Compute the maximum value:
-   double v = stdlib_stats_dmaxsorted( arrays );
-
-   // Print the result:
-   printf( "max: %lf\n", v );
-
-   // Free allocated memory:
-   stdlib_ndarray_free( x );
+    // Create a sorted data buffer (ascending):
+    const double data[] = { -8.0, -6.0, -4.0, -2.0, 1.0, 3.0, 5.0, 7.0 };
+    
+    // Specify the number of array dimensions:
+    const int64_t ndims = 1;
+    
+    // Specify the array shape:
+    int64_t shape[] = { 4 };
+    
+    // Specify the array strides:
+    int64_t strides[] = { 2*STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
+    
+    // Specify the byte offset:
+    const int64_t offset = 0;
+    
+    // Specify the array order:
+    const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
+    
+    // Specify the index mode:
+    const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
+    
+    // Specify the subscript index modes:
+    int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
+    const int64_t nsubmodes = 1;
+    
+    // Create an ndarray:
+    struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)data, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
+    if ( x == NULL ) {
+        fprintf( stderr, "Error allocating memory.\n" );
+        exit( 1 );
+    }
+    
+    // Define a list of ndarrays:
+    const struct ndarray *arrays[] = { x };
+    
+    // Compute the maximum value:
+    double v = stdlib_stats_dmaxsorted( arrays );
+    
+    // Print the result:
+    printf( "max: %lf\n", v );
+    
+    // Free allocated memory:
+    stdlib_ndarray_free( x );
 }
 ```
 

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dmaxsorted/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dmaxsorted/README.md
@@ -191,45 +191,45 @@ double stdlib_stats_dmaxsorted( const struct ndarray *arrays[] );
 int main( void ) {
     // Create a sorted data buffer (ascending):
     const double data[] = { -8.0, -6.0, -4.0, -2.0, 1.0, 3.0, 5.0, 7.0 };
-    
+
     // Specify the number of array dimensions:
     const int64_t ndims = 1;
-    
+
     // Specify the array shape:
     int64_t shape[] = { 4 };
-    
+
     // Specify the array strides:
     int64_t strides[] = { 2*STDLIB_NDARRAY_FLOAT64_BYTES_PER_ELEMENT };
-    
+
     // Specify the byte offset:
     const int64_t offset = 0;
-    
+
     // Specify the array order:
     const enum STDLIB_NDARRAY_ORDER order = STDLIB_NDARRAY_ROW_MAJOR;
-    
+
     // Specify the index mode:
     const enum STDLIB_NDARRAY_INDEX_MODE imode = STDLIB_NDARRAY_INDEX_ERROR;
-    
+
     // Specify the subscript index modes:
     int8_t submodes[] = { STDLIB_NDARRAY_INDEX_ERROR };
     const int64_t nsubmodes = 1;
-    
+
     // Create an ndarray:
     struct ndarray *x = stdlib_ndarray_allocate( STDLIB_NDARRAY_FLOAT64, (uint8_t *)data, ndims, shape, strides, offset, order, imode, nsubmodes, submodes );
     if ( x == NULL ) {
         fprintf( stderr, "Error allocating memory.\n" );
         exit( 1 );
     }
-    
+
     // Define a list of ndarrays:
     const struct ndarray *arrays[] = { x };
-    
+
     // Compute the maximum value:
     double v = stdlib_stats_dmaxsorted( arrays );
-    
+
     // Print the result:
     printf( "max: %lf\n", v );
-    
+
     // Free allocated memory:
     stdlib_ndarray_free( x );
 }


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between `7a025ca7` (2026-04-20 16:07:19 -0400) and `1089250d` (2026-04-21 03:37:01 -0700) — 49 first-parent commits in the window. Fixes are grouped by package, one commit per group.

### `blas/base/cgemv` (originating commit `b3e5d1b5`)

-   **Bug:** when `beta == 0`, the `y = beta*y` short-circuit fills `y` with `alpha` instead of zero, producing `alpha + alpha*A*x` per element whenever `alpha != 0`. Mirror the `dgemv`/`sgemv` pattern by passing `new Complex64( 0.0, 0.0 )` to `cfill` so prior NaN values do not propagate (`lib/base.js` L145–150).
-   **Style:** restore symmetric spacing around `*` in the byte-stride calculations `sa1 = strideA1 * 2` / `sa2 = strideA2 * 2` (`lib/base.js` L163–164).
-   **Style:** add the missing `// MAIN //` section banner before the function JSDoc (`lib/ndarray.js` L25–28).

### `blas/ext/base/ddiff` (originating commit `a0816279`)

-   **Docs:** README intro to the strided example was missing the verb — `to differences of every other element:` → `to compute differences of every other element:` (`README.md` L71).

### `stats/base/ndarray/dmaxsorted` (originating commit `66e748fe`)

-   **Docs:** the first two lines inside `int main()` of the C example used 4-space indentation while the rest of the body uses 3 spaces — re-indent for consistency with sibling `dmeanwd`/`dmeanpn`/`dmeanpw` READMEs (`README.md` L192–193).

### `napi/argv-booleanarray` (originating commit `e60e084f`)

-   **Docs:** `e60e084f` changed `@returns` to `Uint8Array`, but the wrapper still returns the original `BooleanArray` `v`; only the reinterpreted view is passed to the addon. Revert the annotation to `BooleanArray` to match the actual return value and the `@param` (`lib/native.js` L34–35).

## Related Issues

This pull request has the following related issues:

-   None.

## Questions

No.

## Other

### Validation

-   Style guide compliance audit across `blas/**`, `ndarray/**`, `napi/**`, `stats/**`, `math/**`, `_tools/eslint/**`, READMEs touched by `59d0640a`.
-   Bug scan across the union diff plus per-commit diffs.
-   Each finding was independently re-verified against the worktree before applying a fix.

### Excluded

-   Anything requiring interpretation, judgement calls, or sources outside the diff window.
-   Anything reported by a single reviewer that could not be re-verified by re-reading the diff.
-   Subjective preferences not mandated by the style guide.
-   The C-benchmark `malloc` refactor (#8643) and JS-benchmark `format` refactor (#8647) are deliberate idiom migrations — not flagged.
-   `0b14ced4`'s local `PI` macro in place of `M_PI` is intentional for portability — not flagged.
-   `1089250d`'s `eslint-disable-next-line stdlib/no-new-array` suppressions in `math/strided/special/sin-by` tests are intentional (the test exercises sparse-array semantics) — not flagged.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated commit-review pass over the prior 24 hours of `develop`. Each finding was generated by parallel reviewer agents, filtered for high-signal-only issues (objective bugs, unambiguous style-guide violations, on-sight typos), and independently re-verified against the worktree before any fix was applied. A maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
