### PR TITLE
chore: propagate `blas/base/ndarray/*` modernization fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/caxpy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/caxpy/README.md
@@ -54,7 +54,7 @@ var alpha = scalar2ndarray( new Complex64( 1.0, 2.0 ), {
 var z = caxpy( [ x, y, alpha ] );
 // returns <ndarray>[ <Complex64>[ -2.0, 5.0 ], <Complex64>[ -4.0, 11.0 ], <Complex64>[ -6.0, 17.0 ] ]
 
-var bool = ( y === z );
+var bool = ( z === y );
 // returns true
 ```
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/caxpy/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/caxpy/test/test.js
@@ -24,7 +24,7 @@ var tape = require( 'tape' );
 var isSameComplex64Array = require( '@stdlib/assert/is-same-complex64array' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var scalar2ndarray = require( '@stdlib/ndarray/base/from-scalar' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var getData = require( '@stdlib/ndarray/data-buffer' );
 var caxpy = require( './../lib' );
@@ -95,7 +95,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	]);
 	x = vector( xbuf, 5, 1, 0 );
 	y = vector( ybuf, 5, 1, 0 );
-	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), 'complex64', 'row-major' );
+	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), {
+		'dtype': 'complex64'
+	});
 
 	v = caxpy( [ x, y, alpha ] );
 
@@ -128,7 +130,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	]);
 	x = vector( xbuf, 2, 1, 0 );
 	y = vector( ybuf, 2, 1, 0 );
-	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), 'complex64', 'row-major' );
+	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), {
+		'dtype': 'complex64'
+	});
 
 	v = caxpy( [ x, y, alpha ] );
 
@@ -157,7 +161,9 @@ tape( 'if provided empty ndarrays, the function returns the output ndarray uncha
 	ybuf = new Complex64Array( [] );
 	x = vector( xbuf, 0, 1, 0 );
 	y = vector( ybuf, 0, 1, 0 );
-	alpha = scalar2ndarray( new Complex64( 1.0, 2.0 ), 'complex64', 'row-major' );
+	alpha = scalar2ndarray( new Complex64( 1.0, 2.0 ), {
+		'dtype': 'complex64'
+	});
 
 	v = caxpy( [ x, y, alpha ] );
 
@@ -204,7 +210,9 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		1.0
 	]);
 	y = vector( ybuf, 3, 1, 0 );
-	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), 'complex64', 'row-major' );
+	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), {
+		'dtype': 'complex64'
+	});
 
 	v = caxpy( [ x, y, alpha ] );
 
@@ -261,7 +269,9 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		10.0
 	]);
 	y = vector( ybuf, 3, -1, 2 );
-	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), 'complex64', 'row-major' );
+	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), {
+		'dtype': 'complex64'
+	});
 
 	v = caxpy( [ x, y, alpha ] );
 
@@ -330,7 +340,9 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		8.0
 	]);
 	y = vector( ybuf, 4, 1, 2 );
-	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), 'complex64', 'row-major' );
+	alpha = scalar2ndarray( new Complex64( 2.0, 2.0 ), {
+		'dtype': 'complex64'
+	});
 
 	v = caxpy( [ x, y, alpha ] );
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ccopy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ccopy/README.md
@@ -49,7 +49,7 @@ var y = new Complex64Vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 var z = ccopy( [ x, y ] );
 // returns <ndarray>[ <Complex64>[ 1.0, 2.0 ], <Complex64>[ 3.0, 4.0 ], <Complex64>[ 5.0, 6.0 ] ]
 
-var bool = ( y === z );
+var bool = ( z === y );
 // returns true
 ```
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/daxpy/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/daxpy/test/test.js
@@ -23,7 +23,7 @@
 var tape = require( 'tape' );
 var isSameFloat64Array = require( '@stdlib/assert/is-same-float64array' );
 var Float64Array = require( '@stdlib/array/float64' );
-var scalar2ndarray = require( '@stdlib/ndarray/base/from-scalar' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var getData = require( '@stdlib/ndarray/data-buffer' );
 var daxpy = require( './../lib' );
@@ -72,7 +72,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	ybuf = new Float64Array( [ 1.0, 1.0, 1.0, 1.0, 1.0 ] );
 	x = vector( xbuf, 5, 1, 0 );
 	y = vector( ybuf, 5, 1, 0 );
-	alpha = scalar2ndarray( 2.0, 'float64', 'row-major' );
+	alpha = scalar2ndarray( 2.0, {
+		'dtype': 'float64'
+	});
 
 	v = daxpy( [ x, y, alpha ] );
 
@@ -84,7 +86,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	ybuf = new Float64Array( [ 1.0, 1.0 ] );
 	x = vector( xbuf, 2, 1, 0 );
 	y = vector( ybuf, 2, 1, 0 );
-	alpha = scalar2ndarray( 2.0, 'float64', 'row-major' );
+	alpha = scalar2ndarray( 2.0, {
+		'dtype': 'float64'
+	});
 
 	v = daxpy( [ x, y, alpha ] );
 
@@ -108,7 +112,9 @@ tape( 'if provided empty ndarrays, the function returns the output ndarray uncha
 	ybuf = new Float64Array( [] );
 	x = vector( xbuf, 0, 1, 0 );
 	y = vector( ybuf, 0, 1, 0 );
-	alpha = scalar2ndarray( 5.0, 'float64', 'row-major' );
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float64'
+	});
 
 	v = daxpy( [ x, y, alpha ] );
 
@@ -145,7 +151,9 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		1.0
 	]);
 	y = vector( ybuf, 3, 1, 0 );
