### PR TITLE
docs: add missing README C documentation to `stats/base/dists/pareto-type1`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/README.md
@@ -153,6 +153,105 @@ logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, f(x;α,β): %0.4f', x, alpha, beta,
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/pareto-type1/pdf.h"
+```
+
+#### stdlib_base_dists_pareto_type1_pdf( x, alpha, beta )
+
+Evaluates the probability density function (PDF) for a Pareto (Type I) distribution with shape parameter `alpha` and scale parameter `beta` at a value `x`.
+
+```c
+double out = stdlib_base_dists_pareto_type1_pdf( 4.0, 1.0, 1.0 );
+// returns ~0.063
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **alpha**: `[in] double` shape parameter.
+-   **beta**: `[in] double` scale parameter.
+
+```c
+double stdlib_base_dists_pareto_type1_pdf( const double x, const double alpha, const double beta );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/pareto-type1/pdf.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
+int main( void ) {
+    double alpha;
+    double beta;
+    double x;
+    double y;
+    int i;
+
+    for ( i = 0; i < 25; i++ ) {
+        alpha = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 5.0 );
+        beta = random_uniform( 1.0, 5.0 );
+        x = random_uniform( beta, beta + 10.0 );
+        y = stdlib_base_dists_pareto_type1_pdf( x, alpha, beta );
+        printf( "x: %lf, α: %lf, β: %lf, f(x;α,β): %lf\n", x, alpha, beta, y );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">


### PR DESCRIPTION
## Description

Aligning outliers in `stats/base/dists/pareto-type1` with namespace majority patterns (random namespace pick, seed `20260505`).

### Namespace summary

-   **Members analyzed:** 14 (`cdf`, `ctor`, `entropy`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `median`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`); 0 excluded as autogenerated.
-   **Features analyzed:** file tree, `package.json` shape, README sections (set + sequence), `manifest.json` shape, `test/` / `benchmark/` / `examples/` file naming, public signature, return kind, validation prologue, error construction, JSDoc shape, dependency set.
-   **Features with a clear majority (≥75% conformance):** file tree (78.6%), `package.json` top-level keys (85.7%), README L2/L3 section set (78.6%), `test/` files (85.7%), `benchmark/` files (85.7%), `examples/` files (85.7%), JSDoc `hasExample` (100%), `returnKind` (100% for non-`ctor`).
-   **Features without a clear majority (excluded from drift detection):** `package.json` `scripts` keys (0 universal), `package.json` `stdlib` keys (0 universal), README section sequence (most common at 64.3%), `validationPrologue` (mixed across sonnet extractions; underlying behavior is uniform NaN-return), `errorConstruction` (13/14 `plain-string` reflects "no error built" rather than a target style — nothing to normalize toward `format`).

### Per-outlier corrections

#### `stats/base/dists/pareto-type1/pdf`

Adds the missing `## C APIs` section to the README for `stats/base/dists/pareto-type1/pdf`, which ships a full native implementation (`binding.gyp`, `src/main.c`, `src/addon.c`, etc.) but lacked documentation for its C entry point. Within the `stats/base/dists/pareto-type1/` namespace, 11 of 14 sibling packages carry this section (79%), and every sibling with native artifacts includes it — `pdf` was the lone exception. The section is adapted from the `cdf` template, updated with the correct function name, signature, and a worked example (`stdlib_base_dists_pareto_type1_pdf( 4.0, 1.0, 1.0 ) => ~0.063`).

### Validation

-   **Structural feature extraction:** file system walk over each member's package directory; majority computed at the 75% threshold (cutoff = 11 of 14).
-   **Semantic feature extraction:** one Sonnet agent per package read `lib/main.js` / `lib/index.js` / `lib/factory.js` / `lib/native.js` and returned a fixed-schema JSON bundle; all 14 returned valid JSON on first attempt.
-   **Three-agent drift validation:** Opus semantic-review (intentional-deviation detection), Opus cross-reference (test/example/cross-package impact), Sonnet structural-review (per-outlier verdict).
-   **Deliberately excluded from this PR:**
    -   `ctor` outlier flags (no native artifacts, distinct constructor JSDoc shape, `format`-style errors, optional defaults) — intentional deviation: distribution constructors are pure-JS wrappers across stdlib by design.
    -   `median` outlier flags (no native artifacts) — confirmed structural drift but the corresponding fix is a full native port (C source, manifest, Julia fixtures, `test.native.js`); not mechanical, out of scope for the routine. Logged for future work.
    -   `logcdf` / `logpdf` README sequence drift (extra `Notes` section) — package-specific narrative content, not drift.
    -   Semantic features without a clear majority (validation prologue style, error construction style) — flagged variants reflect uniform NaN-return semantics, no target pattern to normalize toward.

## Related Issues

No.

## Questions

No.

## Other

This PR is the output of the cross-package API drift detection routine, run on a uniformly-randomly-sampled eligible namespace (seed `20260505`, `total_eligible = 121`). The full machine-readable report (member list, per-feature majority pattern, conformance percentages, all dropped-correction rationales) is archived alongside the run.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was generated by an automated cross-package drift-detection routine driven by Claude Code. Per-package source extraction was delegated to Sonnet agents, drift validation was performed by three independent Opus/Sonnet agents (semantic-review, cross-reference, structural-review), and the resulting README patch on `stats/base/dists/pareto-type1/pdf` was authored by Claude. A human will audit and promote this draft before merge.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uh9aJkoHLCuUAidAPUbQDU)_