### PR TITLE
chore: propagate JSDoc callback-type alignment to `_tools/markdown`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/markdown/to-html/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/markdown/to-html/lib/main.js
@@ -54,7 +54,7 @@ var hTransform = rehype()
 *
 * @param {(string|Buffer)} markdown - markdown to convert
 * @param {string} [base='/docs/api/develop/'] - base path for internal URLs
-* @param {Function} clbk - callback to invoke on completion
+* @param {Callback} clbk - callback to invoke on completion
 * @throws {TypeError} first argument must be either a string or Buffer
 * @throws {TypeError} last argument must be a function
 *


### PR DESCRIPTION
Propagating fixes merged to `develop` between 2026-04-29 18:17 -0400 and 2026-04-30 11:44 +0530 to sibling packages.

## Description

This pull request propagates a single namespace-alignment correction surfaced in the last 24h of `develop`:

### `chore: align outliers in _tools/* with namespace majority patterns` — propagates a2c531cd9

Aligns `_tools/markdown/to-html/lib/main.js` with sibling files by changing the `clbk` JSDoc type annotation from `{Function}` to `{Callback}`, consistent with the pattern established across `_tools/markdown/inline-svg-equation/lib/main.js` and `_tools/markdown/namespace-toc/lib/async.js`. Propagates the same one-token correction applied to `_tools/lint` in a2c531cd9. No semantic effect.

Target package:

-   `lib/node_modules/@stdlib/_tools/markdown/to-html/lib/main.js`

## Related Issues

None.

## Questions

No.

## Other

### Validation

-   **Pattern search scope:** all `lib/node_modules/@stdlib/_tools/**/*.js` files matching `@param {Function} clbk`, partitioned by top-level `_tools/<sub>/` namespace.
-   **Namespace-majority filter:** kept only sites where the local namespace (`_tools/<sub>/`) had a clear `{Callback}` majority among non-fixture sources. `_tools/github` (55 `{Function}` vs 19 `{Callback}`) and `_tools/scripts` (2 vs 0) were dropped — `{Function}` is the local majority there. `_tools/docs` (4 vs 4) and `_tools/utils` (1 vs 1) were dropped — no majority.
-   **Independent validation:** two opus agents reviewed the surviving site in full; both returned `confirmed`. The `clbk` parameter is a node-style error-first callback (`clbk(error)` / `clbk(null, html)`), no local `Callback` typedef, not a fixture.
-   **Adaptation pass:** mechanical — the source patch applies verbatim modulo the description wording (preserved as `on completion`, the site-local phrasing).
-   **Style-consistency pass:** sonnet agent confirmed JSDoc spacing, leading `* ` continuation, and description wording match stdlib conventions and sibling files.
-   **Deliberately excluded:**
    -   `_tools/eslint/rules/jsdoc-doctest/test/fixtures/valid.js` — ESLint rule test fixture; `{Function}` content is potentially intentional for the rule under test.
    -   Bot-generated commits `e34b36cde` (`docs: update namespace table of contents`) and `6b16c0bec` (`docs: update related packages sections`) — automation downstream of new-package additions, no underlying defect pattern.
    -   `b48118129` (`docs: add hpsf conference image link`) — single-instance content fill; no other empty `src=""` images exist in `docs/`.
    -   The added `namespace-aliases/test/test.js` portion of `a2c531cd9` — a single, already-resolved missing-test outlier; no other lint package lacks `test/test.js`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine. The propagation site was identified by a sonnet pattern-specification agent, validated by two independent opus agents plus an opus adaptation agent and a sonnet style-consistency agent, then committed and opened as a draft. A maintainer should audit before promoting out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_016PUpFRN3sosyXiXyAcEJR4)_