### PR TITLE
chore: add missing keyword

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/ctor/package.json
@@ -67,6 +67,7 @@
     "quantile",
     "properties",
     "props",
-    "univariate"
+    "univariate",
+    "continuous"
   ]
 }


### PR DESCRIPTION
## Description

Aligning outliers in `stats/base/dists/weibull` with namespace majority patterns (random namespace pick, seed `drift-2026-04-25`).

### Namespace summary

- **Target namespace:** `stats/base/dists/weibull`
- **Members:** 15 (none autogenerated)
- **Features analyzed:** structural (file tree, `package.json` keys/keywords, README sections, `manifest.json` shape, test/benchmark/example file naming) and semantic (public signature, validation prologue, error construction, JSDoc shape, `@stdlib/*` dependencies)
- **Features with clear majority (≥75% conformance):** all of the above except per-package documentation specifics (e.g., the optional "Notes" section, present in 2/15 — below threshold).
- **Features without clear majority (excluded from drift detection):** README "Notes" L2 section (2/15), `lib/factory.js` presence (6/15 — split by function class), and `prob` keyword (9/15).

### Outlier corrections

#### `ctor`

Adds the `"continuous"` keyword to `package.json`, aligning with 14 of the other 15 packages in the `weibull` namespace. Placement as the final keyword matches the convention established across 25 of 26 continuous-distribution `ctor` packages.

### Validation

Three independent agents reviewed the candidate corrections:

- **Semantic review (Agent 1, opus):** confirmed no semantic drift across the namespace. Throw-based validation, error construction via `@stdlib/string/format`, and JSDoc shape are consistent within their respective function classes; only `ctor` throws (correctly), and only `ctor` uses `format` (correctly). All other distribution functions follow the return-NaN convention. Spot-checked `cdf`, `mgf`, `ctor`, `median`, `quantile`.
- **Cross-reference review (Agent 2, opus):** verified the keyword change has no test or example coupling and that external references to `weibull/ctor` (in `namespace/pkg2*` and `error/tools/*pkg*` data tables) key on package paths, not keyword arrays. Safe to apply.
- **Structural review (Agent 3, sonnet):** confirmed the single drift item and classified the remaining `ctor` deltas (no `gypfile`, `binding.gyp`, `src/`, `include/`, `manifest.json`, `test/test.native.js`, "C APIs" README section) as intentional — `ctor` is a JS-only constructor with no native bindings. Also confirmed:
  - `mgf` lacking `test/fixtures/julia/{REQUIRE,runner.jl}` is intentional (the test source explicitly notes the function is unavailable in R/Julia).
  - `mgf` lacking the `"probability"` keyword is intentional and matches stdlib-wide convention for `mgf` packages across all distributions.
  - The "Notes" section in `logcdf`/`logpdf` is below the 20% threshold and therefore not considered drift.

### Deliberately excluded

- Intentional deviations: `ctor`'s missing native-binding files and "C APIs" README section; `mgf`'s missing Julia fixtures; `mgf`'s missing `"probability"` keyword.
- Outliers whose tests rely on the deviation: none surfaced.
- Features without a clear majority: README "Notes" section, `lib/factory.js` presence, `prob` keyword.

## Related Issues

None.

## Questions

No.

## Other

Single-package, single-file metadata correction. Within-namespace conformance for `"continuous"`: 14/15 (93%). Cross-namespace conformance for the same keyword in continuous-distribution `ctor` packages: 25/26 (96%). The Weibull distribution is mathematically continuous (k>0 shape, λ>0 scale, support x≥0).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a cross-package API drift-detection routine. The routine extracted structural and semantic features from every package in the namespace, computed per-feature majority patterns at a 75% conformance threshold, ran three independent validation agents (two opus, one sonnet) to filter intentional deviations, and produced this single mechanical metadata correction. A human maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9U1xWCR4dYCuSFi72edMT)_