### PR TITLE
chore: propagate `node/` -> `n/` eslint plugin prefix update across README directives

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/first-unit-test/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/first-unit-test/README.md
@@ -77,7 +77,7 @@ tape( 'main export is a function', function test( t ) {
 
 ## Examples
 
-<!-- eslint-disable node/no-unpublished-require -->
+<!-- eslint-disable n/no-unpublished-require -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/_tools/test-cov/tape-istanbul/README.md
+++ b/lib/node_modules/@stdlib/_tools/test-cov/tape-istanbul/README.md
@@ -75,7 +75,7 @@ runner( 'test*.js', opts, done );
 
 ## Examples
 
-<!-- eslint-disable node/no-path-concat -->
+<!-- eslint-disable n/no-path-concat -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/array/to-json/README.md
+++ b/lib/node_modules/@stdlib/array/to-json/README.md
@@ -87,7 +87,7 @@ For guidance on reviving a JSON-serialized typed array, see [`reviver()`][@stdli
 
 -   The implementation provides basic support for custom typed arrays and sets the `type` field to the closest known typed array type.
 
-    <!-- eslint-disable no-restricted-syntax, no-useless-constructor, new-cap, stdlib/require-globals, node/no-unsupported-features/es-syntax -->
+    <!-- eslint-disable no-restricted-syntax, no-useless-constructor, new-cap, stdlib/require-globals, n/no-unsupported-features/es-syntax -->
 
     ```javascript
     class CustomArray extends Float64Array() {

--- a/lib/node_modules/@stdlib/assert/is-arrow-function/README.md
+++ b/lib/node_modules/@stdlib/assert/is-arrow-function/README.md
@@ -34,7 +34,7 @@ var isArrowFunction = require( '@stdlib/assert/is-arrow-function' );
 
 Tests if a `value` is an [`arrow function`][mdn-arrow-function] such as `( a, b ) => a + b`, `x => x`, or `( x ) => { return x*x; }`.
 
-<!-- eslint-disable func-style, no-restricted-syntax, node/no-unsupported-features/es-syntax -->
+<!-- eslint-disable func-style, no-restricted-syntax, n/no-unsupported-features/es-syntax -->
 
 ```javascript
 var beep = () => {
@@ -60,7 +60,7 @@ bool = isArrowFunction( boop );
 
 ## Examples
 
-<!-- eslint-disable func-style, no-restricted-syntax, no-empty-function, node/no-unsupported-features/es-syntax -->
+<!-- eslint-disable func-style, no-restricted-syntax, no-empty-function, n/no-unsupported-features/es-syntax -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/assert/is-class/README.md
+++ b/lib/node_modules/@stdlib/assert/is-class/README.md
@@ -34,7 +34,7 @@ var isClass = require( '@stdlib/assert/is-class' );
 
 Tests if a value is a [`class`][mdn-class].
 
-<!-- eslint-disable max-classes-per-file, no-restricted-syntax, node/no-unsupported-features/es-syntax  -->
+<!-- eslint-disable max-classes-per-file, no-restricted-syntax, n/no-unsupported-features/es-syntax  -->
 
 ```javascript
 var bool = isClass( class Animal {
@@ -68,7 +68,7 @@ bool = isClass( null );
 
 <!-- eslint no-undef: "error" -->
 
-<!-- eslint-disable no-restricted-syntax, no-empty-function, node/no-unsupported-features/es-syntax -->
+<!-- eslint-disable no-restricted-syntax, no-empty-function, n/no-unsupported-features/es-syntax -->
 
 ```javascript
 var isClass = require( '@stdlib/assert/is-class' );

--- a/lib/node_modules/@stdlib/assert/is-generator-object/README.md
+++ b/lib/node_modules/@stdlib/assert/is-generator-object/README.md
@@ -34,7 +34,7 @@ var isGeneratorObject = require( '@stdlib/assert/is-generator-object' );
 
 Tests if a `value` is a [`generator`][mdn-generator-object] object.
 
-<!-- eslint-disable no-restricted-syntax, node/no-unsupported-features/es-syntax -->
+<!-- eslint-disable no-restricted-syntax, n/no-unsupported-features/es-syntax -->
 
 ```javascript
 function* generateID() {
@@ -63,7 +63,7 @@ bool = isGeneratorObject( {} );
 
 ## Examples
 
-<!-- eslint-disable no-restricted-syntax, node/no-unsupported-features/es-syntax -->
+<!-- eslint-disable no-restricted-syntax, n/no-unsupported-features/es-syntax -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/math/base/tools/continued-fraction/README.md
+++ b/lib/node_modules/@stdlib/math/base/tools/continued-fraction/README.md
@@ -49,7 +49,7 @@ Evaluates the continued fraction described by the supplied `generator` argument.
 
 Using an ES6 [Generator object][es6-generator]:
 
-<!-- eslint-disable no-restricted-syntax, node/no-unsupported-features/es-syntax -->
+<!-- eslint-disable no-restricted-syntax, n/no-unsupported-features/es-syntax -->
 
 ```javascript
 // Continued fraction for (e-1)^(-1):
@@ -171,7 +171,7 @@ function generator() {
 
 ## Examples
 
-<!-- eslint-disable no-restricted-syntax, node/no-unsupported-features/es-syntax -->
+<!-- eslint-disable no-restricted-syntax, n/no-unsupported-features/es-syntax -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/math/base/tools/sum-series/README.md
+++ b/lib/node_modules/@stdlib/math/base/tools/sum-series/README.md
@@ -36,7 +36,7 @@ Computes the sum of the series given by the supplied `generator` argument. `gene
 
 Using an ES6 [Generator object][es6-generator]:
 
-<!-- eslint-disable no-restricted-syntax, node/no-unsupported-features/es-syntax -->
+<!-- eslint-disable no-restricted-syntax, n/no-unsupported-features/es-syntax -->
 
 ```javascript
 var pow = require( '@stdlib/math/base/special/pow' );
@@ -150,7 +150,7 @@ function geometricSeriesClosure( x ) {
 
 ## Examples
 
-<!-- eslint-disable no-restricted-syntax, node/no-unsupported-features/es-syntax -->
+<!-- eslint-disable no-restricted-syntax, n/no-unsupported-features/es-syntax -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/net/http-server/README.md
+++ b/lib/node_modules/@stdlib/net/http-server/README.md
@@ -125,7 +125,7 @@ The function supports the following parameters:
 
 ## Examples
 
-<!-- eslint-disable node/no-process-exit -->
+<!-- eslint-disable n/no-process-exit -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/net/http2-secure-server/README.md
+++ b/lib/node_modules/@stdlib/net/http2-secure-server/README.md
@@ -157,7 +157,7 @@ The function supports the following parameters:
 
 ## Examples
 
-<!-- eslint-disable node/no-process-exit, node/no-unsupported-features/node-builtins -->
+<!-- eslint-disable n/no-process-exit, n/no-unsupported-features/node-builtins -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/os/num-cpus/README.md
+++ b/lib/node_modules/@stdlib/os/num-cpus/README.md
@@ -60,7 +60,7 @@ var n = NUM_CPUS;
 
 <!-- run-disable -->
 
-<!-- eslint-disable node/no-process-exit -->
+<!-- eslint-disable n/no-process-exit -->
 
 <!-- eslint no-undef: "error" -->
 


### PR DESCRIPTION
Propagating fixes merged to `develop` between 2026-04-27 15:46 PT and 2026-04-27 19:00 ET to sibling packages.

## Description

> What is the purpose of this pull request?

This pull request:

-   Propagates the deprecated-eslint-plugin-prefix fix from `54c4bf0a` ("chore: minor clean-up") to README HTML `<!-- eslint-disable ... -->` directives across 11 sibling packages.

### `54c4bf0a` — `node/` -> `n/` plugin prefix in README directives

`54c4bf0a` renamed the ESLint plugin prefix from `node/` to `n/` in `etc/eslint/plugin/index.js`, but 11 README files still carry `<!-- eslint-disable node/... -->` directives that silently no-op against the renamed plugin. Updated each directive to the `n/` prefix so the disable comments resolve to active rules again. Rules referenced are `no-unpublished-require`, `no-path-concat`, `no-process-exit`, `no-unsupported-features/es-syntax`, and `no-unsupported-features/node-builtins` — all present under the `n/` prefix in `etc/eslint/rules/nodejs.js`.

-   `_tools/eslint/rules/first-unit-test`
-   `_tools/test-cov/tape-istanbul`
-   `array/to-json`
-   `assert/is-arrow-function`
-   `assert/is-class`
-   `assert/is-generator-object`
-   `math/base/tools/continued-fraction`
-   `math/base/tools/sum-series`
-   `net/http-server`
-   `net/http2-secure-server`
-   `os/num-cpus`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Pattern search scoped to `lib/**/*.{js,cjs,mjs,ts,md}` and `etc/**`; only `README.md` HTML directives surfaced. Two independent validation agents confirmed every site against `etc/eslint/rules/nodejs.js` to verify each rule resolves under the `n/` prefix; an adaptation agent produced verbatim mechanical patches; a style-consistency agent confirmed each patch preserves indentation, comma-space separators, rule ordering, and trailing whitespace (notably the double-space before `-->` on `assert/is-class/README.md` line 37). All 16 line-level edits across 11 files survived filtering.

**Out of scope / deliberately excluded.** No sites flagged `needs-human`. The 24-hour candidate window also surfaced patterns from `bb1eae9b2` (single-file lint-restructure with no grep signature), `6a4d9614` (already fully propagated across `stats/base/dists/*`), `8b687a9f` (already fully propagated across `blas/base/ndarray/*`), and the backtick-require subpattern of `54c4bf0a7` (already fully propagated). No remaining sites for those patterns.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was generated by Claude Code as part of a fix-propagation routine: candidate commits from the last 24 hours of `develop` were filtered for generalizable patterns, sibling sites were enumerated by `rg`-based search agents, and each proposed patch was independently validated by two opus agents plus an opus adaptation agent and a sonnet style-consistency agent before being applied verbatim.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01BHe7S8gzygcKVXJUjJvkSM)_