### PR TITLE
refactor: align outliers in `ndarray/iter` with namespace error-construction conventions

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/iter/column-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/column-entries/lib/main.js
@@ -120,7 +120,7 @@ function nditerColumnEntries( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least two dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having at least two dimensions.' ) );
 	}
 
 	// Check whether the input array is empty...

--- a/lib/node_modules/@stdlib/ndarray/iter/columns/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/columns/lib/main.js
@@ -120,7 +120,7 @@ function nditerColumns( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least two dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having at least two dimensions.' ) );
 	}
 	// Check whether the input array is empty...
 	N = numel( shape );

--- a/lib/node_modules/@stdlib/ndarray/iter/matrices/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/matrices/lib/main.js
@@ -114,7 +114,7 @@ function nditerMatrices( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 3 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least three dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having at least three dimensions.' ) );
 	}
 	// Check whether the input array is empty...
 	N = numel( shape );

--- a/lib/node_modules/@stdlib/ndarray/iter/matrix-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/matrix-entries/lib/main.js
@@ -120,7 +120,7 @@ function nditerMatrixEntries( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 3 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least three dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having at least three dimensions.' ) );
 	}
 
 	// Check whether the input array is empty...

--- a/lib/node_modules/@stdlib/ndarray/iter/row-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/row-entries/lib/main.js
@@ -120,7 +120,7 @@ function nditerRowEntries( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least two dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having at least two dimensions.' ) );
 	}
 
 	// Check whether the input array is empty...

--- a/lib/node_modules/@stdlib/ndarray/iter/rows/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/rows/lib/main.js
@@ -120,7 +120,7 @@ function nditerRows( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least two dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having at least two dimensions.' ) );
 	}
 	// Check whether the input array is empty...
 	N = numel( shape );


### PR DESCRIPTION
Aligning outliers in `ndarray/iter` with namespace majority patterns (random namespace pick, seed `20260426`).

## Description

This pull request normalizes a single drift item across six packages in the `@stdlib/ndarray/iter` namespace. Each outlier had exactly one `throw new TypeError( '...' )` site that passed a plain string literal instead of routing the message through `format(...)` — diverging from the dominant pattern in the same file (4/5 = 80% of throws already used `format()`, including a static-string `Error` wrapped in `format()` for the read-only check) and from all three sibling packages with analogous dim-checks (`subarrays`, `stacks`, `interleave-subarrays`). Message text is preserved verbatim in every case.

### Namespace summary

-   Target namespace: `ndarray/iter`
-   Members analyzed: 14 (all non-autogenerated)
-   Random selection seed: `20260426`
-   Structural features analyzed: file tree, `package.json` shape, README section structure, test/benchmark/example file naming. **All 14 packages structurally identical** — no structural drift.
-   Semantic features analyzed: public signature, return kind, validation prologue, error construction, JSDoc shape, `@stdlib/*` dependencies.
-   Features with clear majority (≥75%): file tree (100%), `package.json` top-level keys (100%), README section sequence (100%, `Usage` → `Notes` → `Examples` → `See Also`), `returnKind` (100% `iterator`), `jsdocShape.hasExample` (100% true), `errorConstruction` (100% `format` at the package level when classified as "format dominates"). Within-file drift on a single throw site in 6/14 packages.
-   Features without clear majority (excluded from drift detection): `publicSignature`, `validationPrologue`, `dependencies` — these legitimately vary by what each iterator does (`shape` vs `x` input, `readonly` vs `order` option, etc.).

### Per-package notes

#### `ndarray/iter/column-entries`

Fixes a formatting inconsistency in `ndarray/iter/column-entries` where a single dim-check `TypeError` was thrown with a plain string literal rather than wrapped in `format()`, diverging from the other 4 of 5 throws in the file that already use `format()` — including a static-string `Error` on line 113. Across the `ndarray/iter` namespace, 8 of 14 sibling packages use `format()` exclusively, and all 3 analogous dim-check sites in `subarrays`, `stacks`, and `interleave-subarrays` wrap in `format()`. Message text is unchanged; this brings the package into conformance with the established pattern.

#### `ndarray/iter/columns`

