### PR TITLE
docs: correct C API heading function name in `stats/base/dists/exponential/logcdf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/README.md
@@ -163,7 +163,7 @@ logEachMap( 'x: %0.4f, λ: %0.4f, ln(F(x;λ)): %0.4f', x, lambda, logcdf );
 #include "stdlib/stats/base/dists/exponential/logcdf.h"
 ```
 
-#### stdlib_base_dists_exponential_cdf( x, lambda )
+#### stdlib_base_dists_exponential_logcdf( x, lambda )
 
 Evaluates the natural logarithm of the [cumulative distribution function (CDF)][cdf] for an exponential distribution with rate parameter `lambda`.
 


### PR DESCRIPTION
## Description

Corrects a copy-paste typo in the `## C APIs` section of `lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/README.md`. The `####` heading on line 166 documented `stdlib_base_dists_exponential_cdf( x, lambda )` — the `cdf` sibling's function name — instead of the actual function `stdlib_base_dists_exponential_logcdf( x, lambda )`. The same file's subsequent code blocks (lines 171, 181, 222), the public header (`include/stdlib/stats/base/dists/exponential/logcdf.h`), `src/main.c`, and `src/addon.c` all use the correct name.

### `stats/base/dists/exponential/logcdf`

Sole drift item: C API heading text drifted from the function it documents (13/14 = 93% of sibling packages with a C API section name the heading to match the implemented function). One-line fix; no code, tests, or examples touched.

## Related Issues

None.

## Questions

No.

## Other

Cross-package drift scan over the 15 members of `@stdlib/stats/base/dists/exponential/`. Structural extraction (file trees, `package.json` shape, README headings, `manifest.json` shape) and semantic extraction (signatures, validation prologues, error construction, JSDoc shape, dependencies) found one feature with a clear majority and a single outlier:

- **C API `####` heading text matches function name**: 13/14 packages with a C API section conform; `logcdf` was the lone outlier.

Other inter-package differences (`PositiveNumber` vs `NonNegativeNumber` parameter typing, presence of `factory()`, presence of native bindings) reflect genuine semantic groupings (scalar-valued vs bivariate functions; `ctor` is a JS-only constructor) and were excluded from the drift list. Validation: structural review confirmed the heading-name pattern, and a cross-reference check confirmed no test or example references `stdlib_base_dists_exponential_cdf` from within the `logcdf` package.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a cross-package API drift detection routine. The routine extracted structural and semantic features from all 15 packages in `@stdlib/stats/base/dists/exponential/`, computed per-feature majority patterns, and flagged a single outlier — a copy-paste error in the `logcdf` README's C API heading. Validation confirmed the deviation was unintentional (every other reference in the same file already uses the correct function name) and the fix is mechanical (one-word heading correction, no behavior change).

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_015YwpEQiZK6tRWnEn5GFFtX)_