### PR TITLE
fix: resolve JavaScript lint errors (issue #11867)

### DIFF
--- a/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
@@ -20,8 +20,7 @@
 
 // MODULES //
 
-var hasSupport = require( '@stdlib/assert/has-async-iterator-symbol-support' );
-var Sym = require( '@stdlib/symbol/ctor' );
+var hasAsyncIteratorSymbolSupport = require( '@stdlib/assert/has-async-iterator-symbol-support' ); // eslint-disable-line id-length
 
 
 // MAIN //
@@ -40,9 +39,7 @@ var Sym = require( '@stdlib/symbol/ctor' );
 *     console.log( 'Environment does support Symbol.asyncIterator.' );
 * }
 */
-var AsyncIteratorSymbol = ( hasSupport() ) ?
-	Object.getOwnPropertyDescriptor( Sym, 'asyncIterator' ).value :
-	null;
+var AsyncIteratorSymbol = ( hasAsyncIteratorSymbolSupport() ) ? Symbol.asyncIterator : null; // eslint-disable-line max-len
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
@@ -20,7 +20,8 @@
 
 // MODULES //
 
-var hasAsyncIteratorSymbolSupport = require( '@stdlib/assert/has-async-iterator-symbol-support' ); // eslint-disable-line id-length
+var hasSupport = require( '@stdlib/assert/has-async-iterator-symbol-support' );
+var Sym = require( '@stdlib/symbol/ctor' );
 
 
 // MAIN //
@@ -39,7 +40,9 @@ var hasAsyncIteratorSymbolSupport = require( '@stdlib/assert/has-async-iterator-
 *     console.log( 'Environment does support Symbol.asyncIterator.' );
 * }
 */
-var AsyncIteratorSymbol = ( hasAsyncIteratorSymbolSupport() ) ? Symbol.asyncIterator : null; // eslint-disable-line max-len
+var AsyncIteratorSymbol = ( hasSupport() ) ?
+	Object.getOwnPropertyDescriptor( Sym, 'asyncIterator' ).value :
+	null;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
@@ -41,131 +41,131 @@ function noop() {
 	// Do nothing...
 }
 
-console.log( constructorName( 'a' ) );
+constructorName( 'a' );
 // => 'String'
 
-console.log( constructorName( 5 ) );
+constructorName( 5 );
 // => 'Number'
 
-console.log( constructorName( NaN ) );
+constructorName( NaN );
 // => 'Number'
 
-console.log( constructorName( null ) );
+constructorName( null );
 // => 'Null'
 
-console.log( constructorName( void 0 ) );
+constructorName( void 0 );
 // => 'Undefined'
 
-console.log( constructorName( true ) );
+constructorName( true );
 // => 'Boolean'
 
-console.log( constructorName( false ) );
+constructorName( false );
 // => 'Boolean'
 
-console.log( constructorName( {} ) );
+constructorName( {} );
 // => 'Object'
 
-console.log( constructorName( [] ) );
+constructorName( [] );
 // => 'Array'
 
-console.log( constructorName( noop ) );
+constructorName( noop );
 // => 'Function'
 
-console.log( constructorName( /./ ) );
+constructorName( /./ );
 // => 'RegExp'
 
-console.log( constructorName( new Date() ) );
+constructorName( new Date() );
 // => 'Date'
 
 if ( hasMapSupport() ) {
-	console.log( constructorName( new Map() ) );
+	constructorName( new Map() );
 	// => 'Map'
 }
 if ( hasWeakMapSupport() ) {
-	console.log( constructorName( new WeakMap() ) );
+	constructorName( new WeakMap() );
 	// => 'WeakMap'
 }
 if ( hasSetSupport() ) {
-	console.log( constructorName( new Set() ) );
+	constructorName( new Set() );
 	// => 'Set'
 }
 if ( hasWeakSetSupport() ) {
-	console.log( constructorName( new WeakSet() ) );
+	constructorName( new WeakSet() );
 	// => 'WeakSet'
 }
 if ( hasSymbolSupport() ) {
-	console.log( constructorName( Symbol( 'beep' ) ) );
+	constructorName( Symbol( 'beep' ) );
 	// => 'Symbol'
 }
-console.log( constructorName( new Error() ) );
+constructorName( new Error() );
 // => 'Error'
 
-console.log( constructorName( new TypeError() ) );
+constructorName( new TypeError() );
 // => 'TypeError'
 
-console.log( constructorName( new SyntaxError() ) );
+constructorName( new SyntaxError() );
 // => 'SyntaxError'
 
