### PR TITLE
style: align outliers in `complex/float64/base` with namespace majority patterns

### DIFF
--- a/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/c/Makefile
@@ -1,0 +1,127 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles C source files.
+#
+# @param {string} [C_COMPILER] - C compiler
+# @param {string} [CFLAGS] - C compiler flags
+# @param {(string|void)} [fPIC] - compiler flag indicating whether to generate position independent code
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler
+# @param {string} CFLAGS - C compiler flags
+# @param {(string|void)} fPIC - compiler flag indicating whether to generate position independent code
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) -o $@ $< -lm
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/c/benchmark.c
@@ -1,0 +1,141 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark complex number identity.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <complex.h>
+#include <sys/time.h>
+
+#define NAME "identity"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static double rand_double( void ) {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double re;
+	double im;
+	double t;
+	int i;
+
+	double complex z;
+	double complex y;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		re = ( 1000.0*rand_double() ) - 500.0;
+		im = ( 1000.0*rand_double() ) - 500.0;
+		z = re + im*I;
+		y = creal(z) + ( cimag(z) )*I;
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/julia/REQUIRE
+++ b/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/julia/REQUIRE
@@ -1,0 +1,2 @@
+julia 1.5
+BenchmarkTools 0.5.0

--- a/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/julia/benchmark.jl
+++ b/lib/node_modules/@stdlib/complex/float64/base/identity/benchmark/julia/benchmark.jl
@@ -1,0 +1,144 @@
+#!/usr/bin/env julia
+#
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import BenchmarkTools
+using Printf
+
+# Benchmark variables:
+name = "identity";
+repeats = 3;
+
+"""
+	print_version()
+
+Prints the TAP version.
+
+# Examples
+
+``` julia
+julia> print_version()
+```
+"""
+function print_version()
+	@printf( "TAP version 13\n" );
+end
+
+"""
+	print_summary( total, passing )
+
+Print the benchmark summary.
+
+# Arguments
+
+* `total`: total number of tests
+* `passing`: number of passing tests
+
+# Examples
+
+``` julia
+julia> print_summary( 3, 3 )
+```
+"""
+function print_summary( total, passing )
+	@printf( "#\n" );
+	@printf( "1..%d\n", total ); # TAP plan
+	@printf( "# total %d\n", total );
+	@printf( "# pass  %d\n", passing );
+	@printf( "#\n" );
+	@printf( "# ok\n" );
+end
+
+"""
+	print_results( iterations, elapsed )
+
+Print benchmark results.
+
+# Arguments
+
+* `iterations`: number of iterations
+* `elapsed`: elapsed time (in seconds)
+
+# Examples
+
+``` julia
+julia> print_results( 1000000, 0.131009101868 )
+```
+"""
+function print_results( iterations, elapsed )
+	rate = iterations / elapsed
+
+	@printf( "  ---\n" );
+	@printf( "  iterations: %d\n", iterations );
+	@printf( "  elapsed: %0.9f\n", elapsed );
+	@printf( "  rate: %0.9f\n", rate );
+	@printf( "  ...\n" );
+end
+
+"""
+	benchmark()
+
+Run a benchmark.
+
+# Notes
+
+* Benchmark results are returned as a two-element array: [ iterations, elapsed ].
+* The number of iterations is not the true number of iterations. Instead, an 'iteration' is defined as a 'sample', which is a computed estimate for a single evaluation.
+* The elapsed time is in seconds.
+
+# Examples
+
+``` julia
+julia> out = benchmark();
+```
+"""
+function benchmark()
+	t = BenchmarkTools.@benchmark +( ComplexF64( (rand()*1000.0) - 500.0, (rand()*1000.0) - 500.0 ) ) samples=1e6
+
+	# Compute the total "elapsed" time and convert from nanoseconds to seconds:
+	s = sum( t.times ) / 1.0e9;
+
+	# Determine the number of "iterations":
+	iter = length( t.times );
+
+	# Return the results:
+	[ iter, s ];
+end
+
+"""
+	main()
+
+Run benchmarks.
+
+# Examples
+
+``` julia
+julia> main();
+```
+"""
+function main()
+	print_version();
+	for i in 1:repeats
+		@printf( "# julia::%s\n", name );
+		results = benchmark();
+		print_results( results[ 1 ], results[ 2 ] );
+		@printf( "ok %d benchmark finished\n", i );
+	end
+	print_summary( repeats, repeats );
+end
+
+main();

