### PR TITLE
chore: add missing keyword

### DIFF
--- a/lib/node_modules/@stdlib/os/configdir/package.json
+++ b/lib/node_modules/@stdlib/os/configdir/package.json
@@ -56,6 +56,7 @@
     "stdutils",
     "stdutil",
     "utilities",
+    "utility",
     "utils",
     "util",
     "configdir",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Aligning outliers in `os` with namespace majority patterns (random namespace pick, seed `3849209493`).

This pull request:

-   Adds the missing `utility` keyword to `@stdlib/os/configdir`'s `package.json` to bring it in line with the rest of the `os/*` namespace.

### Namespace summary

-   **Namespace:** `os`
-   **Members analyzed:** 8 (`arch`, `byte-order`, `configdir`, `float-word-order`, `homedir`, `num-cpus`, `platform`, `tmpdir`)
-   **Features analyzed:** file tree, `package.json` top-level keys / scripts / stdlib / keywords, `manifest.json` presence, README section set + sequence, `test/` / `benchmark/` / `examples/` file names, export kind, public signature, validation prologue, error construction, JSDoc shape, dependency set.
-   **Features with clear majority (≥75%):** file tree core (13 files, 100%), `package.json` top-level keys (19 keys, 100%), `return kind == value` (100%), keyword set (13 keywords at ≥75%), README sections `Usage` / `Examples` / `CLI` (100%), `See Also` (87.5%), `Notes` (75%).
-   **Features without clear majority (excluded):** `benchmark/benchmark.js` presence (3/8), `manifest.json` presence (2/8), `package.json` `browser` key (3/8), README `C APIs` subsection (2/8), exact ordered README section sequence (5/8), export kind const-vs-function (5/3), validation prologue / error construction (only 1 package validates arguments — insufficient data for a vote).

### Per-outlier corrections

#### `@stdlib/os/configdir`

Added missing `utility` keyword to `package.json`. The keyword is present in 7 of 8 `os/*` packages (87.5% conformance); `configdir` was the sole outlier. Inserted between `"utilities"` and `"utils"` to match the ordering in `os/homedir` and `os/tmpdir`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

What was checked:

-   Structural feature extraction across all 8 members (file tree, `package.json` shape + keywords, `manifest.json` shape, README section headings, `test/` / `benchmark/` / `examples/` file names).
-   Semantic feature extraction on each `lib/main.js` + `lib/index.js` (export kind, public signature, validation prologue, error-construction style, JSDoc shape, `@stdlib/*` dependency set).
-   Three-agent drift validation on every feature where a ≥75% majority was identified (semantic review, cross-reference review, structural review).

What was deliberately excluded:

-   `num-cpus` missing populated `## See Also` content — the section scaffold is present but empty, and the template comment explicitly says *"Do not manually edit this section, as it is automatically populated"*. Fix is owned by the `remark-stdlib-related` tooling, not by a manual patch.
-   `platform` and `tmpdir` missing `## Notes` section — `platform` has nothing noteworthy to document (Agent 1: intentional deviation; Agent 3: no mechanical fix available). `tmpdir`'s `lib/main.js` JSDoc does contain a `## Notes` block, but its content is historical trivia about Node's `os.tmpdir()` introduction in io.js / Node v4 — and stdlib's `tmpdir` does not use `os.tmpdir()`. Porting it would propagate stale content, so dropped as not high-signal.
-   Features without a ≥75% majority (see namespace summary above).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was prepared by Claude Code running a cross-package drift-detection routine over a randomly selected stdlib namespace (seed `3849209493` → `os`). Claude extracted structural and semantic features across the 8 `os/*` members, computed per-feature ≥75% majority patterns, ran three parallel validation agents (opus semantic review, opus cross-reference review, sonnet structural review) against each candidate drift, and applied only the single correction that cleared all three gates: adding `"utility"` to `@stdlib/os/configdir`'s keywords. The remaining candidates (README `Notes` / `See Also` absences) were intentionally dropped because they either require autogen tooling or would propagate stale content. Leaving as a draft for a human maintainer to audit before promotion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01HpagzWPKAxxr2NudhVZuZv)_