### PR TITLE
docs: add missing keywords in `math/strided/special` packages

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/dmskfloor/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dmskfloor/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "math.floor",
     "floor",
     "round",

--- a/lib/node_modules/@stdlib/math/strided/special/dmskinv/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dmskinv/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "inv",
     "multiplicative",
     "inverse",

--- a/lib/node_modules/@stdlib/math/strided/special/dmskramp/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dmskramp/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "ramp",
     "heaviside",
     "max",

--- a/lib/node_modules/@stdlib/math/strided/special/dmskrsqrt/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dmskrsqrt/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "trig",
     "math.sqrt",
     "sqrt",

--- a/lib/node_modules/@stdlib/math/strided/special/dmsksqrt/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dmsksqrt/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "trig",
     "math.sqrt",
     "sqrt",

--- a/lib/node_modules/@stdlib/math/strided/special/dmsktrunc/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dmsktrunc/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "math.trunc",
     "trunc",
     "truncate",

--- a/lib/node_modules/@stdlib/math/strided/special/smskfloor/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/smskfloor/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "math.floor",
     "floor",
     "round",

--- a/lib/node_modules/@stdlib/math/strided/special/smskinv/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/smskinv/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "inv",
     "multiplicative",
     "inverse",

--- a/lib/node_modules/@stdlib/math/strided/special/smskramp/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/smskramp/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "ramp",
     "heaviside",
     "max",

--- a/lib/node_modules/@stdlib/math/strided/special/smskrsqrt/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/smskrsqrt/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "trig",
     "math.sqrt",
     "sqrt",

--- a/lib/node_modules/@stdlib/math/strided/special/smsksqrt/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/smsksqrt/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "trig",
     "math.sqrt",
     "sqrt",

--- a/lib/node_modules/@stdlib/math/strided/special/smsktrunc/package.json
+++ b/lib/node_modules/@stdlib/math/strided/special/smsktrunc/package.json
@@ -54,6 +54,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "math.trunc",
     "trunc",
     "truncate",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Aligns outliers in `math/strided/special` with namespace majority patterns (random namespace pick, seed `20260505`).

### Namespace summary

