### PR TITLE
docs: add missing JSDoc example sections in `_tools/pkgs` packages

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/dep-list/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/dep-list/lib/main.js
@@ -60,6 +60,18 @@ function ascending( a, b ) {
 * @param {boolean} [options.manifest=true] - boolean indicating whether to return dependencies from `manifest.json` files
 * @throws {TypeError} first argument must be a string
 * @returns {(StringArray|EmptyArray)} dependencies
+*
+* @example
+* var deps = depList( '@stdlib/assert/is-number-array' );
+* // returns [...]
+*
+* @example
+* var opts = {
+*     'dev': true
+* };
+*
+* var devDeps = depList( '@stdlib/utils/keys', opts );
+* // returns [...]
 */
 function depList( pkg, options ) {
 	var opts;

--- a/lib/node_modules/@stdlib/_tools/pkgs/dep-list/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/dep-list/lib/main.js
@@ -62,7 +62,7 @@ function ascending( a, b ) {
 * @returns {(StringArray|EmptyArray)} dependencies
 *
 * @example
-* var deps = depList( '@stdlib/assert/is-number-array' );
+* var out = depList( '@stdlib/assert/is-number-array' );
 * // returns [...]
 *
 * @example
@@ -70,7 +70,7 @@ function ascending( a, b ) {
 *     'dev': true
 * };
 *
-* var devDeps = depList( '@stdlib/utils/keys', opts );
+* var out = depList( '@stdlib/utils/keys', opts );
 * // returns [...]
 */
 function depList( pkg, options ) {

--- a/lib/node_modules/@stdlib/_tools/pkgs/namespace-deps/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/namespace-deps/lib/main.js
@@ -60,6 +60,18 @@ function ascending( a, b ) {
 * @param {number} [options.level=1] - dependency level
 * @throws {TypeError} first argument must be a string
 * @returns {(StringArray|EmptyArray)} dependencies
+*
+* @example
+* var deps = namespaceDeps( '@stdlib/assert' );
+* // returns [...]
+*
+* @example
+* var opts = {
+*     'dev': true
+* };
+*
+* var devDeps = namespaceDeps( '@stdlib/assert', opts );
+* // returns [...]
 */
 function namespaceDeps( pkg, options ) {
 	var opts;

--- a/lib/node_modules/@stdlib/_tools/pkgs/namespace-deps/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/namespace-deps/lib/main.js
@@ -62,7 +62,7 @@ function ascending( a, b ) {
 * @returns {(StringArray|EmptyArray)} dependencies
 *
 * @example
-* var deps = namespaceDeps( '@stdlib/assert' );
+* var out = namespaceDeps( '@stdlib/assert' );
 * // returns [...]
 *
 * @example
@@ -70,7 +70,7 @@ function ascending( a, b ) {
 *     'dev': true
 * };
 *
-* var devDeps = namespaceDeps( '@stdlib/assert', opts );
+* var out = namespaceDeps( '@stdlib/assert', opts );
 * // returns [...]
 */
 function namespaceDeps( pkg, options ) {


### PR DESCRIPTION
## Description

This PR adds 

-   `@example` blocks to the `depList` public function JSDoc in `_tools/pkgs/dep-list`, bringing it into line with the 92% of `_tools/pkgs` siblings that document at least one usage example. Examples are lifted directly from the package README: a basic invocation with a package identifier string and an options invocation using `dev: true`. No behavioral, signature, or test changes.
-   `@example` blocks to the public `namespaceDeps` JSDoc in `_tools/pkgs/namespace-deps`, bringing the package into conformance with the 92% of `_tools/pkgs` siblings that document at least one usage example. The two examples are lifted directly from the README: a basic `namespaceDeps( '@stdlib/assert' )` call and a `dev: true` options variant. No signatures, behavior, or tests were changed.

## Related Issues

None.

## Questions

No.

## Other

### Validation

What was checked:
- Structural feature extraction across all 25 members (file tree, `package.json` shape, README section structure, per-subdir file listings).
- Semantic feature extraction via per-package sub-agents (`publicSignature`, `validationPrologue`, `errorConstruction`, `jsdocShape`, `dependencies`).
- Three-agent drift validation (semantic-review, cross-reference, structural-review). Both `dep-list` and `namespace-deps` returned `confirmed-drift` from the semantic-review and cross-reference agents on the `hasExample` finding; no test or doc-tooling cascade was identified.

What was deliberately excluded:
- **Intentional design deviations**: outliers missing `lib/sync.js` (`dep-list`, `installed`, `name2bucket`, `name2standalone`, `namespace-deps`) — five packages are sync-only or async-only by design, so the async/sync split does not apply. Outliers missing `lib/validate.js` (`name2bucket`, `name2standalone`) similarly take no options object and validate inline. Marked `inapplicable` by the structural-review agent.
- **Tests-rely-on-deviation / non-mechanical fixes**: `installed` is missing tests entirely, missing `directories.test`, and lacks a `## Examples` heading; correcting any of these cascades into writing tests or example content, which is out of scope for mechanical drift correction.
- **Empty-section README drift**: `dep-list` and `namespace-deps` have empty `<section class="notes">` containers without `### Notes` headings. Adding the heading without content would create a different kind of weirdness, and content requires package-specific judgement; dropped.
- **Features without clear majority**: `publicSignature` and `validationPrologue` vary with each function's input domain across the namespace; no namespace-wide pattern at ≥75%.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

How AI assistance was used:

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code as part of an automated cross-package drift detection routine. Three independent validator sub-agents (one Opus semantic review, one Opus cross-reference, one Sonnet structural review) confirmed both `dep-list` and `namespace-deps` as mechanical-drift outliers before the change was applied. The example bodies were lifted verbatim from each package's existing `README.md`. A human maintainer should audit before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018TZhAvyL3P8FYzhGm4G1LH)_