-	alpha = scalar2ndarray( 2.0, 'float64', 'row-major' );
+	alpha = scalar2ndarray( 2.0, {
+		'dtype': 'float64'
+	});
 
 	v = daxpy( [ x, y, alpha ] );
 
@@ -181,7 +189,9 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		10.0
 	]);
 	y = vector( ybuf, 3, -1, 2 );
-	alpha = scalar2ndarray( 3.0, 'float64', 'row-major' );
+	alpha = scalar2ndarray( 3.0, {
+		'dtype': 'float64'
+	});
 
 	v = daxpy( [ x, y, alpha ] );
 
@@ -223,7 +233,9 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		8.0
 	]);
 	y = vector( ybuf, 4, 1, 2 );
-	alpha = scalar2ndarray( 3.0, 'float64', 'row-major' );
+	alpha = scalar2ndarray( 3.0, {
+		'dtype': 'float64'
+	});
 
 	v = daxpy( [ x, y, alpha ] );
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dswap/README.md
@@ -54,7 +54,7 @@ var z = dswap( [ x, y ] );
 // x => <ndarray>[ 6.0, 7.0, 8.0, 9.0, 10.0 ]
 // y => <ndarray>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 
-var bool = ( y === z );
+var bool = ( z === y );
 // returns true
 ```
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/gaxpy/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/gaxpy/test/test.js
@@ -22,7 +22,7 @@
 
 var tape = require( 'tape' );
 var isSameArray = require( '@stdlib/assert/is-same-array' );
-var scalar2ndarray = require( '@stdlib/ndarray/base/from-scalar' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var getData = require( '@stdlib/ndarray/data-buffer' );
 var gaxpy = require( './../lib' );
@@ -71,7 +71,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	ybuf = [ 1.0, 1.0, 1.0, 1.0, 1.0 ];
 	x = vector( xbuf, 5, 1, 0 );
 	y = vector( ybuf, 5, 1, 0 );
-	alpha = scalar2ndarray( 2.0, 'generic', 'row-major' );
+	alpha = scalar2ndarray( 2.0, {
+		'dtype': 'generic'
+	});
 
 	v = gaxpy( [ x, y, alpha ] );
 
@@ -83,7 +85,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	ybuf = [ 1.0, 1.0 ];
 	x = vector( xbuf, 2, 1, 0 );
 	y = vector( ybuf, 2, 1, 0 );
-	alpha = scalar2ndarray( 2.0, 'generic', 'row-major' );
+	alpha = scalar2ndarray( 2.0, {
+		'dtype': 'generic'
+	});
 
 	v = gaxpy( [ x, y, alpha ] );
 
@@ -107,7 +111,9 @@ tape( 'if provided empty ndarrays, the function returns the output ndarray uncha
 	ybuf = [];
 	x = vector( xbuf, 0, 1, 0 );
 	y = vector( ybuf, 0, 1, 0 );
-	alpha = scalar2ndarray( 5.0, 'generic', 'row-major' );
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'generic'
+	});
 
 	v = gaxpy( [ x, y, alpha ] );
 
@@ -144,7 +150,9 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		1.0
 	];
 	y = vector( ybuf, 3, 1, 0 );
-	alpha = scalar2ndarray( 2.0, 'generic', 'row-major' );
+	alpha = scalar2ndarray( 2.0, {
+		'dtype': 'generic'
+	});
 
 	v = gaxpy( [ x, y, alpha ] );
 
@@ -180,7 +188,9 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		10.0
 	];
 	y = vector( ybuf, 3, -1, 2 );
-	alpha = scalar2ndarray( 3.0, 'generic', 'row-major' );
+	alpha = scalar2ndarray( 3.0, {
+		'dtype': 'generic'
+	});
 
 	v = gaxpy( [ x, y, alpha ] );
 
@@ -222,7 +232,9 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		8.0
 	];
 	y = vector( ybuf, 4, 1, 2 );
-	alpha = scalar2ndarray( 3.0, 'generic', 'row-major' );
+	alpha = scalar2ndarray( 3.0, {
+		'dtype': 'generic'
+	});
 
 	v = gaxpy( [ x, y, alpha ] );
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/saxpy/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/saxpy/test/test.js
@@ -23,7 +23,7 @@
 var tape = require( 'tape' );
 var isSameFloat32Array = require( '@stdlib/assert/is-same-float32array' );
 var Float32Array = require( '@stdlib/array/float32' );
-var scalar2ndarray = require( '@stdlib/ndarray/base/from-scalar' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var getData = require( '@stdlib/ndarray/data-buffer' );
 var saxpy = require( './../lib' );
@@ -72,7 +72,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	ybuf = new Float32Array( [ 1.0, 1.0, 1.0, 1.0, 1.0 ] );
 	x = vector( xbuf, 5, 1, 0 );
 	y = vector( ybuf, 5, 1, 0 );
-	alpha = scalar2ndarray( 2.0, 'float32', 'row-major' );
+	alpha = scalar2ndarray( 2.0, {
+		'dtype': 'float32'
+	});
 
 	v = saxpy( [ x, y, alpha ] );
 
@@ -84,7 +86,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	ybuf = new Float32Array( [ 1.0, 1.0 ] );
 	x = vector( xbuf, 2, 1, 0 );
 	y = vector( ybuf, 2, 1, 0 );
-	alpha = scalar2ndarray( 2.0, 'float32', 'row-major' );
+	alpha = scalar2ndarray( 2.0, {
+		'dtype': 'float32'
+	});
 
 	v = saxpy( [ x, y, alpha ] );
 
@@ -108,7 +112,9 @@ tape( 'if provided empty ndarrays, the function returns the output ndarray uncha
 	ybuf = new Float32Array( [] );
 	x = vector( xbuf, 0, 1, 0 );
 	y = vector( ybuf, 0, 1, 0 );
-	alpha = scalar2ndarray( 5.0, 'float32', 'row-major' );
+	alpha = scalar2ndarray( 5.0, {
+		'dtype': 'float32'
+	});
 
 	v = saxpy( [ x, y, alpha ] );
 
@@ -145,7 +151,9 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		1.0
 	]);
 	y = vector( ybuf, 3, 1, 0 );
-	alpha = scalar2ndarray( 2.0, 'float32', 'row-major' );
+	alpha = scalar2ndarray( 2.0, {
+		'dtype': 'float32'
+	});
 
 	v = saxpy( [ x, y, alpha ] );
 
@@ -181,7 +189,9 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		10.0
 	]);
 	y = vector( ybuf, 3, -1, 2 );
-	alpha = scalar2ndarray( 3.0, 'float32', 'row-major' );
+	alpha = scalar2ndarray( 3.0, {
+		'dtype': 'float32'
+	});
 
 	v = saxpy( [ x, y, alpha ] );
 
@@ -223,7 +233,9 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		8.0
 	]);
 	y = vector( ybuf, 4, 1, 2 );
-	alpha = scalar2ndarray( 3.0, 'float32', 'row-major' );
+	alpha = scalar2ndarray( 3.0, {
+		'dtype': 'float32'
+	});
 
 	v = saxpy( [ x, y, alpha ] );
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/zaxpy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/zaxpy/README.md
@@ -54,7 +54,7 @@ var alpha = scalar2ndarray( new Complex128( 1.0, 2.0 ), {
 var z = zaxpy( [ x, y, alpha ] );
 // returns <ndarray>[ <Complex128>[ -2.0, 5.0 ], <Complex128>[ -4.0, 11.0 ], <Complex128>[ -6.0, 17.0 ] ]
 
-var bool = ( y === z );
+var bool = ( z === y );
 // returns true
 ```
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/zaxpy/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/zaxpy/test/test.js
@@ -24,7 +24,7 @@ var tape = require( 'tape' );
 var isSameComplex128Array = require( '@stdlib/assert/is-same-complex128array' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var scalar2ndarray = require( '@stdlib/ndarray/base/from-scalar' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var getData = require( '@stdlib/ndarray/data-buffer' );
 var zaxpy = require( './../lib' );
@@ -95,7 +95,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	]);
 	x = vector( xbuf, 5, 1, 0 );
 	y = vector( ybuf, 5, 1, 0 );