Fixes a formatting inconsistency in `ndarray/iter/columns` where one `TypeError` throw was passing a plain string literal directly rather than routing through `format()`, diverging from the other 4 of 5 throws in the same file and from all 3 analogous dim-checks in sibling packages (`subarrays`, `stacks`, `interleave-subarrays`). Across the 14 `ndarray/iter` siblings, 8 use `format()` exclusively; the remaining 6 shared this same single-site deviation. Message text is unchanged.

#### `ndarray/iter/matrices`

Fixes a formatting inconsistency in `ndarray/iter/matrices` where the minimum-dimensions `TypeError` was constructed with a plain string literal rather than `format()`, diverging from the other four throws in the same file (80% conformance) and from all three sibling packages with analogous dimension checks (`subarrays`, `stacks`, `interleave-subarrays`). Across the fourteen `ndarray/iter` packages, eight already use `format()` exclusively; this was one of six exhibiting the same drift. Message text is unchanged.

#### `ndarray/iter/matrix-entries`

Fixes a formatting drift in `ndarray/iter/matrix-entries` where the minimum-dimensions `TypeError` was thrown with a plain string literal instead of `format()`, inconsistent with the other 4/5 throws in the same file and with all 3 analogous dim-checks across sibling packages (`subarrays`, `stacks`, `interleave-subarrays`). Across the broader `ndarray/iter` namespace, 8 of 14 siblings use `format()` exclusively; this package was among the 6 with this single plain-string outlier. The fix wraps the existing message text in `format()` without altering the message content.

#### `ndarray/iter/row-entries`

Fixes a formatting inconsistency in `ndarray/iter/row-entries` where the minimum-dimensions `TypeError` was constructed with a plain string literal rather than `format()`, making it the sole outlier among 5 throws in the file (the other 4, including a static-string `Error`, all use `format()`). Across the 14 `ndarray/iter` sibling packages, 8 use `format()` exclusively; all 3 siblings with analogous dimension-check throws (`subarrays`, `stacks`, `interleave-subarrays`) wrap them in `format()`. The fix wraps the throw in `format()` with the message text preserved verbatim.

#### `ndarray/iter/rows`

Fixes a formatting inconsistency in `ndarray/iter/rows` where the dimension-check `TypeError` was constructed with a plain string literal instead of `format()`, the pattern used by every other throw in the file (4 of the remaining 4 throws, including a static-string `Error` on line 113). Across the `ndarray/iter` namespace, 8 of 14 siblings use `format()` exclusively, and all 3 analogous dim-check sites in `subarrays`, `stacks`, and `interleave-subarrays` wrap their throws in `format()`. Message text is unchanged; this brings the one outlier throw in line with established convention.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

### Validation

What was checked:
-   Structural feature extraction across all 14 namespace members (file trees, `package.json` shape, README headings, test/benchmark/example file naming) — all identical.
-   Per-package semantic feature extraction via 14 parallel sonnet agents (signature, validation prologue, error construction, JSDoc shape, dependencies).
-   Three-agent drift validation: a semantic-review agent (opus), a cross-reference agent (opus), and a structural-review agent (sonnet). All three independently confirmed the drift as mechanical and safe.
-   Direct smoke test: triggering the dim-check throw produces an identical error message to the pre-change version.

What was deliberately excluded:
-   Features that legitimately vary across packages (`publicSignature`, `validationPrologue`, `dependencies`) — these reflect intentional semantic differences (e.g. `entries`/`values`/`indices` use `options.order` whereas the view-returning iterators use `options.readonly`, `select-dimension` takes a `dim` argument, `interleave-subarrays` takes `arrays`+`ndims`, etc.).
-   No outlier was flagged as needing human judgment by the cross-reference agent; tests assert on `TypeError` constructor only and do not depend on exact message text (which is preserved regardless).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

How AI assistance was used:

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift detection routine: a randomly selected stdlib namespace (`ndarray/iter`, seed `20260426`) was scanned for majority-vs-outlier conventions across structural and semantic features, drift findings were independently validated by three review agents, and only mechanical, behavior-preserving corrections were applied. Each per-package commit was generated by Claude Code; a human maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01QrV44r7kSo5LjP8pBpUf1X)_