--- a/lib/node_modules/@stdlib/complex/float64/base/identity/package.json
+++ b/lib/node_modules/@stdlib/complex/float64/base/identity/package.json
@@ -63,6 +63,5 @@
     "float64",
     "complex",
     "cmplx"
-  ],
-  "__stdlib__": {}
+  ]
 }


### PR DESCRIPTION
## Description

Aligning outliers in `@stdlib/complex/float64/base` with namespace majority patterns (random namespace pick, seed `20260504`).

### Namespace summary

- **Members analyzed**: 10 (`add`, `add3`, `assert`, `div`, `identity`, `mul-add`, `mul`, `neg`, `scale`, `sub`); none autogenerated.
- **Features analyzed**: file tree, `package.json` shape (top-level keys, `scripts`, `stdlib`, `directories`, `keywords`, `gypfile`), `manifest.json` presence, README section list/order, `test/`/`benchmark/`/`examples/` filenames, public signature, validation prologue, error construction, JSDoc shape, `@stdlib/*` dependencies.
- **Features with a clear majority (≥75%)**: file-tree elements (27 paths), all 18 universal `package.json` keys, `gypfile: true` (9/10), `manifest.json` presence (9/10), README `## Usage` + `## Examples` (10/10), README `## C APIs` block (9/10), `examples/index.js` (10/10), `test/test.js` (10/10), `test/test.native.js` (9/10), public-signature shape per arity, `errorConstruction = plain-string` (10/10), `returnKind = value` (10/10), `hasExample = true` (10/10).
- **Features without a clear majority (excluded)**: `## See Also` README section (6/10), `## References` (1/10), `test.assign.js` / `test.main.js` / `test.strided.js` and matching benchmarks (6/10 each), `__stdlib__` package.json key (1/10 — but its lone occurrence is itself drift, see below).

### identity

Audited against the 9 non-`assert` members of `@stdlib/complex/float64/base`: `identity` was the sole outlier. Removes vestigial `__stdlib__: {}` from `package.json` (0/9 siblings carry it). Adds `benchmark/c/Makefile`, `benchmark/c/benchmark.c`, `benchmark/julia/REQUIRE`, and `benchmark/julia/benchmark.jl` to reach 100% conformance with the 8/8 native-binding siblings that have these files. C and Julia templates mirror `complex/float64/base/neg` (same unary complex shape).

### Validation

What was checked:

- **Structural feature extraction** across all 10 members (file tree, `package.json`, `manifest.json`, README, test/benchmark/example filenames).
- **Semantic feature extraction** via per-package agents (public signature, validation prologue, error construction, JSDoc shape, `@stdlib/*` dependencies) — uniform across all 9 leaf packages; no semantic drift detected.
- **Three-agent drift validation**: opus semantic-review (no semantic drift), opus cross-reference (tests/examples/cross-tree references unaffected by all 5 fixes), sonnet structural-review (`assert` outliers correctly classified intentional; `identity` outliers all confirmed drift).

What was deliberately excluded:

- `assert`'s 20 missing native-related files and missing `gypfile` field — `assert` is a sub-namespace re-exporter without native bindings, so missing `binding.gyp`, `manifest.json`, `src/`, `lib/main.js`, `lib/native.js`, `examples/c/`, `benchmark/c/`, `benchmark/julia/`, `test/test.native.js` is by design.
- Signature variance across leaves (`(z1,z2)` vs `(z)` vs `(alpha,z)` vs `(alpha,x,y)` vs `(z1,z2,z3)`) — genuine mathematical-shape difference, not drift.
- Features below the 75% threshold (e.g., `## See Also`, `test.assign.js`/`test.strided.js` family).
- Keywords drift on `identity` (`number` keyword absent; `double`/`double-precision`/`dbl`/`float64` present) — not covered by the validated fix set; left for a future targeted pass.
- Anything that would change observable behavior, public signatures, or test expectations.

## Related Issues

None.

## Questions

No.

## Other

This PR is the output of an automated cross-package drift sweep using a 75% majority-vote threshold. Per-package commits, conformance percentages, and the full audit trail (including the dropped `assert` outliers) live in the local drift report; the corrections that survived three-agent validation are the only ones applied here.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package API drift detection routine using majority-vote analysis. Structural and semantic features were extracted from all 10 members of `@stdlib/complex/float64/base`, the majority pattern was computed per feature with a 75% conformance threshold, and three independent validation agents (semantic-review, cross-reference, structural-review) confirmed each correction before it was applied. The benchmark file templates were generated by adapting the corresponding files from sibling package `complex/float64/base/neg`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01N6FvYtyZfivb3Ne7gPjnsm)_