### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/ctor/package.json
@@ -68,6 +68,11 @@
     "properties",
     "props",
     "univariate",
-    "discrete"
+    "discrete",
+    "bernoulli",
+    "binom",
+    "successes",
+    "independent trials",
+    "exponential family"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/package.json
@@ -72,6 +72,9 @@
     "log",
     "ln",
     "natural",
+    "successes",
+    "independent trials",
+    "exponential family",
     "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/package.json
@@ -70,6 +70,9 @@
     "failure",
     "probability mass function",
     "discrete",
+    "successes",
+    "independent trials",
+    "exponential family",
     "univariate"
   ]
 }


### PR DESCRIPTION
## Description

Aligning outliers in `stats/base/dists/binomial` with namespace majority patterns (random namespace pick, seed `2026-05-03-drift-vote`).

### Namespace summary

- **Target:** `@stdlib/stats/base/dists/binomial`
- **Members analyzed:** 14 (`cdf`, `ctor`, `entropy`, `kurtosis`, `logpmf`, `mean`, `median`, `mgf`, `mode`, `pmf`, `quantile`, `skewness`, `stdev`, `variance`)
- **Features analyzed:** file tree, `package.json` top-level keys, `package.json` `keywords`, `package.json` `directories`, README section sequence, test/benchmark/examples filenames, dependency sets (from `lib/main.js` `require` calls), validation prologue sequence, public signature sequence, return kind, JSDoc shape.
- **Features with clear majority (≥75% conformance):** `package.json` top-level key set (18 keys, 100%); `package.json` `directories` keys `benchmark`/`doc`/`example`/`lib`/`test` (100%); README sections `## Usage` and `## Examples` (100%); 14 majority `keywords` (`stdlib`, `stdmath`, `statistics`, `stats`, `distribution`, `dist`, `successes`, `independent trials`, `discrete`, `bernoulli`, `exponential family`, `binomial`, `binom`, `univariate`); 6-step validation-prologue subsequence (`isnan(n)`, `isnan(p)`, `p < 0.0`, `p > 1.0`, `!isNonNegativeInteger(n)`, `n === PINF`) at 12/14 = 85.7%; majority `lib/main.js` deps `@stdlib/math/base/assert/is-nonnegative-integer`, `@stdlib/math/base/assert/is-nan`, `@stdlib/constants/float64/pinf` (each 12/14 = 85.7%).
- **Features without clear majority (excluded from drift detection):** native-bindings file group (`manifest.json`, `binding.gyp`, `include.gypi`, `src/**`, `lib/native.js`, `benchmark/c/**`, `benchmark/benchmark.native.js`, `examples/c/**`, `test/test.native.js`) at 10/14 = 71.4%; `## C APIs` README section / `### Usage` / `### Examples` sub-block at 10/14 = 71.4%; `gypfile` `package.json` key at 10/14 = 71.4%; `test/fixtures/julia/data.json` at 6/14 = 42.9%; public signature shape (split between `(n, p)` summary stats and `(x, n, p)` distribution-functions; no shape ≥75%); error construction (only `ctor` throws; rest return `NaN`).

### `stats/base/dists/binomial/ctor`

Fixes keyword drift in `@stdlib/stats/base/dists/binomial/ctor` relative to the `stats/base/dists/binomial` namespace (14 members). Adds `bernoulli` and `binom`, each present in 13/14 siblings (92.9%), and `successes`, `independent trials`, and `exponential family`, each present in 11/14 siblings (78.6%). Metadata-only change; no code or behavior modified.

### `stats/base/dists/binomial/logpmf`

Adds `successes`, `independent trials`, and `exponential family` to the `package.json` keywords for `@stdlib/stats/base/dists/binomial/logpmf`, aligning with 11/14 siblings in the `stats/base/dists/binomial` namespace (78.6% conformance). The same keywords were missing from `pmf`; both packages lacked the distribution-context terms carried by every summary-statistic sibling (`mean`, `variance`, `kurtosis`, `skewness`, `entropy`, etc.). No code or behavioral changes; metadata only.

### `stats/base/dists/binomial/pmf`

Adds three keywords — `successes`, `independent trials`, and `exponential family` — to `package.json` for `@stdlib/stats/base/dists/binomial/pmf`. All three are present in 11/14 siblings in the `stats/base/dists/binomial` namespace (78.6% conformance); their absence from `pmf` (and `logpmf`) was an oversight relative to the summary-statistic packages (`mean`, `variance`, `kurtosis`, `skewness`, `entropy`, etc.). No code or behavioral changes; metadata only.

### Validation

Checked:

- structural feature extraction (file tree, `package.json` shape, README section list, `manifest.json` shape, test/benchmark/example filenames) across all 14 members.
- semantic feature extraction (public signature, validation prologue, error construction, JSDoc shape, dependency set) across all 14 members by reading each `lib/main.js` directly.
- three-agent drift validation:
  - opus semantic-review judged each candidate semantic outlier (`stdev` validation prologue, `ctor` README sequence, keyword drift on `ctor`/`logpmf`/`pmf`).
  - opus cross-reference confirmed no test, example, or sibling-package documentation references the keyword arrays or relies on `stdev`'s validation implementation.
  - sonnet structural-review confirmed each missing keyword applies to the package's subject matter and that no missing structural element (Julia fixtures on `ctor`/`mode`/`stdev`) is a real drift.

Deliberately excluded:

- `stdev/lib/main.js` lacks the canonical 6-step validation prologue (delegates `return sqrt( variance( n, p ) );`). Marked **intentional deviation**: `variance` already performs identical validation; `sqrt(NaN) === NaN` preserves observable behavior; sibling distributions `poisson/stdev`, `pareto-type1/stdev`, `lognormal/stdev` follow the same delegating idiom. Adding a redundant prologue would not improve correctness.
- `ctor` README structure (`## Usage` → `## binomial` → `### Writable Properties` / `### Computed Properties` / `### Methods` → `## Examples`) deviates from the canonical `## Usage` → `## Examples` ordering. Marked **intentional deviation**: a class constructor's documentation surface legitimately requires intermediate property/method subsections.
- `ctor`/`mode`/`stdev` missing `test/fixtures/julia/REQUIRE` and `test/fixtures/julia/runner.jl` (present in 11/14 siblings, 78.6%). Marked **intentional deviation**: `ctor` is a class constructor with no numerical computation of its own; `mode` is a closed-form integer formula `floor((n+1)*p)` whose tests inline-verify the formula; `stdev` uses Python fixtures (`test/fixtures/python/data.json`, `runner.py`) instead.
- Native-bindings file group (`manifest.json`, `binding.gyp`, `src/`, etc.) at 71.4% conformance — below the 75% threshold and excluded from drift detection.
- Public signature drift between `(n, p)` summary-statistic packages and `(x|t|r, n, p)` distribution-function packages — no signature shape reaches 75%.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

Random namespace pick, seed `2026-05-03-drift-vote`. Eligibility criteria: ≥8 non-autogenerated direct child packages, restricted to the 8–25-member tractable size band for agent budget. The chosen namespace had no autogenerated members, so the full membership is in scope.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: structural and semantic features were extracted from every member of `stats/base/dists/binomial`, majority patterns were computed at a 75% conformance threshold, and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed each correction was high-signal mechanical drift before any file was edited. All edits are pure `package.json` `keywords` additions; no source, test, or behavioral changes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017aK2GkAL5Rpde789kYBtnN)_