### PR TITLE
docs: fix parameter descriptions in `stats/base/dists/lognormal`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/README.md
@@ -38,7 +38,7 @@ var logcdf = require( '@stdlib/stats/base/dists/lognormal/logcdf' );
 
 #### logcdf( x, mu, sigma )
 
-Evaluates the natural logarithm of the [cumulative distribution function][cdf] (CDF) for a [lognormal][lognormal-distribution] distribution with parameters `mu` (mean) and `sigma` (standard deviation).
+Evaluates the natural logarithm of the [cumulative distribution function][cdf] (CDF) for a [lognormal][lognormal-distribution] distribution with parameters `mu` (location parameter) and `sigma` (scale parameter).
 
 ```javascript
 var y = logcdf( 2.0, 0.0, 1.0 );
@@ -83,7 +83,7 @@ y = logcdf( 10.0, 8.0, 0.0 );
 
 #### logcdf.factory( mu, sigma )
 
-Returns a `function` for evaluating the [cumulative distribution function][cdf] (CDF) of a [lognormal][lognormal-distribution] distribution with parameters `mu` (mean) and `sigma` (standard deviation).
+Returns a `function` for evaluating the [cumulative distribution function][cdf] (CDF) of a [lognormal][lognormal-distribution] distribution with parameters `mu` (location parameter) and `sigma` (scale parameter).
 
 ```javascript
 var mylogcdf = logcdf.factory( 10.0, 2.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/docs/repl.txt
@@ -1,8 +1,8 @@
 
 {{alias}}( x, μ, σ )
     Evaluates the natural logarithm of the cumulative distribution function
-    (CDF) for a lognormal distribution with mean `μ` and standard deviation `σ`
-    at a value `x`.
+    (CDF) for a lognormal distribution with location parameter `μ` and scale
+    parameter `σ` at a value `x`.
 
     If provided `NaN` as any argument, the function returns `NaN`.
 
@@ -17,7 +17,7 @@
         Location parameter.
 
     σ: number
-        Standard deviation.
+        Scale parameter.
 
     Returns
     -------
@@ -37,7 +37,7 @@
     > y = {{alias}}( 0.0, 0.0, NaN )
     NaN
 
-    // Negative standard deviation:
+    // Negative scale parameter:
     > y = {{alias}}( 2.0, 0.0, -1.0 )
     NaN
 
@@ -50,8 +50,8 @@
 
 {{alias}}.factory( μ, σ )
     Returns a function for evaluating the natural logarithm of the cumulative
-    distribution function (CDF) of a lognormal distribution with mean `μ` and
-    standard deviation `σ`.
+    distribution function (CDF) of a lognormal distribution with location
+    parameter `μ` and scale parameter `σ`.
 
     Parameters
     ----------
@@ -59,7 +59,7 @@
         Location parameter.
 
     σ: number
-        Standard deviation.
+        Scale parameter.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/docs/types/index.d.ts
@@ -31,15 +31,15 @@ type Unary = ( x: number ) => number;
 */
 interface LogCDF {
 	/**
-	* Evaluates the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution with mean `mu` and standard deviation `sigma` at a value `x`.
+	* Evaluates the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution with location parameter `mu` and scale parameter `sigma` at a value `x`.
 	*
 	* ## Notes
 	*
 	* -   If provided `sigma < 0`, the function returns `NaN`.
 	*
 	* @param x - input value
-	* @param mu - mean
-	* @param sigma - standard deviation
+	* @param mu - location parameter
+	* @param sigma - scale parameter
 	* @returns logarithm of cumulative distribution function
 	*
 	* @example
@@ -63,7 +63,7 @@ interface LogCDF {
 	* // returns NaN
 	*
 	* @example
-	* // Negative standard deviation:
+	* // Negative scale parameter:
 	* var y = logcdf( 2.0, 0.0, -1.0 );
 	* // returns NaN
 	*
@@ -78,10 +78,10 @@ interface LogCDF {
 	( x: number, mu: number, sigma: number ): number;
 
 	/**
-	* Returns a function for evaluating the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution.
+	* Returns a function for evaluating the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution with location parameter `mu` and scale parameter `sigma`.
 	*
-	* @param mu - mean
-	* @param sigma - standard deviation
+	* @param mu - location parameter
+	* @param sigma - scale parameter
 	* @returns logcdf
 	*
 	* @example
@@ -99,8 +99,8 @@ interface LogCDF {
 * Lognormal distribution natural logarithm of cumulative distribution function (CDF).
 *
 * @param x - input value
-* @param mu - mean
-* @param sigma - standard deviation
+* @param mu - location parameter
+* @param sigma - scale parameter
 * @returns evaluated logcdf
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/lib/factory.js
@@ -31,10 +31,10 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 // MAIN //
 
 /**
-* Returns a function for evaluating the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution.
+* Returns a function for evaluating the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution with location parameter `mu` and scale parameter `sigma`.
 *
-* @param {number} mu - mean
-* @param {NonNegativeNumber} sigma - standard deviation
+* @param {number} mu - location parameter
+* @param {NonNegativeNumber} sigma - scale parameter
 * @returns {Function} logcdf
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/lib/main.js
@@ -28,11 +28,11 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 // MAIN //
 
 /**
-* Evaluates the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution with mean `mu` and standard deviation `sigma` at a value `x`.
+* Evaluates the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution with location parameter `mu` and scale parameter `sigma` at a value `x`.
 *
 * @param {number} x - input value
-* @param {number} mu - mean
-* @param {NonNegativeNumber} sigma - standard deviation
+* @param {number} mu - location parameter
+* @param {NonNegativeNumber} sigma - scale parameter
 * @returns {number} logarithm of cumulative distribution function
 *
 * @example
@@ -56,7 +56,7 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 * // returns NaN
 *
 * @example
-* // Negative standard deviation:
+* // Negative scale parameter:
 * var y = logcdf( 2.0, 0.0, -1.0 );
 * // returns NaN
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request aligns `stats/base/dists/lognormal/logcdf` with the 13/14 (93%) namespace majority: `mu` and `sigma` parameter labels corrected from "mean"/"standard deviation" to "location parameter"/"scale parameter" across JSDoc, TS declarations, `repl.txt`, and `README.md`, and the `sigma < 0` example comment updated to "Negative scale parameter" to match sibling phrasing. The `factory.js` JSDoc summary was also given the matching distribution-description prose, which was previously absent. TYPE annotations (`NonNegativeNumber` for `sigma`) are intentionally unchanged — both `main.js` and `factory.js` legitimately accept `sigma === 0` by delegating to the degenerate distribution.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

- **Structural feature extraction:** file system + `package.json` / `manifest.json` / README header parsing across all 14 members.
- **Semantic feature extraction:** per-package agents reading `lib/main.js`, `lib/index.js`, and `lib/factory.js` (where present) to capture public signature, validation prologue, error construction, JSDoc shape, and `@stdlib/*` dependencies.
- **Three-agent drift validation:**
  - Semantic-review confirmed all six terminology drift items in `logcdf` and clarified that `factory.js`'s `NonNegativeNumber` for `sigma` is intentional (factory delegates to the degenerate distribution at `sigma === 0`).
  - Cross-reference review found that `test/test.logcdf.js` (lines 108–127) and `test/test.factory.js` (lines 131–153) both assert that `logcdf(..., sigma=0)` returns the degenerate result, so changing the JSDoc type from `NonNegativeNumber` to `PositiveNumber` would contradict observed behavior — that change was dropped.
  - Structural review confirmed C-binding files sit at 10/14 (below the 75% threshold) and so are not drift; missing Julia fixtures in `logcdf` (12/14 majority) were dropped because adding them mechanically requires regenerating ground-truth JSON and rewiring `test.logcdf.js` / `test.factory.js` to consume them, which exceeds the "mechanical, single-package" scope of this routine; missing Julia fixtures in `ctor` are intentional (constructor has no fixture-based numerical tests).
- **Deliberately excluded:** intentional deviations (`factory.js` `sigma` type and `ctor` test layout), outliers whose tests rely on the deviation (`logcdf` `sigma === 0` tests), and features without a clear majority (C bindings, `returnsTag` type, error construction, validation prologue sequences).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by Claude Code via an automated cross-package API drift detection routine: a randomly selected stdlib namespace (`stats/base/dists/lognormal`, seed `20260428`) had structural and semantic features extracted from each member, the majority pattern computed per feature (75% conformance threshold), and outliers validated by three independent agents (semantic, cross-reference, and structural) before being committed. Only documentation (JSDoc / README / `repl.txt` / TS-decl) wording is changed; behavior, signatures, and types are unchanged.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_017htvg3cbajhuz1XjrjYHfR)_