### PR TITLE
style: align outliers in `streams/node` with namespace majority patterns

### DIFF
--- a/lib/node_modules/@stdlib/streams/node/stderr/README.md
+++ b/lib/node_modules/@stdlib/streams/node/stderr/README.md
@@ -95,6 +95,13 @@ setTimeout( proc.exit, 1000 );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/streams/node/stdin`][@stdlib/streams/node/stdin]</span><span class="delimiter">: </span><span class="description">standard input.</span>
+-   <span class="package-name">[`@stdlib/streams/node/stdout`][@stdlib/streams/node/stdout]</span><span class="delimiter">: </span><span class="description">standard output.</span>
+
 </section>
 
 <!-- /.related -->
@@ -106,6 +113,14 @@ setTimeout( proc.exit, 1000 );
 [standard-streams]: https://en.wikipedia.org/wiki/Standard_streams
 
 [writable-stream]: https://nodejs.org/api/stream.html#stream_class_stream_writable
+
+<!-- <related-links> -->
+
+[@stdlib/streams/node/stdin]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/streams/node/stdin
+
+[@stdlib/streams/node/stdout]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/streams/node/stdout
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/streams/node/stdin/README.md
+++ b/lib/node_modules/@stdlib/streams/node/stdin/README.md
@@ -119,6 +119,13 @@ setTimeout( proc.exit, 1000 );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/streams/node/stderr`][@stdlib/streams/node/stderr]</span><span class="delimiter">: </span><span class="description">standard error.</span>
+-   <span class="package-name">[`@stdlib/streams/node/stdout`][@stdlib/streams/node/stdout]</span><span class="delimiter">: </span><span class="description">standard output.</span>
+
 </section>
 
 <!-- /.related -->
@@ -130,6 +137,14 @@ setTimeout( proc.exit, 1000 );
 [standard-streams]: https://en.wikipedia.org/wiki/Standard_streams
 
 [readable-stream]: https://nodejs.org/api/stream.html#stream_class_stream_readable
+
+<!-- <related-links> -->
+
+[@stdlib/streams/node/stderr]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/streams/node/stderr
+
+[@stdlib/streams/node/stdout]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/streams/node/stdout
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/streams/node/stdout/README.md
+++ b/lib/node_modules/@stdlib/streams/node/stdout/README.md
@@ -95,6 +95,13 @@ setTimeout( proc.exit, 1000 );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/streams/node/stderr`][@stdlib/streams/node/stderr]</span><span class="delimiter">: </span><span class="description">standard error.</span>
+-   <span class="package-name">[`@stdlib/streams/node/stdin`][@stdlib/streams/node/stdin]</span><span class="delimiter">: </span><span class="description">standard input.</span>
+
 </section>
 
 <!-- /.related -->
@@ -106,6 +113,14 @@ setTimeout( proc.exit, 1000 );
 [standard-streams]: https://en.wikipedia.org/wiki/Standard_streams
 
 [writable-stream]: https://nodejs.org/api/stream.html#stream_class_stream_writable
+
+<!-- <related-links> -->
+
+[@stdlib/streams/node/stderr]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/streams/node/stderr
+
+[@stdlib/streams/node/stdin]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/streams/node/stdin
+
+<!-- </related-links> -->
 
 </section>
 


### PR DESCRIPTION
## Description

Aligning outliers in `@stdlib/streams/node` with namespace majority patterns (random namespace pick, seed `2564020013`).

### Namespace summary

- **Namespace:** `streams/node`
- **Members analyzed:** 16 non-autogenerated packages (`debug`, `debug-sink`, `empty`, `from-array`, `from-circular-array`, `from-constant`, `from-iterator`, `from-strided-array`, `inspect`, `inspect-sink`, `join`, `split`, `stderr`, `stdin`, `stdout`, `transform`)
- **Majority threshold:** ≥75% (≥12/16)
- **Features with clear majority:** file presence, `package.json` top-level keys, README L2 sections, `errorConstruction`, `returnKind`, `jsdocShape.hasExample`, common dependency set
- **Features without clear majority (excluded from drift detection):** `package.json` `scripts`/`stdlib` sub-keys (empty across all members), `validationPrologue` predicate sequence (varies with each stream's parameter shape)

### `streams/node/stderr`

Adds a `## See Also` README section linking to `@stdlib/streams/node/stdin` and `@stdlib/streams/node/stdout`. Addresses namespace drift: 12 of 16 packages in `streams/node` (75%) have a populated `## See Also` section, leaving `stderr` as an outlier with an empty `<section class="related">` placeholder. The remaining outlier `transform` is excluded, as its empty `related` field is intentional for a base abstraction.

### `streams/node/stdin`

Adds a `## See Also` section to the README linking to `@stdlib/streams/node/stderr` and `@stdlib/streams/node/stdout`. The `streams/node` namespace has 12/16 packages (75%) with a populated `## See Also` section; `stdin` was an outlier with an empty `<section class="related">` placeholder. `stderr` and `stdout` receive parallel fixes; `transform` is excluded as its empty `related` field is intentional for a base abstraction.

### `streams/node/stdout`

Adds a `## See Also` section to the README linking to `@stdlib/streams/node/stderr` and `@stdlib/streams/node/stdin`. The `streams/node` namespace has 12 of 16 packages (75%) with a populated `## See Also` section; `stdout` was an outlier with an empty `<section class="related">` placeholder. `stderr` and `stdin` receive parallel fixes; `transform` remains intentionally empty as its namespace `related` field is curated as such for the base abstraction.

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural feature extraction:** file tree, `package.json` shape, README section list, test/benchmark/example file naming.
- **Semantic feature extraction:** per-package agents extracted public signature, validation prologue, error construction, JSDoc shape, and `@stdlib/*` dependency set from `lib/main.js`, `lib/index.js`, and `lib/validate.js`.
- **Three-agent drift validation:** opus semantic-review, opus cross-reference, sonnet structural-review — all three returned `confirmed-drift` for `stderr`/`stdin`/`stdout`.
- **Deliberately excluded:**
  - `transform` `## See Also` (its `related` array in `@stdlib/namespace/lib/namespace/t.js` is curated for the base abstraction; manual README population would be clobbered by the auto-populator).
  - `empty` missing `benchmark/benchmark.throughput.js` (no data flow → throughput benchmark inapplicable).
  - `join` `lib/defaults.js` vs majority `lib/defaults.json` (would require consumer-code changes; out of scope).
  - `transform` missing `lib/debug.js` (uses three independent debug namespaces inline by design).
  - `stderr`/`stdin`/`stdout` missing `lib/factory.js`, `lib/validate.js`, `lib/object_mode.js`, etc. (singletons, not factories — these files would have no role).
  - `errorConstruction` outliers: `stderr`/`stdin`/`stdout` use `plain-string` because they have no error paths.
  - `empty` missing `@stdlib/assert/is-nonnegative-number` dep (no `highWaterMark` validation needed).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package API drift-detection routine. The routine selected `streams/node` uniformly at random (seed `2564020013`), extracted structural and semantic features from every member, computed majority patterns at the 75% threshold, validated outlier findings via three independent reviewer agents (two opus, one sonnet), and applied the surviving high-signal mechanical corrections.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01W21kcABk6rJA4Zng9oG6GS)_