### PR TITLE
fix: propagate `API_SUFFIX` wrappers and complex number description wording

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/snansumpw/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/snansumpw/src/main.c
@@ -149,5 +149,5 @@ float API_SUFFIX(stdlib_strided_snansumpw_ndarray)( const CBLAS_INT N, const flo
 	// Recurse by dividing by two, but avoiding non-multiples of unroll factor...
 	n = N / 2;
 	n -= n % 8;
-	return stdlib_strided_snansumpw_ndarray( n, X, strideX, ix ) + stdlib_strided_snansumpw_ndarray( N-n, X, strideX, ix+(n*strideX) );
+	return API_SUFFIX(stdlib_strided_snansumpw_ndarray)( n, X, strideX, ix ) + API_SUFFIX(stdlib_strided_snansumpw_ndarray)( N-n, X, strideX, ix+(n*strideX) );
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/src/main.c
@@ -128,5 +128,5 @@ float API_SUFFIX(stdlib_strided_ssumpw_ndarray)( const CBLAS_INT N, const float 
 	// Recurse by dividing by two, but avoiding non-multiples of unroll factor...
 	n = N / 2;
 	n -= n % 8;
-	return stdlib_strided_ssumpw_ndarray( n, X, strideX, ix ) + stdlib_strided_ssumpw_ndarray( N-n, X, strideX, ix+(n*strideX) );
+	return API_SUFFIX(stdlib_strided_ssumpw_ndarray)( n, X, strideX, ix ) + API_SUFFIX(stdlib_strided_ssumpw_ndarray)( N-n, X, strideX, ix+(n*strideX) );
 }

--- a/lib/node_modules/@stdlib/complex/float32/base/assert/is-almost-equal/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/assert/is-almost-equal/test/test.js
@@ -55,7 +55,7 @@ tape( 'the function returns `false` if provided `NaN` as either real or imaginar
 	t.end();
 });
 
