### PR TITLE
docs: align outliers in `constants/time` with namespace Notes wording

### DIFF
--- a/lib/node_modules/@stdlib/constants/time/milliseconds-in-minute/README.md
+++ b/lib/node_modules/@stdlib/constants/time/milliseconds-in-minute/README.md
@@ -47,7 +47,7 @@ var bool = ( MILLISECONDS_IN_MINUTE === 60000 );
 
 ## Notes
 
--   The value is a generalization and does **not** take into account inaccuracies arising due to complications with time and dates.
+-   The value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
 
 </section>
 

--- a/lib/node_modules/@stdlib/constants/time/milliseconds-in-minute/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/time/milliseconds-in-minute/docs/repl.txt
@@ -3,7 +3,8 @@
     Number of milliseconds in a minute.
 
     The value is a generalization and does **not** take into account
-    inaccuracies arising due to complications with time and dates.
+    inaccuracies due to daylight savings conventions, crossing timezones, or
+    other complications with time and dates.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/constants/time/milliseconds-in-second/README.md
+++ b/lib/node_modules/@stdlib/constants/time/milliseconds-in-second/README.md
@@ -47,7 +47,7 @@ var bool = ( MILLISECONDS_IN_SECOND === 1000 );
 
 ## Notes
 
--   The value is a generalization and does **not** take into account inaccuracies arising due to complications with time and dates.
+-   The value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
 
 </section>
 

--- a/lib/node_modules/@stdlib/constants/time/milliseconds-in-second/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/time/milliseconds-in-second/docs/repl.txt
@@ -3,7 +3,8 @@
     Number of milliseconds in a second.
 
     The value is a generalization and does **not** take into account
-    inaccuracies arising due to complications with time and dates.
+    inaccuracies due to daylight savings conventions, crossing timezones, or
+    other complications with time and dates.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/constants/time/seconds-in-minute/README.md
+++ b/lib/node_modules/@stdlib/constants/time/seconds-in-minute/README.md
@@ -47,7 +47,7 @@ var bool = ( SECONDS_IN_MINUTE === 60 );
 
 ## Notes
 
--   The value is a generalization and does **not** take into account inaccuracies arising due to complications with time and dates.
+-   The value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
 
 </section>
 

--- a/lib/node_modules/@stdlib/constants/time/seconds-in-minute/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/time/seconds-in-minute/docs/repl.txt
@@ -3,7 +3,8 @@
     Number of seconds in a minute.
 
     The value is a generalization and does **not** take into account
-    inaccuracies arising due to complications with time and dates.
+    inaccuracies due to daylight savings conventions, crossing timezones, or
+    other complications with time and dates.
 
     Examples
     --------


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Aligns outliers in `@stdlib/constants/time` with namespace majority patterns (random namespace pick, seed `20260424`).

### Namespace summary

-   **Target namespace:** `@stdlib/constants/time`
-   **Member count:** 15 (all non-autogenerated)
-   **Features analyzed:** file tree, `package.json` shape/scripts/`stdlib` keys, `manifest.json` shape, README heading list, README `## Notes` text, `docs/repl.txt` Notes text, `test/`/`benchmark/`/`examples/` file names, `lib/index.js` body structure.
-   **Features with clear majority (≥75%):** file tree (100%), `package.json` top-level keys (100%), `scripts`/`stdlib` keys (100%, both empty), test/example/benchmark file sets (100%), README heading prefix `## Usage` / `## Notes` / `## Examples` (100%), README Notes sentence — full daylight-savings/timezones phrasing (**80% = 12/15**), `docs/repl.txt` Notes sentence — same phrasing (**80% = 12/15**).
-   **Features without clear majority (excluded):** `lib/index.js` tex-block inclusion (67% — below threshold); `## See Also` section presence (13% — not a majority pattern, and rejected by validation as generator-owned content rather than drift).

### Per-outlier corrections

#### `@stdlib/constants/time/milliseconds-in-minute`

Aligns the `## Notes` disclaimer in `README.md` and `docs/repl.txt` with the full phrasing used by 12 of 15 packages in `@stdlib/constants/time`. The abbreviated legacy text ("inaccuracies arising due to complications with time and dates") is replaced by the standard form that enumerates daylight savings conventions and timezone crossing. Pure editorial fix — no API, tests, or examples touched.

#### `@stdlib/constants/time/milliseconds-in-second`

Aligns the `## Notes` warning in `README.md` and `docs/repl.txt` with the full phrasing used by 12 of the 15 sibling packages (80%) in `@stdlib/constants/time` — replacing the truncated legacy line with the standard text calling out daylight savings, timezone crossings, and other date/time complications. Pure copy edit; no API, tests, or examples affected.

#### `@stdlib/constants/time/seconds-in-minute`

Standardizes the `## Notes` disclaimer in `README.md` and `docs/repl.txt` to match the phrasing used by 12 of the other 15 packages in the `@stdlib/constants/time` namespace (80% conformance). The abbreviated legacy text omitted the explicit references to daylight savings conventions and timezone crossing that the majority wording carries. Pure editorial fix; no API, tests, or examples are affected.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Checked:

-   Structural feature extraction across all 15 members (file tree, `package.json` shape, README headings, `docs/repl.txt` body, test/example/benchmark file names, `lib/index.js` structure).
-   Semantic feature extraction was waived: every member is a constant-value module (no function signature, no validation prologue, no error construction); logged in the local drift report.
-   Three-agent drift validation on the two candidate findings:
    -   Agent 1 (semantic review, opus): confirmed the Notes-text abbreviation is legacy drift (sub-hour sibling `milliseconds-in-hour` and sub-day `minutes-in-hour` already carry the full phrasing, so "abbreviation is intentional for short durations" does not hold); ruled the `## See Also` section an intentional deviation (generator-owned block, populated only where a sibling cross-link exists).
    -   Agent 2 (cross-reference, opus): confirmed tests and examples do not reference the Notes wording and no sibling package imports either variant as a stable contract.
    -   Agent 3 (structural review, sonnet): confirmed the Notes-text correction is mechanical and regression-free; rejected the `## See Also` removal as inapplicable — the section is auto-populated generator output and the empty `<section class="related">` shell in the other 13 packages is the correct state.

Deliberately excluded:

-   `## See Also` section removal from `hours-in-day` / `hours-in-week` — generator-owned content, not drift.
-   `lib/index.js` tex-block normalization — 67% conformance, below the 75% threshold.
-   Any change to public API, test expectations, or example behavior.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running a cross-package drift-detection routine: the namespace (`@stdlib/constants/time`) was picked at random (seed `20260424`), structural features were extracted for every member, majority patterns were computed at a 75% threshold, and three independent validation agents (two opus, one sonnet) confirmed each correction before it was applied. Only the `## Notes` wording in `README.md` and `docs/repl.txt` of three outlier packages was changed — mechanical text substitution to the namespace majority phrasing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013y9F3up4J8xjKW18rP8vjf)_