### PR TITLE
docs: add hpsf conference image link

### DIFF
--- a/docs/talks.md
+++ b/docs/talks.md
@@ -32,7 +32,7 @@ limitations under the License.
 
 <div class="image" align="center">
     <a title="Bringing Complex Computations To Browsers With Open Source" href="https://youtu.be/rox9LZz_ffI">
-        <img width="480" src="" alt="Bringing Complex Computations To Browsers With Open Source">
+        <img width="480" src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@59a6ae8e735cabb5db1603d36ca6d0693f8184b4/docs/assets/talks/hpsf_conference_2026_gunj_joshi.png" alt="Bringing Complex Computations To Browsers With Open Source">
     </a>
     <br>
 </div>


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds the image link for the talk added in #11832.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

None.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
