### PR TITLE
chore: resolve n/no-unsupported-features lint error in `symbol/async-iterator`

### DIFF
--- a/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var hasAsyncIteratorSymbolSupport = require( '@stdlib/assert/has-async-iterator-symbol-support' ); // eslint-disable-line id-length
+var Symbol = require( '@stdlib/symbol/ctor' );
 
 
 // MAIN //


### PR DESCRIPTION
## Summary

Fixes a persistent CI lint failure in `@stdlib/symbol/async-iterator`.

**Root cause:** The file referenced the global `Symbol.asyncIterator` directly. The `n/no-unsupported-features/es-builtins` ESLint rule flags `Symbol.asyncIterator` (available from Node 10.0.0) when the configured Node version range is `>=0.12.18`, treating the access as unsupported.

**Fix:** Shadow the global `Symbol` with the stdlib polyfill `@stdlib/symbol/ctor`, which resolves to the native `Symbol` when available or `null` otherwise. The rule no longer flags the member access because the local variable `Symbol` is not a known built-in being tracked. This pattern is already used in `@stdlib/symbol/to-primitive`.

## Files changed

- `lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js` — add `var Symbol = require( '@stdlib/symbol/ctor' );` in the MODULES section

## Test plan

- [ ] Run `node lib/node_modules/@stdlib/symbol/async-iterator/examples/index.js` — verify no runtime error
- [ ] Run ESLint on the changed file — verify `n/no-unsupported-features/es-builtins` no longer fires
- [ ] Verify CI lint workflow passes on this branch

---

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)