-	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), 'complex128', 'row-major' );
+	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), {
+		'dtype': 'complex128'
+	});
 
 	v = zaxpy( [ x, y, alpha ] );
 
@@ -128,7 +130,9 @@ tape( 'the function multiplies a one-dimensional ndarray `x` by a constant `alph
 	]);
 	x = vector( xbuf, 2, 1, 0 );
 	y = vector( ybuf, 2, 1, 0 );
-	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), 'complex128', 'row-major' );
+	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), {
+		'dtype': 'complex128'
+	});
 
 	v = zaxpy( [ x, y, alpha ] );
 
@@ -157,7 +161,9 @@ tape( 'if provided empty ndarrays, the function returns the output ndarray uncha
 	ybuf = new Complex128Array( [] );
 	x = vector( xbuf, 0, 1, 0 );
 	y = vector( ybuf, 0, 1, 0 );
-	alpha = scalar2ndarray( new Complex128( 1.0, 2.0 ), 'complex128', 'row-major' );
+	alpha = scalar2ndarray( new Complex128( 1.0, 2.0 ), {
+		'dtype': 'complex128'
+	});
 
 	v = zaxpy( [ x, y, alpha ] );
 
@@ -204,7 +210,9 @@ tape( 'the function supports one-dimensional ndarrays having non-unit strides', 
 		1.0
 	]);
 	y = vector( ybuf, 3, 1, 0 );
