### PR TITLE
chore: add missing keywords in `blas/ext/base/ndarray` cusum packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusum/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumkbn/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumkbn/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumkbn2/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumkbn2/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumors/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumors/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumpw/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcusumpw/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusum/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusum/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusumkbn/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusumkbn/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusumkbn2/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusumkbn2/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusumors/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusumors/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusumpw/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcusumpw/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/scusum/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/scusum/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/scusumors/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/scusumors/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "cumulative",
     "accumulate",
     "sum",


### PR DESCRIPTION
## Description

Adds the missing `"blas"` and `"extended"` keywords to twelve cumulative-sum packages under `@stdlib/blas/ext/base/ndarray/`. The keywords are inserted after `"math"` and before `"cumulative"` in `package.json.keywords`, matching the canonical ordering observed in conforming siblings.

### Namespace summary

- **Target:** `@stdlib/blas/ext/base/ndarray`
- **Members analyzed:** 87 (all non-autogenerated)
- **Features extracted:** file tree, `package.json` shape (top-level keys, `scripts`, `stdlib`, `keywords`), README sections (H2/H3 ordered), `manifest.json` shape, test/benchmark/example file naming, `lib/main.js` and `lib/index.js` JSDoc shape (`@param`, `@returns`, `@throws`, `@example`, `## Notes` blocks), function signatures, and `require()` dependency sets, plus `docs/types/index.d.ts` and `docs/repl.txt` section presence
- **Features with clear majority (≥75% conformance):** file tree (100% on 10 universal files; the 6-package native-binding cluster is a known intentional difference), `package.json` top-level keys (100%), `scripts` keys (100%, all `{}`), test/benchmark/example file naming (100% on `test.js` / `benchmark.js` / `index.js`), README H2 sections `Usage` (100%) and `Examples` (100%), JSDoc `@param`/`@returns`/`@example`/`## Notes` (100%), function name = directory camelCase (100%), four ndarray base accessor `require()`s (100%), and `package.json` keywords `stdlib` (100%), `ndarray` (100%), `blas` (86%), `extended` (86%)
- **Features without clear majority (excluded):** `references` README section (31%), `stdmath`/`mathematics`/`math` keywords (99%, but the lone outlier `gjoin-between` is a string operation where their absence is intentional and matches its strided sibling), and `statistics`/`stats`/`sum`/`total`/`summation` keywords (55%, domain-specific and tracks the operation)

### Outlier corrections

#### `@stdlib/blas/ext/base/ndarray/dcusum`

Add `"blas"` and `"extended"` keywords to `package.json` (86% conformance: 75/87 `blas/ext/base/ndarray` siblings carry both). The strided sibling `@stdlib/blas/ext/base/dcusum` and same-family ndarray wrappers (`dsum`, `scusumkbn`) carry these keywords; this package was missing them.

#### `@stdlib/blas/ext/base/ndarray/dcusumkbn`

Added `"blas"` and `"extended"` keywords to `package.json`. 75 of 87 `blas/ext/base/ndarray` siblings (86%) carry both keywords; the intra-family inconsistency is direct: `scusumkbn` and `scusumkbn2` ndarray wrappers and the strided sibling `@stdlib/blas/ext/base/dcusumkbn` all carry them, while this f64 ndarray counterpart did not.

#### `@stdlib/blas/ext/base/ndarray/dcusumkbn2`

Adds `"blas"` and `"extended"` keywords to `package.json`, inserted after `"math"` and before `"cumulative"`. Keyword conformance rises to 86% (75/87), matching the pattern established by the `scusumkbn2` ndarray wrapper and the strided sibling `@stdlib/blas/ext/base/dcusumkbn2`, both of which carry these keywords.

#### `@stdlib/blas/ext/base/ndarray/dcusumors`

Adds `"blas"` and `"extended"` keywords to `package.json`, aligning with the keyword schema present in both the strided sibling `@stdlib/blas/ext/base/dcusumors` and the parallel non-cumulative `@stdlib/blas/ext/base/ndarray/dsumors`. This package was among the non-conforming entries driving the keyword conformance rate to 86% (75/87) across the ndarray BLAS extension suite.

#### `@stdlib/blas/ext/base/ndarray/dcusumpw`

Adds `"blas"` and `"extended"` keywords to `package.json`, inserting them after `"math"` and before `"cumulative"`. Keyword conformance rises to 86% (75/87). Precedent: sibling packages `@stdlib/blas/ext/base/dcusumpw` and `@stdlib/blas/ext/base/ndarray/dsumpw` already carry both keywords.

#### `@stdlib/blas/ext/base/ndarray/gcusum`

Added `"blas"` and `"extended"` keywords to `package.json`, inserted after `"math"` and before `"cumulative"`. Keyword set now conforms to the established pattern carried by the strided sibling `@stdlib/blas/ext/base/gcusum` and the parallel ndarray package `@stdlib/blas/ext/base/ndarray/gsum`. Conformance rises to 86% (75/87).

#### `@stdlib/blas/ext/base/ndarray/gcusumkbn`

Adds `"blas"` and `"extended"` keywords to `package.json` after `"math"` and before `"cumulative"`. The package reaches 86% keyword conformance. Precedent is established by the strided sibling `@stdlib/blas/ext/base/gcusumkbn` and the parallel ndarray wrapper `@stdlib/blas/ext/base/ndarray/gsumkbn`, both of which carry these keywords.

#### `@stdlib/blas/ext/base/ndarray/gcusumkbn2`

