### PR TITLE
docs: follow-up fixes

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/README.md
@@ -47,7 +47,7 @@ The namespace exposes the following APIs:
 
 -   <span class="signature">[`caxpy( arrays )`][@stdlib/blas/base/ndarray/caxpy]</span><span class="delimiter">: </span><span class="description">multiply a one-dimensional single-precision complex floating-point ndarray `x` by a constant `alpha` and add the result to a one-dimensional single-precision complex floating-point ndarray `y`.</span>
 -   <span class="signature">[`ccopy( arrays )`][@stdlib/blas/base/ndarray/ccopy]</span><span class="delimiter">: </span><span class="description">copy values from a one-dimensional single-precision complex floating-point ndarray `x` into a one-dimensional single-precision complex floating-point ndarray `y`.</span>
--   <span class="signature">[`cswap( arrays )`][@stdlib/blas/base/ndarray/cswap]</span><span class="delimiter">: </span><span class="description">interchange two one-dimensional complex single-precision floating-point ndarrays.</span>
+-   <span class="signature">[`cswap( arrays )`][@stdlib/blas/base/ndarray/cswap]</span><span class="delimiter">: </span><span class="description">interchange two one-dimensional single-precision complex floating-point ndarrays.</span>
 -   <span class="signature">[`dasum( arrays )`][@stdlib/blas/base/ndarray/dasum]</span><span class="delimiter">: </span><span class="description">calculate the sum of absolute values for all elements in a one-dimensional double-precision floating-point ndarray.</span>
 -   <span class="signature">[`daxpy( arrays )`][@stdlib/blas/base/ndarray/daxpy]</span><span class="delimiter">: </span><span class="description">multiply a one-dimensional double-precision floating-point ndarray `x` by a constant `alpha` and add the result to a one-dimensional double-precision floating-point ndarray `y`.</span>
 -   <span class="signature">[`dcopy( arrays )`][@stdlib/blas/base/ndarray/dcopy]</span><span class="delimiter">: </span><span class="description">copy values from a one-dimensional double-precision floating-point ndarray `x` into a one-dimensional double-precision floating-point ndarray `y`.</span>
@@ -65,7 +65,7 @@ The namespace exposes the following APIs:
 -   <span class="signature">[`sswap( arrays )`][@stdlib/blas/base/ndarray/sswap]</span><span class="delimiter">: </span><span class="description">interchange two one-dimensional single-precision floating-point ndarrays.</span>
 -   <span class="signature">[`zaxpy( arrays )`][@stdlib/blas/base/ndarray/zaxpy]</span><span class="delimiter">: </span><span class="description">multiply a one-dimensional double-precision complex floating-point ndarray `x` by a constant `alpha` and add the result to a one-dimensional double-precision complex floating-point ndarray `y`.</span>
 -   <span class="signature">[`zcopy( arrays )`][@stdlib/blas/base/ndarray/zcopy]</span><span class="delimiter">: </span><span class="description">copy values from a one-dimensional double-precision complex floating-point ndarray `x` into a one-dimensional double-precision complex floating-point ndarray `y`.</span>
--   <span class="signature">[`zswap( arrays )`][@stdlib/blas/base/ndarray/zswap]</span><span class="delimiter">: </span><span class="description">interchange two one-dimensional complex double-precision floating-point ndarrays.</span>
+-   <span class="signature">[`zswap( arrays )`][@stdlib/blas/base/ndarray/zswap]</span><span class="delimiter">: </span><span class="description">interchange two one-dimensional double-precision complex floating-point ndarrays.</span>
 
 </div>
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/docs/types/index.d.ts
@@ -108,7 +108,7 @@ interface Namespace {
 	ccopy: typeof ccopy;
 
 	/**
-	* Interchanges two one-dimensional complex single-precision floating-point ndarrays.
+	* Interchanges two one-dimensional single-precision complex floating-point ndarrays.
 	*
 	* ## Notes
 	*
@@ -599,7 +599,7 @@ interface Namespace {
 	zcopy: typeof zcopy;
 
 	/**
-	* Interchanges two one-dimensional complex double-precision floating-point ndarrays.
+	* Interchanges two one-dimensional double-precision complex floating-point ndarrays.
 	*
 	* ## Notes
 	*

--- a/lib/node_modules/@stdlib/blas/ext/base/dcartesian-power/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcartesian-power/docs/types/index.d.ts
@@ -43,7 +43,7 @@ interface Routine {
 	* @returns output array
 	*
 	* @example
-	* var Float64Array = require( `@stdlib/array/float64` );
+	* var Float64Array = require( '@stdlib/array/float64' );
 	*
 	* var x = new Float64Array( [ 1.0, 2.0 ] );
 	* var out = new Float64Array( 8 );
@@ -72,7 +72,7 @@ interface Routine {
 	* @returns output array
 	*
 	* @example
-	* var Float64Array = require( `@stdlib/array/float64` );
+	* var Float64Array = require( '@stdlib/array/float64' );
 	*
 	* var x = new Float64Array( [ 1.0, 2.0 ] );
 	* var out = new Float64Array( 8 );
@@ -96,7 +96,7 @@ interface Routine {
 * @returns output array
 *
 * @example
-* var Float64Array = require( `@stdlib/array/float64` );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
 * var x = new Float64Array( [ 1.0, 2.0 ] );
 * var out = new Float64Array( 8 );
@@ -105,7 +105,7 @@ interface Routine {
 * // out => <Float64Array>[ 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 2.0, 2.0 ]
 *
 * @example
-* var Float64Array = require( `@stdlib/array/float64` );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
 * var x = new Float64Array( [ 1.0, 2.0 ] );
 * var out = new Float64Array( 8 );


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-05-03 21:51 UTC and 2026-05-04 09:55 UTC (60188d9..8238153).

## Description

This pull request applies follow-up fixes to commits merged to `develop` over the last 24 hours.

### Fixes by package

-   **`blas/base/ndarray`**: fix word-order inconsistency in `cswap`/`zswap` entries introduced by 6dcb4ea (`lib/node_modules/@stdlib/blas/base/ndarray/README.md`, `lib/node_modules/@stdlib/blas/base/ndarray/docs/types/index.d.ts`); changed "complex single/double-precision" to "single/double-precision complex" to match the convention used by adjacent `caxpy`, `ccopy`, `zaxpy`, and `zcopy` entries.
-   **`blas/ext/base/dcartesian-power`**: fix four `@example` blocks in `lib/node_modules/@stdlib/blas/ext/base/dcartesian-power/docs/types/index.d.ts` (introduced in cb59572) where `require()` calls used backtick-quoted strings instead of single quotes, aligning with stdlib convention used throughout sibling declarations.

## Related Issues

None.

## Questions

No.

## Other

### Validation

Reviewed the union diff `60188d9^..8238153` (21 commits, ~24k lines) for:

-   stdlib JavaScript / TypeScript style guide compliance (two independent passes).
-   stdlib C / Markdown / Make / repl / package metadata style guide compliance.
-   Obvious bugs in the introduced code (two independent passes; both came back clean).

Deliberately excluded from this PR: subjective concerns, "consider"-style suggestions, anything requiring context outside the diff window to validate, and anything where the appropriate fix would require touching files that were not part of the reviewed commits. Fixes were grouped by package and committed separately per stdlib convention.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code: a multi-agent review loop scanned commits merged to `develop` over the prior 24 hours, and the surviving high-signal style/doc fixes were applied and committed by Claude Code. A maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ7BxRueQas4oVCbQMzpU1)_