### PR TITLE
chore: fix JavaScript lint errors (issue #11784)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/create-issue/lib/query.js
+++ b/lib/node_modules/@stdlib/_tools/github/create-issue/lib/query.js
@@ -73,6 +73,7 @@ function query( slug, title, options, clbk ) {
 	* @returns {void}
 	*/
 	function done( error, response, data ) {
+		var reset;
 		var info;
 		if ( arguments.length === 1 ) {
 			debug( 'No available rate limit information.' );
@@ -84,7 +85,8 @@ function query( slug, title, options, clbk ) {
 		info = ratelimit( response.headers );
 		debug( 'Rate limit: %d', info.limit );
 		debug( 'Rate limit remaining: %d', info.remaining );
-		debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
+		reset = ( info.reset && info.reset === info.reset ) ? ( new Date( info.reset*1000 ) ).toISOString() : 'N/A';
+		debug( 'Rate limit reset: %s', reset );
 
 		if ( error ) {
 			return clbk( error, null, info );


### PR DESCRIPTION
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

## Summary

This PR fixes the JavaScript linting failures caused by a `RangeError: Invalid time value` in the `github-create-issue` tool.

## Problem

When the `x-ratelimit-reset` HTTP header is missing or undefined, the `ratelimit` module returns `NaN`. The `query.js` file then attempts to call `(new Date(NaN * 1000)).toISOString()`, which throws a `RangeError` and crashes the lint workflow.

## Solution

Added a defensive check in `lib/node_modules/@stdlib/_tools/github/create-issue/lib/query.js` to validate `info.reset` before constructing a `Date`. If the value is not a valid finite number, the debug log falls back to `N/A`.

## Changes

- `lib/node_modules/@stdlib/_tools/github/create-issue/lib/query.js`: Guarded the `Date.toISOString()` call with a `NaN` check on `info.reset`.

## Testing

- The fix prevents the `RangeError` when rate limit headers are absent.
- Valid rate limit reset timestamps continue to be formatted correctly.
- Error logs for real request failures remain meaningful and unchanged.

resolves #11784