### PR TITLE
docs: propagate recent `ndarray/base` comment and note fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/empty-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/empty-like/docs/types/test.ts
@@ -43,7 +43,7 @@ import emptyLike = require( './index' );
 	emptyLike( zeros( 'generic', sh, ord ) ); // $ExpectType typedndarray<number>
 }
 
-// The compiler throws an error if the function is provided a first argument which is not an ndarray having a recognized/supported data type...
+// The compiler throws an error if the function is provided a first argument which is not an ndarray...
 {
 	emptyLike( '10' ); // $ExpectError
 	emptyLike( 10 ); // $ExpectError

--- a/lib/node_modules/@stdlib/ndarray/base/ones-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/ones-like/docs/types/test.ts
@@ -41,7 +41,7 @@ import onesLike = require( './index' );
 	onesLike( ones( 'generic', sh, ord ) ); // $ExpectType genericndarray<number>
 }
 
-// The compiler throws an error if the function is provided a first argument which is not an ndarray having a recognized/supported data type...
+// The compiler throws an error if the function is provided a first argument which is not an ndarray...
 {
 	onesLike( '10' ); // $ExpectError
 	onesLike( 10 ); // $ExpectError

--- a/lib/node_modules/@stdlib/ndarray/base/rot90/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/rot90/lib/main.js
@@ -39,7 +39,7 @@ var format = require( '@stdlib/string/format' );
 * ## Notes
 *
 * -   If `k > 0`, the function rotates the plane from the first specified dimension toward the second specified dimension. This means that, for a two-dimensional ndarray and `dims = [0, 1]`, the function rotates the plane counterclockwise.
-* -   If `k < 0`, the function rotates the plane from the second specified dimension toward the first specified dimension. This means that, for a two-dimensional ndarray and `dims = [1, 0]`, the function rotates the plane clockwise.
+* -   If `k < 0`, the function rotates the plane from the second specified dimension toward the first specified dimension. This means that, for a two-dimensional ndarray and `dims = [0, 1]`, the function rotates the plane clockwise.
 * -   Each provided dimension index must reside on the interval `[-ndims, ndims-1]`.
 *
 * @param {ndarray} x - input array

--- a/lib/node_modules/@stdlib/ndarray/base/transpose/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/transpose/docs/types/test.ts
@@ -41,7 +41,7 @@ import transpose = require( './index' );
 	transpose( zeros( 'generic', sh, ord ), false ); // $ExpectType genericndarray<number>
 }
 
-// The compiler throws an error if the function is provided a first argument which is not an ndarray having a recognized/supported data type...
+// The compiler throws an error if the function is provided a first argument which is not an ndarray...
 {
 	transpose( '10', false ); // $ExpectError
 	transpose( 10, false ); // $ExpectError

--- a/lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/test.ts
@@ -41,7 +41,7 @@ import zerosLike = require( './index' );
 	zerosLike( zeros( 'generic', sh, ord ) ); // $ExpectType genericndarray<number>
 }
 
-// The compiler throws an error if the function is provided a first argument which is not an ndarray having a recognized/supported data type...
+// The compiler throws an error if the function is provided a first argument which is not an ndarray...
 {
 	zerosLike( '10' ); // $ExpectError
 	zerosLike( 10 ); // $ExpectError


### PR DESCRIPTION
Propagating fixes merged to `develop` between 2026-04-23 15:41 UTC-7 and 2026-04-24 05:33 UTC-7 to sibling packages that carry the same defect.

## Description

This pull request:

-   Propagates the clockwise-rotation note correction from `b5fb2f8` to `ndarray/base/rot90/lib/main.js`, which carried the same JSDoc note as the README / REPL help / type declarations already corrected in that commit.
-   Propagates the TS test comment trim from `1bb47ae` / `8c95fbf` to four sibling packages under `ndarray/base/` (`empty-like`, `ones-like`, `zeros-like`, `transpose`) whose `docs/types/test.ts` files carry the same stale comment above an identical non-ndarray `$ExpectError` block.

### `b5fb2f8` — clockwise rotation note

b5fb2f8 corrected the clockwise rotation note across `README.md`, `docs/repl.txt`, and `docs/types/index.d.ts`, changing the example dimension array from `[1, 0]` to `[0, 1]` so that the note is consistent with the counterclockwise case directly above it — rotation direction is determined by the sign of `k`, not by swapping the `dims` argument. That commit did not touch `lib/main.js`, which carries the identical JSDoc note and contained the same erroneous `dims = [1, 0]`. This PR applies the missing correction to `lib/main.js`.

-   `lib/node_modules/@stdlib/ndarray/base/rot90/lib/main.js`

### `1bb47ae` / `8c95fbf` — TS test `$ExpectError` comment

Propagates the comment fix from `8c95fbf` (`ndarray/base/rotl90`) and `1bb47ae` (`ndarray/base/rotr90`) to the TypeScript test files for `ndarray/base/empty-like`, `ndarray/base/ones-like`, `ndarray/base/zeros-like`, and `ndarray/base/transpose`. Each of those files carried the same stale comment — "...not an ndarray having a recognized/supported data type..." — above a `$ExpectError` block that only tests non-ndarray values (strings, numbers, booleans, etc.), making the "recognized/supported data type" qualifier incorrect. The comment is trimmed to "...not an ndarray..." to accurately reflect what the block actually tests.

-   `lib/node_modules/@stdlib/ndarray/base/empty-like/docs/types/test.ts`
-   `lib/node_modules/@stdlib/ndarray/base/ones-like/docs/types/test.ts`
-   `lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/test.ts`
-   `lib/node_modules/@stdlib/ndarray/base/transpose/docs/types/test.ts`

## Related Issues

No.

## Questions

No.

## Other

### Validation

-   Pattern search scope: `lib/node_modules/@stdlib/ndarray/` for both patterns (sibling namespace of the originating packages).
-   Two independent validation passes on each target site, each agent reading the full target file.
-   Style-consistency pass against the post-fix state of the source packages (`ndarray/base/rot90` README/types/repl for Pattern A; `ndarray/base/rotl90` and `ndarray/base/rotr90` TS tests for Pattern B).

### Deliberately excluded

-   `stats/base/dists/gamma/logcdf/README.md` — structurally parallels the `stats/base/dists/chi/cdf/README.md` fix from `41606e2` (wrong heading levels, missing `<section class="c">` wrapper, JS `## Examples` after C APIs), but the file's JS `<section class="usage">` closer is misplaced such that it swallows the entire C APIs block. Both independent validation agents flagged this as `needs-human`; applying the 4-step restructuring cleanly requires additional judgment to rebalance tags. Dropped from this run.
-   `docs/migration-guides/numpy/README.md` fixes from `588cd1d` / `0e262c8` — localized to the single migration guide; no sibling sites.
-   `blas/ext/to-sortedhp` assertion/description fixes from `3bd03310` — package-specific; the one grep-able typo (`"support string"` vs `"supported string"`) has no other occurrences in the repo outside that commit.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine that reviews commits merged to `develop` over a 24-hour window and applies the equivalent fix at validated sibling sites. Each proposed site was validated by two independent agents and passed a style-consistency pass before inclusion. A maintainer will audit before promotion from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMZ7uxZu7Q4JzqrBWmZS8P)_