### PR TITLE
docs: propagate fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-includes/README.md
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-includes/README.md
@@ -34,7 +34,7 @@ var includes = require( '@stdlib/_tools/remark/plugins/remark-includes' );
 
 Attaches a plugin to a [remark][remark] processor in order to insert content from external Markdown files between include comment directives.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var join = require( 'path' ).join;
@@ -93,7 +93,7 @@ By default, include paths are resolved relative to the processed file's director
 
 ## Examples
 
-<!-- eslint no-undef: "error", node/no-sync: "off" -->
+<!-- eslint no-undef: "error", n/no-sync: "off" -->
 
 ```javascript
 var join = require( 'path' ).join;

--- a/lib/node_modules/@stdlib/blas/base/wasm/ccopy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/ccopy/README.md
@@ -125,7 +125,7 @@ ccopy.ndarray( 2, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -148,7 +148,7 @@ mod.initializeSync();
 
 Copies values from `x` into `y`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -216,7 +216,7 @@ The function has the following parameters:
 
 Copies values from `x` into `y`  using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/cscal/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/cscal/README.md
@@ -139,7 +139,7 @@ cscal.ndarray( 2, ca, cx, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -162,7 +162,7 @@ mod.initializeSync();
 
 Scales values from `cx` by `ca`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -230,7 +230,7 @@ The function has the following parameters:
 
 Scales values from `cx` by `ca`  using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/csrot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/csrot/README.md
@@ -129,7 +129,7 @@ csrot.ndarray( 2, cx, 2, 1, cy, 2, 1, 0.8, 0.6 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -152,7 +152,7 @@ mod.initializeSync();
 
 Applies a plane rotation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -226,7 +226,7 @@ The function has the following parameters:
 
 Applies a plane rotation using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/cswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/cswap/README.md
@@ -128,7 +128,7 @@ cswap.ndarray( 2, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -151,7 +151,7 @@ mod.initializeSync();
 
 Interchanges two complex single-precision floating-point vectors.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -222,7 +222,7 @@ The function has the following parameters:
 
 Interchanges two complex single-precision floating-point vectors using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/dasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dasum/README.md
@@ -117,7 +117,7 @@ sum = dasum.ndarray( 3, x, -1, x.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -140,7 +140,7 @@ mod.initializeSync();
 
 Computes the sum of absolute values.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -187,7 +187,7 @@ The function has the following parameters:
 
 Computes the sum of absolute values using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/daxpy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/daxpy/README.md
@@ -128,7 +128,7 @@ daxpy.ndarray( 3, alpha, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -151,7 +151,7 @@ mod.initializeSync();
 
 Multiplies a vector `x` by a constant and adds the result to `y`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -211,7 +211,7 @@ The function has the following parameters:
 
 Multiplies a vector `x` by a constant and adds the result to `y` using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/dcopy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dcopy/README.md
@@ -122,7 +122,7 @@ dcopy.ndarray( 3, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -145,7 +145,7 @@ mod.initializeSync();
 
 Copies values from `x` into `y`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -204,7 +204,7 @@ The function has the following parameters:
 
 Copies values from `x` into `y` using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/ddot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/ddot/README.md
@@ -122,7 +122,7 @@ var z = ddot.ndarray( 3, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -145,7 +145,7 @@ mod.initializeSync();
 
 Computes the dot product of `x` and `y`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -199,7 +199,7 @@ The function has the following parameters:
 
 Computes the dot product of `x` and `y` using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/dnrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dnrm2/README.md
@@ -113,7 +113,7 @@ var z = dnrm2.ndarray( 4, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -136,7 +136,7 @@ mod.initializeSync();
 
 Computes the L2-norm of a double-precision floating-point vector.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -182,7 +182,7 @@ The function has the following parameters:
 
 Computes the L2-norm of a double-precision floating-point vector using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/drot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/drot/README.md
@@ -129,7 +129,7 @@ drot.ndarray( 3, x, 2, 1, y, 2, 1, 0.8, 0.6 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -152,7 +152,7 @@ mod.initializeSync();
 
 Applies a plane rotation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -218,7 +218,7 @@ The function has the following parameters:
 
 Applies a plane rotation using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/drotm/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/drotm/README.md
@@ -133,7 +133,7 @@ drotm.ndarray( 3, x, 2, 1, y, 2, 1, param );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -156,7 +156,7 @@ mod.initializeSync();
 
 Applies a modified Givens plane rotation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -223,7 +223,7 @@ The function has the following parameters:
 
 Applies a modified Givens plane rotation using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/dscal/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dscal/README.md
@@ -114,7 +114,7 @@ dscal.ndarray( 3, 5.0, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -137,7 +137,7 @@ mod.initializeSync();
 
 Multiplies a vector `x` by a constant `α`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -193,7 +193,7 @@ The function has the following parameters:
 
 Multiplies a vector `x` by a constant `α` using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/dsdot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dsdot/README.md
@@ -122,7 +122,7 @@ var z = dsdot.ndarray( 3, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -145,7 +145,7 @@ mod.initializeSync();
 
 Computes the dot product of `x` and `y` with extended accumulation and result.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -199,7 +199,7 @@ The function has the following parameters:
 
 Computes the dot product of `x` and `y` with extended accumulation and result using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/dswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dswap/README.md
@@ -125,7 +125,7 @@ dswap.ndarray( 3, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -148,7 +148,7 @@ mod.initializeSync();
 
 Interchanges two double-precision floating point vectors.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -212,7 +212,7 @@ The function has the following parameters:
 
 Interchanges two double-precision floating point vectors using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/dznrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dznrm2/README.md
@@ -113,7 +113,7 @@ var z = dznrm2.ndarray( 2, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -136,7 +136,7 @@ mod.initializeSync();
 
 Computes the L2-norm of a complex double-precision floating-point vector.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -185,7 +185,7 @@ The function has the following parameters:
 
 Computes the L2-norm of a complex double-precision floating-point vector using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/idamax/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/idamax/README.md
@@ -114,7 +114,7 @@ var idx = idamax.ndarray( 5, x, 1, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -137,7 +137,7 @@ mod.initializeSync();
 
 Finds the index of the first element having the maximum absolute value.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -183,7 +183,7 @@ The function has the following parameters:
 
 Finds the index of the first element having the maximum absolute value using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/isamax/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/isamax/README.md
@@ -114,7 +114,7 @@ var idx = isamax.ndarray( 5, x, 1, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -137,7 +137,7 @@ mod.initializeSync();
 
 Finds the index of the first element having the maximum absolute value.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -183,7 +183,7 @@ The function has the following parameters:
 
 Finds the index of the first element having the maximum absolute value using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/sasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sasum/README.md
@@ -117,7 +117,7 @@ sum = sasum.ndarray( 3, x, -1, x.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -140,7 +140,7 @@ mod.initializeSync();
 
 Computes the sum of absolute values.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -187,7 +187,7 @@ The function has the following parameters:
 
 Computes the sum of absolute values using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/saxpy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/saxpy/README.md
@@ -128,7 +128,7 @@ saxpy.ndarray( 3, alpha, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -151,7 +151,7 @@ mod.initializeSync();
 
 Multiplies a vector `x` by a constant and adds the result to `y`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -211,7 +211,7 @@ The function has the following parameters:
 
 Multiplies a vector `x` by a constant and adds the result to `y` using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/scasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/scasum/README.md
@@ -113,7 +113,7 @@ var sum = scasum.ndarray( 3, x, 1, x.length-3 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -136,7 +136,7 @@ mod.initializeSync();
 
 Computes the sum of the absolute values of the real and imaginary components of a single-precision complex floating-point vector.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -182,7 +182,7 @@ The function has the following parameters:
 
 Computes the sum of the absolute values of the real and imaginary components of a single-precision complex floating-point vector using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/scnrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/scnrm2/README.md
@@ -113,7 +113,7 @@ var z = scnrm2.ndarray( 2, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -136,7 +136,7 @@ mod.initializeSync();
 
 Computes the L2-norm of a complex single-precision floating-point vector.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -185,7 +185,7 @@ The function has the following parameters:
 
 Computes the L2-norm of a complex single-precision floating-point vector using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/scopy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/scopy/README.md
@@ -122,7 +122,7 @@ scopy.ndarray( 3, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -145,7 +145,7 @@ mod.initializeSync();
 
 Copies values from `x` into `y`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -204,7 +204,7 @@ The function has the following parameters:
 
 Copies values from `x` into `y` using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/sdot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sdot/README.md
@@ -122,7 +122,7 @@ var z = sdot.ndarray( 3, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -145,7 +145,7 @@ mod.initializeSync();
 
 Computes the dot product of `x` and `y`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -199,7 +199,7 @@ The function has the following parameters:
 
 Computes the dot product of `x` and `y` using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/sdsdot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sdsdot/README.md
@@ -123,7 +123,7 @@ var z = sdsdot.ndarray( 3, 0.0, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -146,7 +146,7 @@ mod.initializeSync();
 
 Computes the dot product of two single-precision floating-point vectors with extended accumulation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -201,7 +201,7 @@ The function has the following parameters:
 
 Computes the dot product of two single-precision floating-point vectors with extended accumulation using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/snrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/snrm2/README.md
@@ -113,7 +113,7 @@ var z = snrm2.ndarray( 4, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -136,7 +136,7 @@ mod.initializeSync();
 
 Computes the L2-norm of a single-precision floating-point vector.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -182,7 +182,7 @@ The function has the following parameters:
 
 Computes the L2-norm of a single-precision floating-point vector using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/srot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/srot/README.md
@@ -129,7 +129,7 @@ srot.ndarray( 3, x, 2, 1, y, 2, 1, 0.8, 0.6 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -152,7 +152,7 @@ mod.initializeSync();
 
 Applies a plane rotation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -218,7 +218,7 @@ The function has the following parameters:
 
 Applies a plane rotation using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/srotm/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/srotm/README.md
@@ -133,7 +133,7 @@ srotm.ndarray( 3, x, 2, 1, y, 2, 1, param );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -156,7 +156,7 @@ mod.initializeSync();
 
 Applies a modified Givens plane rotation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -223,7 +223,7 @@ The function has the following parameters:
 
 Applies a modified Givens plane rotation using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/sscal/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sscal/README.md
@@ -114,7 +114,7 @@ sscal.ndarray( 3, 5.0, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -137,7 +137,7 @@ mod.initializeSync();
 
 Multiplies a vector `x` by a constant `α`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -193,7 +193,7 @@ The function has the following parameters:
 
 Multiplies a vector `x` by a constant `α` using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/sswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sswap/README.md
@@ -125,7 +125,7 @@ sswap.ndarray( 3, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -148,7 +148,7 @@ mod.initializeSync();
 
 Interchanges two single-precision floating point vectors.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -212,7 +212,7 @@ The function has the following parameters:
 
 Interchanges two single-precision floating point vectors using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/zcopy/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zcopy/README.md
@@ -125,7 +125,7 @@ zcopy.ndarray( 2, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -148,7 +148,7 @@ mod.initializeSync();
 
 Copies values from `x` into `y`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -216,7 +216,7 @@ The function has the following parameters:
 
 Copies values from `x` into `y`  using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/zdrot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zdrot/README.md
@@ -129,7 +129,7 @@ zdrot.ndarray( 2, zx, 2, 1, zy, 2, 1, 0.8, 0.6 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -152,7 +152,7 @@ mod.initializeSync();
 
 Applies a plane rotation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -226,7 +226,7 @@ The function has the following parameters:
 
 Applies a plane rotation using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/zscal/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zscal/README.md
@@ -139,7 +139,7 @@ zscal.ndarray( 2, alpha, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -162,7 +162,7 @@ mod.initializeSync();
 
 Scales values from `x` by `alpha`.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -230,7 +230,7 @@ The function has the following parameters:
 
 Scales values from `x` by `alpha`  using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/zswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zswap/README.md
@@ -128,7 +128,7 @@ zswap.ndarray( 2, x, 2, 1, y, -1, y.length-1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -151,7 +151,7 @@ mod.initializeSync();
 
 Interchanges two complex double-precision floating-point vectors.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -222,7 +222,7 @@ The function has the following parameters:
 
 Interchanges two complex double-precision floating-point vectors using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dapxsum/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dapxsum/README.md
@@ -111,7 +111,7 @@ var v = dapxsum.ndarray( 4, 5.0, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -134,7 +134,7 @@ mod.initializeSync();
 
 Adds a scalar constant to each double-precision floating-point strided array element and computes the sum.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -182,7 +182,7 @@ The function has the following parameters:
 
 Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dapxsumkbn/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dapxsumkbn/README.md
@@ -111,7 +111,7 @@ var v = dapxsumkbn.ndarray( 4, 5.0, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -134,7 +134,7 @@ mod.initializeSync();
 
 Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using an improved Kahan–Babuška algorithm.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -182,7 +182,7 @@ The function has the following parameters:
 
 Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using an improved Kahan–Babuška algorithm and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dapxsumors/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dapxsumors/README.md
@@ -111,7 +111,7 @@ var v = dapxsumors.ndarray( 4, 5.0, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -134,7 +134,7 @@ mod.initializeSync();
 
 Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using ordinary recursive summation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -182,7 +182,7 @@ The function has the following parameters:
 
 Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using ordinary recursive summation and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dapxsumpw/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dapxsumpw/README.md
@@ -111,7 +111,7 @@ var v = dapxsumpw.ndarray( 4, 5.0, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -134,7 +134,7 @@ mod.initializeSync();
 
 Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using pairwise summation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -182,7 +182,7 @@ The function has the following parameters:
 
 Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using pairwise summation and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dasumpw/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dasumpw/README.md
@@ -131,7 +131,7 @@ var v = dasumpw.ndarray( 4, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -154,7 +154,7 @@ mod.initializeSync();
 
 Computes the sum of absolute values ([_L1_ norm][l1norm]) of double-precision floating-point strided array elements using pairwise summation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -201,7 +201,7 @@ The function has the following parameters:
 
 Computes the sum of absolute values ([_L1_ norm][l1norm]) of double-precision floating-point strided array elements using pairwise summation and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dnanasumors/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dnanasumors/README.md
@@ -110,7 +110,7 @@ var v = dnanasumors.ndarray( 4, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -133,7 +133,7 @@ mod.initializeSync();
 
 Computes the sum of absolute values ([_L1_ norm][l1norm]) of double-precision floating-point strided array elements, ignoring `NaN` values and using ordinary recursive summation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -180,7 +180,7 @@ The function has the following parameters:
 
 Computes the sum of absolute values ([_L1_ norm][l1norm]) of double-precision floating-point strided array elements, ignoring `NaN` values and using ordinary recursive summation and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dnansumkbn2/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dnansumkbn2/README.md
@@ -116,7 +116,7 @@ var v = dnansumkbn2.ndarray( 4, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -139,7 +139,7 @@ mod.initializeSync();
 
 Computes the sum of double-precision floating-point strided array elements, ignoring `NaN` values and using a second-order iterative Kahan–Babuška algorithm.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -182,7 +182,7 @@ The function has the following parameters:
 
 Computes the sum of double-precision floating-point strided array elements, ignoring `NaN` values and using a second-order iterative Kahan–Babuška algorithm and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dnansumpw/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dnansumpw/README.md
@@ -110,7 +110,7 @@ var v = dnansumpw.ndarray( 4, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -133,7 +133,7 @@ mod.initializeSync();
 
 Computes the sum of double-precision floating-point strided array elements, ignoring `NaN` values and using pairwise summation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -180,7 +180,7 @@ The function has the following parameters:
 
 Computes the sum of double-precision floating-point strided array elements, ignoring `NaN` values and using pairwise summation and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/sapxsumkbn/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/sapxsumkbn/README.md
@@ -111,7 +111,7 @@ var v = sapxsumkbn.ndarray( 4, 5.0, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -134,7 +134,7 @@ mod.initializeSync();
 
 Adds a scalar constant to each single-precision floating-point strided array element and computes the sum using an improved Kahan–Babuška algorithm.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -182,7 +182,7 @@ The function has the following parameters:
 
 Adds a scalar constant to each single-precision floating-point strided array element and computes the sum using an improved Kahan–Babuška algorithm and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/quantile/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/quantile/docs/types/index.d.ts
@@ -104,8 +104,8 @@ interface Quantile {
 * Lognormal distribution quantile function.
 *
 * @param p - input value
-* @param mu - mean
-* @param sigma - standard deviation
+* @param mu - location parameter
+* @param sigma - scale parameter
 * @returns evaluated quantile function
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/strided/wasm/dmeanors/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/wasm/dmeanors/README.md
@@ -110,7 +110,7 @@ var y = dmeanors.ndarray( 4, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -133,7 +133,7 @@ mod.initializeSync();
 
 Computes the [arithmetic mean][arithmetic-mean] of a double-precision floating-point strided array using ordinary recursive summation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -180,7 +180,7 @@ The function has the following parameters:
 
 Computes the [arithmetic mean][arithmetic-mean] of a double-precision floating-point strided array using ordinary recursive summation and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/stats/strided/wasm/dmeanpw/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/wasm/dmeanpw/README.md
@@ -110,7 +110,7 @@ var y = dmeanpw.ndarray( 4, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -133,7 +133,7 @@ mod.initializeSync();
 
 Computes the [arithmetic mean][arithmetic-mean] of a double-precision floating-point strided array using pairwise summation.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -179,7 +179,7 @@ The function has the following parameters:
 
 Computes the [arithmetic mean][arithmetic-mean] of a double-precision floating-point strided array using pairwise summation and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/stats/strided/wasm/dmeanwd/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/wasm/dmeanwd/README.md
@@ -110,7 +110,7 @@ var y = dmeanwd.ndarray( 4, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -133,7 +133,7 @@ mod.initializeSync();
 
 Computes the [arithmetic mean][arithmetic-mean] of a double-precision floating-point strided array using Welford's algorithm.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -180,7 +180,7 @@ The function has the following parameters:
 
 Computes the [arithmetic mean][arithmetic-mean] of a double-precision floating-point strided array using Welford's algorithm and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/stats/strided/wasm/dnanvariancewd/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/wasm/dnanvariancewd/README.md
@@ -115,7 +115,7 @@ var v = dnanvariancewd.ndarray( 5, 1, x, 2, 1 );
 
 Returns a new WebAssembly [module wrapper][@stdlib/wasm/module-wrapper] instance which uses the provided WebAssembly [memory][@stdlib/wasm/memory] instance as its underlying memory.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -138,7 +138,7 @@ mod.initializeSync();
 
 Computes the [variance][variance] of a double-precision floating-point strided array ignoring `NaN` values and using Welford's algorithm.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );
@@ -186,7 +186,7 @@ The function has the following parameters:
 
 Computes the [variance][variance] of a double-precision floating-point strided array ignoring `NaN` values and using Welford's algorithm and alternative indexing semantics.
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 ```javascript
 var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/utils/dirname/README.md
