### PR TITLE
chore: minor clean-up

### DIFF
--- a/etc/eslint/plugin/index.js
+++ b/etc/eslint/plugin/index.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-// eslint-disable-next-line node/no-unpublished-require
+// eslint-disable-next-line n/no-unpublished-require
 var plugin = require( './../../../lib/node_modules/@stdlib/_tools/eslint/rules/scripts/plugin.js' );
 
 

--- a/etc/eslint/plugin/package.json
+++ b/etc/eslint/plugin/package.json
@@ -14,6 +14,7 @@
     }
   ],
   "main": "./index.js",
+  "directories": {},
   "scripts": {},
   "homepage": "https://github.com/stdlib-js/stdlib",
   "repository": {

--- a/lib/node_modules/@stdlib/blas/ext/base/dcartesian-square/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcartesian-square/docs/types/index.d.ts
@@ -38,7 +38,7 @@ interface Routine {
 	* @returns output array
 	*
 	* @example
-	* var Float64Array = require( `@stdlib/array/float64` );
+	* var Float64Array = require( '@stdlib/array/float64' );
 	*
 	* var x = new Float64Array( [ 1.0, 2.0 ] );
 	* var out = new Float64Array( 8 );
@@ -66,7 +66,7 @@ interface Routine {
 	* @returns output array
 	*
 	* @example
-	* var Float64Array = require( `@stdlib/array/float64` );
+	* var Float64Array = require( '@stdlib/array/float64' );
 	*
 	* var x = new Float64Array( [ 1.0, 2.0 ] );
 	* var out = new Float64Array( 8 );
@@ -89,7 +89,7 @@ interface Routine {
 * @returns output array
 *
 * @example
-* var Float64Array = require( `@stdlib/array/float64` );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
 * var x = new Float64Array( [ 1.0, 2.0 ] );
 * var out = new Float64Array( 8 );
@@ -98,7 +98,7 @@ interface Routine {
 * // out => <Float64Array>[ 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 2.0, 2.0 ]
 *
 * @example
-* var Float64Array = require( `@stdlib/array/float64` );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
 * var x = new Float64Array( [ 1.0, 2.0 ] );
 * var out = new Float64Array( 8 );


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between `28917cf0` (2026-04-26 12:48 UTC) and `19216fd1` (2026-04-27 05:56 UTC). 20 first-parent commits in the window were audited by four parallel reviewers (two style, two bug); after dedup, re-verification, and maintainer review, three high-signal issues remain.

-   Fix `@example` blocks in `@stdlib/blas/ext/base/dcartesian-square` (`a023392`): `index.d.ts` used backtick template literals in four `require` calls (`lib/node_modules/@stdlib/blas/ext/base/dcartesian-square/docs/types/index.d.ts`, lines 41, 69, 92, 101); replaced with single quotes per style guide.
-   In `d4191cc`, `etc/eslint/plugin/index.js` (line 23) disables `node/no-unpublished-require`, but the plugin was migrated to `eslint-plugin-n` in `0dc62ae3`, making the directive a no-op under the `n/` prefix and tripping `--report-unused-disable-directives`; updated to `n/no-unpublished-require`.
-   Also from `d4191cc`, the new `etc/eslint/plugin/package.json` was missing the canonical `"directories": {}` field, which `update_directories` adds and which `Lint Changed Files` enforces; inserted to clear the failing CI lint.

## Related Issues

No.

## Questions

No.

## Other

**Validation**

Checked across the 20-commit window:

-   Style-guide compliance against `docs/style-guides/javascript` and `docs/style-guides/text`, using sibling reference packages (`dcusum`, `ddiff`/`sdiff`, `gscatter`) as the gold standard.
-   Static bug scan: stride/offset arithmetic, off-by-one bounds, copy-paste mistakes in JSDoc / signature pairs, and bench-refactor `format(...)` substitutions versus the original concatenations.
-   Logic + security: row/column-major branches, edge-case handling (`N <= 0`, empty inputs), TypeScript declarations versus underlying packages.
-   Reproduced the `Lint Changed Files` failure locally (`update_directories etc/eslint/plugin`) to identify the missing `directories` field in `etc/eslint/plugin/package.json`.

Deliberately excluded:

-   Anything requiring interpretation or judgment (suggestions, "nice to haves", subjective style preferences).
-   Anything requiring code outside the diff window to validate.
-   Pre-existing `node/...` ESLint disable directives in files not touched by `0dc62ae3` — out of scope per the migration's incremental rollout.
-   Repeated boilerplate across the new BLAS packages — intentional per stdlib's package template.

A local report (`commit-review-2026-04-27.md`, kept outside the working tree) records the full review, including findings dropped during filtering and on maintainer request.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated commit-review pass over the last 24 hours of `develop`. Four parallel reviewer agents flagged candidate issues; each surviving issue was independently re-verified against the diff before a fix was applied. Maintainer audit expected before promoting from draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
