### PR TITLE
refactor: merge two-condition argument-validation blocks into single if-statement

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mean/lib/main.js
@@ -63,11 +63,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 function mean( r, p ) {
 	if (
 		isnan( r ) ||
-		isnan( p )
-	) {
-		return NaN;
-	}
-	if (
+		isnan( p ) ||
 		r <= 0.0 ||
 		p < 0.0 ||
 		p > 1.0

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mean/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mean/src/main.c
@@ -33,11 +33,7 @@
 double stdlib_base_dists_negative_binomial_mean( const double r, const double p ) {
 	if (
 		stdlib_base_is_nan( r ) ||
-		stdlib_base_is_nan( p )
-	) {
-		return 0.0 / 0.0; // NaN
-	}
-	if (
+		stdlib_base_is_nan( p ) ||
 		r <= 0.0 ||
 		p < 0.0 ||
 		p > 1.0


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Aligns outliers in `@stdlib/stats/base/dists/negative-binomial` with namespace majority patterns (random namespace pick, seed `20260504`).

### Namespace summary

-   **Target:** `stats/base/dists/negative-binomial`
-   **Members analyzed:** 12 (`cdf`, `ctor`, `kurtosis`, `logpmf`, `mean`, `mgf`, `mode`, `pmf`, `quantile`, `skewness`, `stdev`, `variance`); none autogenerated
-   **Conformance threshold:** ⌈12 × 0.75⌉ = 9 packages
-   **Features with clear majority (≥75%):** file tree (10 files, 100% conformance), `package.json` top-level keys (18 keys, 100%), universal keywords (10, 100%), JSDoc `@example` presence (100%), `returnKind` (`value`, 100%), validation-prologue structure (single-block-or, 10/12 = 83%; `ctor` excluded as it throws rather than returning NaN)
-   **Features without clear majority (excluded from drift detection):** native-binding presence (7/12 = 58% — intentional split between iterative and closed-form computations); JSDoc `r`-parameter description text (6/6 split between "successes" and "failures" — flagged for future work); `lib/factory.js` presence (5/12 = 42%, function-class-specific)

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### `mean`

Merges the two-condition argument-validation blocks in `lib/main.js` and `src/main.c` into a single `if`-statement, matching the convention used by 10 of 12 JS siblings (83%) and 6 of 7 native-binding C siblings (86%) in the `negative-binomial` namespace. No logic change; the NaN-return path and guarded conditions are identical.

### Validation

Three independent passes audited the single drift finding before it advanced to a commit:

-   **Structural feature extraction** confirmed the file tree, `package.json` shape, README L2 sections, and keywords are uniform across the namespace; the only structural split is the native-binding bundle (`binding.gyp`, `src/`, `include/`, `manifest.json`, `lib/native.js`, `directories.{include,src}`, `gypfile`), which tracks an intentional implementation choice and is below the 75% threshold.
-   **Semantic feature extraction** over `lib/main.js`, `lib/index.js`, and validation prologues identified `mean` as the sole JS package using a two-block prologue.
-   **Three-agent drift validation** (`semantic-review`, `cross-reference`, `structural-review`) returned `confirmed-drift`, `ok-to-apply`, and `no-drift` respectively. The cross-reference pass verified test/example/consumer code does not depend on the deviating structure, and additionally surfaced the parallel two-block layout in `mean/src/main.c`, which is corrected in the same commit.

Deliberately excluded:

-   The split between "successes" and "failures" wording in JSDoc `r`-parameter descriptions (6/6 split, no clear majority) — flagged for a follow-up that reconciles the JSDoc with the README narrative (which uniformly says "successes").
-   The `p < 0.0` vs `p <= 0.0` variation in `pmf`/`logpmf` prologues — `pmf` and `logpmf` carry trailing `p === 0.0` branches that imply the deviation is intentional, not drift.
-   The native-binding bundle — a deliberate per-function choice, not a convention.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was generated by Claude Code running the cross-package drift-detection routine: structural and semantic features were extracted across the namespace, the majority pattern computed at a 75% threshold, and the single surviving outlier validated by three independent review passes (semantic, cross-reference, structural) before the mechanical merge was applied. The diff is purely cosmetic — no behavior change.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01G3fvA26dWnnxHXn3hhzKfH)_