### PR TITLE
style: align outliers in `number/float32/base` with namespace majority patterns

### DIFF
--- a/lib/node_modules/@stdlib/number/float32/base/to-float16/README.md
+++ b/lib/node_modules/@stdlib/number/float32/base/to-float16/README.md
@@ -168,6 +168,12 @@ int main( void ) {
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/number/float64/base/to-float16`][@stdlib/number/float64/base/to-float16]</span><span class="delimiter">: </span><span class="description">convert a double-precision floating-point number to the nearest half-precision floating-point number.</span>
+
 </section>
 
 <!-- /.related -->
@@ -179,6 +185,12 @@ int main( void ) {
 [ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
 
 [half-precision-floating-point-format]: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
+
+<!-- <related-links> -->
+
+[@stdlib/number/float64/base/to-float16]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/float64/base/to-float16
+
+<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/number/float32/base/to-int32/lib/index.js
+++ b/lib/node_modules/@stdlib/number/float32/base/to-int32/lib/index.js
@@ -48,9 +48,9 @@
 
 // MODULES //
 
-var float32ToInt32 = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = float32ToInt32;
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/float32/base/to-uint32/lib/index.js
+++ b/lib/node_modules/@stdlib/number/float32/base/to-uint32/lib/index.js
@@ -48,9 +48,9 @@
 
 // MODULES //
 
-var float32ToUint32 = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = float32ToUint32;
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/float32/base/ulp-difference/README.md
+++ b/lib/node_modules/@stdlib/number/float32/base/ulp-difference/README.md
@@ -125,6 +125,12 @@ console.log( d );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/number/float64/base/ulp-difference`][@stdlib/number/float64/base/ulp-difference]</span><span class="delimiter">: </span><span class="description">compute the number of representable double-precision floating-point values that separate two double-precision floating-point numbers along the real number line.</span>
+
 </section>
 
 <!-- /.related -->
@@ -138,6 +144,8 @@ console.log( d );
 [ulp]: https://en.wikipedia.org/wiki/Unit_in_the_last_place
 
 <!-- <related-links> -->
+
+[@stdlib/number/float64/base/ulp-difference]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/float64/base/ulp-difference
 
 <!-- </related-links> -->
 


### PR DESCRIPTION
## Description

Aligning outliers in `number/float32/base` with namespace majority patterns (random namespace pick, seed `20260427`).

This PR was produced by an automated cross-package drift-detection routine. For each feature shared across the namespace's 18 sibling packages, the routine computed the majority pattern at a 75% conformance threshold, validated each outlier through three independent review agents, and grouped the surviving mechanical fixes into one commit per outlier package.

### Namespace summary

-   **Target:** `number/float32/base`
-   **Members analyzed:** 18 (none autogenerated)
-   **Random seed:** `20260427`
-   **Selection pool:** 51 public namespaces with 10–25 members (full random pool was 101; bracketed by size for session tractability — documented in the local report)
-   **Features with clear majority (≥75% conformance):** file tree, `package.json` keys, `package.json` `directories` keys, README H2 sections (`Usage`, `Examples`, `See Also`), `lib/index.js` require-alias variable name, `validationPrologue` (empty across all members), `errorConstruction` (none across all members except `from-binary-string` which already uses `format`).
-   **Features without clear majority (excluded):** native-addon scaffolding (`binding.gyp`, `manifest.json`, `include/`, `src/`, `gypfile`, `benchmark.native.js`, `test.native.js`) — all sit at 12/18 = 66.7% because the namespace cleanly splits into NAPI vs. non-NAPI subgroups; `## C APIs` and `## Notes` README sections similarly track the NAPI split rather than a namespace-wide convention.

### Per-outlier corrections

#### `number/float32/base/to-int32`

Renamed the local `lib/index.js` require alias from `float32ToInt32` to `main`. The `var main = require('./main.js')` form is shared by 14 of 17 non-`assert` siblings (82.4%). The exported value is unchanged; nothing else in the package references the inner alias.

#### `number/float32/base/to-uint32`

Same drift as `to-int32`: renamed `float32ToUint32` to `main` in `lib/index.js`. Brings the file into line with the 82.4% majority. No behavior change.

#### `number/float32/base/to-float16`

Populated the empty `<section class="related">` block in `README.md` with a See Also link to the parallel `@stdlib/number/float64/base/to-float16` and added the matching `<related-links>` reference. The `## See Also` section is present in 14 of 18 namespace packages (77.8%); the convention is a link to the float64 counterpart, which exists for this package.

#### `number/float32/base/ulp-difference`

Same drift as `to-float16`: populated the empty `<section class="related">` with a See Also link to `@stdlib/number/float64/base/ulp-difference` and filled the existing `<related-links>` placeholder. Brings the README in line with the 77.8% namespace majority.

### Validation

Each candidate cleared three independent reviews:

-   **Semantic review (Agent 1):** confirmed each outlier reflects unintentional drift rather than a genuine semantic difference. Rejected `to-float16/lib/index.js` (the `var builtin` alias is required by the polyfill dispatch) and `significand` See Also (no parallel `float64/base/significand` exists, so the conventional sibling link is unavailable).
-   **Cross-reference review (Agent 2):** verified that no test, example, benchmark, `.d.ts` file, or sibling package documentation depends on the deviating behavior. The `index.js` aliases are local to the file body; the README additions are documentation-only.
-   **Structural review (Agent 3):** confirmed the majority patterns are genuine namespace conventions (not plurality noise) and that the proposed templates match canonical siblings (`signbit`, `identity`, `from-word`, `to-word`).

Deliberately excluded:

-   `to-float16/lib/index.js` — `var builtin = require('./main.js')` is intentional; main.js exports either `Math.f16round` or `null` and `index.js` dispatches to a polyfill.
-   `significand/README.md` See Also — no parallel `float64/base/significand` package exists; choosing alternative links is editorial, not mechanical.
-   `assert/` outliers — `number/float32/base/assert` is a sub-namespace package and intentionally lacks `benchmark/`, `lib/main.js`, `docs/repl.txt`, etc.
-   All NAPI-related structural features (66.7% conformance, below the 75% threshold).

## Related Issues

No.

## Questions

No.

## Other

The full drift report (per-feature majority patterns, conformance percentages, per-package outlier list, dropped corrections with reasons, and the random selection criteria) is preserved alongside this PR for audit. The routine deliberately leaves this PR in **draft** state — a maintainer should audit before promoting to ready.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated cross-package drift-detection routine driven by Claude Code (Opus 4.7). The routine extracted structural features programmatically, derived majority patterns at a 75% conformance threshold, and validated each outlier through three independent LLM review agents (one Sonnet, two Opus) before applying any change. All file edits were applied mechanically from the validated drift findings; no behavioral logic was generated. A human maintainer is expected to audit before promoting this PR out of draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_012aeqsyY32Ls3mKjhq6cGX8)_