### PR TITLE
fix: shadow global Symbol in async-iterator to resolve lint

### DIFF
--- a/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var hasAsyncIteratorSymbolSupport = require( '@stdlib/assert/has-async-iterator-symbol-support' ); // eslint-disable-line id-length
+var Symbol = require( '@stdlib/symbol/ctor' );
 
 
 // MAIN //


### PR DESCRIPTION
**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/25195861572 (issue #11867, 2026-05-01)

**Symptom:**

```
lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
  42:65  error  The 'Symbol.asyncIterator' is still an experimental feature and is not supported until Node.js 10.0.0. The configured version range is '>=0.12.18'  n/no-unsupported-features/es-builtins
```

**Root cause:**

`eslint-plugin-n`'s `no-unsupported-features/es-builtins` rule flags any global `Symbol.*` property access when the package's `engines.node` range predates the Node.js version that introduced that property. The package declares `>=0.12.18`, but `Symbol.asyncIterator` requires Node ≥ 10. Because no local `Symbol` binding existed in the file, the rule saw the global and triggered.

**Fix:**

Add `var Symbol = require( '@stdlib/symbol/ctor' );` to the `// MODULES //` section. A local binding named `Symbol` shadows the global; the rule no longer applies its version check to `Symbol.asyncIterator`. Runtime behavior is unchanged — `hasAsyncIteratorSymbolSupport()` already guards the ternary, so the `Symbol.asyncIterator` property is never evaluated in environments where the stdlib Symbol polyfill would return `undefined`. This is the identical pattern used in `@stdlib/symbol/to-primitive` (line 24 of its `lib/main.js`).

**Validation:**

- Confirmed the change mirrors `@stdlib/symbol/to-primitive/lib/main.js` exactly.
- `@stdlib/symbol/async-iterator/package.json` has empty `dependencies: {}`; this matches the established sibling pattern (`to-primitive` also has empty deps but requires `@stdlib/symbol/ctor`).
- Three independent reviewers (two opus, one sonnet) all approved in the first cycle:
  - Reviewer A (correctness): fix silences the lint rule; `hasAsyncIteratorSymbolSupport()` guard prevents any runtime error in environments where ctor returns `undefined`; only one `Symbol.*` reference in the file.
  - Reviewer B (regression): no consumer packages affected; shadowing is module-scoped; change is one line; no import cycle; package.json update not required.
  - Reviewer C (style): spacing and placement match stdlib conventions exactly; fix is an exact structural match to the sibling pattern.

**Reviewer notes:**

- Reviewer A noted that `@stdlib/symbol/ctor` returns `void 0` (not `null`) on Symbol-unsupported environments; the brief's description said `null`. This is a documentation inaccuracy in the brief only — runtime behavior is correct because the guard prevents the property access.
- Reviewer C noted the commit subject is ~85 characters, slightly over the 72-character guideline. Retained for clarity; can be shortened at maintainer discretion.

**Related:** issue #11867 (cluster 2 of that issue — `utils/constructor-name` — is addressed in a separate draft PR)

## Contributing Guidelines

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtffxZSzg8cvnHCG84ovyv)_