### PR TITLE
docs: align outliers in `os/*` with namespace majority patterns

### DIFF
--- a/lib/node_modules/@stdlib/os/num-cpus/README.md
+++ b/lib/node_modules/@stdlib/os/num-cpus/README.md
@@ -134,6 +134,13 @@ $ num-cpus
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/os/arch`][@stdlib/os/arch]</span><span class="delimiter">: </span><span class="description">operating system CPU architecture for which the JavaScript runtime binary was compiled.</span>
+-   <span class="package-name">[`@stdlib/os/platform`][@stdlib/os/platform]</span><span class="delimiter">: </span><span class="description">platform on which the current process is running.</span>
+
 </section>
 
 <!-- /.related -->
@@ -145,6 +152,14 @@ $ num-cpus
 [node-os]: https://nodejs.org/api/os.html#os_os_cpus
 
 [hardware-concurrency]: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency
+
+<!-- <related-links> -->
+
+[@stdlib/os/arch]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/os/arch
+
+[@stdlib/os/platform]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/os/platform
+
+<!-- </related-links> -->
 
 </section>
 


### PR DESCRIPTION
## Description

Aligning outliers in `os/*` with namespace majority patterns (random namespace pick, seed `20260428`).

### Namespace summary

-   **Target namespace:** `@stdlib/os`
-   **Members analyzed:** 8 (`arch`, `byte-order`, `configdir`, `float-word-order`, `homedir`, `num-cpus`, `platform`, `tmpdir`) — all non-autogenerated
-   **Features analyzed:** file tree, `package.json` shape, README headings, `manifest.json` shape, `test`/`benchmark`/`examples` filenames, public signature, return kind, validation prologue, error construction, JSDoc shape, `@stdlib/*` dependencies
-   **Features with clear majority (≥75%):** universal file tree (13 files in 8/8), universal `package.json` top-level keys (19 keys in 8/8), `## Usage`/`## Examples`/`## CLI` README headings (8/8), `## See Also` (7/8), `## Notes` (6/8), `returnKind: value` (8/8), `hasExample: true` (8/8)
-   **Features without clear majority:** `package.json` `browser` key (3/8), `manifest.json` presence (2/8), `benchmark/benchmark.js` (3/8), `errorConstruction` (only `configdir` actually throws), `publicSignature` (7/8 export a constant; `configdir` exports a function with one optional parameter)

### Per-package corrections

#### `os/num-cpus`

Populated the empty `<section class="related">` block with a `## See Also` listing for `@stdlib/os/arch` and `@stdlib/os/platform`, plus the corresponding `<related-links>` reference definitions. The section scaffold was already present but lacked all content. Brings `num-cpus` in line with 7 of 8 (87.5%) `os/*` siblings that carry a populated See Also list.

### Validation

Checked:

-   Structural feature extraction across all 8 members (file tree, `package.json` shape, README headings, `manifest.json` presence, test/benchmark/examples filenames).
-   Semantic feature extraction via per-package agents (public signature, validation prologue, error construction, JSDoc shape, `@stdlib/*` dependency set).
-   Three-agent drift validation (semantic-review, cross-reference, structural-review) on every flagged outlier.

Deliberately excluded:

-   `os/platform` and `os/tmpdir` lacking `## Notes` — both flagged by Agent 1 / Agent 3 as intentional deviations: `platform` is a thin pass-through over `process.platform` with nothing noteworthy beyond Node's own docs; `tmpdir` was split (Agent 1 leaned drift, Agent 3 leaned intentional, Agent 2 marked `needs-human` since meaningful Notes copy is editorial work). Per the routine, any `needs-human` or `intentional-deviation` verdict drops the outlier.
-   Features without a clear ≥75% majority (`browser` key, `manifest.json`, `benchmark/benchmark.js`, error construction, signature shape).
-   Outliers reflecting genuine semantic differences: C-binding extras in `byte-order`/`float-word-order`, `lib/browser.js`/`lib/navigator.js` in `num-cpus`/`platform`, `configdir`'s optional `path` parameter and validation prologue.

The full per-feature majority/conformance/outlier table and the per-agent verdict matrix live in the run's local report.

## Related Issues

None.

## Questions

None.

## Other

Generated by the cross-package API drift detection routine (majority-vote variant). Random namespace pick seed: `20260428`. Eligibility filter: ≥8 non-autogenerated direct child packages. Conformance threshold: ≥75%. Validation pipeline: per-package semantic-feature extraction (sonnet) + three-agent drift validation (opus + opus + sonnet) with unanimous-non-rejection gating.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude (Opus 4.7) running the cross-package API drift detection routine. Namespace selection was deterministic from seed `20260428`; structural feature extraction ran via shell tooling; per-package semantic feature extraction was delegated to parallel sonnet agents; the resulting outlier set was validated by three independent review agents (semantic-review, cross-reference, structural-review) before any change was applied. Only the single drift item that received a non-rejection verdict from all three reviewers advanced to a commit.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJShvWSVtXZ7f5HCXXrcNb)_