### PR TITLE
fix: correct C delegation and benchmark inputs in `stats/strided/dpcorr`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dpcorr/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/dpcorr/benchmark/c/benchmark.length.c
@@ -152,7 +152,7 @@ static double benchmark2( int iterations, int len ) {
 	c = 0.0;
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
-		c = stdlib_strided_dpcorr_ndarray( len, x, 1, 0, x, 1, 0 );
+		c = stdlib_strided_dpcorr_ndarray( len, x, 1, 0, y, 1, 0 );
 		if ( c != c ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/stats/strided/dpcorr/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dpcorr/src/main.c
@@ -50,5 +50,5 @@ double API_SUFFIX(stdlib_strided_dpcorr)( const CBLAS_INT N, const double *X, co
 * @return             output value
 */
 double API_SUFFIX(stdlib_strided_dpcorr_ndarray)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX, const double *Y, const CBLAS_INT strideY, const CBLAS_INT offsetY ) {
-	return stdlib_strided_dpcorrwd_ndarray( N, X, strideX, offsetX, Y, strideY, offsetY );
+	return API_SUFFIX(stdlib_strided_dpcorrwd_ndarray)( N, X, strideX, offsetX, Y, strideY, offsetY );
 }


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-05-01 17:21 EDT (`755a2ee2`) and 2026-05-02 14:53 +0530 (`6b8823ef`).

## Description

This pull request fixes two bugs introduced in the new `stats/strided/dpcorr` package (`6b8823ef`):

### `stats/strided/dpcorr`

- Fix missing `API_SUFFIX(...)` wrapper around `stdlib_strided_dpcorrwd_ndarray` call at `lib/node_modules/@stdlib/stats/strided/dpcorr/src/main.c:53`, introduced in `6b8823ef`, causing resolution to a non-existent symbol when built against the 64-bit ABI.
- Fix copy-paste bug in `benchmark2` introduced in `6b8823ef`, where `stdlib_strided_dpcorr_ndarray` was called with `x` passed for both array arguments instead of `x` and `y`, causing the benchmark to always compute the autocorrelation of `x` and leaving the allocated `y` array unused (`lib/node_modules/@stdlib/stats/strided/dpcorr/benchmark/c/benchmark.length.c`, line 155).

## Related Issues

None.

## Questions

No.

## Other

### Validation

The 19 commits in the window were audited by four review agents (two for stdlib code-style compliance, two for bugs). Both findings above were independently re-verified by reading the diff and comparing against sibling packages (`stats/strided/dpcorrwd`, `stats/strided/dvariance`).

Deliberately excluded from this PR:

- `repl.txt` vs `README.md` discrepancy (`N <= 0` vs `N <= 1`) in `stats/strided/dpcorr` — inherited verbatim from the `stats/strided/dpcorrwd` reference; out of scope for this window.
- The same `x`-passed-twice pattern in `stats/strided/dpcorrwd/benchmark/c/benchmark.length.c` — outside the 24-hour diff window.
- Hoisted `done` callback in `_tools/github/star-repo/factory.js` (`c7a6b5c8`) — closure refs verified intact; no action needed.
- All Dependabot bumps, README structural sweeps, JSDoc `@throws` ordering, `package.json` keyword alignment, and the EditorConfig EOL fix — mechanical, no defects observed.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored primarily by Claude Code: a summary agent digested the last 24 hours of `develop` commits, four parallel review agents (two style, two bug-hunt) identified candidate issues, and the surviving high-signal findings were re-verified manually before applying the fixes. Each fix was confirmed against sibling-package patterns (`stats/strided/dpcorrwd`, `stats/strided/dvariance`) prior to commit.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_012VgKGaXwsACnoLu7UenrRc)_