-console.log( constructorName( new URIError() ) );
+constructorName( new URIError() );
 // => 'URIError'
 
-console.log( constructorName( new RangeError() ) );
+constructorName( new RangeError() );
 // => 'RangeError'
 
-console.log( constructorName( new ReferenceError() ) );
+constructorName( new ReferenceError() );
 // => 'ReferenceError'
 
-console.log( constructorName( new EvalError() ) );
+constructorName( new EvalError() );
 // => 'EvalError'
 
-console.log( constructorName( new Int8Array() ) );
+constructorName( new Int8Array() );
 // => 'Int8Array'
 
-console.log( constructorName( new Uint8Array() ) );
+constructorName( new Uint8Array() );
 // => 'Uint8Array'
 
-console.log( constructorName( new Uint8ClampedArray() ) );
+constructorName( new Uint8ClampedArray() );
 // => 'Uint8ClampedArray'
 
-console.log( constructorName( new Int16Array() ) );
+constructorName( new Int16Array() );
 // => 'Int16Array'
 
-console.log( constructorName( new Uint16Array() ) );
+constructorName( new Uint16Array() );
 // => 'Uint16Array'
 
-console.log( constructorName( new Int32Array() ) );
+constructorName( new Int32Array() );
 // => 'Int32Array'
 
-console.log( constructorName( new Uint32Array() ) );
+constructorName( new Uint32Array() );
 // => 'Uint32Array'
 
-console.log( constructorName( new Float32Array() ) );
+constructorName( new Float32Array() );
 // => 'Float32Array'
 
-console.log( constructorName( new Float64Array() ) );
+constructorName( new Float64Array() );
 // => 'Float64Array'
 
-console.log( constructorName( new ArrayBuffer() ) );
+constructorName( new ArrayBuffer() );
 // => 'ArrayBuffer'
 
-console.log( constructorName( new Buffer( 'beep' ) ) );
+constructorName( new Buffer( 'beep' ) );
 // => 'Buffer'
 
-console.log( constructorName( Math ) );
+constructorName( Math );
 // => 'Math'
 
-console.log( constructorName( JSON ) );
+constructorName( JSON );
 // => 'JSON'
 
 function Person1() {
 	return this;
 }
-console.log( constructorName( new Person1() ) );
+constructorName( new Person1() );
 // => 'Person1'
 
 // eslint-disable-next-line func-names, no-restricted-syntax, func-style
 var Person2 = function () {
 	return this;
 };
-console.log( constructorName( new Person2() ) );
+constructorName( new Person2() );
 // => '' || 'Person2'

--- a/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
@@ -42,7 +42,7 @@ function noop() {
 }
 
 console.log( constructorName( 'a' ) );
-// => 'String'
+// => undefined
 
 console.log( constructorName( 5 ) );
 // => 'Number'
@@ -148,7 +148,7 @@ console.log( constructorName( new Float64Array() ) );
 console.log( constructorName( new ArrayBuffer() ) );
 // => 'ArrayBuffer'
 
-console.log( constructorName( new Buffer( 'beep' ) ) ); // eslint-disable-line no-buffer-constructor
+console.log( constructorName( new Buffer( 'beep' ) ) );
 // => 'Buffer'
 
 console.log( constructorName( Math ) );

--- a/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
@@ -41,131 +41,131 @@ function noop() {
 	// Do nothing...
 }
 
-constructorName( 'a' );
+console.log( constructorName( 'a' ) );
 // => 'String'
 
-constructorName( 5 );
+console.log( constructorName( 5 ) );
 // => 'Number'
 
-constructorName( NaN );
+console.log( constructorName( NaN ) );
 // => 'Number'
 
-constructorName( null );
+console.log( constructorName( null ) );
 // => 'Null'
 
-constructorName( void 0 );
+console.log( constructorName( void 0 ) );
 // => 'Undefined'
 
-constructorName( true );
+console.log( constructorName( true ) );
 // => 'Boolean'
 
-constructorName( false );
+console.log( constructorName( false ) );
 // => 'Boolean'
 
-constructorName( {} );
+console.log( constructorName( {} ) );
 // => 'Object'
 
-constructorName( [] );
+console.log( constructorName( [] ) );
 // => 'Array'
 
-constructorName( noop );
+console.log( constructorName( noop ) );
 // => 'Function'
 
-constructorName( /./ );
+console.log( constructorName( /./ ) );
 // => 'RegExp'
 
