### PR TITLE
docs: align JS API subheadings to H4 in `stats/strided/dnanrangeabs`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dnanrangeabs/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/dnanrangeabs/README.md
@@ -38,7 +38,7 @@ The [**range**][range] is defined as the difference between the maximum and mini
 var dnanrangeabs = require( '@stdlib/stats/strided/dnanrangeabs' );
 ```
 
-### dnanrangeabs( N, x, strideX )
+#### dnanrangeabs( N, x, strideX )
 
 Computes the [range][range] of absolute values of a double-precision floating-point strided array, ignoring `NaN` values.
 
@@ -82,7 +82,7 @@ var v = dnanrangeabs( 4, x1, 2 );
 // returns 3.0
 ```
 
-### dnanrangeabs.ndarray( N, x, strideX, offsetX )
+#### dnanrangeabs.ndarray( N, x, strideX, offsetX )
 
 Computes the [range][range] of absolute values of a double-precision floating-point strided array, ignoring `NaN` values and using alternative indexing semantics.
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Demotes two JS-API subheadings in `lib/node_modules/@stdlib/stats/strided/dnanrangeabs/README.md` (`### dnanrangeabs( … )` and `### dnanrangeabs.ndarray( … )`) from H3 to H4, matching the heading level used by 238/239 (99.6%) sibling packages in `stats/strided` for function-signature subheadings nested under `## Usage`.

### `stats/strided/dnanrangeabs`

The JS Usage block in `dnanrangeabs/README.md` was the lone outlier in the namespace using `###` for the function-signature subheadings. Every other `stats/strided` package places these subheadings at `####`, immediately under the `## Usage` H2. The fix is purely structural: two heading lines, no behaviour or content changes.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Conformance: `####` for JS Usage subheadings — 238/239 = 99.6% of `stats/strided` non-aggregator packages. The aggregator package `stats/strided/distances` was excluded from the vote because it is structurally distinct (a namespace re-export, not a function package).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a cross-package API drift detection routine that compares structural features across all packages in a stdlib namespace, identifies the majority pattern per feature, and proposes mechanical corrections for outliers. The drift was detected by extracting H2/H3/H4 heading levels from every `README.md` under `lib/node_modules/@stdlib/stats/strided/`; the fix demotes two subheadings so they match the convention shared by 238 sibling packages.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_013DZtA4JCDzAHqeqy63DatP)_