### PR TITLE
docs: fix broken Markdown link (issue #11868)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dgemv/test/test.dgemv.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/test/test.dgemv.native.js
@@ -39,7 +39,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );

--- a/lib/node_modules/@stdlib/datasets/cmudict/README.md
+++ b/lib/node_modules/@stdlib/datasets/cmudict/README.md
@@ -252,7 +252,7 @@ The data files (databases) and their contents are licensed under a [BSD-2-Clause
 
 <section class="links">
 
-[cmudict]: http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about
+[cmudict]: https://github.com/cmusphinx/cmudict
 
 [arpabet]: https://en.wikipedia.org/wiki/ARPABET
 

--- a/lib/node_modules/@stdlib/ndarray/base/unary-by/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-by/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var format = require( '@stdlib/string/format' );
 var iterationOrder = require( '@stdlib/ndarray/base/iteration-order' );
 var strides2order = require( '@stdlib/ndarray/base/strides2order' );
 var minmaxViewBufferIndex = require( '@stdlib/ndarray/base/minmax-view-buffer-index' );
@@ -224,7 +225,7 @@ function unaryBy( arrays, fcn, clbk, thisArg ) {
 	shy = y.shape;
 	ndims = shx.length;
 	if ( ndims !== shy.length ) {
-		throw new Error( 'invalid arguments. Arrays must have the same number of dimensions (i.e., same rank). ndims(x) == '+ndims+'. ndims(y) == '+shy.length+'.' );
+		throw new Error( format( 'invalid arguments. Arrays must have the same number of dimensions (i.e., same rank). ndims(x) == %d. ndims(y) == %d.', ndims, shy.length ) );
 	}
 	// Determine whether we can avoid iteration altogether...
 	if ( ndims === 0 ) {


### PR DESCRIPTION
Fixes a broken Markdown link in `lib/node_modules/@stdlib/datasets/cmudict/README.md`.

The original URL (`http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about`) is no longer 
accessible (HTTP status 0). Updated to the current official GitHub repositor

*Related Issues*
resolves #11868

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)