### PR TITLE
fix: handle invalid rate limit reset value in github-create-issue (issue #11784)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/create-issue/lib/query.js
+++ b/lib/node_modules/@stdlib/_tools/github/create-issue/lib/query.js
@@ -84,7 +84,7 @@ function query( slug, title, options, clbk ) {
 		info = ratelimit( response.headers );
 		debug( 'Rate limit: %d', info.limit );
 		debug( 'Rate limit remaining: %d', info.remaining );
-		debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
+		debug( 'Rate limit reset: %s', ( info.reset ) ? (new Date( info.reset*1000 )).toISOString() : 'N/A' );
 
 		if ( error ) {
 			return clbk( error, null, info );


### PR DESCRIPTION
## Description

This PR fixes a runtime `RangeError` that caused the JavaScript lint workflow to crash, as reported in #11784.

## Problem

The automated lint workflow failed with the following error:

```
Oops! Something went wrong! :(

ESLint: 8.57.1

RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at done (/home/runner/work/stdlib/stdlib/lib/node_modules/@stdlib/_tools/github/create-issue/lib/query.js:87:64)
```

The crash occurred in the `github-create-issue` tool's `query.js` file when attempting to log the GitHub API rate limit reset time.

### Root Cause

When GitHub's API response headers lack the `X-RateLimit-Reset` header (or when the `ratelimit` helper returns an object with `reset` set to `undefined` or `null`), the expression `new Date( info.reset*1000 )` evaluates to `new Date( NaN )`, which is an invalid date. Calling `.toISOString()` on an invalid `Date` object throws a `RangeError`.

## Solution

Added a guard to check `info.reset` before constructing a `Date` object.

**Before:**
```javascript
debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
```

**After:**
```javascript
debug( 'Rate limit reset: %s', ( info.reset ) ? (new Date( info.reset*1000 )).toISOString() : 'N/A' );
```

### Why this solution is correct

- **Defensive programming:** The GitHub API may omit rate limit headers in certain error responses, edge cases, or enterprise deployments. The code now gracefully handles missing data instead of crashing.
- **Minimal change:** Only one line was modified, preserving all existing behavior when `info.reset` is present and valid.
- **Consistent with stdlib style:** The fix uses a concise ternary expression, which is idiomatic for the codebase.
- **No breaking changes:** When `info.reset` is a valid Unix timestamp (the normal case), the output is identical to before.

## Related Issues

resolves #11784

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