-   **Member count:** 81 non-autogenerated packages (no autogen markers detected; see local drift report for eligibility criteria).
-   **Features analyzed:** file tree, `package.json` top-level keys / `scripts` / `__stdlib__` / `keywords` / `directories`, `manifest.json` keys, README h2/h3 sequence, `test/`, `benchmark/`, `examples/` filenames, public function JSDoc shape (param types, returns type, throws count, `@example` presence), source-file location, parameter count.
-   **Features with clear majority (≥75%):** universal `package.json` top-level key set (19 keys, 81/81); universal file-tree elements (`README.md`, `package.json`, `lib/index.js`, `lib/main.js`, `lib/ndarray.js`, `benchmark/benchmark.js`, `benchmark/benchmark.ndarray.js`, `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, `examples/index.js`, `test/test.js`, `test/test.ndarray.js` — all 81/81); README `## Examples` and `## Usage` sections (81/81); README `## See Also` section (70/81 ≈ 86%); `@example` presence in JSDoc (81/81); first-positional-keyword `stdlib` (81/81); follow-on math keywords `stdmath`, `mathematics`, `math` after `stdlib` (69/81 ≈ 85%).
-   **Features without clear majority (excluded from drift detection):** `directories` field shape (44/26/11 split across native+include / no-native / older-with-`scripts`), native-addon files (`binding.gyp`, `lib/native.js`, `manifest.json`, `src/Makefile`, `src/addon.c`: 55/81 ≈ 68%), C-side benchmark/example scaffolding (44/81 ≈ 54%), README `## Notes` section (26/81 ≈ 32%), `## C APIs` README section (44/81 ≈ 54%), `lib/data.js` / `lib/types.json` / `scripts/types.js` (11/81; older dispatch-based subfamily), `@param N` type tag (`NonNegativeInteger` 70/81 vs `integer` 11/81 — the 11 are the older `dispatch`-based variants and `integer` matches their underlying `@stdlib/strided/dispatch` convention; intentional). README h2/h3 contiguous-sequence majority did not exceed 75% (4 distinct sequences distributed 44/15/11/11). Validation prologue and error construction did not apply (this namespace delegates argument validation to `@stdlib/strided/dispatch`, `@stdlib/strided/base/unary`, `@stdlib/strided/base/dmap`, `@stdlib/strided/base/map-by`, etc.).

The single drift correction that survived three-agent validation: 12 outlier packages — `dmskfloor`, `dmskinv`, `dmskramp`, `dmskrsqrt`, `dmsksqrt`, `dmsktrunc`, `smskfloor`, `smskinv`, `smskramp`, `smskrsqrt`, `smsksqrt`, `smsktrunc` — were missing the `stdmath`, `mathematics`, `math` keyword triple that appears in 69/81 (85%) of namespace siblings, including every other `dmsk*`/`smsk*` math sibling (e.g. `dmskabs`, `dmskceil`, `smskabs`, `smskceil`). Each fix inserts the three keywords immediately after `stdlib` in `package.json`. One commit per outlier; no source-code changes.

#### `math/strided/special/dmskfloor`

Aligns `math/strided/special/dmskfloor` with the `math/strided/special` namespace convention followed by 85% of packages (69/81): inserts `stdmath`, `mathematics`, and `math` as keywords immediately after `stdlib` in `package.json`. No source changes.

#### `math/strided/special/dmskinv`

Aligns `math/strided/special/dmskinv` with the `math/strided/special` namespace convention, where 85% of packages (69/81) include `stdmath`, `mathematics`, and `math` as keywords following `stdlib` in `package.json`. This package was one of 12 outliers missing those keywords. No source changes.

#### `math/strided/special/dmskramp`

Aligns `dmskramp` with the `math/strided/special` namespace convention followed by 85% of packages: keywords `stdmath`, `mathematics`, and `math` are inserted after `stdlib` in `package.json`. No source changes. Brings the package into conformance with the rest of the namespace.

#### `math/strided/special/dmskrsqrt`

Aligns `math/strided/special/dmskrsqrt` with the `math/strided/special` namespace convention followed by 85% of packages (69/81): inserts `stdmath`, `mathematics`, and `math` as keywords immediately after `stdlib` in `package.json`. No source changes.

#### `math/strided/special/dmsksqrt`

Aligns `math/strided/special/dmsksqrt` with the `math/strided/special` namespace convention followed by 85% of members (69/81 packages), which list `stdmath`, `mathematics`, and `math` as keywords immediately after `stdlib` in `package.json`. No source changes; keyword-only metadata fix.

#### `math/strided/special/dmsktrunc`

Aligns `math/strided/special/dmsktrunc` with the `math/strided/special` namespace convention followed by 85% of packages (69/81): inserts `stdmath`, `mathematics`, and `math` as keywords in `package.json` immediately after `stdlib`. No source changes.

#### `math/strided/special/smskfloor`

Aligns `math/strided/special/smskfloor` with the 85% majority pattern in the `math/strided/special` namespace by inserting the `stdmath`, `mathematics`, and `math` keywords after `stdlib` in `package.json`. No source changes. Closes the keyword drift for this package.

#### `math/strided/special/smskinv`

Aligns `math/strided/special/smskinv` with the `math/strided/special` namespace convention, where 85% of packages (69/81) include `stdmath`, `mathematics`, and `math` as keywords following `stdlib` in `package.json`. No source changes; metadata only.

#### `math/strided/special/smskramp`

Aligns `math/strided/special/smskramp` with the `math/strided/special` namespace convention, where 85% of packages (69/81) list `stdmath`, `mathematics`, and `math` as keywords following `stdlib` in `package.json`. This package was among 12 outliers missing those keywords. No source changes.

#### `math/strided/special/smskrsqrt`

Aligns `math/strided/special/smskrsqrt` with the `math/strided/special` namespace convention followed by 85% of packages (69/81): inserts `stdmath`, `mathematics`, and `math` as keywords after `stdlib` in `package.json`. No source changes.

#### `math/strided/special/smsksqrt`

Aligns `math/strided/special/smsksqrt` with the 85% majority pattern across the `math/strided/special` namespace by inserting the missing `stdmath`, `mathematics`, and `math` keywords after `stdlib` in `package.json`. No source changes.

#### `math/strided/special/smsktrunc`

Aligns `math/strided/special/smsktrunc` with the 85% majority pattern across the `math/strided/special` namespace by inserting the missing `stdmath`, `mathematics`, and `math` keywords after `stdlib` in `package.json`. No source changes.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   **Structural feature extraction** over all 81 members: file tree, `package.json` shape and values, `manifest.json` shape, README h2/h3 sequence, `test/`/`benchmark/`/`examples/` filenames.
-   **Semantic feature extraction** over all 81 members: public-function JSDoc (param types, returns type, throws count, `@example` presence), parameter count, source-file location, function name. Validation-prologue and error-construction features were not applicable to this namespace — every member delegates argument validation to a `@stdlib/strided/*` base helper, so there is no per-package prologue.
-   **Three-agent drift validation** for the keyword finding: an opus semantic-review agent (intentional-vs-drift), an opus cross-reference agent (test/example/tooling impact), and a sonnet structural-review agent (insertion-position confirmation). All three returned `confirmed-drift` for all 12 outliers; no `intentional-deviation`, `needs-human`, or `insufficient-evidence`.
-   **Deliberately excluded from this PR:**
    -   The 11 packages with `## Notes` instead of `## See Also` in their README (the `See Also` section is autogenerated by stdlib tooling — the section comment reads "Do not manually edit this section, as it is automatically populated"; manual edits would fight the generator).
    -   The `@param N` type drift between `NonNegativeInteger` (70/81) and `integer` (11/81) — the 11 `integer` packages use `@stdlib/strided/dispatch`, whose own JSDoc declares `N` as `integer`; the JSDoc matches the underlying primitive and is intentional.
    -   The `directories` / native-addon / C-scaffolding feature splits — none reached 75% conformance globally.
    -   Any "while we're here" cleanups not directly tied to a confirmed drift.

The full drift report (eligibility data, per-feature distributions, agent verdicts, dropped findings) is saved locally at `~/drift-reports/drift-math-strided-special-2026-05-05.md`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was generated by an automated cross-package drift-detection routine run by Claude Code on behalf of @Planeshifter. The routine selected `math/strided/special` uniformly at random (seed `20260505`) from eligible namespaces, extracted structural and semantic features from all 81 non-autogenerated members, computed per-feature majority patterns at the 75% conformance threshold, and validated outliers through three independent review agents (opus semantic-review, opus cross-reference, sonnet structural-review). Only the single drift finding for which all three agents returned `confirmed-drift` advanced to a patch; the 12 commits on this branch each apply that fix to one outlier package. Per-package PR-body sections were drafted by per-package sonnet refinement agents and lightly edited for consistency.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_018ph9FtEaEnrwve1NBhcC8S)_