### PR TITLE
chore: propagate recent fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/sdiff/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdiff/README.md
@@ -68,7 +68,7 @@ The function has the following parameters:
 -   **workspace**: workspace [`Float32Array`][@stdlib/array/float32]. Must have `N + N1 + N2 - 1` elements.
 -   **strideW**: stride length for `workspace`.
 
-The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to differences of every other element:
+The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to compute differences of every other element:
 
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/lib/main.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var ln = require( '@stdlib/math/base/special/ln' );
 
 
@@ -64,8 +63,6 @@ var ln = require( '@stdlib/math/base/special/ln' );
 */
 function entropy( a, b ) {
 	if (
-		isnan( a ) ||
-		isnan( b ) ||
 		!isInteger( a ) ||
 		!isInteger( b ) ||
 		a > b

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/lib/main.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 var pow = require( '@stdlib/math/base/special/pow' );
 
@@ -65,8 +64,6 @@ var pow = require( '@stdlib/math/base/special/pow' );
 function kurtosis( a, b ) {
 	var n2;
 	if (
-		isnan( a ) ||
-		isnan( b ) ||
 		!isInteger( a ) ||
 		!isInteger( b ) ||
 		a > b

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/lib/main.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 
 
@@ -63,8 +62,6 @@ var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 */
 function mean( a, b ) {
 	if (
-		isnan( a ) ||
-		isnan( b ) ||
 		!isInteger( a ) ||
 		!isInteger( b ) ||
 		a > b

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/lib/main.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 
 
@@ -63,8 +62,6 @@ var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 */
 function median( a, b ) {
 	if (
-		isnan( a ) ||
-		isnan( b ) ||
 		!isInteger( a ) ||
 		!isInteger( b ) ||
 		a > b

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/lib/main.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 
 
@@ -63,8 +62,6 @@ var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 */
 function skewness( a, b ) {
 	if (
-		isnan( a ) ||
-		isnan( b ) ||
 		!isInteger( a ) ||
 		!isInteger( b ) ||
 		a > b

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/lib/main.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
@@ -70,8 +69,6 @@ var SQRT1O12 = sqrt( 1.0/12.0 );
 */
 function stdev( a, b ) {
 	if (
-		isnan( a ) ||
-		isnan( b ) ||
 		!isInteger( a ) ||
 		!isInteger( b ) ||
 		a > b

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/lib/main.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 var pow = require( '@stdlib/math/base/special/pow' );
 
@@ -64,8 +63,6 @@ var pow = require( '@stdlib/math/base/special/pow' );
 */
 function variance( a, b ) {
 	if (
-		isnan( a ) ||
-		isnan( b ) ||
 		!isInteger( a ) ||
 		!isInteger( b ) ||
 		a > b


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-04-21T04:45Z and 2026-04-22T13:30Z to sibling packages with the same underlying defect.

### Source: `11fe9784` — docs typo

Propagates the typo fix from `11fe9784`, which corrected a missing verb in the example intro sentence of `ddiff`'s README ("to differences" → "to compute differences"). Applied the identical correction to `blas/ext/base/sdiff`, the float32 sibling. No logic changes.

- `lib/node_modules/@stdlib/blas/ext/base/sdiff/README.md`

### Source: `80a434fd` — redundant `isnan` guards

Propagates `80a434fd`, which removed redundant `isnan` pre-checks that are already subsumed by `!isInteger()` — since `isInteger(NaN)` returns `false`, the explicit NaN guards are dead code. Applies the same removal (two guard clauses plus the `is-nan` require) across the seven `stats/base/dists/discrete-uniform/` distribution properties: `mean`, `variance`, `entropy`, `kurtosis`, `skewness`, `stdev`, and `median`. Sibling files covering `cdf`, `logcdf`, `logpmf`, `pmf`, `quantile`, and `mgf` are excluded because they additionally guard continuous inputs (e.g., `isnan(x)`, `isnan(p)`, `isnan(t)`) that have no equivalent named validator, so partial removal there requires adaptation beyond the scope of the source commit.

- `lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/lib/main.js`
- `lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/lib/main.js`
- `lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/lib/main.js`
- `lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/lib/main.js`
- `lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/lib/main.js`
- `lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/lib/main.js`
- `lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/lib/main.js`

## Related Issues

None.

## Questions

No.

## Other

### Validation

- Pattern search scope:
  - `80a434fd` — all `lib/node_modules/@stdlib/stats/base/dists/**/lib/main.js` requiring `@stdlib/math/base/assert/is-nan` (406 files narrowed to 39 with a named validator + isnan guard, then read in full).
  - `11fe9784` — full repo `rg` for `"to differences of every other element"`.
- Two independent Opus validation agents read each of the seven `discrete-uniform` targets in full and separately returned `confirmed` for all seven. A Sonnet style-consistency pass re-verified that each post-removal imports block remains correctly ordered and that untouched sibling files (e.g. `discrete-uniform/cdf`) legitimately retain their `isnan(x)` guards.
- Deliberately excluded (flagged `needs-human` or out of scope):
  - `negative-binomial/mean` — exact two-block shape match, but the next block has no named validator (only `r <= 0.0`, `p < 0.0`, `p > 1.0`). Behavior is preserved only via arithmetic NaN propagation, a weaker guarantee than the source commit's intent.
  - `hypergeometric/{cdf,logpmf,pmf,quantile}` — `isnan(N/K/n)` are redundant but `isnan(x)` / `isnan(p)` gate continuous inputs; partial removal is adaptive, not mechanical.
  - `binomial/*` (13 files), `erlang/*` (8 files), `discrete-uniform/{cdf,logcdf,logpmf,pmf,quantile,mgf}` — same reason: remaining `isnan(x)` / `isnan(p)` / `isnan(t)` clauses are not covered by any named validator.
  - `1089250d` (missing `eslint-disable stdlib/no-new-array` in `sin-by/test/test.ndarray.js`) — search confirmed every other `math/strided/{special,ops}/*-by/test/test.*.js` already carries the comment from `bf821ca6`. No remaining sites.
  - Source commits outside this pattern set (`refactor!:` `NaN`-check removals in `number/{int32,uint32}/base/muldw`, README indentation normalization in `stats/base/ndarray/dmaxsorted`, rot90 description rewrite, migration-guide phrasing tweaks) — each is either a breaking API change or specific to a single file with no sibling that matches the exact pattern.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by Claude Code running the fix-propagation routine: it enumerated fixes merged to `develop` in the last 24 hours, extracted pattern signatures, searched for sibling sites, and filtered candidates through independent validation agents. Each landed change was reviewed against the original commit's intent before inclusion.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md