Added `"blas"` and `"extended"` keywords to `package.json` after `"math"` and before `"cumulative"`. Keyword conformance rises to 86% (75/87). Precedent established by the strided sibling and the parallel ndarray wrapper `@stdlib/blas/ext/base/ndarray/gsumkbn2`.

#### `@stdlib/blas/ext/base/ndarray/gcusumors`

Added `"blas"` and `"extended"` keywords to `package.json` after `"math"` and before `"cumulative"`. Follows precedent set by the strided sibling `@stdlib/blas/ext/base/gcusumors` and the parallel ndarray wrapper `@stdlib/blas/ext/base/ndarray/gsumors`, both of which carry these keywords. Conformance: 86% (75/87).

#### `@stdlib/blas/ext/base/ndarray/gcusumpw`

Adds `"blas"` and `"extended"` keywords to `package.json`, inserted after `"math"` and before `"cumulative"`. Keyword conformance rises to 86% (75/87). Matches the ordering established by the strided sibling `@stdlib/blas/ext/base/gcusumpw` and the parallel ndarray wrapper `@stdlib/blas/ext/base/ndarray/gsumpw`.

#### `@stdlib/blas/ext/base/ndarray/scusum`

Adds `"blas"` and `"extended"` keywords to `package.json`, inserted after `"math"` and before `"cumulative"`. Keyword conformance across the ndarray wrapper family stands at 86% (75/87); sibling wrappers `@stdlib/blas/ext/base/ndarray/scusumkbn` and `scusumkbn2` carry these keywords, as does the strided counterpart `@stdlib/blas/ext/base/scusum`. This change brings the package into alignment with established conventions in the extended BLAS ndarray namespace.

#### `@stdlib/blas/ext/base/ndarray/scusumors`

Adds `"blas"` and `"extended"` keywords to `package.json`, inserted after `"math"` and before `"cumulative"`. Keyword conformance across the ndarray BLAS extended family stands at 86% (75/87); the same-family `@stdlib/blas/ext/base/ndarray/scusumkbn` and the strided sibling `@stdlib/blas/ext/base/scusumors` both carry these keywords. This change brings `scusumors` into alignment with established precedent.

### Validation

Three independent validation agents reviewed each outlier before any patch was applied:

1. **Semantic-review (Opus):** for each outlier, compared `lib/main.js` and the strided sibling against conforming ndarray wrappers (`dsum`, `dsumkbn`, `gsumors`, `scusumkbn`, etc.). Result for all 12 outliers: `confirmed-drift`. Within the cumulative-sum family itself, `scusumkbn` and `scusumkbn2` ndarray wrappers carry the keywords while structurally identical siblings do not — this internal inconsistency, combined with universal keyword presence in the strided counterparts, indicates inadvertent omission via copy-paste from an earlier template rather than any semantic intent.
2. **Cross-reference (Opus):** verified `test/test.js` and `examples/index.js` files in each outlier do not reference `package.json` contents or keywords; the only files mentioning the `keyword` field are the `package.json` files themselves. Result for all 12 outliers: `safe-to-fix`. No cascade into tests, examples, types, or REPL fixtures.
3. **Structural-review (Sonnet):** confirmed each outlier is a genuine BLAS extension (cumulative summation routines under `@stdlib/blas/ext/base/ndarray/`) and that the canonical insertion position (after `"math"`, before `"cumulative"`) is determinable from sibling ordering (`scusumkbn`, `dsumkbn`). Result for all 12 outliers: `confirmed-drift`.

### Deliberately excluded

- `gjoin` README missing `## Notes` heading (86/87 = 99% have it; the empty `<section class="notes">` block is structurally present but lacks content) — fix would require writing package-specific prose, not a mechanical patch.
- `gjoin-between` lacking `stdmath`/`mathematics`/`math` keywords (99% have them) — `gjoin-between` is a string-join operation; its strided sibling `@stdlib/blas/ext/base/gjoin-between` likewise omits these math keywords. Intentional deviation.
- `statistics`/`stats`/`sum`/`total`/`summation` keyword distribution (55%) — below the 75% majority threshold and tracks the operation type.
- The 6-package native-binding cluster (`csum`, `dnansum`, `dsum`, `snansum`, `ssum`, `zsum`) extra files (`binding.gyp`, `manifest.json`, `lib/native.js`, etc.) — intentional, only present where a C implementation exists.
- `references` H2 section (31%) — present where mathematical references warrant it; below threshold.

## Related Issues

None.

## Questions

None.

## Other

- Random seed: `20260506` (deterministic from today's date for reproducibility); namespace pick was `blas/ext/base/ndarray` from 122 eligible namespaces with ≥8 non-autogenerated members.
- Branch: `philipp/drift-blas-ext-base-ndarray-2026-05-06`.
- Per-package commits keep the audit trail readable per-outlier rather than per-feature; 12 commits in total.
- No tests, examples, types, or REPL fixtures were modified — `package.json.keywords` is the only diff.
- Full local report (member list, feature distributions including the 6-package native-binding cluster, agent verdicts, dropped findings) saved at `~/drift-reports/drift-blas-ext-base-ndarray-2026-05-06.md`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package API drift detection routine: a structural and semantic feature scan over the 87 `blas/ext/base/ndarray` packages, three independent validation agents (semantic-review, cross-reference, structural-review) per outlier, and a final per-package PR-body refinement pass. Every patch is a two-line addition to `package.json.keywords` at a deterministic position; no code, signatures, types, tests, examples, or REPL fixtures were changed. A human will audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_016AVf7vBBfR9U63Kpwhn6cR)_