+++ b/lib/node_modules/@stdlib/utils/dirname/README.md
@@ -47,7 +47,7 @@ var dir = dirname( './foo/bar/index.js' );
 
 ## Examples
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/utils/extname/README.md
+++ b/lib/node_modules/@stdlib/utils/extname/README.md
@@ -47,7 +47,7 @@ var ext = extname( 'index.js' );
 
 ## Examples
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/utils/parallel/README.md
+++ b/lib/node_modules/@stdlib/utils/parallel/README.md
@@ -211,7 +211,7 @@ parallel( files, opts, done );
 
 <!-- run-disable -->
 
-<!-- eslint-disable node/no-sync -->
+<!-- eslint-disable n/no-sync -->
 
 <!-- eslint no-undef: "error" -->
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Propagates fixes merged to `develop` between 2026-04-28 18:13 UTC and 2026-04-29 13:30 UTC to sibling packages that share the same defect.

### `docs: fix parameter descriptions in stats/base/dists/lognormal/quantile`

Propagates 9fedcf96, which corrected `mu` and `sigma` descriptions from "mean"/"standard deviation" to "location parameter"/"scale parameter" across the `logcdf` submodule. The same correction was missed in the top-level quantile JSDoc at `stats/base/dists/lognormal/quantile/docs/types/index.d.ts:107-108`. Surrounding prose was already accurate; only the `@param` tag descriptions required updating.

