### PR TITLE
fix: update stride validation error messages

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/main.js
@@ -49,7 +49,7 @@ var ndarray = require( './ndarray.js' );
 * @param {Collection} workspace - workspace array for tracking row match candidates
 * @param {integer} strideW - stride length for `workspace`
 * @throws {TypeError} first argument must be a valid order
-* @throws {RangeError} fifth argument must be a valid stride
+* @throws {RangeError} fifth argument must be greater than or equal to max(1,N)
 * @returns {integer} row index
 *
 * @example
@@ -73,7 +73,7 @@ function glastIndexOfRow( order, M, N, A, LDA, x, strideX, workspace, strideW ) 
 		s = M;
 	}
 	if ( LDA < max( 1, s ) ) {
-		throw new RangeError( format( 'invalid argument. Fifth argument must be a valid stride. Value: `%d`.', LDA ) );
+		throw new RangeError( format( 'invalid argument. Fifth argument must be greater than or equal to max(1,%d). Value: `%d`.', s, LDA ) );
 	}
 	if ( isColumnMajor( order ) ) {
 		sa1 = 1;

--- a/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/main.js
@@ -49,7 +49,7 @@ var ndarray = require( './ndarray.js' );
 * @param {Collection} workspace - workspace array for tracking row match candidates
 * @param {integer} strideW - stride length for `workspace`
 * @throws {TypeError} first argument must be a valid order
-* @throws {RangeError} fifth argument must be greater than or equal to max(1,N)
+* @throws {RangeError} fifth argument must be a valid stride
 * @returns {integer} row index
 *
 * @example

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.js
@@ -49,7 +49,7 @@ var ndarray = require( './ndarray.js' );
 * @param {Uint8Array} workspace - workspace array for tracking row match candidates
 * @param {integer} strideW - stride length for `workspace`
 * @throws {TypeError} first argument must be a valid order
-* @throws {RangeError} fifth argument must be a valid stride
+* @throws {RangeError} fifth argument must be greater than or equal to max(1,N)
 * @returns {integer} row index
 *
 * @example
@@ -76,7 +76,7 @@ function slastIndexOfRow( order, M, N, A, LDA, x, strideX, workspace, strideW ) 
 		s = M;
 	}
 	if ( LDA < max( 1, s ) ) {
-		throw new RangeError( format( 'invalid argument. Fifth argument must be a valid stride. Value: `%d`.', LDA ) );
+		throw new RangeError( format( 'invalid argument. Fifth argument must be greater than or equal to max(1,%d). Value: `%d`.', s, LDA ) );
 	}
 	if ( isColumnMajor( order ) ) {
 		sa1 = 1;

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.js
@@ -49,7 +49,7 @@ var ndarray = require( './ndarray.js' );
 * @param {Uint8Array} workspace - workspace array for tracking row match candidates
 * @param {integer} strideW - stride length for `workspace`
 * @throws {TypeError} first argument must be a valid order
-* @throws {RangeError} fifth argument must be greater than or equal to max(1,N)
+* @throws {RangeError} fifth argument must be a valid stride
 * @returns {integer} row index
 *
 * @example

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.native.js
@@ -43,7 +43,7 @@ var addon = require( './../src/addon.node' );
 * @param {Uint8Array} workspace - workspace array for tracking row match candidates
 * @param {integer} strideW - stride length for `workspace`
 * @throws {TypeError} first argument must be a valid order
-* @throws {RangeError} fifth argument must be greater than or equal to max(1,N)
+* @throws {RangeError} fifth argument must be a valid stride
 * @returns {integer} row index
 *
 * @example

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.native.js
@@ -43,7 +43,7 @@ var addon = require( './../src/addon.node' );
 * @param {Uint8Array} workspace - workspace array for tracking row match candidates
 * @param {integer} strideW - stride length for `workspace`
 * @throws {TypeError} first argument must be a valid order
-* @throws {RangeError} fifth argument must be a valid stride
+* @throws {RangeError} fifth argument must be greater than or equal to max(1,N)
 * @returns {integer} row index
 *
 * @example
@@ -68,7 +68,7 @@ function slastIndexOfRow( order, M, N, A, LDA, x, strideX, workspace, strideW ) 
 		s = M;
 	}
 	if ( LDA < max( 1, s ) ) {
-		throw new RangeError( format( 'invalid argument. Fifth argument must be a valid stride. Value: `%d`.', LDA ) );
+		throw new RangeError( format( 'invalid argument. Fifth argument must be greater than or equal to max(1,%d). Value: `%d`.', s, LDA ) );
 	}
 	return addon( resolveOrder( order ), M, N, A, LDA, x, strideX, workspace, strideW ); // eslint-disable-line max-len
 }


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between `11fb87da` (2026-05-07 13:37 -0500) and `5fd5c85c` (2026-05-08 16:47 +0500). Two sibling-consistency fixes across recently-added `blas/ext/base` packages:

-   **`blas/ext/base/slast-index-of-row`** — The error message in `lib/slast_index_of_row.js` and `lib/slast_index_of_row.native.js` (`03cd59e4`) lacks the lower bound specification that `sindex-of-row` and sibling packages include; updated both files and their JSDoc `@throws` tags to use the form `'invalid argument. Fifth argument must be greater than or equal to max(1,%d). Value: \`%d\`.'` with both stride and `LDA` parameters.

-   **`blas/ext/base/glast-index-of-row`** — `7c02336d` has incomplete stride validation messaging in `lib/main.js`: the runtime throw omits the required lower bound and the `@throws` tag lacks context. Aligned both the error format string and documentation with the sibling `gindex-of-row` implementation, which provides the full constraint `max(1,N)` for auditability.

## Related Issues

No related issues.

## Questions

No.

## Other

### Validation

What was checked:

-   stdlib code-style compliance for the four new `blas/ext/base` packages (`cwhere`, `dindex-of-column`, `slast-index-of-row`, `glast-index-of-row`) and supporting commits, comparing each against established sibling packages.
-   Bug scan over the diff (loop bounds, stride math, NaN/inf handling, N-API argument validation, row-major vs column-major branching, negative-stride paths, format-string arity, JSDoc/runtime contract agreement).

What was deliberately excluded:

-   Anything requiring interpretation, judgement calls, or context outside the diff window to validate.
-   The auto-generated REPL data dump (`ddb2fb7e`) and TypeScript declaration auto-updates (`cecfaba8`, `583a8336`) — spot-checked only.
-   Subjective preferences, "could be cleaner" suggestions, and nitpicks.

### Note on revisions

An earlier revision of this PR also included a documentation-wording change to `blas/ext/base/dindex-of-column` ("stride of the" → "stride length for the"). That commit was dropped after maintainer review: the original phrasing already matched the majority sibling convention (`dindex-of-row`, `sindex-of-row`, `gindex-of-row`), so the change was unwarranted.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code as part of an automated 24-hour commit-review pass. Findings were produced by parallel reviewer agents, independently re-verified against sibling packages before any edit, and limited to high-signal sibling-consistency fixes. A maintainer should audit before promoting out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_011khUcNFhVFVmsnp7Tcp1vR)_