### PR TITLE
chore: fix JavaScript lint errors (issue #11852)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/star-repo/lib/factory.js
+++ b/lib/node_modules/@stdlib/_tools/github/star-repo/lib/factory.js
@@ -84,19 +84,20 @@ function factory( options, clbk ) {
 			throw new Error( format( 'invalid argument. Repository slug must consist of an owner and a repository (e.g., "stdlib-js/utils"). Value: `%s`.', slug ) );
 		}
 		query( slug, opts, done );
-		/**
-		* Callback invoked after receiving an API response.
-		*
-		* @private
-		* @param {(Error|null)} error - error object
-		* @param {Object} info - response info
-		* @returns {void}
-		*/
-		function done( error, info ) {
-			error = error || null;
-			info = info || null;
-			clbk( error, info );
-		}
+	}
+
+	/**
+	* Callback invoked after receiving an API response.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Object} info - response info
+	* @returns {void}
+	*/
+	function done( error, info ) {
+		error = error || null;
+		info = info || null;
+		clbk( error, info );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/idamax/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/idamax/test/test.ndarray.js
@@ -57,13 +57,13 @@ tape( 'the function finds the index of the element with the maximum absolute val
 	idx = idamax( 4, x, 1, 0 );
 	t.strictEqual( idx, expected, 'returns expected value' );
 
-	x = new Float64Array( [
+	x = new Float64Array([
 		0.2,  // 1
 		-0.6, // 2
 		0.3,  // 3
 		5.0,
 		5.0
-	] );
+	]);
 	expected = 1;
 
 	idx = idamax( 3, x, 1, 0 );
@@ -77,11 +77,11 @@ tape( 'if provided an `N` parameter less than `1`, the function returns `-1`', f
 	var idx;
 	var x;
 
-	x = new Float64Array( [
+	x = new Float64Array([
 		1.0,
 		2.0,
 		3.0
-	] );
+	]);
 	expected = -1;
 
 	idx = idamax( 0, x, 1, 0 );
@@ -95,11 +95,11 @@ tape( 'if provided an `N` parameter equal to `1`, the function returns `0`', fun
 	var idx;
 	var x;
 
-	x = new Float64Array( [
+	x = new Float64Array([
 		1.0,
 		2.0,
 		3.0
-	] );
+	]);
 	expected = 0;
 
 	idx = idamax( 1, x, 1, 1 );

--- a/lib/node_modules/@stdlib/strided/base/binary-dtype-signatures/lib/index.js
+++ b/lib/node_modules/@stdlib/strided/base/binary-dtype-signatures/lib/index.js
@@ -34,7 +34,7 @@
 * ];
 *
 * var sigs = signatures( dtypes, dtypes, dtypes );
-* // returns [ 'float64', 'float64', 'float64', ... ]
+* // returns [ 'float32', 'float32', 'float32', ... ]
 */
 
 // MODULES //


### PR DESCRIPTION
## Summary

Fixes 3 lint errors from CI run on 2026-04-30:

- **`stdlib/no-unnecessary-nested-functions`** in `@stdlib/_tools/github/star-repo/lib/factory.js`: moved nested `done` callback from inside `star` to the outer `factory` scope
- **`stdlib/jsdoc-doctest`** in `@stdlib/strided/base/binary-dtype-signatures/lib/index.js`: corrected doctest return value from `float64` to `float32` to match actual output (consistent with `main.js`)
- **`stdlib/eol-open-bracket-spacing`** in `@stdlib/blas/base/idamax/test/test.ndarray.js`: removed spaces in multi-line `Float64Array([ ... ])` expressions at lines 60, 80, 98 to match the style used elsewhere in the file

## Related Issues

resolves #11852

## Contributing Guidelines

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)