### PR TITLE
docs: add `@example` JSDoc tag in `process/node-version`

### DIFF
--- a/lib/node_modules/@stdlib/process/node-version/lib/main.js
+++ b/lib/node_modules/@stdlib/process/node-version/lib/main.js
@@ -30,6 +30,10 @@ var proc = require( './process.js' );
 *
 * @constant
 * @type {string}
+*
+* @example
+* console.log( VERSION );
+* // => <string>
 */
 var VERSION = proc.versions.node;
 


### PR DESCRIPTION
## Description

This pull request:

-   Adds a missing `@example` JSDoc tag to `lib/main.js` in `@stdlib/process/node-version`. 11 of 12 sibling packages in `@stdlib/process` (~92%) carry an `@example` block in `lib/main.js`; `node-version` was the only outlier. The added example mirrors the `argv`/`env` style (a `console.log` of the exported constant followed by a `// =>` comment).

## Related Issues

No.

## Questions

No.

## Other

Per-package conformance: `@example` present in `lib/main.js` for 11/12 (~92%) of `@stdlib/process` packages prior to this change; this PR closes the gap.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code as part of an automated cross-package API drift detection routine. The routine extracted structural and semantic features from every package in the `@stdlib/process` namespace, identified `@example` presence in `lib/main.js` as a feature with a clear majority (11/12), and proposed adding the missing tag to `node-version`. Three independent validator agents (semantic-review, cross-reference, structural-review) confirmed the deviation as drift rather than intentional. The example body itself is a two-line `console.log`/`// =>` snippet consistent with `argv` and `env`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfYzjX5F2cJnQrKbPhbGNB)_