### PR TITLE
bench: add missing benchmark to `dstructs/compact-adjacency-matrix`

### DIFF
--- a/lib/node_modules/@stdlib/dstructs/compact-adjacency-matrix/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/dstructs/compact-adjacency-matrix/benchmark/benchmark.js
@@ -1,0 +1,71 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var instanceOf = require( '@stdlib/assert/instance-of' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var CompactAdjacencyMatrix = require( './../lib' );
+
+
+// MAIN //
+
+bench( format( '%s::instantiation,new', pkg ), function benchmark( b ) {
+	var adj;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		adj = new CompactAdjacencyMatrix( 10 );
+		if ( typeof adj !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !instanceOf( adj, CompactAdjacencyMatrix ) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
+	var compactAdjacencyMatrix;
+	var adj;
+	var i;
+
+	compactAdjacencyMatrix = CompactAdjacencyMatrix;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		adj = compactAdjacencyMatrix( 10 );
+		if ( typeof adj !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !instanceOf( adj, CompactAdjacencyMatrix ) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/dstructs/compact-adjacency-matrix/package.json
+++ b/lib/node_modules/@stdlib/dstructs/compact-adjacency-matrix/package.json
@@ -15,6 +15,7 @@
   ],
   "main": "./lib",
   "directories": {
+    "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
     "lib": "./lib",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Aligns outliers in the `@stdlib/dstructs` namespace with namespace majority patterns (random namespace pick, seed `drift-routine-2026-04-27`).

### Namespace summary

-   **Target**: `@stdlib/dstructs`
-   **Members analyzed**: 8 (`circular-buffer`, `compact-adjacency-matrix`, `doubly-linked-list`, `fifo`, `linked-list`, `named-typed-tuple`, `stack`, `struct`); zero autogenerated, zero excluded.
-   **Features analyzed**: file tree / directory presence, `package.json` shape (top keys, `directories`, `scripts`, `keywords`), README section list and order, manifest shape, test/benchmark/example file naming, public signature, return kind, validation prologue, error construction, JSDoc shape, `@stdlib/*` dependency set.
-   **Features with clear majority (≥75%)**: presence of `lib/`, `test/`, `examples/`, `README.md`, `package.json`, `benchmark/` (87.5%), `docs/` (87.5%); identical top-level `package.json` keys across all 8; `directories.benchmark` (87.5%) and `directories.doc` (87.5%); `returnKind: value` (100%); `jsdocShape.hasExample: true` (100%); README sections `Usage` (100%) and `Examples` (100%); deps `@stdlib/utils/define-nonenumerable-read-only-property` and `@stdlib/utils/define-nonenumerable-read-only-accessor` (100%).
-   **Features without clear majority (excluded)**: README sections `Notes` (62.5%) and `See Also` (62.5%); README section ordering (no contiguous subsequence ≥75% beyond `Usage→Examples`); public-signature arity (0 args 50%, 1 arg 37.5%, 2 args 12.5%); validation prologue (no shared subsequence ≥75%); `errorConstruction` (`format` 62.5%, others split). All dropped from drift detection.

### `compact-adjacency-matrix`

Adds a missing `benchmark/` directory and `directories.benchmark` entry to `@stdlib/dstructs/compact-adjacency-matrix`, bringing it into line with 7 of 8 siblings (87.5%) in the `dstructs` namespace. The benchmark covers both `new` and no-`new` instantiation paths using the standard boilerplate shared across the namespace. Without this, the package was the sole outlier in an otherwise consistent drift run.

### Validation

Three independent agents reviewed the candidate corrections:

-   **Semantic-review (opus)** — confirmed there are no semantic-feature drift findings: the plain-string throws in `linked-list`/`doubly-linked-list` use static messages without interpolation (not concatenation drift); `fifo`/`stack` contain no throws at all; signature variation is genuine API difference, not stylistic drift.
-   **Cross-reference (opus)** — confirmed `compact-adjacency-matrix`'s test suite has no benchmark-file dependency, no upstream README in the namespace references the missing path, and the change is purely additive.
-   **Structural-review (sonnet)** — confirmed `compact-adjacency-matrix` benchmark drift; flagged `struct`'s missing `docs/` as `needs-human` (real REPL/types content cannot be safely auto-stubbed) and dropped from this run.

### Excluded from this run

-   `struct` is missing the `docs/` directory (`docs/repl.txt`, `docs/types/index.d.ts`) at 87.5% sibling conformance, but the fix requires authoring real package-specific REPL examples and TypeScript declarations — out of scope for mechanical drift correction. Logged for human authorship.
-   All semantic features (signatures, validation prologues, error construction, JSDoc paramTag types) are below the 75% majority threshold across the namespace; nothing advanced.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

This PR is the output of an automated cross-package API drift detection routine over the `@stdlib/dstructs` namespace. Namespace was picked uniformly at random from eligible (≥8 non-autogenerated members, ≤50% autogenerated) namespaces using seed `drift-routine-2026-04-27`. Detailed per-feature majority pattern, conformance percentages, outlier list, and validation-agent verdicts are in the local drift report (not committed to the repo). PR is intentionally left in **draft** state pending maintainer audit.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code running an automated cross-package drift-detection routine: namespace selection, structural feature extraction, semantic feature extraction (per-package sonnet agents), three-agent drift validation (opus + sonnet), and patch application. The generated `benchmark/benchmark.js` scaffold mirrors the boilerplate of sibling benchmarks in the namespace; the `package.json` `directories.benchmark` entry is a one-line additive change. PR is left in draft for human audit before promotion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3Xf8psrX9CDj1KvW8f9xC)_