### PR TITLE
chore: fix JavaScript lint errors (issue #4582)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/entries.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/entries.js
@@ -61,7 +61,8 @@ function entryPoints( pkgs, clbk ) {
 	var k;
 
 	total = pkgs.length;
-	out = new Array( total );
+	out = [];
+	out.length = total;
 
 	count = 0;
 


### PR DESCRIPTION
## Description

Replaced usage of `new Array()` with an array literal approach to satisfy linting rules while maintaining existing behavior.

## Related Issues

resolves #4582

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].
- [contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

### AI Assistance

- [x] No

---

@stdlib-js/reviewers