-tape( 'the function returns `true` if provided two complex single-precision floating-point numbers which are the same value irrespective of the specified number of ULPs', function test( t ) {
+tape( 'the function returns `true` if provided two single-precision complex floating-point numbers which are the same value irrespective of the specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 
@@ -77,7 +77,7 @@ tape( 'the function returns `true` if provided two complex single-precision floa
 	t.end();
 });
 
-tape( 'the function returns `true` if provided two complex single-precision floating-point numbers which are approximately equal within a specified number of ULPs', function test( t ) {
+tape( 'the function returns `true` if provided two single-precision complex floating-point numbers which are approximately equal within a specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 
@@ -93,7 +93,7 @@ tape( 'the function returns `true` if provided two complex single-precision floa
 	t.end();
 });
 
-tape( 'the function returns `false` if provided two complex single-precision floating-point numbers which are not approximately equal within a specified number of ULPs', function test( t ) {
+tape( 'the function returns `false` if provided two single-precision complex floating-point numbers which are not approximately equal within a specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 

--- a/lib/node_modules/@stdlib/complex/float32/base/assert/is-almost-same-value/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/assert/is-almost-same-value/test/test.js
@@ -55,7 +55,7 @@ tape( 'the function treats `NaNs` as the same value', function test( t ) {
 	t.end();
 });
 
-tape( 'the function returns `true` if provided two complex single-precision floating-point numbers which are the same value irrespective of the specified number of ULPs', function test( t ) {
+tape( 'the function returns `true` if provided two single-precision complex floating-point numbers which are the same value irrespective of the specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 
@@ -77,7 +77,7 @@ tape( 'the function returns `true` if provided two complex single-precision floa
 	t.end();
 });
 
-tape( 'the function returns `true` if provided two complex single-precision floating-point numbers which are approximately the same value within a specified number of ULPs', function test( t ) {
+tape( 'the function returns `true` if provided two single-precision complex floating-point numbers which are approximately the same value within a specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 
@@ -93,7 +93,7 @@ tape( 'the function returns `true` if provided two complex single-precision floa
 	t.end();
 });
 
-tape( 'the function returns `false` if provided two complex single-precision floating-point numbers which are not approximately the same value within a specified number of ULPs', function test( t ) {
+tape( 'the function returns `false` if provided two single-precision complex floating-point numbers which are not approximately the same value within a specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 

--- a/lib/node_modules/@stdlib/complex/float64/base/assert/is-almost-equal/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/assert/is-almost-equal/test/test.js
@@ -55,7 +55,7 @@ tape( 'the function returns `false` if provided `NaN` as either real or imaginar
 	t.end();
 });
 
-tape( 'the function returns `true` if provided two complex double-precision floating-point numbers which are the same value irrespective of the specified number of ULPs', function test( t ) {
+tape( 'the function returns `true` if provided two double-precision complex floating-point numbers which are the same value irrespective of the specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 
@@ -77,7 +77,7 @@ tape( 'the function returns `true` if provided two complex double-precision floa
 	t.end();
 });
 
-tape( 'the function returns `true` if provided two complex double-precision floating-point numbers which are approximately equal within a specified number of ULPs', function test( t ) {
+tape( 'the function returns `true` if provided two double-precision complex floating-point numbers which are approximately equal within a specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 
@@ -93,7 +93,7 @@ tape( 'the function returns `true` if provided two complex double-precision floa
 	t.end();
 });
 
-tape( 'the function returns `false` if provided two complex double-precision floating-point numbers which are not approximately equal within a specified number of ULPs', function test( t ) {
+tape( 'the function returns `false` if provided two double-precision complex floating-point numbers which are not approximately equal within a specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 

--- a/lib/node_modules/@stdlib/complex/float64/base/assert/is-almost-same-value/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/assert/is-almost-same-value/test/test.js
@@ -55,7 +55,7 @@ tape( 'the function treats `NaNs` as the same value', function test( t ) {
 	t.end();
 });
 
-tape( 'the function returns `true` if provided two complex double-precision floating-point numbers which are the same value irrespective of the specified number of ULPs', function test( t ) {
+tape( 'the function returns `true` if provided two double-precision complex floating-point numbers which are the same value irrespective of the specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 
@@ -77,7 +77,7 @@ tape( 'the function returns `true` if provided two complex double-precision floa
 	t.end();
 });
 
-tape( 'the function returns `true` if provided two complex double-precision floating-point numbers which are approximately the same value within a specified number of ULPs', function test( t ) {
+tape( 'the function returns `true` if provided two double-precision complex floating-point numbers which are approximately the same value within a specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 
@@ -93,7 +93,7 @@ tape( 'the function returns `true` if provided two complex double-precision floa
 	t.end();
 });
 
-tape( 'the function returns `false` if provided two complex double-precision floating-point numbers which are not approximately the same value within a specified number of ULPs', function test( t ) {
+tape( 'the function returns `false` if provided two double-precision complex floating-point numbers which are not approximately the same value within a specified number of ULPs', function test( t ) {
 	var z1;
 	var z2;
 

--- a/lib/node_modules/@stdlib/stats/strided/dsempn/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dsempn/src/main.c
@@ -47,5 +47,5 @@ double API_SUFFIX(stdlib_strided_dsempn)( const CBLAS_INT N, const double correc
 * @return             output value
 */
 double API_SUFFIX(stdlib_strided_dsempn_ndarray)( const CBLAS_INT N, const double correction, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
-	return stdlib_base_sqrt( stdlib_strided_dvariancepn_ndarray( N, correction, X, strideX, offsetX ) / (double)N );
+	return stdlib_base_sqrt( API_SUFFIX(stdlib_strided_dvariancepn_ndarray)( N, correction, X, strideX, offsetX ) / (double)N );
 }

--- a/lib/node_modules/@stdlib/stats/strided/dsmeanpn/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dsmeanpn/src/main.c
@@ -67,11 +67,11 @@ double API_SUFFIX(stdlib_strided_dsmeanpn_ndarray)( const CBLAS_INT N, const flo
 	dN = (double)N;
 
 	// Compute an estimate for the mean:
-	mu = stdlib_strided_dssum_ndarray( N, X, strideX, offsetX );
+	mu = API_SUFFIX(stdlib_strided_dssum_ndarray)( N, X, strideX, offsetX );
 	mu /= dN;
 
 	// Compute an error term:
-	c = stdlib_strided_dsapxsum_ndarray( N, -mu, X, strideX, offsetX );
+	c = API_SUFFIX(stdlib_strided_dsapxsum_ndarray)( N, -mu, X, strideX, offsetX );
 	c /= dN;
 
 	return mu + c;

--- a/lib/node_modules/@stdlib/stats/strided/dsvariancepn/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dsvariancepn/src/main.c
@@ -73,7 +73,7 @@ double API_SUFFIX(stdlib_strided_dsvariancepn_ndarray)( const CBLAS_INT N, const
 		return 0.0;
 	}
 	// Compute an estimate for the mean:
-	mu = stdlib_strided_dssum_ndarray( N, X, strideX, offsetX ) / dN;
+	mu = API_SUFFIX(stdlib_strided_dssum_ndarray)( N, X, strideX, offsetX ) / dN;
 
 	// Compute the variance...
 	ix = offsetX;

--- a/lib/node_modules/@stdlib/stats/strided/dztest/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dztest/src/main.c
@@ -98,7 +98,7 @@ void API_SUFFIX(stdlib_strided_dztest_ndarray)( const CBLAS_INT N, const enum ST
 	stderr = sigma / stdlib_base_sqrt( (double)N );
 
 	// Compute the arithmetic mean of the input array:
-	xmean = stdlib_strided_dmean_ndarray( N, X, strideX, offsetX );
+	xmean = API_SUFFIX(stdlib_strided_dmean_ndarray)( N, X, strideX, offsetX );
 
 	// Compute the test statistic (i.e., the z-score, which is the distance of the sample mean from the population mean in units of standard error):
 	stat = ( xmean - mu ) / stderr;

--- a/lib/node_modules/@stdlib/stats/strided/dztest2/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/dztest2/src/main.c
@@ -117,8 +117,8 @@ void API_SUFFIX(stdlib_strided_dztest2_ndarray)( const CBLAS_INT NX, const CBLAS
 	stderr = stdlib_base_sqrt( ( xvar / (double)NX ) + ( yvar / (double)NY ) );
 
 	// Compute the arithmetic means of the input arrays:
-	xmean = stdlib_strided_dmean_ndarray( NX, X, strideX, offsetX );
-	ymean = stdlib_strided_dmean_ndarray( NY, Y, strideY, offsetY );
+	xmean = API_SUFFIX(stdlib_strided_dmean_ndarray)( NX, X, strideX, offsetX );
+	ymean = API_SUFFIX(stdlib_strided_dmean_ndarray)( NY, Y, strideY, offsetY );
 
 	// Compute the test statistic (i.e., the z-score, which is the standardized difference between the sample means of x and y, adjusted by the hypothesized difference, in units of the standard error):
 	stat = ( xmean - ymean - diff ) / stderr;

--- a/lib/node_modules/@stdlib/stats/strided/sztest/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/sztest/src/main.c
@@ -98,7 +98,7 @@ void API_SUFFIX(stdlib_strided_sztest_ndarray)( const CBLAS_INT N, const enum ST
 	stderr = sigma / stdlib_base_sqrt( (double)N ); // note: intentionally evaluated in double-precision to avoid `N` exceeding max safe float32 integer
 
 	// Compute the arithmetic mean of the input array:
-	xmean = stdlib_strided_smean_ndarray( N, X, strideX, offsetX );
+	xmean = API_SUFFIX(stdlib_strided_smean_ndarray)( N, X, strideX, offsetX );
 
 	// Compute the test statistic (i.e., the z-score, which is the distance of the sample mean from the population mean in units of standard error):
 	stat = ( (double)xmean - (double)mu ) / stderr;

--- a/lib/node_modules/@stdlib/stats/strided/sztest2/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/sztest2/src/main.c
@@ -117,8 +117,8 @@ void API_SUFFIX(stdlib_strided_sztest2_ndarray)( const CBLAS_INT NX, const CBLAS
 	stderr = stdlib_base_sqrt( ( xvar / (double)NX ) + ( yvar / (double)NY ) ); // note: intentionally evaluated in double-precision to avoid `NX` and `NY` exceeding max safe float32 integer
 
 	// Compute the arithmetic means of the input arrays:
-	xmean = stdlib_strided_smean_ndarray( NX, X, strideX, offsetX );
-	ymean = stdlib_strided_smean_ndarray( NY, Y, strideY, offsetY );
+	xmean = API_SUFFIX(stdlib_strided_smean_ndarray)( NX, X, strideX, offsetX );
+	ymean = API_SUFFIX(stdlib_strided_smean_ndarray)( NY, Y, strideY, offsetY );
 
 	// Compute the test statistic (i.e., the z-score, which is the standardized difference between the sample means of x and y, adjusted by the hypothesized difference, in units of the standard error):
 	stat = ( (double)xmean - (double)ymean - (double)diff ) / stderr;


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-05-04 17:00 EDT and 2026-05-05 03:03 PDT to sibling packages.

**`fix:` — Missing `API_SUFFIX(...)` wrappers around internal `_ndarray` calls** (a65e1fd9f, 851675024)

Internal calls to `API_SUFFIX`-decorated strided ndarray routines were made using bare symbol names (e.g., `stdlib_strided_drss_ndarray(...)` instead of `API_SUFFIX(stdlib_strided_drss_ndarray)(...)`). When the project is built with a non-empty CBLAS integer suffix, the bare name is an undefined symbol, causing link failure; the bug is silent only when the suffix is empty. Affected packages span pairwise summation helpers with self-recursive `_ndarray` calls and z-test and variance routines delegating to sibling `_ndarray` entry points.

-   `blas/ext/base/snansumpw`
-   `blas/ext/base/ssumpw`
-   `stats/strided/dsempn`
-   `stats/strided/dsmeanpn`
-   `stats/strided/dsvariancepn`
-   `stats/strided/dztest`
-   `stats/strided/dztest2`
-   `stats/strided/sztest`
-   `stats/strided/sztest2`

**`docs:` — Word order: "{single,double}-precision complex floating-point"** (b0713eab3, a3a5677b7)

`tape(...)` descriptions in four assert packages used the reversed form "complex {single,double}-precision floating-point" rather than the canonical "{single,double}-precision complex floating-point" established across the rest of the project. The fix propagates the word-order correction from b0713eab3 and a3a5677b7, bringing the test descriptions into agreement with each package's own `lib/main.js` JSDoc.

-   `complex/float32/base/assert/is-almost-equal`
-   `complex/float32/base/assert/is-almost-same-value`
-   `complex/float64/base/assert/is-almost-equal`
-   `complex/float64/base/assert/is-almost-same-value`

## Related Issues

None.

## Questions

None.

## Other

**Validation.** Each candidate site was searched via ripgrep across `lib/node_modules/@stdlib/`, scoped to the namespaces in which the source commits originated (`stats/strided/*`, `blas/ext/base/*`, `complex/float{32,64}/base/assert/*`). Two independent validation passes confirmed (a) the calling function is itself `API_SUFFIX`-wrapped at its definition, (b) the called function's definition uses `API_SUFFIX(...)`, and (c) the bare-name call lies inside the wrapped function body. A separate adaptation pass produced the per-site mechanical patch and a style-consistency pass confirmed each replacement matches the surrounding file's spacing and call conventions.

**Deliberately excluded.** Calls to `stdlib_strided_stride2offset` were not wrapped — the function's definition is unsuffixed, so wrapping its call sites would produce undefined symbols (~390 ripgrep hits dropped on this basis). Sites flagged `needs-human` by any agent were dropped. Adaptive fixes requiring cross-package edits were dropped. The `docs: restore section template comments` (86e9aee4) and `refactor: merge two-condition argument-validation blocks` (79dedda7) commits were not propagated — neither produces a generalizable search signature without risking subtle regressions.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine. Source commits were identified within the last 24 hours on `develop`, fix patterns specified, candidate sites validated independently by two reviewers and a style-consistency pass, and patches applied mechanically. A maintainer should review before merging.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mk2wYwSW6dy5wTrPBEnfuK)_