### PR TITLE
chore: fix JavaScript lint errors (issue #9110)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/dispatch-workflow/lib/query.js
+++ b/lib/node_modules/@stdlib/_tools/github/dispatch-workflow/lib/query.js
@@ -83,7 +83,18 @@ function query( slug, id, options, clbk ) {
 		info = ratelimit( response.headers );
 		debug( 'Rate limit: %d', info.limit );
 		debug( 'Rate limit remaining: %d', info.remaining );
-		debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
+
+		if ( typeof info.reset === 'number' ) {
+			var resetTime = new Date( info.reset * 1000 );
+			var time = resetTime.getTime();
+
+			debug(
+				'Rate limit reset: %s',
+				isNaN( time ) ? 'invalid timestamp' : resetTime.toISOString()
+				);
+			} else {
+				debug( 'Rate limit reset: not provided' );
+			}
 
 		if ( error ) {
 			return clbk( error, info );


### PR DESCRIPTION
## Description
Fixed a `RangeError: Invalid time value` in 
`dispatch-workflow/lib/query.js` caused by calling `.toISOString()`  on an invalid Date object when `info.reset` is undefined or  not a valid number.

## Changes
- Added `typeof` check to ensure `info.reset` is a number
- Stored `getTime()` result in `time` variable
- Used `isNaN()` guard before calling `.toISOString()`

## Related Issues
resolves #9110

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Research and understanding

#### Disclosure

I used ChatGPT to understand the runtime error in `dispatch-workflow/lib/query.js` and to help design a safe validation fix for `info.reset` before calling `.toISOString()`. The final implementation was reviewed and applied manually by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
