### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/star-repo/lib/factory.js
+++ b/lib/node_modules/@stdlib/_tools/github/star-repo/lib/factory.js
@@ -84,19 +84,20 @@ function factory( options, clbk ) {
 			throw new Error( format( 'invalid argument. Repository slug must consist of an owner and a repository (e.g., "stdlib-js/utils"). Value: `%s`.', slug ) );
 		}
 		query( slug, opts, done );
-		/**
-		* Callback invoked after receiving an API response.
-		*
-		* @private
-		* @param {(Error|null)} error - error object
-		* @param {Object} info - response info
-		* @returns {void}
-		*/
-		function done( error, info ) {
-			error = error || null;
-			info = info || null;
-			clbk( error, info );
-		}
+	}
+
+	/**
+	* Callback invoked after receiving an API response.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Object} info - response info
+	* @returns {void}
+	*/
+	function done( error, info ) {
+		error = error || null;
+		info = info || null;
+		clbk( error, info );
 	}
 }
 

--- a/lib/node_modules/@stdlib/strided/base/binary-dtype-signatures/lib/index.js
+++ b/lib/node_modules/@stdlib/strided/base/binary-dtype-signatures/lib/index.js
@@ -34,7 +34,7 @@
 * ];
 *
 * var sigs = signatures( dtypes, dtypes, dtypes );
-* // returns [ 'float64', 'float64', 'float64', ... ]
+* // returns [ 'float32', 'float32', 'float32', ... ]
 */
 
 // MODULES //


### PR DESCRIPTION
Resolves #11852.

## Description

Fix the two JavaScript lint errors reported by [run 25140647799](https://github.com/stdlib-js/stdlib/actions/runs/25140647799):

```
factory.js
  95:3  error  Function 'done' should be moved to outer function scope  stdlib/no-unnecessary-nested-functions

binary-dtype-signatures/lib/index.js
  21:1  error  Displayed return value is `[ 'float64', 'float64', 'float64', ... ]`, but expected `[ 'float32', 'float32', ..., 'uint8', 'int32' ]` instead  stdlib/jsdoc-doctest
```

### `_tools/github/star-repo/lib/factory.js`

Move `done` out of `star` so it sits at the same scope as `star`. `done` only references `clbk` from the outer `factory` scope, so the nested form was unnecessary. This matches the convention used by the recent `repl/presentation/lib/commands/end.js` fix (#11813) and by sibling files in `_tools/github/`.

### `strided/base/binary-dtype-signatures/lib/index.js`

Update the `@example` doctest to match the actual return value. With `dtypes = [ 'float64', 'float32', 'int32', 'uint8' ]`, the implementation calls `dt3.sort()` which mutates the shared `dt1`/`dt2`/`dt3` array (since `dt3 = dt1` aliases the same reference), so iteration starts from the smallest sorted dtype `'float32'`. The first three signature triple elements are therefore `'float32', 'float32', 'float32'`, not `'float64'`. The sibling `main.js` already documents the correct form.

## Related Issues

-   #11852

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)

#### Disclosure

This PR was written by Claude Code; I (the author) reviewed the diff against the recently merged #11813 fix and ran the example locally to confirm the new doctest matches the actual output before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
