### PR TITLE
style: align outliers in `stats/base/dists/logistic` with namespace majority patterns

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/test/fixtures/julia/REQUIRE
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/test/fixtures/julia/REQUIRE
@@ -1,0 +1,3 @@
+Distributions 0.23.8
+julia 1.5
+JSON 0.21

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/test/fixtures/julia/runner.jl
@@ -2,7 +2,7 @@
 #
 # @license Apache-2.0
 #
-# Copyright (c) 2018 The Stdlib Authors.
+# Copyright (c) 2026 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/test/fixtures/julia/runner.jl
@@ -1,0 +1,73 @@
+#!/usr/bin/env julia
+#
+# @license Apache-2.0
+#
+# Copyright (c) 2018 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import Distributions: std, Logistic
+import JSON
+
+"""
+	gen( mu, s, name )
+
+Generate fixture data and write to file.
+
+# Arguments
+
+* `mu`: location parameter
+* `s`: scale parameter
+* `name::AbstractString`: output filename
+
+# Examples
+
+``` julia
+julia> mu = rand( 1000 ) .* -10.0;
+julia> s = rand( 1000 ) .* 5.0;
+julia> gen( mu, s, "data.json" );
+```
+"""
+function gen( mu, s, name )
+	z = Array{Float64}( undef, length(mu) );
+	for i in eachindex(mu)
+		z[ i ] = std( Logistic( mu[i], s[i] ) );
+	end
+
+	# Store data to be written to file as a collection:
+	data = Dict([
+		("mu", mu),
+		("s", s),
+		("expected", z)
+	]);
+
+	# Based on the script directory, create an output filepath:
+	filepath = joinpath( dir, name );
+
+	# Write the data to the output filepath as JSON:
+	outfile = open( filepath, "w" );
+	write( outfile, JSON.json(data) );
+	write( outfile, "\n" );
+	close( outfile );
+end
+
+# Get the filename:
+file = @__FILE__;
+
+# Extract the directory in which this file resides:
+dir = dirname( file );
+
+# Generate fixtures:
+mu = rand( 100 ) .* 2.0 .- 4.0;
+s = rand( 100 ) .* 5.0;
+gen( mu, s, "data.json" );


### PR DESCRIPTION
## Description

Aligning outliers in `stats/base/dists/logistic` with namespace majority patterns (random namespace pick, seed `20260503`).

### Namespace summary

- **Members analyzed:** 15 (cdf, ctor, entropy, kurtosis, logcdf, logpdf, mean, median, mgf, mode, pdf, quantile, skewness, stdev, variance)
- **Autogenerated members excluded:** 0
- **Features analyzed:** file tree, `package.json` shape, `manifest.json` shape, README section ordering, test/benchmark/example file naming, public signature, validation prologue, error construction, JSDoc shape, `@stdlib/*` dependency set
- **Features with clear majority (≥75% conformance):** file tree (multiple shared paths at 87–93%), README section ordering at 80%, JSDoc shape at 100%
- **Features without clear majority (excluded from drift detection):** `errorConstruction` (only `ctor` throws — others return `NaN`); validation-prologue scale guard splits cleanly along a mathematical fault line — 8 zero-arg `(mu, s)` functions use `s <= 0.0`, 6 parameterized `(x|t|p, mu, s)` functions use `s < 0.0` to keep the `s == 0` degenerate-distribution branch reachable

### Outlier package: `stats/base/dists/logistic/stdev`

`stats/base/dists/logistic/stdev` is missing `test/fixtures/julia/REQUIRE` and `test/fixtures/julia/runner.jl`, which 13 of 15 sibling packages in `stats/base/dists/logistic` (87%) ship as standard fixture infrastructure; `stdev` and `ctor` are the only packages without it, but `ctor` is exempt by convention, making `stdev` the sole non-conforming outlier. Added the two Julia files mirroring `variance/test/fixtures/julia/runner.jl` with `Distributions.var` swapped for `Distributions.std`; existing Python/scipy fixtures are left in place.

## Related Issues

None.

## Questions

None.

## Other

### Validation

Three independent agents reviewed the drift findings before any commits were made:

- **Agent 1 (semantic review, opus):** confirmed the validation-prologue split is intentional (degenerate-distribution handling for parameterized functions only) and that `ctor`'s use of `format`-built throws is intentional given its constructor contract.
- **Agent 2 (cross-reference, opus):** confirmed `stdev/test/test.js` only requires `./fixtures/python/data.json`, so adding Julia files is purely additive; no sibling references `stdev`'s fixture path; the `variance` Julia runner is directly adaptable.
- **Agent 3 (structural review, sonnet):** confirmed `ctor`'s missing native files are intentional (no `gypfile`, no native code); confirmed the `Notes` section in `logcdf`/`logpdf` READMEs documents log-domain numerical stability (intentional deviation, not drift).

Deliberately excluded from this PR:

- `ctor` missing `binding.gyp`, `manifest.json`, `lib/native.js`, `src/*`, `include.gypi`, `examples/c/*`, `benchmark/c/*`, `benchmark/benchmark.native.js`, `test/test.native.js`, plus the Julia fixture pair — `ctor` is a pure-JS constructor with no native implementation; all native infrastructure is structurally inapplicable.
- `logcdf`/`logpdf` extra `Notes` README section — documents log-domain overflow/underflow guidance that does not apply to non-log siblings.
- The `errorConstruction` feature — no clear majority (only `ctor` throws).
- Switching `stdev`'s `test.js` from Python to Julia fixture data — would require regenerating fixture values under a different RNG and changing test inputs; out of scope for a mechanical drift correction.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package drift-detection routine. The routine randomly picked the `stats/base/dists/logistic` namespace (seed `20260503`), extracted structural and semantic features from all 15 member packages, computed the 75% majority pattern per feature, and validated outliers via three parallel review agents (Opus semantic, Opus cross-reference, Sonnet structural). Only the one drift correction whose three agents unanimously cleared as `confirmed-drift` advanced to a commit.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0173bk7bdtFWiQZVX7v1cSuj)_