### PR TITLE
docs: restore section template comments in `ndarray/base/diagonal` and `ndarray/last`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/diagonal/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/diagonal/README.md
@@ -22,6 +22,8 @@ limitations under the License.
 
 > Return a view of the diagonal of a matrix (or stack of matrices).
 
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
 <section class="intro">
 
 For an `M`-by-`N` matrix `A`, the `k`-th diagonal is defined as
@@ -60,6 +62,8 @@ the main diagonal is `[ a_{0,0}, a_{1,1}, a_{2,2} ]`, the super-diagonal `k = 1`
 
 <!-- /.intro -->
 
+<!-- Package usage documentation. -->
+
 <section class="usage">
 
 ## Usage
@@ -93,6 +97,8 @@ The function accepts the following arguments:
 
 <!-- /.usage -->
 
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
 <section class="notes">
 
 ## Notes
@@ -106,6 +112,8 @@ The function accepts the following arguments:
 </section>
 
 <!-- /.notes -->
+
+<!-- Package usage examples. -->
 
 <section class="examples">
 
@@ -140,6 +148,8 @@ console.log( ndarray2array( y ) );
 </section>
 
 <!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">
 

--- a/lib/node_modules/@stdlib/ndarray/last/README.md
+++ b/lib/node_modules/@stdlib/ndarray/last/README.md
@@ -22,7 +22,7 @@ limitations under the License.
 
 > Return a read-only view of the last element (or subarray) along one or more [`ndarray`][@stdlib/ndarray/ctor] dimensions.
 
-<!-- Section to include introductory text. Make sure to keep an empty line after the intro section element. -->
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
 <section class="intro">
 


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between `c2b92b4` (2026-05-02 18:43:33 -0700) and `186eaa37` (2026-05-03 04:42:10 -0700).

This pull request:

-   **`ndarray/base/diagonal`**: Fixes `ndarray/base/diagonal` README (`632bef35`) which omitted the five boilerplate section-separator HTML comments required before each top-level `<section>`, present in sibling packages such as `ndarray/base/rot90`.
-   **`ndarray/last`**: Fix truncated intro-section template comment in `lib/node_modules/@stdlib/ndarray/last/README.md` introduced in `9e8bb89b`; restores the canonical wording (`...intro \`section\` element and another before the \`/section\` close.`) consistent with all sibling packages.

## Related Issues

No.

## Questions

No.

## Other

Validation audit of the 18 commits merged to `develop` in the past 24 hours (range `c2b92b4..186eaa37`):

-   **Checked**: stdlib code style compliance against `docs/style-guides`; objective bug scan over the union diff and the introduced code in the new packages (`blas/base/ndarray/cswap`, `blas/base/ndarray/zswap`, `ndarray/base/diagonal`, `ndarray/base/reverse-dimensions`, `ndarray/last`); follow-up fixes in the `stats/strided/dpcorr` chain.
-   **Excluded**: subjective concerns, "could be" issues, anything requiring out-of-window changes, anything already addressed by the in-window `bench: refactor to use string interpolation in utils`, `style: resolve lint error in ndarray/fancy`, and `chore: propagate fixes to sibling packages` commits.
-   **Result**: only the two README template-comment fixes above survived multi-agent corroboration and re-verification against the diff and reference siblings.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated review of commits merged to `develop` in the past 24 hours. Style-compliance and bug-scan agents inspected the union diff; only findings corroborated by re-reading the diff against reference siblings were applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN5NTCuMBNT3XsWLVKS6tm)_