-	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), 'complex128', 'row-major' );
+	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), {
+		'dtype': 'complex128'
+	});
 
 	v = zaxpy( [ x, y, alpha ] );
 
@@ -261,7 +269,9 @@ tape( 'the function supports one-dimensional ndarrays having negative strides', 
 		10.0
 	]);
 	y = vector( ybuf, 3, -1, 2 );
-	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), 'complex128', 'row-major' );
+	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), {
+		'dtype': 'complex128'
+	});
 
 	v = zaxpy( [ x, y, alpha ] );
 
@@ -330,7 +340,9 @@ tape( 'the function supports one-dimensional ndarrays having non-zero offsets', 
 		8.0
 	]);
 	y = vector( ybuf, 4, 1, 2 );
-	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), 'complex128', 'row-major' );
+	alpha = scalar2ndarray( new Complex128( 2.0, 2.0 ), {
+		'dtype': 'complex128'
+	});
 
 	v = zaxpy( [ x, y, alpha ] );
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/zcopy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/zcopy/README.md
@@ -49,7 +49,7 @@ var y = new Complex128Vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 var z = zcopy( [ x, y ] );
 // returns <ndarray>[ <Complex128>[ 1.0, 2.0 ], <Complex128>[ 3.0, 4.0 ], <Complex128>[ 5.0, 6.0 ] ]
 
