### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/repl/presentation/lib/commands/end.js
+++ b/lib/node_modules/@stdlib/repl/presentation/lib/commands/end.js
@@ -37,15 +37,15 @@ function command( pres ) {
 	*/
 	function onCommand() {
 		pres._repl.once( 'drain', onDrain ); // eslint-disable-line no-underscore-dangle
+	}
 
-		/**
-		* Callback invoked upon a `drain` event.
-		*
-		* @private
-		*/
-		function onDrain() {
-			pres.end().show();
-		}
+	/**
+	* Callback invoked upon a `drain` event.
+	*
+	* @private
+	*/
+	function onDrain() {
+		pres.end().show();
 	}
 }
 


### PR DESCRIPTION
Resolves #11803.

## Description

Move \`onDrain\` out of \`onCommand\` in \`lib/node_modules/@stdlib/repl/presentation/lib/commands/end.js\` so it sits at the same scope as \`onCommand\`. \`onDrain\` only references \`pres\` from the outer \`command\` scope, so the nested form was unnecessary. The new layout matches the convention already used by \`next.js\`, \`prev.js\`, \`last.js\`, \`jump.js\`, and other sibling command files in the same directory.

Resolves the \`stdlib/no-unnecessary-nested-functions\` lint failure reported by the automated workflow ([run 24970593105](https://github.com/stdlib-js/stdlib/actions/runs/24970593105)):

\`\`\`
end.js
  46:3  error  Function 'onDrain' should be moved to outer function scope  stdlib/no-unnecessary-nested-functions
\`\`\`

## Related Issues

-   #11803

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)

#### Disclosure

This PR was written by Claude Code; I (the author) reviewed the diff against the project's existing sibling command files before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md