### PR TITLE
fix: address doctest regex span and stale eslint-disable in `utils/constructor-name` example

### DIFF
--- a/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
@@ -38,7 +38,7 @@ var Symbol = require( '@stdlib/symbol/ctor' );
 var constructorName = require( './../lib' );
 
 function noop() {
-	// Do nothing...
+	return;
 }
 
 console.log( constructorName( 'a' ) );
@@ -148,7 +148,7 @@ console.log( constructorName( new Float64Array() ) );
 console.log( constructorName( new ArrayBuffer() ) );
 // => 'ArrayBuffer'
 
-console.log( constructorName( new Buffer( 'beep' ) ) ); // eslint-disable-line no-buffer-constructor
+console.log( constructorName( new Buffer( 'beep' ) ) );
 // => 'Buffer'
 
 console.log( constructorName( Math ) );

--- a/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
@@ -38,6 +38,7 @@ var Symbol = require( '@stdlib/symbol/ctor' );
 var constructorName = require( './../lib' );
 
 function noop() {
+	// Do nothing...
 	return;
 }
 

--- a/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
@@ -39,7 +39,7 @@ var constructorName = require( './../lib' );
 
 function noop() {
 	// Do nothing...
-	return;
+	return; // eslint-disable-line no-useless-return
 }
 
 console.log( constructorName( 'a' ) );


### PR DESCRIPTION
**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/25195861572 (issue #11867, 2026-05-01)

**Symptom:**

```
lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
  39:1   error  Displayed return value is `'String'`, but expected `undefined` instead  stdlib/doctest
  151:57 error  Unused eslint-disable directive (no problems were reported from 'no-buffer-constructor')
```

**Root cause:**

Error 1 (`stdlib/doctest`): The rule's `RE_ANNOTATION` regex uses `[^;]*;\n` to locate annotated expressions. `[^;]*` is greedy and matches any non-semicolon character, including newlines. The original `noop()` body contained only `// Do nothing...` — no semicolon — so the regex spanned from `function noop` across the entire function body and the trailing blank line to `console.log( constructorName( 'a' ) );` on line 44. The rule then associated `// => 'String'` with the `function` identifier, evaluated the combined expression in a VM sandbox, and got `undefined` (not `'String'`).

Error 2 (unused `eslint-disable-line`): The `no-buffer-constructor` rule is no longer active in the project's ESLint configuration, making the inline directive on line 151 stale.

**Fix:**

Two minimal edits to `lib/node_modules/@stdlib/utils/constructor-name/examples/index.js`:

1. Add `return; // eslint-disable-line no-useless-return` after `// Do nothing...` in `noop()`. This inserts a semicolon inside the function body, causing `RE_ANNOTATION`'s `[^;]*` to stop inside the function instead of spanning across it. The `// Do nothing...` comment is preserved to match stdlib noop conventions. The `no-useless-return` disable is required because ESLint flags a bare `return;` at the end of a void function. The `RE_ESLINT_INLINE` preprocessor in the `stdlib/doctest` rule strips `eslint-disable-line` comments before running `RE_ANNOTATION`, so the doctest fix is unaffected by the suppression comment.

2. Remove `// eslint-disable-line no-buffer-constructor` from line 151. The rule is not present in `etc/eslint/.eslintrc.js`, `.eslintrc.examples.js`, or `.eslintrc.overrides.js`, confirming the directive is stale.

Neither change alters the runtime behavior of the example. `noop` is only consumed by `constructorName( noop )` to demonstrate a `'Function'` result; its return value is never used.

**Validation:**

- Reviewed regex trace: with `return;` in the body (comment stripped by `RE_ESLINT_INLINE`), `[^;]*` matches `noop() {\n\t// Do nothing...\n\treturn` and stops at `;`. The following `\n}` does not match `\n//`, so the wrong match attempt fails. The regex then correctly matches `console.log( constructorName( 'a' ) );\n// => 'String'` as intended.
- Confirmed `no-buffer-constructor` absent from all project ESLint configs; removing the directive will not introduce a new error.
- Coverage: `utils/constructor-name` 100% (statements, branches, functions, lines).
- Three independent reviewers (two opus, one sonnet) over two cycles: all approved.

**Reviewer notes:**

- Reviewer C (style) noted that the README (`lib/node_modules/@stdlib/utils/constructor-name/README.md`) still shows the original `// Do nothing...`-only noop body. The README is not processed by `stdlib/doctest` (the rule is disabled for markdown), so this is not a lint issue. Aligning the README is out of scope but could be done as a follow-up.
- Several other `// eslint-disable-line no-buffer-constructor` directives exist elsewhere in the repo (e.g., `buffer/from-buffer`, `buffer/from-array`, `assert/is-gzip-buffer`). Those are separate packages and out of scope here, but a repo-wide cleanup may be warranted.

**Related:** issue #11867 (clusters 1 and 2 of that issue — `symbol/async-iterator` and `ndarray/fancy` — are addressed separately in draft PR #11882)

## Contributing Guidelines

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)