-var bool = ( y === z );
+var bool = ( z === y );
 // returns true
 ```
 


### PR DESCRIPTION
Propagating fixes merged to `develop` between 2026-04-22 17:30 PDT and 2026-04-23 03:05 PDT to sibling packages.

## Description

This pull request:

-   Propagates two independent mechanical fixes identified across the `chore: modernize examples and benchmarks` series (16 commits on 2026-04-22/23, representative SHA `1f183560`) and the `chore: follow-up fixes` commit (`40db61db`) to the sibling packages the source commits did not reach.

### `blas/base/ndarray/*` README identity-check form (`eb98b400`)

Propagates the `( z === y )` identity-check form introduced in `1f183560` to the five remaining output-ndarray README examples that still use the `var bool = ( y === z );` pattern. Affected packages: `blas/base/ndarray/caxpy`, `blas/base/ndarray/zaxpy`, `blas/base/ndarray/ccopy`, `blas/base/ndarray/zcopy`, and `blas/base/ndarray/dswap`. Purely mechanical one-line edits with no behavioral changes.

-   `lib/node_modules/@stdlib/blas/base/ndarray/caxpy/README.md`
-   `lib/node_modules/@stdlib/blas/base/ndarray/zaxpy/README.md`
-   `lib/node_modules/@stdlib/blas/base/ndarray/ccopy/README.md`
-   `lib/node_modules/@stdlib/blas/base/ndarray/zcopy/README.md`
-   `lib/node_modules/@stdlib/blas/base/ndarray/dswap/README.md`

### `blas/base/ndarray/*axpy` `scalar2ndarray` test modernization (`03235e5c`)

Propagates the modernization from commit `1f183560` to the `test/test.js` files missed in the original series: `blas/base/ndarray/{daxpy,saxpy,caxpy,zaxpy,gaxpy}/test/test.js`. Each file is updated to import `scalar2ndarray` from `ndarray/from-scalar` (top-level) instead of the deprecated `ndarray/base/from-scalar`, and to call it with the options-object form `scalar2ndarray( val, { 'dtype': '...' } )` matching the dtype used by the respective package. Behavior is preserved because `ndarray/from-scalar` defaults to `row-major` order and `alpha` is consumed as an ndarray throughout.

-   `lib/node_modules/@stdlib/blas/base/ndarray/daxpy/test/test.js` (`float64`)
-   `lib/node_modules/@stdlib/blas/base/ndarray/saxpy/test/test.js` (`float32`)
-   `lib/node_modules/@stdlib/blas/base/ndarray/caxpy/test/test.js` (`complex64`)
-   `lib/node_modules/@stdlib/blas/base/ndarray/zaxpy/test/test.js` (`complex128`)
-   `lib/node_modules/@stdlib/blas/base/ndarray/gaxpy/test/test.js` (`generic`)

## Related Issues

No.

## Questions

No.

## Other

### Validation

-   Pattern search scoped to `blas/base/ndarray/*` siblings under the source commits' namespace; no wider sweep.
-   Two independent opus validation agents each confirmed every target site has the defect and the source-commit fix applies. No `needs-human` flags.
-   Adaptation agent confirmed self-containment: no `package.json` updates required (the modernized module is already transitively present via each package's `examples/index.js` and `benchmark/benchmark.js`).
-   Sonnet style-consistency agent matched the multi-line options-object form (`{\n\t\t'dtype': '...'\n\t}`) against modernized sibling tests (`blas/ext/base/ndarray/dsort`, `dsortins`, `dsorthp`) and confirmed the README `( z === y )` wording matches `scopy`, `dcopy`, `daxpy`, `saxpy`.
-   Syntax check (`node --check`) passed on all five modernized test files.

### Deliberately excluded

-   The broader "modernize ndarray construction via `@stdlib/ndarray/vector/<dtype>` instead of `@stdlib/ndarray/base/ctor`" pattern (1,250+ hits repo-wide, 5,700+ hits for the companion `@stdlib/random/array/*` pattern). These are adaptive transformations whose per-site tailoring (complex vs. float buffers, REPL alias rewrites, docs type signatures) is outside the "direct analog, self-contained" bar for this run.
-   The stale `/* eslint-disable space-in-parens */` directive removed by `40db61db`: cosmetic-only, not user-visible, excluded per the HIGH-SIGNAL filter.
-   Sites where cross-package changes would be needed.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine. Source-commit pattern extraction, candidate-site enumeration, independent validation, and style-consistency review were all run as sub-agent passes; every proposed patch was cross-verified by two independent opus agents before being applied. A human maintainer will audit before promotion out of draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sgfg2LAYn9KMXFqEbSV6xi)_