### PR TITLE
style: align `math/strided/special` README outliers with namespace conventions

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/acos-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/acos-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/acosh-by`][@stdlib/math/strided/special/acosh-by]</span><span class="delimiter">: </span><span class="description">compute the hyperbolic arccosine of each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/acos]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/acos
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/acosh-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/acosh-by
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/strided/special/acosh-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/acosh-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/acos-by`][@stdlib/math/strided/special/acos-by]</span><span class="delimiter">: </span><span class="description">compute the arccosine of each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/acosh]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/acosh
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/acos-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/acos-by
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/strided/special/acot-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/acot-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/acoth-by`][@stdlib/math/strided/special/acoth-by]</span><span class="delimiter">: </span><span class="description">compute the inverse hyperbolic cotangent of each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/acot]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/acot
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/acoth-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/acoth-by
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/strided/special/acoth-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/acoth-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/acot-by`][@stdlib/math/strided/special/acot-by]</span><span class="delimiter">: </span><span class="description">compute the inverse cotangent of each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/acoth]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/acoth
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/acot-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/acot-by
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/strided/special/acovercos-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/acovercos-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/acoversin-by`][@stdlib/math/strided/special/acoversin-by]</span><span class="delimiter">: </span><span class="description">compute the inverse coversed sine of each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/acovercos]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/acovercos
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/acoversin-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/acoversin-by
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/strided/special/acoversin-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/acoversin-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/acovercos-by`][@stdlib/math/strided/special/acovercos-by]</span><span class="delimiter">: </span><span class="description">compute the inverse coversed cosine of each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/acoversin]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/acoversin
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/acovercos-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/acovercos-by
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/strided/special/avercos-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/avercos-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/aversin-by`][@stdlib/math/strided/special/aversin-by]</span><span class="delimiter">: </span><span class="description">compute the inverse versed sine of each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/avercos]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/avercos
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/aversin-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/aversin-by
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/strided/special/aversin-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/aversin-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/avercos-by`][@stdlib/math/strided/special/avercos-by]</span><span class="delimiter">: </span><span class="description">compute the inverse versed cosine of each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/aversin]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/aversin
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/avercos-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/avercos-by
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/strided/special/cos-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/cos-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/sin-by`][@stdlib/math/strided/special/sin-by]</span><span class="delimiter">: </span><span class="description">compute the sine of each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/cos]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cos
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/sin-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/sin-by
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/strided/special/sin-by/README.md
+++ b/lib/node_modules/@stdlib/math/strided/special/sin-by/README.md
@@ -229,6 +229,12 @@ console.log( y );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/strided/special/cos-by`][@stdlib/math/strided/special/cos-by]</span><span class="delimiter">: </span><span class="description">compute the cosine for each element retrieved from an input strided array via a callback function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -242,6 +248,12 @@ console.log( y );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [@stdlib/math/base/special/sin]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/sin
+
+<!-- <related-links> -->
+
+[@stdlib/math/strided/special/cos-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/strided/special/cos-by
+
+<!-- </related-links> -->
 
 </section>
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request aligns outliers in `math/strided/special` with the namespace's majority README conventions (random namespace pick, seed `1682455737`). It:

-   Adds a missing `## See Also` README section to 10 `-by` packages whose `<section class="related">` block was empty, matching the section present in 70/81 (86.4%) of sibling packages.
-   Touches only `README.md` files — no source, test, example, or API changes.

### Namespace summary

-   Target: `math/strided/special`
-   Member count: 81 non-autogenerated packages (no autogenerated exclusions)
-   Features analyzed: 11 (8 structural, 3 semantic)
-   Features with a clear majority (≥75% conformance): `file_tree` (100%), `pkg_top_keys` (100%), `validation_prologue` (100% empty — packages delegate), `error_construction` (100% none), `jsdoc_has_example` (100%), `setReadOnly` dependency (100% on re-check), `readme_see_also` (86.4%), `jsdoc_throws` (86% none)
-   Features without a clear majority (excluded): `readme_section_sequence` (4 competing sequences), `public_signature` (4 shapes split 26/22/22/11), `return_kind` (classification noise; barely at 75%)
-   Single actionable drift finding: 11 `-by` packages missed the `## See Also` README section. After three-agent validation, 10 advanced; `binet-by` dropped as intentional deviation (no natural sibling).

### Per-package changes

#### `math/strided/special/acos-by`

Added `## See Also` block referencing `math/strided/special/acosh-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

#### `math/strided/special/acosh-by`

Added `## See Also` block referencing `math/strided/special/acos-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

#### `math/strided/special/acot-by`

Added `## See Also` block referencing `math/strided/special/acoth-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

#### `math/strided/special/acoth-by`

Added `## See Also` block referencing `math/strided/special/acot-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

#### `math/strided/special/acovercos-by`

Added `## See Also` block referencing `math/strided/special/acoversin-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

#### `math/strided/special/acoversin-by`

Added `## See Also` block referencing `math/strided/special/acovercos-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

#### `math/strided/special/avercos-by`

Added `## See Also` block referencing `math/strided/special/aversin-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

#### `math/strided/special/aversin-by`

Added `## See Also` block referencing `math/strided/special/avercos-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

#### `math/strided/special/cos-by`

Added `## See Also` block referencing `math/strided/special/sin-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

#### `math/strided/special/sin-by`

Added `## See Also` block referencing `math/strided/special/cos-by`. Matches existing `-by` sibling-pairing template (86.4% conformance across the namespace).

### Validation

-   Structural extraction across all 81 members (file tree, `package.json`, README sections, `manifest.json`, test/benchmark/example filenames).
-   Semantic extraction via 4 batched sonnet agents (`publicSignature`, `validationPrologue`, `errorConstruction`, `jsdocShape`, `dependencies`, `returnKind`).
-   Three-agent drift validation (opus semantic-review, opus cross-reference, sonnet structural-review) — unanimous `confirmed-drift` on the 10 applied fixes.

**Deliberately excluded:**

-   `binet-by` (Agent 1 marked intentional deviation — no natural strided/special sibling).
-   `jsdoc_throws` outliers (`abs`, `abs2`, `cbrt`, `ceil`, `deg2rad`, `floor`, `inv`, `ramp`, `rsqrt`, `sqrt`, `trunc`) — the 11 generic-dispatch packages genuinely throw via `dispatch()` and warrant documented `@throws` tags; not drift.
-   Features below the 75% majority threshold.

## Related Issues

> Does this pull request have any related issues?

None — routine drift maintenance.

## Questions

> Any questions for reviewers of this pull request?

None.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Applied as one commit per outlier package for per-package auditability.
-   The `## See Also` sections and the `<related-links>` link-ref blocks use the exact template from `asin-by`/`asinh-by`, `atan-by`/`atanh-by`, and `ahavercos-by`/`ahaversin-by`.
-   Full drift report saved locally at `~/drift-reports/drift-math-strided-special-2026-04-22.md` (not in tree).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was drafted by Claude (Anthropic) under the cross-package drift-detection routine. Structural and semantic features were extracted across all 81 namespace members; three independent validator agents (opus × 2, sonnet × 1) unanimously confirmed drift on the 10 applied fixes. The See Also blocks match the exact template used by existing `-by` sibling pairings.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
