### PR TITLE
chore: propagate recent fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/ops/add-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/add-by/test/test.main.js
@@ -77,7 +77,9 @@ tape( 'the function performs element-wise addition via a callback function', fun
 	addBy( x.length, x, 1, y, 1, z, 1, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -86,8 +88,10 @@ tape( 'the function performs element-wise addition via a callback function', fun
 	addBy( x.length, x, 1, y, 1, z, 1, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/ops/add-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/add-by/test/test.main.js
@@ -79,6 +79,7 @@ tape( 'the function performs element-wise addition via a callback function', fun
 
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -91,6 +92,7 @@ tape( 'the function performs element-wise addition via a callback function', fun
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();

--- a/lib/node_modules/@stdlib/math/strided/ops/add-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/add-by/test/test.ndarray.js
@@ -78,6 +78,7 @@ tape( 'the function performs element-wise addition via a callback function', fun
 
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -90,6 +91,7 @@ tape( 'the function performs element-wise addition via a callback function', fun
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();

--- a/lib/node_modules/@stdlib/math/strided/ops/add-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/add-by/test/test.ndarray.js
@@ -76,7 +76,9 @@ tape( 'the function performs element-wise addition via a callback function', fun
 	addBy( x.length, x, 1, 0, y, 1, 0, z, 1, 0, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -85,8 +87,10 @@ tape( 'the function performs element-wise addition via a callback function', fun
 	addBy( x.length, x, 1, 0, y, 1, 0, z, 1, 0, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.main.js
@@ -77,7 +77,9 @@ tape( 'the function performs element-wise multiplication via a callback function
 	mulBy( x.length, x, 1, y, 1, z, 1, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -86,8 +88,10 @@ tape( 'the function performs element-wise multiplication via a callback function
 	mulBy( x.length, x, 1, y, 1, z, 1, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.main.js
@@ -79,6 +79,7 @@ tape( 'the function performs element-wise multiplication via a callback function
 
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -91,6 +92,7 @@ tape( 'the function performs element-wise multiplication via a callback function
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();

--- a/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.ndarray.js
@@ -78,6 +78,7 @@ tape( 'the function performs element-wise multiplication via a callback function
 
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -90,6 +91,7 @@ tape( 'the function performs element-wise multiplication via a callback function
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();

--- a/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.ndarray.js
@@ -76,7 +76,9 @@ tape( 'the function performs element-wise multiplication via a callback function
 	mulBy( x.length, x, 1, 0, y, 1, 0, z, 1, 0, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -85,8 +87,10 @@ tape( 'the function performs element-wise multiplication via a callback function
 	mulBy( x.length, x, 1, 0, y, 1, 0, z, 1, 0, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/ops/sub-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub-by/test/test.main.js
@@ -79,6 +79,7 @@ tape( 'the function performs element-wise subtraction via a callback function', 
 
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -91,6 +92,7 @@ tape( 'the function performs element-wise subtraction via a callback function', 
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();

--- a/lib/node_modules/@stdlib/math/strided/ops/sub-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub-by/test/test.main.js
@@ -77,7 +77,9 @@ tape( 'the function performs element-wise subtraction via a callback function', 
 	subBy( x.length, x, 1, y, 1, z, 1, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -86,8 +88,10 @@ tape( 'the function performs element-wise subtraction via a callback function', 
 	subBy( x.length, x, 1, y, 1, z, 1, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/ops/sub-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub-by/test/test.ndarray.js
@@ -78,6 +78,7 @@ tape( 'the function performs element-wise subtraction via a callback function', 
 
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -90,6 +91,7 @@ tape( 'the function performs element-wise subtraction via a callback function', 
 	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+
 	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();

--- a/lib/node_modules/@stdlib/math/strided/ops/sub-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub-by/test/test.ndarray.js
@@ -76,7 +76,9 @@ tape( 'the function performs element-wise subtraction via a callback function', 
 	subBy( x.length, x, 1, 0, y, 1, 0, z, 1, 0, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -85,8 +87,10 @@ tape( 'the function performs element-wise subtraction via a callback function', 
 	subBy( x.length, x, 1, 0, y, 1, 0, z, 1, 0, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
+	// eslint-disable-next-line stdlib/no-new-array
 	y = new Array( 5 ); // sparse array
 	y[ 2 ] = rand();
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/abs-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/abs-by/test/test.ndarray.js
@@ -61,6 +61,7 @@ tape( 'the function computes the absolute value of each indexed strided array el
 	absBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -69,6 +70,7 @@ tape( 'the function computes the absolute value of each indexed strided array el
 	absBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = -3.0;
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/abs2-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/abs2-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the squared absolute value of each indexed strided 
 	abs2By( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the squared absolute value of each indexed strided 
 	abs2By( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/abs2-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/abs2-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the squared absolute value of each indexed strided 
 	abs2By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the squared absolute value of each indexed strided 
 	abs2By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/acos-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acos-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the arccosine via a callback function', function te
 	acosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the arccosine via a callback function', function te
 	acosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/acos-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acos-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the arccosine via a callback function', function te
 	acosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the arccosine via a callback function', function te
 	acosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/acosh-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acosh-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the hyperbolic arccosine via a callback function', 
 	acoshBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the hyperbolic arccosine via a callback function', 
 	acoshBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/acosh-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acosh-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the hyperbolic arccosine via a callback function', 
 	acoshBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the hyperbolic arccosine via a callback function', 
 	acoshBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/acot-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acot-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the inverse cotangent via a callback function', fun
 	acotBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the inverse cotangent via a callback function', fun
 	acotBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/acot-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acot-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the inverse cotangent via a callback function', fun
 	acotBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the inverse cotangent via a callback function', fun
 	acotBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/acoth-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acoth-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the inverse hyperbolic cotangent via a callback fun
 	acothBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the inverse hyperbolic cotangent via a callback fun
 	acothBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/acoth-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acoth-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the inverse hyperbolic cotangent via a callback fun
 	acothBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the inverse hyperbolic cotangent via a callback fun
 	acothBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/acoversin-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/acoversin-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the inverse coversed sine via a callback function',
 	acoversinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the inverse coversed sine via a callback function',
 	acoversinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/ahaversin-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/ahaversin-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the inverse half-value versed sine via a callback f
 	ahaversinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the inverse half-value versed sine via a callback f
 	ahaversinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/ahaversin-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/ahaversin-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the inverse half-value versed sine via a callback f
 	ahaversinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the inverse half-value versed sine via a callback f
 	ahaversinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/asin-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/asin-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the arcsine via a callback function', function test
 	asinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the arcsine via a callback function', function test
 	asinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/asin-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/asin-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the arcsine via a callback function', function test
 	asinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the arcsine via a callback function', function test
 	asinBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/asinh-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/asinh-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the hyperbolic arcsine via a callback function', fu
 	asinhBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the hyperbolic arcsine via a callback function', fu
 	asinhBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/atan-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/atan-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the arctangent via a callback function', function t
 	atanBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the arctangent via a callback function', function t
 	atanBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/atanh-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/atanh-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the hyperbolic arctangent via a callback function',
 	atanhBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the hyperbolic arctangent via a callback function',
 	atanhBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/atanh-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/atanh-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the hyperbolic arctangent via a callback function',
 	atanhBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the hyperbolic arctangent via a callback function',
 	atanhBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/avercos-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/avercos-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the inverse versed cosine via a callback function',
 	avercosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the inverse versed cosine via a callback function',
 	avercosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/besselj0-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/besselj0-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the Bessel function of the first kind of order zero
 	besselj0By( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the Bessel function of the first kind of order zero
 	besselj0By( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/besselj0-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/besselj0-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the Bessel function of the first kind of order zero
 	besselj0By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the Bessel function of the first kind of order zero
 	besselj0By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/besselj1-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/besselj1-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the Bessel function of the first kind of order one 
 	besselj1By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the Bessel function of the first kind of order one 
 	besselj1By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/bessely0-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/bessely0-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the Bessel function of the second kind of order zer
 	bessely0By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the Bessel function of the second kind of order zer
 	bessely0By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/bessely1-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/bessely1-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the Bessel function of the second kind of order one
 	bessely1By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the Bessel function of the second kind of order one
 	bessely1By( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/binet-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/binet-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function evaluates Binet\'s formula extended to real numbers via a ca
 	binetBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function evaluates Binet\'s formula extended to real numbers via a ca
 	binetBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/binet-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/binet-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function evaluates Binet\'s formula extended to real numbers via a ca
 	binetBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function evaluates Binet\'s formula extended to real numbers via a ca
 	binetBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/cbrt-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/cbrt-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the cube root of each indexed strided array element
 	cbrtBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the cube root of each indexed strided array element
 	cbrtBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/cbrt-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/cbrt-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the cube root of each indexed strided array element
 	cbrtBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the cube root of each indexed strided array element
 	cbrtBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the cosine via a callback function', function test(
 	cosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the cosine via a callback function', function test(
 	cosBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/sin-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/sin-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the sine of each indexed strided array element via 
 	sinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the sine of each indexed strided array element via 
 	sinBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/sqrt-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/sqrt-by/test/test.main.js
@@ -74,6 +74,7 @@ tape( 'the function computes the principal square root via a callback function',
 	sqrtBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -82,6 +83,7 @@ tape( 'the function computes the principal square root via a callback function',
 	sqrtBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/math/strided/special/sqrt-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/special/sqrt-by/test/test.ndarray.js
@@ -73,6 +73,7 @@ tape( 'the function computes the principal square root via a callback function',
 	sqrtBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
@@ -81,6 +82,7 @@ tape( 'the function computes the principal square root via a callback function',
 	sqrtBy( x.length, x, 1, 0, y, 1, 0, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];

--- a/lib/node_modules/@stdlib/ndarray/from-scalar-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/from-scalar-like/lib/main.js
@@ -23,7 +23,7 @@
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
-var isComplexDataType = require( '@stdlib/array/base/assert/is-complex-floating-point-data-type' );
+var isComplexDataType = require( '@stdlib/ndarray/base/assert/is-complex-floating-point-data-type' );
 var isAccessorArray = require( '@stdlib/array/base/assert/is-accessor-array' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
 var accessorSetter = require( '@stdlib/array/base/accessor-setter' );

--- a/lib/node_modules/@stdlib/ndarray/from-scalar/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/from-scalar/lib/main.js
@@ -23,7 +23,7 @@
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
 var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
-var isComplexDataType = require( '@stdlib/array/base/assert/is-complex-floating-point-data-type' );
+var isComplexDataType = require( '@stdlib/ndarray/base/assert/is-complex-floating-point-data-type' );
 var isComplexLike = require( '@stdlib/assert/is-complex-like' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isAccessorArray = require( '@stdlib/array/base/assert/is-accessor-array' );


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between `2026-04-20T16:07:19-04:00` and `2026-04-21T03:37:01-07:00` (SHA range `7a025ca74..1089250db`) to sibling packages sharing the same defect.

### `fix:` — wrong validation package (source `b7f85c29d`)

Array-dtype assertion `@stdlib/array/base/assert/is-complex-floating-point-data-type` checks against `@stdlib/array/dtypes`, but these consumers resolve `dt` from ndarray dtype strings (either via `getDType(x)` or `opts.dtype`), so the guard would misfire on ndarray-only dtypes. Swapped for the `@stdlib/ndarray/base/assert/...` variant already used by `broadcast-scalar` and `broadcast-scalar-like`.

Source: `b7f85c29d`

Targets:
- `lib/node_modules/@stdlib/ndarray/from-scalar/lib/main.js`
- `lib/node_modules/@stdlib/ndarray/from-scalar-like/lib/main.js`

### `chore:` — missing `stdlib/no-new-array` disable directives in `*-by` tests (source `1089250db`)

The `stdlib/no-new-array` rule is `error` (see `etc/eslint/rules/stdlib.js:4475`), so intentional sparse-array construction via `new Array( N )` requires an explicit `// eslint-disable-next-line stdlib/no-new-array` on the preceding line. 40 sibling `*-by` test files under `math/strided/ops/` and `math/strided/special/` carried the idiom without the directive; added 92 directives total. For the `ops/{add,sub,mul}-by` files, consecutive `x =` and `y =` sparse-array assignments each received their own preceding directive, since `eslint-disable-next-line` only silences the single following line.

Source: `1089250db`

Targets (40 files):
- `math/strided/ops/add-by/test/{test.main,test.ndarray}.js`
- `math/strided/ops/mul-by/test/{test.main,test.ndarray}.js`
- `math/strided/ops/sub-by/test/{test.main,test.ndarray}.js`
- `math/strided/special/{abs,abs2,acos,acosh,acot,acoth,acoversin,ahaversin,asin,asinh,atan,atanh,avercos,besselj0,besselj1,bessely0,bessely1,binet,cbrt,cos,sin,sqrt}-by/test/test.*.js` (the specific `test.main.js` / `test.ndarray.js` files still missing the directive; full list in the local report)

## Related Issues

No.

## Questions

No.

## Other

### Validation

- Pattern search scope: ndarray namespace for the validation-package swap; `math/strided/{ops,special}/*-by` test files for the lint-disable directive.
- Candidate enumeration: `rg` / script-driven search, cross-checked by a sonnet Explore agent. Results reconciled against a Python pass that classifies each sparse-array line as `needs-fix` or `already-fixed` based on the preceding line.
- Independent validation: opus agent audited (a) Pattern A target files to confirm `dt` originates from ndarray dtype context (verified via `getDType` / `opts.dtype` / `DEFAULT_CMPLX`), and (b) a sampled cross-section of Pattern B sites to confirm the idiom is intentional sparse-array construction and the preceding line lacks a disable directive. All sampled sites returned `confirmed`.
- Style: patches match source-commit style verbatim — single-line module-path swap for Pattern A, tab-indented `// eslint-disable-next-line stdlib/no-new-array` preceding each `new Array(...)` for Pattern B.

### Deliberately excluded

- Sites already fixed by the source commit (`math/strided/special/sin-by/test/test.ndarray.js`) and sibling `*-by` files that already had the directive (e.g. `acovercos-by`, `abs-by/test.main.js`, `atan-by/test.main.js`).
- `chore: add missing npm engine constraint to stats/base/dists/*/ctor` (`187e14109`) — touches only `package.json`, excluded per chore-propagation scope rules.
- `docs: update namespace table of contents` (`0f62461c9`, `f38217702`) — auto-generated ToC updates with no generalizable signature.
- `chore: clean-up native wrappers` (`e3862232d`): all 7 `napi/argv-*/lib/native.js` sites matching the pattern are already in the corrected form.
- `chore: clean-up` (`9cc43caf4`) targeting `napi/argv-booleanarray`: effectively reverted by `e60e084fe`, so the guarded form is now the canonical shape; no propagation target.
- `docs: propagate recent fixes to sibling packages` (`59d0640a1`): the "does not perform rotation" → "a rotation" typo fix and `argv-bool` "number → boolean" typo fix have no remaining sites in the ndarray rotation namespace or type-specific `argv-*` packages.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the fix-propagation routine: it enumerated `fix:` / `chore:` / `docs:` commits merged to `develop` in the preceding 24 hours, derived pattern signatures, searched for sibling sites via `rg`, validated each candidate with an opus audit agent, and applied the propagated patches. A human maintainer will audit before promoting out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
