### PR TITLE
chore: migrate `math/iter/special` examples to `random/iter/uniform`

### DIFF
--- a/lib/node_modules/@stdlib/math/iter/special/abs/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/abs/README.md
@@ -93,18 +93,17 @@ The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/iter/randu' );
-var iterAdd = require( '@stdlib/math/iter/ops/add' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterAbs = require( '@stdlib/math/iter/special/abs' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( -2.0, 2.0, {
     'seed': 1234,
     'iter': 10
 });
 
 // Create an iterator which consumes the pseudorandom number iterator:
-var it = iterAbs( iterAdd( rand, -0.5 ) );
+var it = iterAbs( rand );
 
 // Perform manual iteration...
 var r;

--- a/lib/node_modules/@stdlib/math/iter/special/abs/examples/index.js
+++ b/lib/node_modules/@stdlib/math/iter/special/abs/examples/index.js
@@ -18,18 +18,17 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/iter/randu' );
-var iterAdd = require( '@stdlib/math/iter/ops/add' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterAbs = require( './../lib' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( -2.0, 2.0, {
 	'seed': 1234,
 	'iter': 10
 });
 
 // Create an iterator which consumes the pseudorandom number iterator:
-var it = iterAbs( iterAdd( rand, -0.5 ) );
+var it = iterAbs( rand );
 
 // Perform manual iteration...
 var r;

--- a/lib/node_modules/@stdlib/math/iter/special/abs2/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/abs2/README.md
@@ -93,18 +93,17 @@ The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/iter/randu' );
-var iterAdd = require( '@stdlib/math/iter/ops/add' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterAbs2 = require( '@stdlib/math/iter/special/abs2' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( -2.0, 2.0, {
     'seed': 1234,
     'iter': 10
 });
 
 // Create an iterator which consumes the pseudorandom number iterator:
-var it = iterAbs2( iterAdd( rand, -0.5 ) );
+var it = iterAbs2( rand );
 
 // Perform manual iteration...
 var r;

--- a/lib/node_modules/@stdlib/math/iter/special/abs2/examples/index.js
+++ b/lib/node_modules/@stdlib/math/iter/special/abs2/examples/index.js
@@ -18,18 +18,17 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/iter/randu' );
-var iterAdd = require( '@stdlib/math/iter/ops/add' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterAbs2 = require( './../lib' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( -2.0, 2.0, {
 	'seed': 1234,
 	'iter': 10
 });
 
 // Create an iterator which consumes the pseudorandom number iterator:
-var it = iterAbs2( iterAdd( rand, -0.5 ) );
+var it = iterAbs2( rand );
 
 // Perform manual iteration...
 var r;

--- a/lib/node_modules/@stdlib/math/iter/special/cos/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/cos/README.md
@@ -94,11 +94,11 @@ The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterCos = require( '@stdlib/math/iter/special/cos' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 0.0, 6.28, {
     'seed': 1234,
     'iter': 10
 });

--- a/lib/node_modules/@stdlib/math/iter/special/cos/examples/index.js
+++ b/lib/node_modules/@stdlib/math/iter/special/cos/examples/index.js
@@ -18,11 +18,11 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterCos = require( './../lib' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 0.0, 6.28, {
 	'seed': 1234,
 	'iter': 10
 });

--- a/lib/node_modules/@stdlib/math/iter/special/cospi/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/cospi/README.md
@@ -95,11 +95,11 @@ The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterCospi = require( '@stdlib/math/iter/special/cospi' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 0.0, 2.0, {
     'seed': 1234,
     'iter': 10
 });

--- a/lib/node_modules/@stdlib/math/iter/special/cospi/examples/index.js
+++ b/lib/node_modules/@stdlib/math/iter/special/cospi/examples/index.js
@@ -18,11 +18,11 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterCospi = require( './../lib' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 0.0, 2.0, {
 	'seed': 1234,
 	'iter': 10
 });

--- a/lib/node_modules/@stdlib/math/iter/special/inv/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/inv/README.md
@@ -93,11 +93,11 @@ The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterInv = require( '@stdlib/math/iter/special/inv' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 1.0, 10.0, {
     'seed': 1234,
     'iter': 10
 });

--- a/lib/node_modules/@stdlib/math/iter/special/inv/examples/index.js
+++ b/lib/node_modules/@stdlib/math/iter/special/inv/examples/index.js
@@ -18,11 +18,11 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterInv = require( './../lib' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 1.0, 10.0, {
 	'seed': 1234,
 	'iter': 10
 });

--- a/lib/node_modules/@stdlib/math/iter/special/sin/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/sin/README.md
@@ -94,11 +94,11 @@ The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterSin = require( '@stdlib/math/iter/special/sin' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 0.0, 6.28, {
     'seed': 1234,
     'iter': 10
 });

--- a/lib/node_modules/@stdlib/math/iter/special/sin/examples/index.js
+++ b/lib/node_modules/@stdlib/math/iter/special/sin/examples/index.js
@@ -18,11 +18,11 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterSin = require( './../lib' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 0.0, 6.28, {
 	'seed': 1234,
 	'iter': 10
 });

--- a/lib/node_modules/@stdlib/math/iter/special/sinpi/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/sinpi/README.md
@@ -95,11 +95,11 @@ The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterSinpi = require( '@stdlib/math/iter/special/sinpi' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 0.0, 2.0, {
     'seed': 1234,
     'iter': 10
 });

--- a/lib/node_modules/@stdlib/math/iter/special/sinpi/examples/index.js
+++ b/lib/node_modules/@stdlib/math/iter/special/sinpi/examples/index.js
@@ -18,11 +18,11 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/iter/randu' );
+var uniform = require( '@stdlib/random/iter/uniform' );
 var iterSinpi = require( './../lib' );
 
 // Create a seeded iterator for generating pseudorandom numbers:
-var rand = randu({
+var rand = uniform( 0.0, 2.0, {
 	'seed': 1234,
 	'iter': 10
 });


### PR DESCRIPTION
## Description

This pull request migrates the `examples/index.js` file (and the matching inline code block in `README.md`) for seven packages under `lib/node_modules/@stdlib/math/iter/special/` from the legacy `@stdlib/random/iter/randu` pseudorandom source to the conventional `@stdlib/random/iter/uniform` source, using a sampling interval matched to each function's mathematical domain.

### Namespace summary

- **Members analyzed:** 97 (all non-autogenerated)
- **Features with clear majority (≥75%):** README structure, package.json shape, file tree, function signature shape, JSDoc shape, example pseudorandom source pattern
- **Drift identified on a single feature:** example pseudorandom source pattern. 88 of 97 packages (90.7%) use `@stdlib/random/iter/uniform( a, b, { 'seed': 1234, 'iter': 10 } )`; 9 deviate.
- **Outliers retained as intentional deviation:** `factorial`, `factorialln` (use `@stdlib/random/iter/discrete-uniform` because the underlying functions are integer-valued).
- **Outliers corrected:** `abs`, `abs2`, `cos`, `cospi`, `inv`, `sin`, `sinpi`.

### Per-outlier corrections

#### `math/iter/special/abs`

Migrates `examples/index.js` and the corresponding `README.md` code block from the legacy `randu` + `iterAdd(rand, -0.5)` shift pattern to `@stdlib/random/iter/uniform( -2.0, 2.0, ... )`. The shift approach was a workaround that obscured intent; the `uniform` iterator expresses the range directly. Interval precedent follows the `signum` and `ramp` sibling cluster (90.7% conformance).

#### `math/iter/special/abs2`

Migrates `examples/index.js` and the corresponding `README.md` code block from the legacy `randu` + `iterAdd(rand, -0.5)` shift pattern to `@stdlib/random/iter/uniform( -2.0, 2.0, ... )`. As with `abs`, the shift was an implicit range selection with no documented rationale. Interval follows the `signum` and `ramp` sibling cluster (90.7% conformance).

#### `math/iter/special/cos`

Migrates `examples/index.js` and the corresponding `README.md` code block from `randu` to `@stdlib/random/iter/uniform( 0.0, 6.28, ... )`, spanning one full period of cosine. The `[0, 1)` output of `randu` exercised only a fraction of the function's domain. Interval follows the `cosm1`, `coversin`, and `havercos` sibling cluster (90.7% conformance).

#### `math/iter/special/cospi`

Migrates `examples/index.js` and the corresponding `README.md` code block from `randu` to `@stdlib/random/iter/uniform( 0.0, 2.0, ... )`, spanning one full period of `cos(πx)`. The `[0, 1)` range of `randu` covered only half a period of the scaled argument. Interval follows the `acovercos`, `acoversin`, and `aversin` sibling cluster (90.7% conformance).

#### `math/iter/special/inv`

Migrates `examples/index.js` and the corresponding `README.md` code block from `randu` to `@stdlib/random/iter/uniform( 1.0, 10.0, ... )`. Values drawn from `[0, 1)` caused `1/x` to blow up near zero, producing outputs that were uninformative for demonstration purposes. Interval follows the `acosh` and `acoth` sibling cluster (90.7% conformance).

#### `math/iter/special/sin`

Migrates `examples/index.js` and the corresponding `README.md` code block from `randu` to `@stdlib/random/iter/uniform( 0.0, 6.28, ... )`, spanning one full period of sine. Migration shape is identical to `cos`. Interval follows the `cosm1`, `coversin`, and `havercos` sibling cluster (90.7% conformance).

#### `math/iter/special/sinpi`

Migrates `examples/index.js` and the corresponding `README.md` code block from `randu` to `@stdlib/random/iter/uniform( 0.0, 2.0, ... )`, spanning one full period of `sin(πx)`. Migration shape is identical to `cospi`. Interval follows the `acovercos`, `acoversin`, and `aversin` sibling cluster (90.7% conformance).

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural extraction** across all 97 members confirmed 100% conformance on file tree, `package.json` top-level keys, `package.json` scripts, and `README.md` section structure (`## Usage`, `## Notes`, `## Examples`, `## See Also`).
- **Semantic extraction** (cheap source-grep over `lib/main.js` of every member) confirmed uniform JSDoc shape (`@param`/`@returns`/`@throws` types), uniform error-handling delegation to the underlying `iter/tools/map` / `iter/tools/map2`, and identified the example pseudorandom source as the only feature with detectable drift.
- **Three-agent drift validation** (semantic review, cross-reference, structural review) confirmed all 7 corrected outliers as `confirmed-drift` and confirmed `factorial`/`factorialln` as `intentional-deviation`.
- **Deliberately excluded from this PR:** features without a clear majority (none observed); outliers whose tests rely on the deviation (none observed; tests do not depend on example output); the 5 binary-function packages (`atan2`, `beta`, `betaln`, `log`, `pow`) whose 2-arg signature reflects a genuine semantic difference and is not drift; `factorial`, `factorialln`, which intentionally use `discrete-uniform` because the underlying functions are integer-valued.
- **Each example file** was executed locally and produced finite values matching the expected mathematical output.

Each correction was committed as a separate commit, one per package, so the audit trail is per-package rather than per-feature.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a cross-package API drift detection routine: the random target namespace was selected, structural and semantic features were extracted across all 97 members, a 90.7% majority pattern was identified for the example pseudorandom source, three validation agents (two opus, one sonnet) confirmed the 7 outliers as unintentional drift, and the corrections were applied mechanically.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqGYLHLpXrp7baqtrMoRgx)_