### PR TITLE
chore: follow-up fixes

### DIFF
--- a/docs/migration-guides/numpy/README.md
+++ b/docs/migration-guides/numpy/README.md
@@ -35,10 +35,10 @@ limitations under the License.
 | Broadcast a scalar to a specified shape | `np.broadcast_to(np.array(scalar), shape)` | [`broadcastScalar(scalar, shape)`][@stdlib/ndarray/broadcast-scalar] |
 | Copy an array | `np.copy(x)` | [`copy(x)`][@stdlib/ndarray/copy] |
 | Count the number of falsy values in an array | `x.size-np.count_nonzero(x)` | [`countFalsy(x)`][@stdlib/ndarray/count-falsy] |
-| Count the number of truthy values in an array | `np.count_nonzeros(x)` | [`countTruthy(x)`][@stdlib/ndarray/count-truthy] |
+| Count the number of truthy values in an array | `np.count_nonzero(x)` | [`countTruthy(x)`][@stdlib/ndarray/count-truthy] |
 | Test whether an array includes a specific value | `np.any(np.equal(x,v))` | [`includes(x,v)`][@stdlib/ndarray/includes] |
 | Reverse the elements along a dimension | `np.flip(x, axis=dim)` | [`reverseDimension(x, dim)`][@stdlib/ndarray/reverse-dimension] |
-| Prepend a a specified number of singleton dimensions | `np.reshape(x, (1,)*n + x.shape)` | [`prependSingletonDimensions(x, n)`][@stdlib/ndarray/prepend-singleton-dimensions] |
+| Prepend a specified number of singleton dimensions | `np.reshape(x, (1,)*n + x.shape)` | [`prependSingletonDimensions(x, n)`][@stdlib/ndarray/prepend-singleton-dimensions] |
 | Test whether an array contains at least `n` truthy values | `np.count_nonzero(x) >= n` | [`some(x, n)`][@stdlib/ndarray/some] |
 
 <!-- lint enable table-pipe-alignment -->

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/c/benchmark.length.c
@@ -120,6 +120,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/sdiff/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdiff/README.md
@@ -68,7 +68,7 @@ The function has the following parameters:
 -   **workspace**: workspace [`Float32Array`][@stdlib/array/float32]. Must have `N + N1 + N2 - 1` elements.
 -   **strideW**: stride length for `workspace`.
 
-The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to differences of every other element:
+The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to compute differences of every other element:
 
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );

--- a/lib/node_modules/@stdlib/ndarray/base/reinterpret-boolean/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/reinterpret-boolean/docs/types/test.ts
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable space-in-parens */
-
 import zeros = require( '@stdlib/ndarray/base/zeros' );
 import reinterpretBoolean = require( './index' );
 


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-04-21 12:06:09 -0700 (`6f2e5f611`) and 2026-04-22 04:44:47 -0700 (`78898df73`).

Findings were gathered by running four independent reviewers (two style-guide, two bug-hunting) across the union diff of the window; only issues reproducible from the diff alone and supported by a concrete fix are included. Each bullet cites the originating commit:

### `blas/ext/base/scusumkbn2`

-   Memory leak in `c5b700a07`: `lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/c/benchmark.length.c` refactored `benchmark1` to heap-allocate `x` and `y` but forgot to `free` them; add matching `free` calls before `return elapsed;` to match `benchmark2`.

### `blas/ext/base/sdiff`

-   Fix missing verb in sdiff README (`7c287ff7a`, `lib/node_modules/@stdlib/blas/ext/base/sdiff/README.md`): insert "compute" in sentence that reads "to differences of every other element" to match `ddiff` peer implementation.

### `docs/migration-guides/numpy`

-   Fix typos in numpy migration guide: correct `np.count_nonzeros` to `np.count_nonzero` (`1be7bcc81`, `docs/migration-guides/numpy/README.md`) and remove duplicated article in "Prepend a a specified number of singleton dimensions".

### `ndarray/base/reinterpret-boolean`

-   Remove stray eslint directive from `lib/node_modules/@stdlib/ndarray/base/reinterpret-boolean/docs/types/test.ts` (`be023a59`). The `/* eslint-disable space-in-parens */` comment serves no purpose — the file has no violations and sibling modules don't carry it.

## Related Issues

None.

## Questions

No.

## Other

### Validation

Checked:

-   Style-guide compliance for all new `blas/ext/base`, `ndarray/base`, `napi`, `number/{u,}int32/base/muldw`, `blas/base/cgemv`, and the NumPy migration guide additions against `docs/style-guides` and sibling reference packages.
-   Bug scan across the full union diff focused on new code paths (unitspace reductions, `sdiff` forward-difference recursion, reinterpret casts, `rot180` indexing, N-API strided boolean matrix parsing) plus the mechanical VLA→heap C benchmark refactor (malloc/free balance, no double-free).

Deliberately excluded (did not meet the high-signal bar):

-   Breaking `NaN`-guard removals in `number/{u,}int32/base/muldw` and the redundant-`isnan` drop in `stats/base/dists/hypergeometric/mean` — intentional per the `refactor!` / `refactor:` commit messages.
-   Namespace-ordering concerns around `reinterpretComplex64`/`reinterpretComplex128` and `rot180`/`rot90` — stdlib uses natural numeric ordering for dtype suffixes (see `@stdlib/array` where `Complex64Array` precedes `Complex128Array`), so the existing ordering is consistent.
-   Early-return guard `if ( total <= 1 || k >= total )` in `blas/ext/base/sdiff/lib/ndarray.js` and `src/main.c` — the peer package `blas/ext/base/ddiff` carries the identical guard, so revisiting it would require a scope expansion beyond this window.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was prepared by Claude Code: an automated 24-hour review pass spawned four independent reviewer agents (two style, two bug) against the union diff of commits merged to `develop`, findings were cross-verified by re-reading the diff, and the surviving issues were fixed mechanically. All fixes are local, reversible, and reference-verified against sibling packages.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md