### PR TITLE
docs: align outliers in `math/base/tools` with namespace majority patterns

### DIFF
--- a/lib/node_modules/@stdlib/math/base/tools/evalpoly-compile-c/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/tools/evalpoly-compile-c/docs/repl.txt
@@ -1,0 +1,44 @@
+
+{{alias}}( c[, options] )
+    Compiles a C function string for evaluating a polynomial having
+    coefficients `c`.
+
+    The coefficients should be ordered in ascending degree, thus matching
+    summation notation.
+
+    By default, the function assumes double-precision floating-point arithmetic.
+    To emulate single-precision floating-point arithmetic, set the `dtype`
+    option to `'float'`.
+
+    The function is intended for non-browser environments for the purpose of
+    generating C source files.
+
+    Parameters
+    ----------
+    c: Array<number>
+        Polynomial coefficients sorted in ascending degree.
+
+    options: Object (optional)
+        Function options.
+
+    options.dtype: string (optional)
+        Input value floating-point data type. Must be either 'double' or
+        'float'. Default: 'double'.
+
+    options.name: string (optional)
+        Function name. Default: 'evalpoly'.
+
+    Returns
+    -------
+    out: string
+        Function string for evaluating a polynomial.
+
+    Examples
+    --------
+    > var str = {{alias}}( [ 3.0, 2.0, 1.0 ] )
+    <string>
+
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/tools/evalpoly-compile/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/tools/evalpoly-compile/docs/repl.txt
@@ -1,0 +1,41 @@
+
+{{alias}}( c[, options] )
+    Compiles a module string containing an exported function for evaluating a
+    polynomial having coefficients `c`.
+
+    The coefficients should be ordered in ascending degree, thus matching
+    summation notation.
+
+    By default, the function assumes double-precision floating-point arithmetic.
+    To emulate single-precision floating-point arithmetic, set the `dtype`
+    option to `'float32'`.
+
+    The function is intended for non-browser environments for the purpose of
+    generating module files.
+
+    Parameters
+    ----------
+    c: Array<number>
+        Polynomial coefficients sorted in ascending degree.
+
+    options: Object (optional)
+        Function options.
+
+    options.dtype: string (optional)
+        Input value floating-point data type. Must be either 'float64' or
+        'float32'. Default: 'float64'.
+
+    Returns
+    -------
+    out: string
+        Module string exporting a function for evaluating a polynomial.
+
+    Examples
+    --------
+    > var str = {{alias}}( [ 3.0, 2.0, 1.0 ] )
+    <string>
+
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/tools/evalrational-compile-c/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/tools/evalrational-compile-c/docs/repl.txt
@@ -1,0 +1,49 @@
+
+{{alias}}( P, Q[, options] )
+    Compiles a C function string for evaluating a rational function having
+    numerator coefficients `P` and denominator coefficients `Q`.
+
+    The coefficients should be ordered in ascending degree, thus matching
+    summation notation.
+
+    By default, the function assumes double-precision floating-point arithmetic.
+    To emulate single-precision floating-point arithmetic, set the `dtype`
+    option to `'float'`.
+
+    The function is intended for non-browser environments for the purpose of
+    generating C source files.
+
+    Parameters
+    ----------
+    P: Array<number>
+        Numerator polynomial coefficients sorted in ascending degree.
+
+    Q: Array<number>
+        Denominator polynomial coefficients sorted in ascending degree.
+
+    options: Object (optional)
+        Function options.
+
+    options.dtype: string (optional)
+        Input value floating-point data type. Must be either 'double' or
+        'float'. Default: 'double'.
+
+    options.name: string (optional)
+        Function name. Default: 'evalrational'.
+
+    Returns
+    -------
+    out: string
+        Function string for evaluating a rational function.
+
+    Examples
+    --------
+    > var P = [ -6.0, -5.0 ];
+    > var Q = [ 3.0, 0.5 ];
+    > var str = {{alias}}( P, Q )
+    <string>
+
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/tools/evalrational-compile/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/tools/evalrational-compile/docs/repl.txt
@@ -1,0 +1,47 @@
+
+{{alias}}( P, Q[, options] )
+    Compiles a module string containing an exported function for evaluating a
+    rational function having numerator coefficients `P` and denominator
+    coefficients `Q`.
+
+    The coefficients should be ordered in ascending degree, thus matching
+    summation notation.
+
+    By default, the function assumes double-precision floating-point arithmetic.
+    To emulate single-precision floating-point arithmetic, set the `dtype`
+    option to `'float32'`.
+
+    The function is intended for non-browser environments for the purpose of
+    generating module files.
+
+    Parameters
+    ----------
+    P: Array<number>
+        Numerator polynomial coefficients sorted in ascending degree.
+
+    Q: Array<number>
+        Denominator polynomial coefficients sorted in ascending degree.
+
+    options: Object (optional)
+        Function options.
+
+    options.dtype: string (optional)
+        Input value floating-point data type. Must be either 'float64' or
+        'float32'. Default: 'float64'.
+
+    Returns
+    -------
+    out: string
+        Module string exporting a function for evaluating a rational function.
+
+    Examples
+    --------
+    > var P = [ -6.0, -5.0 ];
+    > var Q = [ 3.0, 0.5 ];
+    > var str = {{alias}}( P, Q )
+    <string>
+
+
+    See Also
+    --------
+


