### PR TITLE
docs: trim stale `@param` tags in three `_tools/makie/plugins` plugins

### DIFF
--- a/lib/node_modules/@stdlib/_tools/makie/plugins/makie-list-pkgs-names/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/makie/plugins/makie-list-pkgs-names/lib/main.js
@@ -79,7 +79,6 @@ function stderr( data ) {
 *
 * @param {string} dir - Makefile directory
 * @param {string} cwd - current working directory
-* @param {string} subpath - subdirectory path
 */
 function plugin( dir, cwd ) {
 	var opts;

--- a/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-complexity/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-complexity/lib/main.js
@@ -78,8 +78,6 @@ function stderr( data ) {
 * Plugin to view a complexity report.
 *
 * @param {string} dir - Makefile directory
-* @param {string} cwd - current working directory
-* @param {string} subpath - subdirectory path
 */
 function plugin( dir ) {
 	var opts;

--- a/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-cov/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-cov/lib/main.js
@@ -78,8 +78,6 @@ function stderr( data ) {
 * Plugin to view a test coverage report.
 *
 * @param {string} dir - Makefile directory
-* @param {string} cwd - current working directory
-* @param {string} subpath - subdirectory path
 */
 function plugin( dir ) {
 	var opts;


### PR DESCRIPTION
## Description

This pull request:

-   Removes stale `@param` JSDoc tags from three plugins in `@stdlib/_tools/makie/plugins` whose JSDoc documented parameters that their `plugin` function neither declares nor uses. The documentation now matches each function's actual signature.

### Namespace summary

-   **Namespace:** `@stdlib/_tools/makie/plugins`
-   **Members:** 23 packages (none autogenerated)
-   **Features analyzed:** file tree, `package.json` shape, public function signature, JSDoc `@param` tags, helper-callback set, dependency set, error-construction style
-   **Features with clear majority (≥75%):** file tree (100%), `package.json` top-level keys (100%), keyword prefixes `tools`/`makie`/`make`/`makefile`/`plugin` (100%), `( dir, cwd, subpath )` signature (19/23 = 82.6%), `process` + `child_process.spawn` dependency pair (22/23 = 95.7%), `onError`/`onFinish` helper callbacks (22/23 = 95.7%), `stdout`/`stderr` helper callbacks (21/23 = 91.3%)
-   **Features without clear majority (excluded from drift analysis):** keyword arrays beyond the shared 5-keyword prefix, package descriptions

### Per-outlier corrections

### `makie-list-pkgs-names`

Removes a stale `@param {string} subpath` JSDoc tag from the `plugin` function, which accepts two parameters `(dir, cwd)` and does not reference `subpath` in its implementation. Across the `_tools/makie/plugins` namespace, 82.6% of packages define `plugin( dir, cwd, subpath )`; this package is among those whose signatures legitimately differ, and the documentation now reflects the actual interface. No runtime behavior changes.

### `makie-view-complexity`

The `plugin` function accepts a single `dir` parameter, which it uses as the working directory when spawning the `make view-complexity` process. JSDoc contained two stale `@param` tags — `cwd` and `subpath` — for arguments the function neither declares nor uses; both have been removed. The corrected documentation matches the implementation and reflects the same convention applied to the other plugins in this namespace whose signatures diverge from the 82.6% `(dir, cwd, subpath)` norm.

### `makie-view-cov`

Removes stale `@param {string} cwd` and `@param {string} subpath` JSDoc tags from `makie-view-cov`, which accepts a single `dir` argument and invokes the `view-cov` make target with no additional parameters. The function signature `(dir, cwd, subpath)` is the documented convention in 82.6% of packages in the `_tools/makie/plugins` namespace; this package is one of three that legitimately diverge, and its documentation now reflects only what the implementation accepts. No logic was changed.

### Validation

-   **Structural extraction:** file tree, `package.json` keys, README sections, manifest keys, test/benchmark/example file naming. All 23 plugins share an identical 3-file layout (`lib/index.js`, `lib/main.js`, `package.json`) and identical 16-key `package.json` shape; no structural drift was found.
-   **Semantic extraction:** signatures, JSDoc tags, helper callbacks, requires, error construction. Drift was localised to JSDoc `@param` tags in the three packages above.
-   **Three-agent triage** (Agent 1 semantic-review, Agent 2 cross-reference) confirmed all three deviations as drift with no cascade. Agent 3 (structural-review) did not apply: this is a purely semantic correction.
-   **Deliberately excluded:** intentional shorter-signature packages whose JSDoc already matches their implementation (`makie-repl`); helper-callback differences in `makie-repl` and `makie-stats-list-contributors`, which use `stdio: 'inherit'` and intentionally do not capture `stdout`/`stderr`; keyword-array variation, which has no clear majority beyond the shared 5-keyword prefix.
-   **Cross-run dedup:** no open PRs and no merged PRs in the last 14 days touch this namespace.

## Related Issues

None.

## Questions

None.

## Other

The branch contains 54 commits of unrelated prior work that were already pushed before this drift run started. The three drift commits at `HEAD~2..HEAD` are the only changes proposed by this PR. Cherry-pick or filter as appropriate when reviewing.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift-detection routine. The routine extracts structural and semantic features from every package in a randomly-picked namespace, identifies the majority pattern per feature at the 75% threshold, runs a multi-agent triage on the outliers (semantic-review, cross-reference, structural-review), and applies only those mechanical corrections that survive triage. The three corrections in this PR were each independently confirmed as JSDoc-vs-implementation drift by the triage agents; the function bodies were left untouched.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_011wxsyifegUjMvwQQudHGN4)_