### PR TITLE
build: complete `eslint-plugin-n` rename in override configs

### DIFF
--- a/etc/eslint/.eslintrc.markdown.js
+++ b/etc/eslint/.eslintrc.markdown.js
@@ -149,7 +149,7 @@ eslint.rules[ 'no-unused-vars' ] = 'off';
 *
 * @private
 */
-eslint.rules[ 'node/no-unpublished-require' ] = 'off';
+eslint.rules[ 'n/no-unpublished-require' ] = 'off';
 
 
 // EXPORTS //

--- a/etc/eslint/overrides/index.js
+++ b/etc/eslint/overrides/index.js
@@ -162,7 +162,7 @@ var overrides = [
 			'stdlib/return-annotations-values': 'off',
 			'strict': 'off',
 			'vars-on-top': 'off',
-			'node/no-unpublished-require': 'off'
+			'n/no-unpublished-require': 'off'
 		}
 	},
 	{


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Renames two stale `node/no-unpublished-require` keys to `n/no-unpublished-require` left over from the migration in 0dc62ae39a4 ("build: replace `eslint-plugin-node` with `eslint-plugin-n`").
-   Affected files: `etc/eslint/.eslintrc.markdown.js`, `etc/eslint/overrides/index.js`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The defining file (`etc/eslint/rules/nodejs.js`) already registers the rule under the new key `n/no-unpublished-require`, so the previous override entries no longer match anything and the rule fires on every README that requires a devDependency such as `eslint`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code following my instructions.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md