Target package:

-   `lib/node_modules/@stdlib/stats/base/dists/lognormal/quantile/docs/types/index.d.ts`

**Two further sites in `lib/node_modules/@stdlib/stats/base/dists/lognormal/docs/types/index.d.ts` (lines 142-143 and 313-314) were dropped from this run.** That file fails `Lint Changed Files` on pre-existing JSDoc example value mismatches in the `logpdf` block at lines 176/179 — `// returns ~-4.269` and `// returns ~-3.689` should be `~-4.275` / `~-3.672` (introduced in `cfc58ab9b`, unrelated to the propagation). Those sites need a separate PR that also corrects the `logpdf` example values.

### `chore: propagate node/no-sync → n/no-sync across remaining README directives`

Completes the `node/no-sync` → `n/no-sync` rename started in d689d2dc, which swept README ESLint directives following the `eslint-plugin-node` → `eslint-plugin-n` rename tracked in earlier commits (0dc62ae3, c7d0cd5e). This PR covers 50 README files and 143 ESLint-directive instances under `lib/node_modules/@stdlib/` that d689d2dc did not reach, including one inline-config variant in `_tools/remark/plugins/remark-includes/README.md:96`. That inline-config rename is required for correctness, not just consistency: leaving it as `node/no-sync` causes `remark-lint-eslint` to emit `Definition for rule 'node/no-sync' was not found` because the plugin no longer exposes that rule name.