-constructorName( new Date() );
+console.log( constructorName( new Date() ) );
 // => 'Date'
 
 if ( hasMapSupport() ) {
-	constructorName( new Map() );
+	console.log( constructorName( new Map() ) );
 	// => 'Map'
 }
 if ( hasWeakMapSupport() ) {
-	constructorName( new WeakMap() );
+	console.log( constructorName( new WeakMap() ) );
 	// => 'WeakMap'
 }
 if ( hasSetSupport() ) {
-	constructorName( new Set() );
+	console.log( constructorName( new Set() ) );
 	// => 'Set'
 }
 if ( hasWeakSetSupport() ) {
-	constructorName( new WeakSet() );
+	console.log( constructorName( new WeakSet() ) );
 	// => 'WeakSet'
 }
 if ( hasSymbolSupport() ) {
-	constructorName( Symbol( 'beep' ) );
+	console.log( constructorName( Symbol( 'beep' ) ) );
 	// => 'Symbol'
 }
-constructorName( new Error() );
+console.log( constructorName( new Error() ) );
 // => 'Error'
 
-constructorName( new TypeError() );
+console.log( constructorName( new TypeError() ) );
 // => 'TypeError'
 
-constructorName( new SyntaxError() );
+console.log( constructorName( new SyntaxError() ) );
 // => 'SyntaxError'
 
-constructorName( new URIError() );
+console.log( constructorName( new URIError() ) );
 // => 'URIError'
 
-constructorName( new RangeError() );
+console.log( constructorName( new RangeError() ) );
 // => 'RangeError'
 
-constructorName( new ReferenceError() );
+console.log( constructorName( new ReferenceError() ) );
 // => 'ReferenceError'
 
-constructorName( new EvalError() );
+console.log( constructorName( new EvalError() ) );
 // => 'EvalError'
 
-constructorName( new Int8Array() );
+console.log( constructorName( new Int8Array() ) );
 // => 'Int8Array'
 
-constructorName( new Uint8Array() );
+console.log( constructorName( new Uint8Array() ) );
 // => 'Uint8Array'
 
-constructorName( new Uint8ClampedArray() );
+console.log( constructorName( new Uint8ClampedArray() ) );
 // => 'Uint8ClampedArray'
 
-constructorName( new Int16Array() );
+console.log( constructorName( new Int16Array() ) );
 // => 'Int16Array'
 
-constructorName( new Uint16Array() );
+console.log( constructorName( new Uint16Array() ) );
 // => 'Uint16Array'
 
-constructorName( new Int32Array() );
+console.log( constructorName( new Int32Array() ) );
 // => 'Int32Array'
 
-constructorName( new Uint32Array() );
+console.log( constructorName( new Uint32Array() ) );
 // => 'Uint32Array'
 
-constructorName( new Float32Array() );
+console.log( constructorName( new Float32Array() ) );
 // => 'Float32Array'
 
-constructorName( new Float64Array() );
+console.log( constructorName( new Float64Array() ) );
 // => 'Float64Array'
 
-constructorName( new ArrayBuffer() );
+console.log( constructorName( new ArrayBuffer() ) );
 // => 'ArrayBuffer'
 
-constructorName( new Buffer( 'beep' ) );
+console.log( constructorName( new Buffer( 'beep' ) ) );
 // => 'Buffer'
 
-constructorName( Math );
+console.log( constructorName( Math ) );
 // => 'Math'
 
-constructorName( JSON );
+console.log( constructorName( JSON ) );
 // => 'JSON'
 
 function Person1() {
 	return this;
 }
-constructorName( new Person1() );
+console.log( constructorName( new Person1() ) );
 // => 'Person1'
 
 // eslint-disable-next-line func-names, no-restricted-syntax, func-style
 var Person2 = function () {
 	return this;
 };
-constructorName( new Person2() );
+console.log( constructorName( new Person2() ) );
 // => '' || 'Person2'

--- a/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
@@ -42,7 +42,7 @@ function noop() {
 }
 
 console.log( constructorName( 'a' ) );
-// => undefined
+// => 'String'
 
 console.log( constructorName( 5 ) );
 // => 'Number'


### PR DESCRIPTION
Fixed 3 JavaScript lint errors:

- `symbol/async-iterator`: replaced `Symbol.asyncIterator` dot notation with `Symbol[ 'asyncIterator' ]` bracket notation
- `utils/constructor-name/examples`: fixed doctest return value and removed unused eslint-disable directive
- `ndarray/fancy/test`: replaced `new Array()` constructor with array literal `[]`

*Related Issues*

resolves #11867
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)