### PR TITLE
docs: propagate recent doc fixes to sibling `ndarray`, `stats/base/ndarray`, and `types` packages

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/empty-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/docs/types/test.ts
@@ -103,7 +103,7 @@ import emptyLike = require( './index' );
 	emptyLike( zeros( 'generic', sh, ord ), { 'dtype': 'generic' } ); // $ExpectType genericndarray<number>
 }
 
-// The compiler throws an error if the function is provided a first argument is not an ndarray which has a recognized/supported data type...
+// The compiler throws an error if the function is provided a first argument which is not an ndarray...
 {
 	emptyLike( '10' ); // $ExpectError
 	emptyLike( 10 ); // $ExpectError

--- a/lib/node_modules/@stdlib/ndarray/zeros-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/zeros-like/docs/types/test.ts
@@ -97,7 +97,7 @@ import zerosLike = require( './index' );
 	zerosLike( zeros( 'generic', sh, ord ), { 'dtype': 'generic' } ); // $ExpectType genericndarray<number>
 }
 
-// The compiler throws an error if the function is provided a first argument is not an ndarray which has a recognized/supported data type...
+// The compiler throws an error if the function is provided a first argument which is not an ndarray...
 {
 	zerosLike( '10' ); // $ExpectError
 	zerosLike( 10 ); // $ExpectError

--- a/lib/node_modules/@stdlib/stats/base/ndarray/covarmtk/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/covarmtk/README.md
@@ -126,7 +126,7 @@ var v = covarmtk( [ x, y, correction, meanx, meany ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  first one-dimensional input ndarray.
     2.  second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/covarmtk/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/covarmtk/docs/repl.txt
@@ -10,7 +10,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         -   first one-dimensional input ndarray.
         -   second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dcovarmtk/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dcovarmtk/README.md
@@ -127,7 +127,7 @@ var v = dcovarmtk( [ x, y, correction, meanx, meany ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  first one-dimensional input ndarray.
     2.  second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dcovarmtk/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dcovarmtk/docs/repl.txt
@@ -10,7 +10,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         -   first one-dimensional input ndarray.
         -   second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dmeanstdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dmeanstdev/README.md
@@ -124,7 +124,7 @@ var v = dmeanstdev( [ x, out, correction ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  a one-dimensional input ndarray.
     2.  a one-dimensional output ndarray to store the [mean][arithmetic-mean] and [standard deviation][standard-deviation].

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dmeanstdev/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dmeanstdev/docs/repl.txt
@@ -8,7 +8,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         - a one-dimensional input ndarray.
         - a one-dimensional output ndarray to store the mean and standard

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dztest/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dztest/README.md
@@ -78,7 +78,7 @@ var bool = ( v === out );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  a one-dimensional input ndarray.
     2.  a zero-dimensional output ndarray containing a [results object][@stdlib/stats/base/ztest/one-sample/results/float64].

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dztest/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dztest/docs/repl.txt
@@ -6,7 +6,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         - a one-dimensional input ndarray.
         - a zero-dimensional output ndarray containing a results object.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dztest2/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dztest2/README.md
@@ -85,7 +85,7 @@ var bool = ( v === out );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  first one-dimensional input ndarray.
     2.  second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dztest2/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dztest2/docs/repl.txt
@@ -6,7 +6,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         - first one-dimensional input ndarray.
         - second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scovarmtk/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scovarmtk/README.md
@@ -127,7 +127,7 @@ var v = scovarmtk( [ x, y, correction, meanx, meany ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  first one-dimensional input ndarray.
     2.  second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/scovarmtk/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/scovarmtk/docs/repl.txt
@@ -10,7 +10,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         -   first one-dimensional input ndarray.
         -   second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/sztest/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/sztest/README.md
@@ -78,7 +78,7 @@ var bool = ( v === out );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  a one-dimensional input ndarray.
     2.  a zero-dimensional output ndarray containing a [results object][@stdlib/stats/base/ztest/one-sample/results/float32].

--- a/lib/node_modules/@stdlib/stats/base/ndarray/sztest/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/sztest/docs/repl.txt
@@ -6,7 +6,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         - a one-dimensional input ndarray.
         - a zero-dimensional output ndarray containing a results object.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/sztest2/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/sztest2/README.md
@@ -85,7 +85,7 @@ var bool = ( v === out );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  first one-dimensional input ndarray.
     2.  second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/sztest2/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/sztest2/docs/repl.txt
@@ -6,7 +6,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         - first one-dimensional input ndarray.
         - second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/ztest/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/ztest/README.md
@@ -77,7 +77,7 @@ var bool = ( v === out );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  a one-dimensional input ndarray.
     2.  a zero-dimensional output ndarray containing a [results object][@stdlib/stats/base/ztest/one-sample/results/float64].

--- a/lib/node_modules/@stdlib/stats/base/ndarray/ztest/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/ztest/docs/repl.txt
@@ -5,7 +5,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         - a one-dimensional input ndarray.
         - a zero-dimensional output ndarray containing a results object.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/ztest2/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/ztest2/README.md
@@ -84,7 +84,7 @@ var bool = ( v === out );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays in order:
+-   **arrays**: array-like object containing the following ndarrays:
 
     1.  first one-dimensional input ndarray.
     2.  second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/stats/base/ndarray/ztest2/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/ztest2/docs/repl.txt
@@ -5,7 +5,7 @@
     Parameters
     ----------
     arrays: ArrayLikeObject<ndarray>
-        Array-like object containing the following ndarrays in order:
+        Array-like object containing the following ndarrays:
 
         - first one-dimensional input ndarray.
         - second one-dimensional input ndarray.

--- a/lib/node_modules/@stdlib/types/index.d.ts
+++ b/lib/node_modules/@stdlib/types/index.d.ts
@@ -570,7 +570,7 @@ declare module '@stdlib/types/array' {
 	* @example
 	* const buf = new Uint8Array( 8 );
 	*
-	* const z: Complex64Array = {
+	* const z: BooleanArray = {
 	*     'byteLength': 8,
 	*     'byteOffset': 0,
 	*     'BYTES_PER_ELEMENT': 1,


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-04-24 15:07 PDT and 2026-04-24 17:40 PDT to sibling packages with the same defect.

### `3ca7c21` — drop redundant data-type qualifier in `*-like` test comments

Propagates the fix from `3ca7c21` — dropping the verbose `"having a recognized/supported data type"` qualifier from the first-argument `$ExpectError` block comment — to the top-level sibling packages, which also carried a grammar defect (`"first argument is not an ndarray which has"` instead of `"first argument which is not an ndarray"`). Both issues are corrected to the canonical form: `// The compiler throws an error if the function is provided a first argument which is not an ndarray...`.

-   `lib/node_modules/@stdlib/ndarray/empty-like/docs/types/test.ts`
-   `lib/node_modules/@stdlib/ndarray/zeros-like/docs/types/test.ts`

### `5a06940` — fix `BooleanArray` `@example` annotation typo

Commit `5a06940` fixed a copy-paste typo in which the `@example` block for `Complex32Array` was annotated `Complex64Array`; the same defect pattern appeared in the `BooleanArray` interface, where the `@example` block carried a `Complex64Array` annotation instead of `BooleanArray`. This patch corrects that stray annotation so the documented example matches the interface it illustrates.

-   `lib/node_modules/@stdlib/types/index.d.ts`

### `be5b88f` — drop redundant `in order` from `stats/base/ndarray/*` parameter docs

Follows `be5b88f`, which removed the redundant qualifier "in order" from `containing the following ndarrays in order:` headers in `blas/base/ndarray/*` docs; the bulleted list already implies order, making the phrase noise. This commit applies the same mechanical replacement to the equivalent headers in both `README.md` and `docs/repl.txt` for the following `stats/base/ndarray` packages:

-   `lib/node_modules/@stdlib/stats/base/ndarray/covarmtk`
-   `lib/node_modules/@stdlib/stats/base/ndarray/dcovarmtk`
-   `lib/node_modules/@stdlib/stats/base/ndarray/dmeanstdev`
-   `lib/node_modules/@stdlib/stats/base/ndarray/dztest`
-   `lib/node_modules/@stdlib/stats/base/ndarray/dztest2`
-   `lib/node_modules/@stdlib/stats/base/ndarray/scovarmtk`
-   `lib/node_modules/@stdlib/stats/base/ndarray/sztest`
-   `lib/node_modules/@stdlib/stats/base/ndarray/sztest2`
-   `lib/node_modules/@stdlib/stats/base/ndarray/ztest`
-   `lib/node_modules/@stdlib/stats/base/ndarray/ztest2`

JSDoc and TypeScript type stubs are unchanged, consistent with the scope of the source commit.

## Related Issues

None.

## Questions

No.

## Other

### Validation

-   **Search scope**: each source pattern was searched within the directories the source commit touched plus their immediate sibling namespaces (`ndarray/*` for the `*-like` test comment; `lib/node_modules/@stdlib/types/` for the `@example` annotation; `stats/base/ndarray/*` for the `in order` qualifier). Originating packages already fixed by the source commits were excluded.
-   **Independent validation**: two independent Opus validation agents reviewed every candidate site by reading each file in full; both returned `confirmed` for all 23 sites. A separate Sonnet style-consistency agent confirmed each replacement matches the verbatim form established by the source commit.
-   **Deliberately excluded**:
    -   The `numpy` migration-guide stray-bracket pattern from `5a06940` — no remaining occurrences in scope.
    -   The `csum` `@returns {number}` → `Complex64` pattern from `09c66469` — sibling complex-sum packages already use the correct return type.
    -   The "modernize examples and benchmarks" wave (~20 chore commits) — large scope, ongoing maintainer-paced rollout, not a defect of this routine's class.
    -   The `## Notes` JSDoc-restructuring patterns from `81d0c40`, `b490c625`, `bdc1f9b` — adaptive per-site rewriting beyond mechanical analog scope.
    -   The `f5a9f7d` "one-dimensional" qualifier additions — `stats/base/ndarray/*` already use the qualifier on list items.
    -   Namespace re-export files (`blas/ext/base/ndarray/docs/types/index.d.ts`, `stats/base/ndarray/docs/types/index.d.ts`) — source commits left these untouched.
    -   JSDoc / `docs/types/index.d.ts` for stats packages — source `be5b88f` only edited user-facing README/repl.txt; matching scope.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a routine that scans recent `develop` commits for generalizable doc fixes and propagates them to sibling packages. Each propagation site was independently verified by two Opus validation agents and a Sonnet style-consistency agent before patches were applied; the changes are pure mechanical text replacements drawn verbatim from the cited source commits.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcnaPHgSyGJYgXhhitjVFz)_