### PR TITLE
docs: fix wording in dswap notes for `blas/base/ndarray`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/docs/types/index.d.ts
@@ -216,8 +216,8 @@ interface Namespace {
 	*
 	* -   The function expects the following ndarrays:
 	*
-	*     -   first one-dimensional input ndarray.
-	*     -   second one-dimensional input ndarray.
+	*     -   a first one-dimensional input ndarray.
+	*     -   a second one-dimensional input ndarray.
 	*
 	* @param arrays - array-like object containing ndarrays
 	* @returns second input ndarray


### PR DESCRIPTION
## Description

Follow-up fix for commits merged to `develop` between 2026-04-25T16:41:07-07:00 and 2026-04-26T05:11:55-07:00 (SHA range `9135c0356..2e347f39e`, 31 first-parent commits).

This pull request:

-   **`blas/base/ndarray`** — Fix missing "a" articles in `dswap` Notes block bullets introduced in be8badf0b0 (`lib/node_modules/@stdlib/blas/base/ndarray/docs/types/index.d.ts`, lines 219–220); entries read "first one-dimensional input ndarray." and "second one-dimensional input ndarray." instead of "a first one-dimensional input ndarray." and "a second one-dimensional input ndarray." consistent with every other entry in the same sweep.

## Related Issues

No.

## Questions

No.

## Other

Validation performed across the 24h commit window:

-   **Style guide compliance** (`docs/style-guides/`) — checked all newly added packages (`ndarray/{rot180,rotl90,to-rot90,to-rotr90,unflatten,ndarraylike2scalar,base/to-rot180,base/to-rotl90}`, `blas/ext/base/ndarray/{dunitspace,sunitspace,cunitspace,zunitspace,gunitspace}`) against their reference peers.
-   **Bug scan** — diff-only review of all 31 commits for objective runtime bugs, cross-family copy-paste errors in the d/s/c/z/g unitspace variants, format-string arity mismatches, and ULP test-tolerance correctness.

Deliberately excluded:

-   Subjective concerns or "could be cleaner" suggestions.
-   Anything requiring code outside the diff window to validate.
-   Style preferences not encoded in `docs/style-guides/`.
-   Boilerplate intentionally shared across the rotation and unitspace families.

Originally also included a wording change to `ndarray/ndarraylike2scalar`'s TypeError message; reverted per @kgryte — single-argument APIs use the "Must provide an ndarray" form (cf. `ndarray/data-buffer`, `ndarray/dtype`), and the multi-argument "First argument must be..." references the audit picked were not analogous.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as a follow-up sweep over commits merged to `develop` in the last 24 hours; reviewer agents flagged candidate issues, each was independently re-verified against the diff and reference peers, and only validated high-signal fixes were applied. A maintainer should still audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
