### PR TITLE
docs: correct parameter prose in `stats/base/dists/gumbel/mgf` doc comments

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/docs/types/index.d.ts
@@ -31,14 +31,14 @@ type Unary = ( t: number ) => number;
 */
 interface MGF {
 	/**
-	* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `b` at a value `t`.
+	* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `beta` at a value `t`.
 	*
 	* ## Notes
 	*
 	* -   If provided `beta <= 0`, the function returns `NaN`.
 	*
 	* @param t - input value
-	* @param mu - mean
+	* @param mu - location parameter
 	* @param beta - scale parameter
 	* @returns evaluated MGF
 	*
@@ -74,9 +74,9 @@ interface MGF {
 	( t: number, mu: number, beta: number ): number;
 
 	/**
-	* Returns a function for evaluating the moment-generating function (MGF) of a Gumbel distribution with location parameter `mu` and scale parameter `b`.
+	* Returns a function for evaluating the moment-generating function (MGF) of a Gumbel distribution with location parameter `mu` and scale parameter `beta`.
 	*
-	* @param mu - mean
+	* @param mu - location parameter
 	* @param beta - scale parameter
 	* @returns MGF
 	*
@@ -93,10 +93,10 @@ interface MGF {
 }
 
 /**
-* Gamma distribution moment-generating function (MGF).
+* Gumbel distribution moment-generating function (MGF).
 *
 * @param t - input value
-* @param mu - mean
+* @param mu - location parameter
 * @param beta - scale parameter
 * @returns evaluated MGF
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/include/stdlib/stats/base/dists/gumbel/mgf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/include/stdlib/stats/base/dists/gumbel/mgf.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `b` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `beta` at a value `t`.
 */
 double stdlib_base_dists_gumbel_mgf( const double t, const double mu, const double beta );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/lib/factory.js
@@ -29,9 +29,9 @@ var exp = require( '@stdlib/math/base/special/exp' );
 // MAIN //
 
 /**
-* Returns a function for evaluating the moment-generating function (MGF) of a Gumbel distribution with location parameter `mu` and scale parameter `b`.
+* Returns a function for evaluating the moment-generating function (MGF) of a Gumbel distribution with location parameter `mu` and scale parameter `beta`.
 *
-* @param {number} mu - mean
+* @param {number} mu - location parameter
 * @param {PositiveNumber} beta - scale parameter
 * @returns {Function} MGF
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/lib/main.js
@@ -28,10 +28,10 @@ var exp = require( '@stdlib/math/base/special/exp' );
 // MAIN //
 
 /**
-* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `b` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `beta` at a value `t`.
 *
 * @param {number} t - input value
-* @param {number} mu - mean
+* @param {number} mu - location parameter
 * @param {PositiveNumber} beta - scale parameter
 * @returns {number} evaluated MGF
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `b` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `beta` at a value `t`.
 *
 * @private
 * @param {number} t - input value

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/src/main.c
@@ -22,7 +22,7 @@
 #include "stdlib/math/base/special/exp.h"
 
 /**
-* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `b` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a Gumbel distribution with location parameter `mu` and scale parameter `beta` at a value `t`.
 *
 * @param t       input value
 * @param mu      location parameter


### PR DESCRIPTION
## Description

Documentation prose in `@stdlib/stats/base/dists/gumbel/mgf` referenced the scale parameter as `b` and labeled the location parameter `mu` as "mean", and the package's TypeScript declaration opened the `declare var` JSDoc block with "Gamma distribution" — copy-paste artifacts inconsistent with both `mgf`'s own README/repl.txt and 13/13 sibling packages in the namespace. Six files were normalized to the namespace convention; no behavior, signatures, exports, or test expectations change.

### Namespace summary

-   **Members analyzed:** 15 (all non-autogenerated children of `stats/base/dists/gumbel/`)
-   **Majority threshold:** 12/15 (≥75%)
-   **Features analyzed:** file tree, `package.json` shape, `manifest.json` presence, README sections (set + order), test/benchmark/examples filenames, public signature, validation prologue, return kind, error construction, JSDoc shape, doc-comment prose, dependencies
-   **Features with clear majority that produced advancing corrections:** doc-comment prose for the location/scale parameters and the function-summary line (1 outlier package, 13 sites)
-   **Features with clear majority but no advancing corrections:** structural drift on `ctor` (no native bindings), `mgf` and `skewness` (no `test/fixtures/julia/`) — see Validation
-   **Features without clear majority:** none — every observed feature either reached 75% or had a single dominant value

### `stats/base/dists/gumbel/mgf`

The function-summary line in `lib/main.js`, `lib/factory.js`, `lib/native.js`, `docs/types/index.d.ts`, `include/stdlib/stats/base/dists/gumbel/mgf.h`, and `src/main.c` referenced the scale parameter as `` `b` `` (13/13 sibling packages and `mgf`'s own README/repl.txt use `` `beta` ``). The `@param mu` description in `lib/main.js`, `lib/factory.js`, and three sites in `docs/types/index.d.ts` was "mean" rather than "location parameter" (13/13 siblings use "location parameter"; `mu` is not the mean of the Gumbel distribution — `mu + beta·γ_E` is). The `declare var mgf` JSDoc opened with "Gamma distribution moment-generating function (MGF)." (5/5 factory-style siblings open with "Gumbel distribution …"). Total: 13 sites, 6 files, +13 / −13 LOC.

### Validation

What was checked:

-   Structural feature extraction across all 15 members (file tree, `package.json` shape, README headings, test/benchmark/examples file naming).
-   Semantic feature extraction (public signature, validation prologue, return kind, doc-comment prose, JSDoc shape, dependencies) across the 14 function-style packages, plus the JS/TS/C documentation prose.
-   Independent validation passes against the surviving outlier:
    1.  Opus semantic-review on `mgf`'s doc-comment drift → `confirmed-drift` (parameter is named `beta` in code; `mu` is a location parameter, not the mean; `Gamma distribution` is a copy-paste artifact).
    2.  Opus cross-reference against `mgf`'s tests, examples, factory, native bindings, namespace re-exports, and any consumer importing the package → `safe-to-apply` (no test, fixture, or downstream consumer references the existing wording).

What was deliberately excluded:

-   `ctor`'s missing `binding.gyp`, `manifest.json`, native bindings, and `## C APIs` README section — inapplicable to a JavaScript constructor with property accessors.
-   `mgf`'s and `skewness`'s missing `test/fixtures/julia/` directory — `mgf`'s tests already exercise analytically known values; `skewness` for Gumbel is a parameter-independent constant (Julia ground-truth fixtures would be mathematically meaningless).
-   `lib/factory.js` / `lib/index.js` only present in the six factory-style packages — minority pattern, not drift.
-   The `## Notes` README section in `logcdf`/`logpdf` — minority pattern reflecting genuine domain notes for those functions.

## Other

This PR is the output of a per-namespace cross-package drift-detection routine. The full per-feature majority/conformance/outlier breakdown and per-agent verdicts are recorded in the local report at `~/drift-reports/drift-stats-base-dists-gumbel-2026-05-09.md`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

-   [x] Yes
-   [ ] No

How AI assistance was used:

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated cross-package drift-detection routine. The routine extracted structural and semantic features from every member of `stats/base/dists/gumbel/`, computed per-feature majority patterns at a 75% threshold, and dispatched two independent Opus validation agents (semantic review, cross-reference safety check) against the surviving findings. The single advancing finding produced this 13-site, 6-file, behavior-preserving prose normalization.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNv5pVrWJ8PZBavSNwyDiB)_