### PR TITLE
chore: fix JavaScript lint errors (issue #11235)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dgemv/test/test.dgemv.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/test/test.dgemv.native.js
@@ -39,7 +39,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );


### PR DESCRIPTION
Removed an unexpected empty line between `require` statements in 
`test.dgemv.native.js` (line 42), which was causing the JavaScript 
lint workflow to fail with `stdlib/no-empty-lines-between-requires`.

Resolves #11235

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)