### PR TITLE
docs: align keywords in `string/base` with namespace majority patterns

### DIFF
--- a/lib/node_modules/@stdlib/string/base/code-point-at/package.json
+++ b/lib/node_modules/@stdlib/string/base/code-point-at/package.json
@@ -57,6 +57,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "code",
     "point",
     "pt",

--- a/lib/node_modules/@stdlib/string/base/ends-with/package.json
+++ b/lib/node_modules/@stdlib/string/base/ends-with/package.json
@@ -55,6 +55,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "string",
     "str",
     "check",

--- a/lib/node_modules/@stdlib/string/base/for-each-code-point-right/package.json
+++ b/lib/node_modules/@stdlib/string/base/for-each-code-point-right/package.json
@@ -56,6 +56,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "for",
     "each",
     "foreach",

--- a/lib/node_modules/@stdlib/string/base/for-each-code-point/package.json
+++ b/lib/node_modules/@stdlib/string/base/for-each-code-point/package.json
@@ -56,6 +56,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "for",
     "each",
     "foreach",

--- a/lib/node_modules/@stdlib/string/base/for-each-grapheme-cluster/package.json
+++ b/lib/node_modules/@stdlib/string/base/for-each-grapheme-cluster/package.json
@@ -56,6 +56,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "for",
     "each",
     "foreach",

--- a/lib/node_modules/@stdlib/string/base/for-each-right/package.json
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/package.json
@@ -56,6 +56,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "for",
     "each",
     "foreachright",

--- a/lib/node_modules/@stdlib/string/base/for-each/package.json
+++ b/lib/node_modules/@stdlib/string/base/for-each/package.json
@@ -56,6 +56,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "for",
     "each",
     "foreach",

--- a/lib/node_modules/@stdlib/string/base/format-interpolate/package.json
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/package.json
@@ -55,6 +55,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "string",
     "str",
     "format",

--- a/lib/node_modules/@stdlib/string/base/format-tokenize/package.json
+++ b/lib/node_modules/@stdlib/string/base/format-tokenize/package.json
@@ -55,6 +55,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "string",
     "str",
     "format",

--- a/lib/node_modules/@stdlib/string/base/right-trim/package.json
+++ b/lib/node_modules/@stdlib/string/base/right-trim/package.json
@@ -55,6 +55,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "string",
     "str",
     "whitespace",

--- a/lib/node_modules/@stdlib/string/base/slice-code-points/package.json
+++ b/lib/node_modules/@stdlib/string/base/slice-code-points/package.json
@@ -50,6 +50,7 @@
   ],
   "keywords": [
     "stdlib",
+    "stdstring",
     "string",
     "str",
     "base",
@@ -60,6 +61,8 @@
     "point",
     "codepoint",
     "utilities",
-    "utils"
+    "utility",
+    "utils",
+    "util"
   ]
 }

--- a/lib/node_modules/@stdlib/string/base/slice-grapheme-clusters/package.json
+++ b/lib/node_modules/@stdlib/string/base/slice-grapheme-clusters/package.json
@@ -55,6 +55,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "string",
     "str",
     "slice",

--- a/lib/node_modules/@stdlib/string/base/trim/package.json
+++ b/lib/node_modules/@stdlib/string/base/trim/package.json
@@ -55,6 +55,7 @@
     "utility",
     "utils",
     "util",
+    "base",
     "string",
     "str",
     "whitespace",


### PR DESCRIPTION
## Description

This pull request aligns outlier packages in the `@stdlib/string/base` namespace with majority `package.json` `keywords` conventions (random namespace pick, seed `20260429`).

### Namespace summary

- **Namespace:** `@stdlib/string/base`
- **Members analyzed:** 60 leaf packages (1 namespace package excluded)
- **Majority threshold:** 45 of 60 (75%)
- **Features with clear majority (≥75%):** file tree, `package.json` top-level keys, `os`, `engines`, `main`, `types`, `directories`, README `Usage`/`Examples` sections, `keywords` set, `returnKind`, JSDoc `@example`/`@param`/`@returns` coverage
- **Features without clear majority (excluded):** `errorConstruction` (only `format-interpolate` throws), `validationPrologue` (no validation in `/base/`), README ## section *order* (top sequence at 62%), `__stdlib__` field (22%)

### Outlier packages

#### `string/base/slice-code-points`

Keyword block was missing `stdstring`, `utility`, and `util` — each present in 96–98% of namespace siblings. Inserted at canonical positions; existing order otherwise untouched.

#### `string/base/code-point-at`, `ends-with`, `for-each`, `for-each-code-point`, `for-each-code-point-right`, `for-each-grapheme-cluster`, `for-each-right`, `format-interpolate`, `format-tokenize`, `right-trim`, `slice-grapheme-clusters`, `trim`

Each was missing the `base` keyword (47/60 = 78% in-namespace conformance). Inserted immediately after `util` to match the canonical leading-block layout. One commit per package per the routine.

Note: the five `for-each*` packages also use `stdutils`/`stdutil` in place of the conventional `stdstring` in their leading block. That secondary deviation is **out of scope** for this PR — it requires human review since it is not strictly a missing-element drift but a substitution.

## Related Issues

None.

## Questions

None.

## Other

### Validation

Cross-package drift was identified by extracting structural and semantic features from all 60 leaf packages, computing per-feature majority patterns at the 75% threshold, and gating each candidate fix through three independent reviewers:

- **Semantic review** (Opus): confirmed no semantic-feature drift in the namespace; `format-interpolate`'s concat-style throws have no in-namespace majority and are deliberately not touched.
- **Cross-reference review** (Opus): confirmed `package.json.keywords` is read by no test, example, benchmark, or sibling tooling in `string/base/`; modifications cannot affect API contracts or test expectations.
- **Structural review** (Sonnet): confirmed `distances` is a namespace aggregator (intentional deviation) and verified the canonical keyword-block layout used by the corrected packages.

### Excluded from this run

- **`distances`** — namespace package (re-exports `hamming` and `levenshtein`); missing `lib/main.js`, `benchmark/`, `docs/repl.txt` and most leaf-keyword conventions are *intentional* given its package shape.
- **`format-interpolate` error construction** — concat-style throws diverge from the global `format` convention, but only one package in the namespace throws, so no in-namespace majority exists; out of scope per the routine's strict majority-vote rule.
- **README `See Also` section** — auto-populated by tooling; missing sections are upstream automation territory, not drift.
- **`for-each*` `stdutils`/`stdutil` substitution** — flagged for human review; not a strict missing-element drift.

A full local audit report is saved alongside the worktree as `drift-string-base-2026-04-29.md`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package drift-detection routine: structural and semantic features were extracted programmatically, three independent agents validated each candidate correction, and only fixes confirmed as mechanical, behavior-preserving metadata edits were applied. Human authors should audit the keyword insertions against the namespace conventions before promoting from draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01T9GDym1j17ujeUdc1C39H6)_