### PR TITLE
test: collapse exact-match guard in `stats/base/dists/wald` tests

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/test/test.factory.js
@@ -256,11 +256,7 @@ tape( 'the created function evaluates the pdf for `x` given parameters `mu` and 
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( mu[i], lambda[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 1500 ), 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1500 ), true, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/test/test.native.js
@@ -217,11 +217,7 @@ tape( 'the function evaluates the pdf for `x` given parameters `mu` and `lambda`
 	lambda = data.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 1500 ), 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1500 ), true, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/test/test.pdf.js
@@ -208,11 +208,7 @@ tape( 'the function evaluates the pdf for `x` given parameters `mu` and `lambda`
 	lambda = data.lambda;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 1500 ), 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 1500 ), true, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/test/test.js
@@ -111,11 +111,7 @@ tape( 'the function returns the skewness of a Wald distribution', function test(
 	lambda = data.lambda;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = skewness( mu[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'mu:'+mu[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 20 ), 'within tolerance. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 20 ), true, 'within tolerance. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/test/test.native.js
@@ -120,11 +120,7 @@ tape( 'the function returns the skewness of a Wald distribution', opts, function
 	lambda = data.lambda;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = skewness( mu[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'mu:'+mu[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 20 ), 'within tolerance. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 20 ), true, 'within tolerance. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/variance/test/test.js
@@ -111,11 +111,7 @@ tape( 'the function returns the variance of a Wald distribution', function test(
 	lambda = data.lambda;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'mu:'+mu[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 20 ), 'within tolerance. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 20 ), true, 'within tolerance. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/variance/test/test.native.js
@@ -120,11 +120,7 @@ tape( 'the function returns the variance of a Wald distribution', opts, function
 	lambda = data.lambda;
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'mu:'+mu[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 20 ), 'within tolerance. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 20 ), true, 'within tolerance. mu: '+mu[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Propagates fixes merged to `develop` between 2026-05-01 02:09:52 -0700 and 2026-05-01 04:48:43 -0500 to sibling packages.

### `stats/base/dists/wald`: collapse exact-match-or-tolerance test guard

Propagates the `eeaf7c4` refactor from `stats/base/dists/wald/mode` — which collapsed the branched exact-match-or-tolerance guard into a single unconditional `t.strictEqual( isAlmostSameValue( y, expected[i], TOL ), true, ... )` — to the 7 test files across `stats/base/dists/wald/pdf`, `stats/base/dists/wald/variance`, and `stats/base/dists/wald/skewness`. The collapse is safe because `isAlmostSameValue(a, a, tol)` returns `true` for any finite tolerance, so the exact-match branch was always redundant.

Source: eeaf7c4 (`refactor: reduce number of arithmetic operations`)

Targets:

-   `lib/node_modules/@stdlib/stats/base/dists/wald/pdf/test/test.factory.js`
-   `lib/node_modules/@stdlib/stats/base/dists/wald/pdf/test/test.native.js`
-   `lib/node_modules/@stdlib/stats/base/dists/wald/pdf/test/test.pdf.js`
-   `lib/node_modules/@stdlib/stats/base/dists/wald/skewness/test/test.js`
-   `lib/node_modules/@stdlib/stats/base/dists/wald/skewness/test/test.native.js`
-   `lib/node_modules/@stdlib/stats/base/dists/wald/variance/test/test.js`
-   `lib/node_modules/@stdlib/stats/base/dists/wald/variance/test/test.native.js`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Search scope was `lib/node_modules/@stdlib/stats/base/dists/wald/**/test/*.js`. Two independent validation agents read each candidate file in full and confirmed the defect; an adaptation agent produced concrete patches preserving each site's tolerance and `else`-branch message verbatim; a style-consistency agent checked indentation and spacing against the source commit's form. All 7 sites were unanimously `confirmed` and self-contained within the target test file.

**Excluded.**

-   `dabdc73c` (`docs: update examples`, `ndarray/vector/ctor`): the `dtypes('real_and_generic')` → `dtypes('integer_and_generic')` change pairs an integer-valued `discreteUniform` generator with the appropriate dtype filter. 4 textually similar example sites exist under `ndarray/base/{nullary,unary}-strided1d-dispatch{,-factory}`, but each requires a judgment call about the example's intended dtype kind and was therefore deferred to manual review per the routine's high-signal-only criterion.
-   `642af215` (`docs: remove extra empty line`, `stats/base/ndarray/dmeanlipw/README.md`): no remaining sibling READMEs with the `<!-- /.c -->\n\n\n* * *` double-blank-line pattern.
-   `eeaf7c48` arithmetic-reduction part (`3.0*r/2.0` repeated subexpression in `wald/mode/lib/main.js` and `src/main.c`): no other distribution function reuses that exact algebraic form.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was prepared by Claude Code as part of an automated fix-propagation routine: the recent `develop` commit window was scanned for generalizable fixes, candidate sibling sites were enumerated by `rg`, and four parallel validation/adaptation/style agents independently confirmed each propagation site before the patches were applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01GPuYKaY2S5M6QNwbwsrgPE)_