### PR DESCRIPTION
## Description

Aligning outliers in `math/base/tools` with namespace majority patterns (random namespace pick, seed `20260430`).

This pull request adds the missing `docs/repl.txt` to the four `*-compile*` packages so that REPL help is available across the entire `math/base/tools` namespace, matching the dominant convention. New file content is derived deterministically from each package's existing JSDoc and TypeScript declarations; no source, behavior, or public API changes.

### Namespace summary

-   **Target:** `math/base/tools`
-   **Members analyzed:** 17 (no autogenerated packages excluded)
-   **Features with a clear majority (≥75% conformance):** file-tree presence (`README.md`, `package.json`, `lib/index.js`, `lib/main.js`, `test/test.js`, `benchmark/benchmark.js`, `examples/index.js`, `docs/types/index.d.ts`, `docs/types/test.ts`, `docs/repl.txt`), `package.json` top-level keys, `returnKind`, JSDoc `@example` / `@returns` presence
-   **Features without a clear majority (excluded from drift detection):** `publicSignature` (genuinely heterogeneous — `(c, x)` evaluators vs `(P, Q, x)` rational vs `(n, x)` polynomial vs `(generator, options)` series), README L2 heading sequence, dependencies, `lib/factory.js` presence (65%), `Notes` section in README (71%)
-   **Features not applicable:** `validationPrologue` and `errorConstruction` — no package in this namespace throws

### `math/base/tools/evalpoly-compile`

Adds missing `docs/repl.txt` to bring the package in line with sibling convention — 13/17 (76%) of `math/base/tools` packages carry this file, including `evalpoly` itself. Content was derived directly from the existing JSDoc and TypeScript declarations for `compile(c[, options])` with no behavior or API changes.

### `math/base/tools/evalpoly-compile-c`

Adds missing `docs/repl.txt` to bring the package into conformance with the `math/base/tools` namespace, where 13/17 siblings (76%) carry this file. Content was derived directly from existing JSDoc and TypeScript declarations for `compile(c[, options])` — no API or behavior change.

### `math/base/tools/evalrational-compile`

Adds missing `docs/repl.txt`, flagged by the drift routine as absent in this package while present in 13/17 (76%) of `math/base/tools` siblings — including `evalrational` itself. The file was derived directly from existing JSDoc and TypeScript declarations for `compile(P, Q[, options])`; no behavior or API changes.

### `math/base/tools/evalrational-compile-c`

Adds missing `docs/repl.txt` to bring the package into conformance with the `math/base/tools` namespace, where 13/17 siblings (76%) carry this file. Content was derived directly from the existing JSDoc and TypeScript declarations for `compile(P, Q[, options])` — no API or behavior change.

### Validation

What was checked:

-   Structural feature extraction across all 17 members (file tree, `package.json` shape, README headings, test/benchmark/example layout)
-   Semantic feature extraction via per-package agents reading `lib/main.js` / `lib/index.js` / `lib/basic.js` (publicSignature, returnKind, validationPrologue, errorConstruction, JSDoc shape, dependencies)
-   Three-agent drift validation: opus semantic-review, opus cross-reference, sonnet structural-review

What was deliberately excluded:

-   `lib/main.js` "drift" in `continued-fraction` and `sum-series` — both deliberately split implementation across `lib/basic.js` and `lib/generators.js` and select between them at runtime via `lib/index.js`. Marked `intentional-deviation` / `needs-human` and dropped.
-   Heterogeneous public signatures across the namespace — no single majority shape.
-   Validation prologue and error construction — no package in `math/base/tools` throws, so there is no normalization target.
-   Features that fell short of the 75% threshold (`Notes` L2 section at 71%, `lib/factory.js` at 65%, `See Also` at 35%).

## Related Issues

No related issues.

## Questions

No.

## Other

Random namespace pick, seed `20260430`. Detailed run report (per-feature distributions, dropped corrections, agent verdicts) is kept locally outside the repo tree at `~/drift-reports/drift-math-base-tools-2026-04-30.md`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code running an automated cross-package drift-detection routine: structural and semantic features were extracted from every member of `math/base/tools`, three independent validation agents confirmed each correction, and the four added `docs/repl.txt` files were derived deterministically from the existing JSDoc and TypeScript declarations of each package.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01CaQ6RVQdrFSgnbUSM3XJLf)_