### PR TITLE
refactor: align `blas/ext/base/gcartesian-square` JSDoc and accessor return with siblings

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/accessors.js
@@ -29,7 +29,7 @@ var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 * Computes the Cartesian square for a strided accessor array.
 *
 * @private
-* @param {NonNegativeInteger} N - number of indexed elements
+* @param {PositiveInteger} N - number of indexed elements
 * @param {Object} x - input array object
 * @param {Collection} x.data - input array data
 * @param {Array<Function>} x.accessors - array element accessors
@@ -41,7 +41,7 @@ var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 * @param {integer} strideOut1 - stride length for the first dimension of `out`
 * @param {integer} strideOut2 - stride length for the second dimension of `out`
 * @param {NonNegativeInteger} offsetOut - starting index for `out`
-* @returns {Collection} output array
+* @returns {Object} output array object
 *
 * @example
 * var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
@@ -86,7 +86,7 @@ function gcartesianSquare( N, x, strideX, offsetX, out, strideOut1, strideOut2, 
 			}
 			ix += strideX;
 		}
-		return obuf;
+		return out;
 	}
 	// Column-major...
 	for ( i = 0; i < N; i++ ) { // Note: these loops inline the equivalent of `gfill` to avoid the overhead of intermediate object creation and accessor dispatch on each call...
@@ -106,7 +106,7 @@ function gcartesianSquare( N, x, strideX, offsetX, out, strideOut1, strideOut2, 
 			io += strideOut1;
 		}
 	}
-	return obuf;
+	return out;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/accessors.js
@@ -29,7 +29,7 @@ var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 * Computes the Cartesian square for a strided accessor array.
 *
 * @private
-* @param {PositiveInteger} N - number of indexed elements
+* @param {NonNegativeInteger} N - number of indexed elements
 * @param {Object} x - input array object
 * @param {Collection} x.data - input array data
 * @param {Array<Function>} x.accessors - array element accessors

--- a/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/main.js
@@ -34,7 +34,7 @@ var ndarray = require( './ndarray.js' );
 * Computes the Cartesian square for a strided array.
 *
 * @param {string} order - storage layout
-* @param {PositiveInteger} N - number of indexed elements
+* @param {NonNegativeInteger} N - number of indexed elements
 * @param {Collection} x - input array
 * @param {integer} strideX - stride length for `x`
 * @param {Collection} out - output array

--- a/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/main.js
@@ -34,7 +34,7 @@ var ndarray = require( './ndarray.js' );
 * Computes the Cartesian square for a strided array.
 *
 * @param {string} order - storage layout
-* @param {NonNegativeInteger} N - number of indexed elements
+* @param {PositiveInteger} N - number of indexed elements
 * @param {Collection} x - input array
 * @param {integer} strideX - stride length for `x`
 * @param {Collection} out - output array

--- a/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/ndarray.js
@@ -36,7 +36,7 @@ var accessors = require( './accessors.js' );
 *
 * -   Pairs are stored as rows in the output matrix, where the first column contains the first element of each pair and the second column contains the second element.
 *
-* @param {PositiveInteger} N - number of indexed elements
+* @param {NonNegativeInteger} N - number of indexed elements
 * @param {Collection} x - input array
 * @param {integer} strideX - stride length for `x`
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcartesian-square/lib/ndarray.js
@@ -36,7 +36,7 @@ var accessors = require( './accessors.js' );
 *
 * -   Pairs are stored as rows in the output matrix, where the first column contains the first element of each pair and the second column contains the second element.
 *
-* @param {NonNegativeInteger} N - number of indexed elements
+* @param {PositiveInteger} N - number of indexed elements
 * @param {Collection} x - input array
 * @param {integer} strideX - stride length for `x`
 * @param {NonNegativeInteger} offsetX - starting index for `x`
@@ -68,7 +68,8 @@ function gcartesianSquare( N, x, strideX, offsetX, out, strideOut1, strideOut2, 
 	xobj = arraylike2object( x );
 	oobj = arraylike2object( out );
 	if ( xobj.accessorProtocol || oobj.accessorProtocol ) {
-		return accessors( N, xobj, strideX, offsetX, oobj, strideOut1, strideOut2, offsetOut ); // eslint-disable-line max-len
+		accessors( N, xobj, strideX, offsetX, oobj, strideOut1, strideOut2, offsetOut ); // eslint-disable-line max-len
+		return out;
 	}
 	ix = offsetX;
 	io = offsetOut;


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-05-06 14:57 -0400 and 2026-05-06 18:39 -0700 (SHA range `26286631e` … `5293ab638`, 22 first-parent commits).

## Description

This pull request:

-   Aligns `blas/ext/base/gcartesian-square` with sibling strided routines in `blas/ext/base`.

### `blas/ext/base/gcartesian-square`

-   Fixes a return-value inconsistency introduced in `0c3e5bd9e` for `blas/ext/base/gcartesian-square`: `accessors.js` now returns `out` (not the underlying buffer `obuf`) with a corrected `@returns {Object} output array object` annotation, and `ndarray.js` invokes `accessors(...)` for its side effect and returns `out` directly, aligning behavior and docs with the sibling `gcartesian-power` package.
-   Fix incorrect `{NonNegativeInteger}` annotation on parameter `N` in `blas/ext/base/gcartesian-square` (introduced in `0c3e5bd9e`), aligning with the `{PositiveInteger}` convention used across all sibling strided routines in `blas/ext/base`.

## Related Issues

None.

## Questions

No.

## Other

Generated by an automated review of the 22 first-parent commits merged to `develop` in the preceding 24-hour window.

**Validation performed:**

-   stdlib code style guideline compliance (`docs/style-guides/javascript`, `docs/style-guides/c`).
-   Comparison against established sibling reference packages: `gcartesian-power`, `gfill`, `gcusum`, `dwhere`, `swhere`, `zwhere`.
-   Bug scan limited to the diff window itself (no out-of-window context required for any landed fix).
-   Re-read of every modified file post-edit to confirm fixes match the proposed change exactly.

**Deliberately excluded:**

-   Anything requiring interpretation of intent (e.g., the `to-reversed-dimensions` JSDoc-vs-error-message wording, where downstream `reverseDimensions` enforces the broader contract).
-   The "missing intro section" in the `gcartesian-square` README, which is consistent with every other cartesian-family sibling (`gcartesian-power`, `dcartesian-power`, `scartesian-power`, `dcartesian-square`, `scartesian-square`).
-   Subjective preferences and any change requiring edits outside the diff window.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as a follow-up review of commits merged to `develop` in the preceding 24 hours. Findings were validated against established sibling packages, and only high-signal issues with concrete, in-scope fixes were applied.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcyaJTucBpsNQXhxSnBokV)_