### PR TITLE
chore: update package entry point to reflect convention

### DIFF
--- a/lib/node_modules/@stdlib/constants/array/package.json
+++ b/lib/node_modules/@stdlib/constants/array/package.json
@@ -13,7 +13,7 @@
       "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
     }
   ],
-  "main": "lib/index.js",
+  "main": "./lib",
   "directories": {
     "doc": "./docs",
     "example": "./examples",

--- a/lib/node_modules/@stdlib/constants/path/package.json
+++ b/lib/node_modules/@stdlib/constants/path/package.json
@@ -13,7 +13,7 @@
       "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
     }
   ],
-  "main": "lib/index.js",
+  "main": "./lib",
   "directories": {
     "doc": "./docs",
     "example": "./examples",

--- a/lib/node_modules/@stdlib/constants/unicode/package.json
+++ b/lib/node_modules/@stdlib/constants/unicode/package.json
@@ -13,7 +13,7 @@
       "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
     }
   ],
-  "main": "lib/index.js",
+  "main": "./lib",
   "directories": {
     "doc": "./docs",
     "example": "./examples",


### PR DESCRIPTION
## Description

Aligning outliers in `@stdlib/constants` with namespace majority patterns (random namespace pick, seed `20260503`).

This pull request normalizes the `package.json` `"main"` field across the three outlier members of the `@stdlib/constants` namespace. The fix is mechanical and behaviorally inert under Node.js module resolution.

### Namespace summary

- **Members:** 15 (`array`, `complex128`, `complex64`, `float16`, `float32`, `float64`, `int16`, `int32`, `int8`, `path`, `time`, `uint16`, `uint32`, `uint8`, `unicode`)
- **Features analyzed:** file tree, `package.json` shape and key values, `manifest.json` shape, README section structure, test/benchmark/example file naming, `lib/index.js` structure, namespace-aggregator dependencies
- **Features with clear majority (≥75%):** file tree (100%), `package.json` top-level keys (100%), `directories` (100%), `engines` (100%), `scripts` (100%), `types` (100%), README `##` sections `[Usage, Examples]` (100%), test/example file names (100%), `@stdlib/utils/define-read-only-property` dependency (100%), `package.json` `"main"` field value (80% → `"./lib"`)
- **Features without clear majority (excluded from drift detection):** namespace variable name in `lib/index.js` (`constants` 9/15 vs `ns` 6/15 — 60% plurality), README copyright year, README title (path/unicode use disambiguating titles, treated as intentional)

### Per-outlier notes

#### `constants/array`

Aligns `package.json` `main` field with the namespace-wide convention: `"./lib"` instead of `"lib/index.js"`. 12 of 15 packages in `@stdlib/constants` (80%) already use the `"./lib"` form. No behavioral change — Node.js resolves both identically.

#### `constants/path`

Aligns the `main` field in `package.json` with the `"./lib"` convention used by 12 of 15 packages (80%) in the `@stdlib/constants` namespace. The previous value `"lib/index.js"` resolves identically under Node.js module resolution, so there is no behavioral change. Purely a consistency fix to reduce drift within the namespace.

#### `constants/unicode`

Aligns the `main` field with the `./lib` pattern used by 12 of 15 packages (80%) in `@stdlib/constants`. The previous value `"lib/index.js"` resolves identically under Node.js but diverges from namespace convention. No functional change.

## Related Issues

None.

## Questions

None.

## Other

### Validation

- **Structural feature extraction:** file tree, `package.json` keys/values, README headings, test/example/benchmark file names — extracted via filesystem and JSON parsing across all 15 members.
- **Semantic feature extraction:** these members are namespace-aggregator packages (no `lib/main.js`, no validation prologue, no error construction, no exported function with parameters), so the routine's semantic-schema fields are largely N/A. Dependency sets were extracted and confirmed identical (100% of members import only `@stdlib/utils/define-read-only-property` plus their own `@stdlib/constants/<self>/*` children).
- **Three-agent drift validation:** the `main` field drift was reviewed independently by (1) an Opus semantic-review agent, (2) an Opus cross-reference agent that grepped the repo for explicit `lib/index.js` references and inspected each outlier's tests/examples, and (3) a Sonnet structural-review agent that confirmed the 12/15 split and checked broader stdlib conventions. All three agents returned `confirmed-drift` for all three outliers.

**Deliberately excluded:**
- The `lib/index.js` namespace variable naming drift (`constants` vs `ns`) — neither value reaches the 75% threshold, so the feature has no clear majority.
- README title variations (`# Constants` vs `# Path Constants` vs `# Unicode Constants`) — the `path` and `unicode` titles are intentional disambiguation, not drift.
- README copyright year variations — content drift, not structural.
- Outliers whose tests/examples rely on the deviating value — none found; all tests/examples use relative `require('./../lib')` and are unaffected by the change.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code as part of a cross-package drift detection routine: a randomly-selected namespace (`@stdlib/constants`, seed `20260503`) was scanned for structural and semantic feature drift via majority vote (≥75% threshold). Outliers were validated by three independent review agents (one Sonnet structural-review, two Opus semantic/cross-reference) before any change was applied. A maintainer should audit the diff and the seed before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_014ayKKUVABxAvUA3zSNJgpE)_