**Two READMEs were dropped from the propagation** because their `Lint Markdown files` checks fail on pre-existing issues unrelated to this fix:

- `blas/ext/base/wasm/dapx/README.md` — mismatched section class at line 245 (`<section class="notes">` closed by `<!-- /.usage -->`)
- `fs/append-file/README.md` — `no-restricted-syntax`: uses `fs.existsSync` instead of `@stdlib/fs/exists` in an example block at lines 101-108

Target packages (50): `_tools/remark/plugins/remark-includes`; `blas/base/wasm/{ccopy,cscal,csrot,cswap,dasum,daxpy,dcopy,ddot,dnrm2,drot,drotm,dscal,dsdot,dswap,dznrm2,idamax,isamax,sasum,saxpy,scasum,scnrm2,scopy,sdot,sdsdot,snrm2,srot,srotm,sscal,sswap,zcopy,zdrot,zscal,zswap}`; `blas/ext/base/wasm/{dapxsum,dapxsumkbn,dapxsumors,dapxsumpw,dasumpw,dnanasumors,dnansumkbn2,dnansumpw,sapxsumkbn}`; `stats/strided/wasm/{dmeanors,dmeanpw,dmeanwd,dnanvariancewd}`; `utils/{dirname,extname,parallel}`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   Pattern search ran across each source commit's stated scope: `lib/node_modules/@stdlib/stats/base/dists/lognormal/**` for the JSDoc param fix; `lib/node_modules/@stdlib/**/README.md` for the ESLint plugin-namespace rename.
-   Two independent validation passes confirmed each candidate site against the surrounding file context (verifying the JSDoc block belonged to a non-mean/non-stdev lognormal function; verifying every `node/no-sync` occurrence sat inside an HTML-comment ESLint directive in a README).
-   A style-consistency pass verified indentation and adjacent-block phrasing matched stdlib conventions and existing sibling submodules (location parameter / scale parameter is already used in skewness, stdev, cdf, pdf, etc.).
-   Final markdown-lint run confirmed locally before push: 50 of 52 candidate READMEs lint clean; the 2 outliers (`dapx`, `fs/append-file`) carry pre-existing structural errors unrelated to this propagation and were dropped.

