### PR TITLE
docs: add missing period and align keywords in `constants/float16`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float16/ln-half/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/ln-half/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/constants/float16/ln-half",
   "version": "0.0.0",
-  "description": "Natural logarithm of 1/2 as a half-precision floating-point number",
+  "description": "Natural logarithm of 1/2 as a half-precision floating-point number.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/constants/float16/ln-two/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/ln-two/package.json
@@ -63,6 +63,7 @@
     "half",
     "sgl",
     "precision",
+    "float",
     "floating-point",
     "float16"
   ]

--- a/lib/node_modules/@stdlib/constants/float16/max-base10-exponent-subnormal/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/max-base10-exponent-subnormal/package.json
@@ -58,6 +58,7 @@
     "half",
     "floating-point",
     "float",
+    "float16",
     "ieee754",
     "exponent",
     "max",

--- a/lib/node_modules/@stdlib/constants/float16/max-base10-exponent/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/max-base10-exponent/package.json
@@ -58,6 +58,7 @@
     "half",
     "floating-point",
     "float",
+    "float16",
     "ieee754",
     "exponent",
     "max",

--- a/lib/node_modules/@stdlib/constants/float16/max-base2-exponent-subnormal/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/max-base2-exponent-subnormal/package.json
@@ -58,6 +58,7 @@
     "flt",
     "floating-point",
     "float",
+    "float16",
     "ieee754",
     "bias",
     "exponent",

--- a/lib/node_modules/@stdlib/constants/float16/max-base2-exponent/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/max-base2-exponent/package.json
@@ -59,6 +59,7 @@
     "flt",
     "floating-point",
     "float",
+    "float16",
     "ieee754",
     "bias",
     "exponent",

--- a/lib/node_modules/@stdlib/constants/float16/max-safe-integer/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/max-safe-integer/package.json
@@ -52,6 +52,8 @@
     "stdmath",
     "constant",
     "const",
+    "mathematics",
+    "math",
     "max",
     "maximum",
     "safe",

--- a/lib/node_modules/@stdlib/constants/float16/min-base10-exponent-subnormal/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/min-base10-exponent-subnormal/package.json
@@ -59,6 +59,7 @@
     "floating-point",
     "float",
     "float16",
+    "ieee754",
     "exponent",
     "min",
     "minimum",

--- a/lib/node_modules/@stdlib/constants/float16/min-base10-exponent/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/min-base10-exponent/package.json
@@ -58,6 +58,7 @@
     "half",
     "floating-point",
     "float",
+    "float16",
     "ieee754",
     "exponent",
     "min",

--- a/lib/node_modules/@stdlib/constants/float16/min-base2-exponent-subnormal/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/min-base2-exponent-subnormal/package.json
@@ -58,6 +58,7 @@
     "float",
     "flt",
     "floating-point",
+    "float16",
     "ieee754",
     "bias",
     "exponent",

--- a/lib/node_modules/@stdlib/constants/float16/min-base2-exponent/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/min-base2-exponent/package.json
@@ -59,6 +59,7 @@
     "flt",
     "floating-point",
     "float",
+    "float16",
     "ieee754",
     "bias",
     "exponent",

--- a/lib/node_modules/@stdlib/constants/float16/min-safe-integer/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/min-safe-integer/package.json
@@ -52,6 +52,8 @@
     "stdmath",
     "constant",
     "const",
+    "mathematics",
+    "math",
     "min",
     "minimum",
     "safe",

--- a/lib/node_modules/@stdlib/constants/float16/num-bytes/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/num-bytes/package.json
@@ -58,6 +58,7 @@
     "half-precision",
     "floating-point",
     "float",
+    "float16",
     "ieee754",
     "size",
     "sizeof",

--- a/lib/node_modules/@stdlib/constants/float16/precision/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/precision/package.json
@@ -57,6 +57,7 @@
     "half",
     "floating-point",
     "float",
+    "float16",
     "ieee754",
     "precision",
     "significand"

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-three/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-three/package.json
@@ -63,6 +63,7 @@
     "half",
     "half-precision",
     "floating-point",
+    "float",
     "float16",
     "16bit",
     "16-bit"


### PR DESCRIPTION
Aligning outliers in `constants/float16` with namespace majority patterns (random namespace pick, seed `20260429`).

## Description

This pull request normalizes `package.json` metadata across 15 outlier packages in `@stdlib/constants/float16` so that they conform to the patterns observed in the rest of the namespace. All edits are purely additive metadata fixes — keyword additions and one trailing-period restoration — that do not change any observable behavior, public signature, or test expectation.

### Namespace summary

- **Target namespace:** `@stdlib/constants/float16`
- **Member count:** 53 (no autogenerated members; all 53 eligible)
- **75% conformance threshold:** 40 / 53 packages
- **Features analyzed:** file tree, `package.json` top-level keys, `package.json` scripts/stdlib subkeys, `package.json` keywords, `package.json` description shape, `manifest.json` shape, README `##`/`###` section sequence, `docs/types/index.d.ts` shape, `docs/repl.txt` shape, dependencies / devDependencies sets.
- **Features with a clear majority and detected drift:**
  - `package.json` keywords (set-valued; 10 majority keywords, 14 outliers)
  - `package.json` description trailing period (scalar; 52/53 = 98% conformance, 1 outlier)
