### PR TITLE
docs: align outliers in `constants/time` with namespace majority patterns

### DIFF
--- a/lib/node_modules/@stdlib/constants/time/milliseconds-in-minute/README.md
+++ b/lib/node_modules/@stdlib/constants/time/milliseconds-in-minute/README.md
@@ -47,7 +47,7 @@ var bool = ( MILLISECONDS_IN_MINUTE === 60000 );
 
 ## Notes
 
--   The value is a generalization and does **not** take into account inaccuracies arising due to complications with time and dates.
+-   The value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
 
 </section>
 

--- a/lib/node_modules/@stdlib/constants/time/milliseconds-in-minute/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/time/milliseconds-in-minute/docs/repl.txt
@@ -3,7 +3,8 @@
     Number of milliseconds in a minute.
 
     The value is a generalization and does **not** take into account
-    inaccuracies arising due to complications with time and dates.
+    inaccuracies due to daylight savings conventions, crossing timezones, or
+    other complications with time and dates.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/constants/time/milliseconds-in-second/README.md
+++ b/lib/node_modules/@stdlib/constants/time/milliseconds-in-second/README.md
@@ -47,7 +47,7 @@ var bool = ( MILLISECONDS_IN_SECOND === 1000 );
 
 ## Notes
 
--   The value is a generalization and does **not** take into account inaccuracies arising due to complications with time and dates.
+-   The value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
 
 </section>
 

--- a/lib/node_modules/@stdlib/constants/time/milliseconds-in-second/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/time/milliseconds-in-second/docs/repl.txt
@@ -3,7 +3,8 @@
     Number of milliseconds in a second.
 
     The value is a generalization and does **not** take into account
-    inaccuracies arising due to complications with time and dates.
+    inaccuracies due to daylight savings conventions, crossing timezones, or
+    other complications with time and dates.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/constants/time/seconds-in-minute/README.md
+++ b/lib/node_modules/@stdlib/constants/time/seconds-in-minute/README.md
@@ -47,7 +47,7 @@ var bool = ( SECONDS_IN_MINUTE === 60 );
 
 ## Notes
 
--   The value is a generalization and does **not** take into account inaccuracies arising due to complications with time and dates.
+-   The value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
 
 </section>
 

--- a/lib/node_modules/@stdlib/constants/time/seconds-in-minute/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/time/seconds-in-minute/docs/repl.txt
@@ -3,7 +3,8 @@
     Number of seconds in a minute.
 
     The value is a generalization and does **not** take into account
-    inaccuracies arising due to complications with time and dates.
+    inaccuracies due to daylight savings conventions, crossing timezones, or
+    other complications with time and dates.
 
     Examples
     --------


### PR DESCRIPTION
## Description

Aligning outliers in `constants/time` with namespace majority patterns (random namespace pick, seed `20260501`).

### Namespace summary

- **Target:** `@stdlib/constants/time`
- **Members analyzed:** 15 (all non-autogenerated)
- **Features extracted:** file tree, `package.json` shape, README sections, `manifest.json` shape, test/benchmark/example file naming, README and `docs/repl.txt` "Notes" prose
- **Features with clear majority (≥75% conformance):** file tree (100%), `package.json` top-level keys (100%), README H2 sections `Usage`/`Notes`/`Examples` (100%), test file layout (100%), example file layout (100%), and the long-form "Notes" wording in `README.md`/`docs/repl.txt` (80%, 12/15)
- **Features without clear majority (excluded from drift detection):** `docs/repl.txt` "See Also" auto-population (variable, manually populated downstream), keyword arrays under `package.json.keywords` (varies by unit; no shared majority pattern), and the optional `tex` derivation block in `lib/index.js` (10/15, below threshold and tracks whether the constant has a non-trivial derivation)

Function-shape semantic features (`publicSignature`, `validationPrologue`, `errorConstruction`, `jsdocShape`) are inapplicable here — every member exports a single integer constant, so per-package semantic-extraction agents were skipped and the analysis is structural-only. This is documented in the local report.

### Outlier corrections

#### `@stdlib/constants/time/milliseconds-in-minute`

`@stdlib/constants/time/milliseconds-in-minute`: normalizes "Notes" prose in `README.md` and `docs/repl.txt` to the long variant ("inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates"), matching 12/15 (80%) of `constants/time/*` siblings.

#### `@stdlib/constants/time/milliseconds-in-second`

`@stdlib/constants/time/milliseconds-in-second`: normalizes "Notes" prose in `README.md` and `docs/repl.txt` to the long variant ("inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates"), matching 80% of `constants/time/*` siblings.

#### `@stdlib/constants/time/seconds-in-minute`

`@stdlib/constants/time/seconds-in-minute`: normalizes the "Notes" prose in `README.md` and `docs/repl.txt` to the long variant ("inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates"), matching 80% of `constants/time/*` siblings.

### Validation

Three independent validation agents reviewed each outlier before any patch was applied:

1. **Semantic-review (Opus):** for each outlier, compared `lib/index.js` and surrounding docs against majority siblings. Result for all three outliers: `confirmed-drift`. Sub-minute units like `seconds-in-hour` and `minutes-in-hour` are equally DST-irrelevant yet still use the long note, so the short-form wording does not track a deliberate semantic boundary.
2. **Cross-reference (Opus):** verified `test/test.js` files assert numeric equality only and do not depend on the Notes wording. Confirmed the short-form wording also appears in `lib/node_modules/@stdlib/repl/help/data/data.{csv,json}`, but those are downstream artifacts generated from each package's `docs/repl.txt` by `repl/help/scripts/build.js`. No `AUTOGENERATED` markers in any of the six edited files. Result for all three outliers: `safe-to-fix`.
3. **Structural-review (Sonnet):** confirmed the long-form note is byte-identical across all 12 majority packages and that applying it to the three outliers introduces no factual inaccuracy. Result for all three outliers: `confirmed-drift`.

### Deliberately excluded

- README "See Also" / `<section class="related">` blocks — these are auto-populated downstream; drift is upstream and out of scope for this routine.
- Keyword arrays under `package.json.keywords` — no shared majority pattern (each unit has its own abbreviation triplet, e.g. `seconds`/`secs`/`sec`, while `milliseconds`/`ms` only ships two variants).
- `tex` derivation block in `lib/index.js` — present in 10/15 (67%, below threshold) and tracks whether the constant has a non-trivial multiplicative derivation; absence in leaf constants like `hours-in-day` or `months-in-year` is intentional.

## Related Issues

None.

## Questions

None.

## Other

- Random seed: `20260501` (deterministic from today's date for reproducibility).
- Branch: `philipp/drift-constants-time-2026-05-01`.
- Per-package commits keep the audit trail readable per-outlier rather than per-feature.
- Downstream `repl/help/data/{data.csv,data.json}` will pick up the corrected wording the next time `repl/help/scripts/build.js` runs; not regenerated in this PR to keep the diff focused.
- Full local report (member list, feature distributions, dropped findings) saved at `~/drift-reports/drift-constants-time-2026-05-01.md`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package API drift detection routine: a structural feature scan over the 15 `constants/time` packages, three independent validation agents (semantic-review, cross-reference, structural-review) per outlier, and a final per-package PR-body refinement pass. Every patch is a textual normalization of the "Notes" wording to the namespace majority; no code, signatures, or test expectations were changed. A human will audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01TZ25GvuUvqBvNrmkn64hwR)_