### PR TITLE
chore: fix JavaScript lint errors (issue #11732)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/entries.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/entries.js
@@ -61,7 +61,7 @@ function entryPoints( pkgs, clbk ) {
 	var k;
 
 	total = pkgs.length;
-	out = new Array( total );
+	out = [];
 
 	count = 0;
 
@@ -72,14 +72,14 @@ function entryPoints( pkgs, clbk ) {
 		main = pkgs[ i ].id;
 
 		debug( 'Determined main entry point for package: %s (%d of %d). Main: %s', pkg, k, total, main );
-		out[ i ] = {
+		out.push({
 			'id': main,
 			'pkg': pkg,
 			'dir': pkgs[ i ].dir,
 			'entries': [
 				main
 			]
-		};
+		});
 	}
 	debug( 'Finished determining main entry points.' );
 


### PR DESCRIPTION
Resolves #11732.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a JavaScript lint error in `lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/entries.js`.
-   Replaces `new Array( total )` with an array literal `[]` and `push()` to comply with the `stdlib/no-new-array` ESLint rule.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11732

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The change is semantically equivalent: after the initialization loop runs, the resulting array has the same length and contents as before. Subsequent `out[ idx ]` accesses in the async `done` callback are unaffected since push order matches index order.
-   Verified that the `stdlib/no-new-array` rule no longer fires on the modified file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I used AI assistance only to locate and understand the issue, review the change, and help draft documentation, comments, and messages. The code change itself was authored manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md