### PR TITLE
style: resolve lint error in `ndarray/fancy`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.get_nd.js
+++ b/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.get_nd.js
@@ -78,7 +78,8 @@ tape( 'a FancyArray constructor returns an instance which has a `get` method whi
 
 	function badValue( value, dim ) {
 		return function badValue() {
-			var args = new Array( shape.length );
+			var args =[];
+			args.length=shape.length;
 			var i;
 
 			for ( i = 0; i < args.length; i++ ) {

--- a/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.get_nd.js
+++ b/lib/node_modules/@stdlib/ndarray/fancy/test/test.instance.get_nd.js
@@ -78,16 +78,18 @@ tape( 'a FancyArray constructor returns an instance which has a `get` method whi
 
 	function badValue( value, dim ) {
 		return function badValue() {
-			var args =[];
-			args.length=shape.length;
+			var args;
+			var v;
 			var i;
 
-			for ( i = 0; i < args.length; i++ ) {
+			args = [];
+			for ( i = 0; i < shape.length; i++ ) {
 				if ( i === dim ) {
-					args[ i ] = value;
+					v = value;
 				} else {
-					args[ i ] = 0;
+					v = 0;
 				}
+				args.push( v );
 			}
 			arr.get.apply( arr, args );
 		};


### PR DESCRIPTION
Partially addresses #11867

## Description

> What is the purpose of this pull request?

This pull request:

-Replaced usage of new Array() with array literal and set length explicitly to comply with lint rules.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11867

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> Used AI assistance for understanding the lint error and guidance, but implemented the fix manually.

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
