### PR TITLE
docs: add missing trailing periods in README descriptions

### DIFF
--- a/lib/node_modules/@stdlib/constants/complex128/README.md
+++ b/lib/node_modules/@stdlib/constants/complex128/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Constants
 
-> 128-bit complex number mathematical constants
+> 128-bit complex number mathematical constants.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var constants = require( '@stdlib/constants/complex128' );
 
 #### constants
 
-128-bit complex number mathematical constants
+128-bit complex number mathematical constants.
 
 ```javascript
 var c = constants;

--- a/lib/node_modules/@stdlib/repl/presentation/README.md
+++ b/lib/node_modules/@stdlib/repl/presentation/README.md
@@ -912,7 +912,7 @@ function done() {
 
 #### Presentation.prototype.show()
 
-Shows a presentation slide (i.e., writes a rendered slide to the presentation [REPL][@stdlib/repl])
+Shows a presentation slide (i.e., writes a rendered slide to the presentation [REPL][@stdlib/repl]).
 
 <!-- eslint-disable stdlib/no-redeclare -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/cdf/README.md
@@ -87,7 +87,7 @@ y = cdf( 0.9, 1.5 );
 
 #### cdf.factory( p )
 
-Returns a function for evaluating the [cumulative distribution function][cdf] of a [Bernoulli][bernoulli-distribution] distribution with success probability `p`
+Returns a function for evaluating the [cumulative distribution function][cdf] of a [Bernoulli][bernoulli-distribution] distribution with success probability `p`.
 
 ```javascript
 var mycdf = cdf.factory( 0.5 );

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/cdf/README.md
@@ -87,7 +87,7 @@ y = cdf( 2.0, 1.5 );
 
 #### cdf.factory( p )
 
-Returns a function for evaluating the [cumulative distribution function][cdf] of a [geometric][geometric-distribution] distribution with success probability `p`
+Returns a function for evaluating the [cumulative distribution function][cdf] of a [geometric][geometric-distribution] distribution with success probability `p`.
 
 ```javascript
 var mycdf = cdf.factory( 0.5 );

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
@@ -87,7 +87,7 @@ y = logcdf( 2.0, 1.5 );
 
 #### logcdf.factory( p )
 
-Returns a function for evaluating the logarithm of the [cumulative distribution function][cdf] of a [geometric][geometric-distribution] distribution with success probability `p`
+Returns a function for evaluating the logarithm of the [cumulative distribution function][cdf] of a [geometric][geometric-distribution] distribution with success probability `p`.
 
 ```javascript
 var mylogcdf = logcdf.factory( 0.5 );


### PR DESCRIPTION
## Description

Codebase-wide scan for README descriptions missing a trailing period; applies the period in the five clean-drift cases.

The scan walked all 5,485 stdlib package READMEs and checked two patterns:

1. The blockquote tagline immediately following the package's first H1 heading.
2. The plain-text description on the line directly following a `#### …` h4 header.

Both patterns are stylistically expected to terminate in `.` / `!` / `?` / `:` and the convention is consistently followed across the codebase. The scan returned exactly one tagline outlier and 23 h4-description outliers; 18 of the 23 are intentional and were not touched (`TODO` placeholders in shared/scaffold READMEs, and lines that continue mid-sentence into a following code block or table). The remaining 5 are clean drift and are fixed in this PR.

### Files touched

- `constants/complex128/README.md` — tagline (line 23) and `#### constants` h4 description (line 35).
- `repl/presentation/README.md` — `Presentation.prototype.show()` description (line 915). Every other prototype-method description in the same file ends with a period.
- `stats/base/dists/bernoulli/cdf/README.md` — `cdf.factory( p )` description (line 90). All sibling distribution `factory` descriptions (`normal`, `binomial`, `poisson`, `exponential`, `uniform`, …) end with a period.
- `stats/base/dists/geometric/cdf/README.md` — `cdf.factory( p )` description (line 90).
- `stats/base/dists/geometric/logcdf/README.md` — `logcdf.factory( p )` description (line 90).

## Related Issues

None.

## Questions

No.

## Other

### Scan methodology

For each README in `lib/node_modules/@stdlib/`:

- **Tagline check**: locate the first `# …` H1 heading (skipping HTML comments / license blocks); read forward up to 8 lines for the first `> …` blockquote; flag if its trimmed text doesn't end in `.`/`!`/`?`/`:`.
- **H4 check**: for each `#### …` h4 heading, look at the next non-blank line; if it begins with plain prose (not a code fence, list bullet, blockquote, table, HTML, or markdown link/image), flag if it doesn't end in punctuation.

After applying the 5 fixes, the tagline check returns 0 findings and the h4 check returns 18 findings, every one of which is either a deliberate `TODO` or a multi-paragraph description whose first paragraph ends with a comma/clause continuation.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code. Initial scope was a drift-detection routine over the `@stdlib/constants` namespace; per @Planeshifter's review, the scope was narrowed to README trailing-period drift only and broadened to a codebase-wide scan, with the rename / test-description findings dropped. All five corrections are mechanical single-character additions.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