### Deliberately excluded

-   `refactor: remove duplicated assignments` (16f0b29f) — single-file cleanup in `blas/ext/base/dcartesian-square/src/main.c`. The single sibling (`scartesian-square`) was committed after the fix and already in the corrected form; no other BLAS C source matched the same `if (isrm) { ... } else { ... }` duplicate-hoisting shape.
-   Pattern A sites 1 and 2 in `lognormal/docs/types/index.d.ts` — dropped after CI flagged pre-existing TypeScript-declarations lint errors in that file's `logpdf` block (`returns ~-4.269` / `~-3.689` versus actual `~-4.275` / `~-3.672`, introduced in `cfc58ab9b`).
-   `lib/node_modules/@stdlib/blas/ext/base/wasm/dapx/README.md` — dropped after Lint Changed Files surfaced a pre-existing `mismatched-section-class` error at line 245.
-   `lib/node_modules/@stdlib/fs/append-file/README.md` — dropped after Lint Changed Files surfaced a pre-existing `no-restricted-syntax` error (`fs.existsSync` used instead of `@stdlib/fs/exists`) at lines 101-108.
-   `// eslint-disable-line node/no-sync` in `_tools/utils/jsdelivr-url/bin/cli` and `utils/library-manifest/bin/cli` — non-README, outside the source commit's stated scope.
-   Bot-generated `docs: update REPL namespace documentation` (52dd2b8a) and asset-only commits (`docs: add hpsf talk`, `docs: add Zen of stdlib`) — no propagable pattern.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated fix-propagation routine. Claude enumerated `fix:`/`docs:`/`chore:` commits merged to `develop` in the last 24 hours, distilled fix patterns, searched for sibling sites, and ran independent validation and style-consistency passes before applying mechanical text replacements. After the initial push, three CI failures (TypeScript-declarations lint and two markdown-lint annotations) surfaced pre-existing issues in three of the touched files (`lognormal/docs/types/index.d.ts`, `dapx/README.md`, `fs/append-file/README.md`); all three files were dropped from the propagation per the routine's "if a pre-existing lint failure surfaces in a touched file, drop that file" guidance. The PR is filed as a draft for human audit before promotion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md