- **Features with a clear majority and zero drift:** `package.json` top-level key set (18 keys, 100% uniform); file tree of 8 universal files (100% uniform); empty `dependencies` / `devDependencies` / `scripts` / `stdlib` (100% uniform); `docs/types/index.d.ts` `declare const FLOAT16_X: number;` shape (100% uniform).
- **Features excluded due to no clear majority:**
  - README `##` section sequence — only 26/53 (49%) follow `[Usage, Examples]`; remainder add `C APIs` (15) or `See Also` (13). The `C APIs` section is conditional on the package having a C native binding (`manifest.json` + `include/*.h`), which itself is intentional and not drift. `See Also` cross-links are optional and per-package.
  - `manifest.json` / `include/*.h` files (15-16/53) — present only on integer-valued constants that ship C bindings; legitimately absent on the floating-point constants. Conditional, not drift.
  - Constant-level JSDoc `@see` tag — borderline at 41/53 = 77%, but adding `@see` requires per-package research (Wikipedia / OEIS links) and is non-mechanical. Excluded as out of scope for an additive metadata pass.
- **Features not applicable to this namespace:** semantic features (public function signature, validation prologue, error-construction style, return kind) — `constants/*` packages export single values rather than functions, so no semantic majority vote was meaningful. Documented and skipped.

### Per-outlier corrections

#### `constants/float16/ln-two`
Added `float` keyword (51/53 = 96% of `constants/float16` siblings carry it). Closes a one-keyword gap; no other changes.

#### `constants/float16/max-base10-exponent`
Added `float16` keyword (44/53 = 83%). Brings the package in line with the rest of the namespace; metadata-only.

#### `constants/float16/max-base10-exponent-subnormal`
Added `float16` keyword (44/53 = 83%). Same drift pattern as the rest of the `*-base*-exponent*` group.

#### `constants/float16/max-base2-exponent`
Added `float16` keyword (44/53 = 83%). Standardizes discoverability across the exponent constants.

#### `constants/float16/max-base2-exponent-subnormal`
Added `float16` keyword (44/53 = 83%). Mirrors the fix applied across the `*-base*-exponent*` group.

#### `constants/float16/max-safe-integer`
Added `mathematics` and `math` keywords (51/53 = 96% each). Both safe-integer constants in the namespace had the same drift; this is the `max-` half.

#### `constants/float16/min-base10-exponent`
Added `float16` keyword (44/53 = 83%). Same drift pattern as its `max-` counterpart.

#### `constants/float16/min-base10-exponent-subnormal`
Added `ieee754` keyword (52/53 = 98%). The only package in the namespace lacking the `ieee754` keyword; the constant is defined directly by the IEEE 754 standard.

#### `constants/float16/min-base2-exponent`
Added `float16` keyword (44/53 = 83%). Same drift pattern as the rest of the exponent group.

#### `constants/float16/min-base2-exponent-subnormal`
Added `float16` keyword (44/53 = 83%). Completes the exponent-group cleanup.

#### `constants/float16/min-safe-integer`
Added `mathematics` and `math` keywords (51/53 = 96% each). Companion fix to `max-safe-integer`.

#### `constants/float16/num-bytes`
Added `float16` keyword (44/53 = 83%). The package describes the byte size of a float16 value; the keyword belongs.

#### `constants/float16/precision`
Added `float16` keyword (44/53 = 83%). Describes the float16 significand precision; the keyword belongs.

#### `constants/float16/sqrt-three`
Added `float` keyword (51/53 = 96%). The package already carries `float16` and `floating-point`; `float` was the lone gap.

#### `constants/float16/ln-half`
Added the trailing period to the `description` field (52/53 = 98% of namespace siblings end the `description` string with a period). Pure punctuation fix.

## Questions

No.

## Other

### Validation audit

Three independent agents reviewed every flagged outlier before any commit was made:

- **Semantic review** (opus): for each outlier, inspected the package's `lib/index.js` and `README.md` and confirmed the missing keyword (or trailing period) reflects stale metadata rather than a deliberate semantic difference. Verdict on all 15 outliers: `confirmed-drift`.
- **Cross-reference review** (opus): for each outlier, verified that no `test/test.js`, `examples/index.js`, or sibling package documentation references the affected metadata in a way that would require a cascading change. Verdict on all 15 outliers: `safe` (mechanical, no cascade).
- **Structural review** (sonnet): for each outlier, confirmed the majority pattern is the right pattern to apply and that the "missing" item is not legitimately inapplicable. Verdict on all 15 outliers: `confirmed-drift`.

What was deliberately excluded from this pass:
- README section drift on `C APIs` and `See Also` — conditional or optional, not enforceable as a single majority pattern.
- Constant-level JSDoc `@see` tag drift — borderline majority and non-mechanical (would require per-package research for the right reference link).
- The `single` keyword inherited by `ln-half` and any other extras that are not part of the majority set — outside the scope of an additive metadata pass.
- All semantic features — not applicable to a value-exporting `constants/*` namespace.

The full local audit report (per-feature distributions, full outlier lists, drop reasons, and the random seed) is preserved at `~/drift-reports/drift-constants-float16-2026-04-29.md`.

### Process notes

This PR was opened on branch `claude/compassionate-ritchie-CuGzQ` because the harness pre-assigned that branch for this session; the routine's preferred `philipp/drift-<namespace>-<date>` form is documented in the local report.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code running the cross-package API drift detection routine. Random namespace selection, structural feature extraction, majority-vote computation, and three-agent validation (two opus, one sonnet) ran automatically; the per-package metadata edits, commits, and PR body were composed by Claude Code based on the validated drift findings. A human maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_011sBeKV2dRzvYJiudfJuS7V)_