### PR TITLE
refactor: optimize `number/uint32/base/muldw` implementation for better performance

### DIFF
--- a/lib/node_modules/@stdlib/number/uint32/base/muldw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/muldw/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var minstd = require( '@stdlib/random/base/minstd' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -33,12 +33,17 @@ var umuldw = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var x;
 	var y;
+	var z;
 	var i;
+
+	x = discreteUniform( 100, 0x10000, 0x10000000, {
+		'dtype': 'uint32'
+	});
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = minstd();
-		y = umuldw( x, x );
+		z = x[ i%x.length ];
+		y = umuldw( z, z );
 		if ( isnan( y[0] ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -55,14 +60,19 @@ bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var x;
 	var y;
+	var z;
 	var i;
 
-	out = [ 0.0, 0.0];
+	x = discreteUniform( 100, 0x10000, 0x10000000, {
+		'dtype': 'uint32'
+	});
+
+	out = [ 0.0, 0.0 ];
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = minstd();
-		y = umuldw.assign( x, x, out, 1, 0 );
+		z = x[ i%x.length ];
+		y = umuldw.assign( z, z, out, 1, 0 );
 		if ( isnan( y[0] ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/number/uint32/base/muldw/lib/assign.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/muldw/lib/assign.js
@@ -76,7 +76,7 @@ function umuldw(a, b, out, stride, offset ) {
 	k = ( t >>> 16 ) >>> 0;
 
 	out[ offset ] = ( ( ha*hb ) + w1 + k ) >>> 0; // compute the higher 32 bits and cast to an unsigned 32-bit integer
-	out[ offset + stride ] = umul(a, b) >>> 0; // compute the lower 32 bits and cast to an unsigned 32-bit integer
+	out[ offset + stride ] = umul( a, b ) >>> 0; // compute the lower 32 bits and cast to an unsigned 32-bit integer
 
 	return out;
 }

--- a/lib/node_modules/@stdlib/number/uint32/base/muldw/lib/assign.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/muldw/lib/assign.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var umul = require( '@stdlib/number/uint32/base/mul' );
 
 
 // VARIABLES //
@@ -49,7 +49,6 @@ var LOW_WORD_MASK = 0x0000ffff>>>0; // asm type annotation
 function umuldw(a, b, out, stride, offset ) {
 	var w1;
 	var w2;
-	var w3;
 	var ha;
 	var hb;
 	var la;
@@ -57,11 +56,6 @@ function umuldw(a, b, out, stride, offset ) {
 	var t;
 	var k;
 
-	if ( isnan( a ) || isnan( b ) ) {
-		out[ offset ] = NaN;
-		out[ offset + stride ] = NaN;
-		return out;
-	}
 	a >>>= 0; // asm type annotation
 	b >>>= 0; // asm type annotation
 
@@ -72,7 +66,6 @@ function umuldw(a, b, out, stride, offset ) {
 	lb = ( b & LOW_WORD_MASK ) >>> 0;
 
 	t = ( la*lb ) >>> 0;
-	w3 = ( t & LOW_WORD_MASK ) >>> 0;
 	k = ( t >>> 16 ) >>> 0;
 
 	t = ( ( ha*lb ) + k ) >>> 0;
@@ -83,7 +76,7 @@ function umuldw(a, b, out, stride, offset ) {
 	k = ( t >>> 16 ) >>> 0;
 
 	out[ offset ] = ( ( ha*hb ) + w1 + k ) >>> 0; // compute the higher 32 bits and cast to an unsigned 32-bit integer
-	out[ offset + stride ] = ( ( t << 16 ) + w3) >>> 0; // compute the lower 32 bits and cast to an unsigned 32-bit integer
+	out[ offset + stride ] = umul(a, b) >>> 0; // compute the lower 32 bits and cast to an unsigned 32-bit integer
 
 	return out;
 }

--- a/lib/node_modules/@stdlib/number/uint32/base/muldw/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/muldw/lib/main.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var fcn = require( './assign.js' );
 
 
@@ -38,10 +37,6 @@ var fcn = require( './assign.js' );
 * // returns [ 954437176, 1908874354 ]
 */
 function umuldw( a, b ) {
-	if ( isnan( a ) || isnan( b ) ) {
-		return [ NaN, NaN ];
-	}
-
 	return fcn( a, b, [ 0, 0 ], 1, 0 );
 }
 

--- a/lib/node_modules/@stdlib/number/uint32/base/muldw/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/muldw/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var fcn = require( './assign.js' );
 
 
@@ -37,6 +38,10 @@ var fcn = require( './assign.js' );
 * // returns [ 954437176, 1908874354 ]
 */
 function umuldw( a, b ) {
+	if ( isnan( a ) || isnan( b ) ) {
+		return [ NaN, NaN ];
+	}
+
 	return fcn( a, b, [ 0, 0 ], 1, 0 );
 }
 

--- a/lib/node_modules/@stdlib/number/uint32/base/muldw/test/test.assign.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/muldw/test/test.assign.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var umuldw = require( './../lib/assign.js' );
 
@@ -36,31 +35,6 @@ var data = require( './fixtures/c/data.json' );
 tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
 	t.strictEqual( typeof umuldw, 'function', 'main export is a function' );
-	t.end();
-});
-
-tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
-	var out;
-	var v;
-
-	out = [ 0, 0 ];
-	v = umuldw( NaN, 1, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isnan( v[0] ), true, 'returns expected value' );
-	t.strictEqual( isnan( v[1] ), true, 'returns expected value' );
-
-	out = [ 0, 0 ];
-	v = umuldw( 1, NaN, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isnan( v[0] ), true, 'returns expected value' );
-	t.strictEqual( isnan( v[1] ), true, 'returns expected value' );
-
-	out = [ 0, 0 ];
-	v = umuldw( NaN, NaN, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isnan( v[0] ), true, 'returns expected value' );
-	t.strictEqual( isnan( v[1] ), true, 'returns expected value' );
-
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/number/uint32/base/muldw/test/test.main.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/muldw/test/test.main.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var umuldw = require( './../lib/main.js' );
 
 
@@ -35,24 +34,6 @@ var data = require( './fixtures/c/data.json' );
 tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
 	t.strictEqual( typeof umuldw, 'function', 'main export is a function' );
-	t.end();
-});
-
-tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
-	var v;
-
-	v = umuldw( NaN, 1 );
-	t.strictEqual( isnan( v[0] ), true, 'returns expected value' );
-	t.strictEqual( isnan( v[1] ), true, 'returns expected value' );
-
-	v = umuldw( 1, NaN );
-	t.strictEqual( isnan( v[0] ), true, 'returns expected value' );
-	t.strictEqual( isnan( v[1] ), true, 'returns expected value' );
-
-	v = umuldw( NaN, NaN );
-	t.strictEqual( isnan( v[0] ), true, 'returns expected value' );
-	t.strictEqual( isnan( v[1] ), true, 'returns expected value' );
-
 	t.end();
 });
 


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Optimizes `number/uint32/base/muldw` implementation to improve performance by moving the `isnan` check out of the lower level implementation.
- Utilizes `number/uint32/base/mul` for computing the lower half of the double word product to reduce unnecessary calculation.
- Remove NaN tests for the lower level implementation.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
