### PR TITLE
chore: fix JavaScript lint errors (issue #11750)

### DIFF
--- a/lib/node_modules/@stdlib/stats/kstest/test/test.marsaglia.js
+++ b/lib/node_modules/@stdlib/stats/kstest/test/test.marsaglia.js
@@ -51,6 +51,7 @@ tape( 'the function correctly evaluates the CDF of D_n', function test( t ) {
 		1.0,
 		0.9999621,
 		0.0003629,
+
 		0.0237449,
 		0.5725584,
 		0.0175789,

--- a/lib/node_modules/@stdlib/stats/kstest/test/test.marsaglia.js
+++ b/lib/node_modules/@stdlib/stats/kstest/test/test.marsaglia.js
@@ -43,11 +43,19 @@ tape( 'the function correctly evaluates the CDF of D_n', function test( t ) {
 	var n;
 	var i;
 
-	d = [ 0.3, -0.1, 1.5, 0.5, 0.1, 0.1, 0.05, 0.05, 0.8, 0.274 ]; // eslint-disable-line array-element-newline
-	n = [ 10.0, 10.0, 10.0, 20.0, 10.0, 20.0, 300.0, 80.0, 1.0, 10.0 ]; // eslint-disable-line array-element-newline
+	d = [ 0.3, -0.1, 1.5, 0.5, 0.1, 0.1, 0.05, 0.05, 0.8, 0.274 ];
+	n = [ 10.0, 10.0, 10.0, 20.0, 10.0, 20.0, 300.0, 80.0, 1.0, 10.0 ];
 	expected = [
-		0.7294644, 0.0, 1.0, 0.9999621, 0.0003629,
-		0.0237449, 0.5725584, 0.0175789, 0.6, 0.6284796
+		0.7294644,
+		0.0,
+		1.0,
+		0.9999621,
+		0.0003629,
+		0.0237449,
+		0.5725584,
+		0.0175789,
+		0.6,
+		0.6284796
 	];
 	for ( i = 0; i < expected.length; i++ ) {
 		actual = pKolmogorov( d[ i ], n[ i ] ).toFixed( 7 );


### PR DESCRIPTION
## Description

This PR fixes JavaScript linting errors reported in #11750 in the `test.marsaglia.js` file.

## Problem

The automated lint workflow detected the following errors in `lib/node_modules/@stdlib/stats/kstest/test/test.marsaglia.js`:

```
  46:65  error  Unused eslint-disable directive (no problems were reported from 'array-element-newline')
  47:70  error  Unused eslint-disable directive (no problems were reported from 'array-element-newline')
  49:13  error  There should be a linebreak after this element                                            array-element-newline
  49:18  error  There should be a linebreak after this element                                            array-element-newline
  ...
```

## Solution

### Changes Made

1. **Removed unused `eslint-disable-line` directives** from the `d` and `n` array declarations (lines 46–47). These directives were no longer needed and triggered `unused-eslint-disable` errors.

2. **Reformatted the `expected` array** so each element is on its own line, satisfying the `array-element-newline` ESLint rule.

**Before:**
```javascript
d = [ 0.3, -0.1, 1.5, 0.5, 0.1, 0.1, 0.05, 0.05, 0.8, 0.274 ]; // eslint-disable-line array-element-newline
n = [ 10.0, 10.0, 10.0, 20.0, 10.0, 20.0, 300.0, 80.0, 1.0, 10.0 ]; // eslint-disable-line array-element-newline
expected = [
	0.7294644, 0.0, 1.0, 0.9999621, 0.0003629,
	0.0237449, 0.5725584, 0.0175789, 0.6, 0.6284796
];
```

**After:**
```javascript
d = [ 0.3, -0.1, 1.5, 0.5, 0.1, 0.1, 0.05, 0.05, 0.8, 0.274 ];
n = [ 10.0, 10.0, 10.0, 20.0, 10.0, 20.0, 300.0, 80.0, 1.0, 10.0 ];
expected = [
	0.7294644,
	0.0,
	1.0,
	0.9999621,
	0.0003629,
	0.0237449,
	0.5725584,
	0.0175789,
	0.6,
	0.6284796
];
```

### Why this solution is correct

- The `d` and `n` arrays are concise single-line declarations that do not violate the project's `array-element-newline` configuration, making the disable comments redundant.
- The `expected` array spans multiple lines, so the `array-element-newline` rule requires each element to be on its own line for consistency and readability.
- No test logic or values were changed; only formatting was updated.

## Related Issues

resolves #11750

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
