### PR TITLE
chore: rename internal variable to `main` in two `string` packages

### DIFF
--- a/lib/node_modules/@stdlib/string/remove-utf8-bom/lib/index.js
+++ b/lib/node_modules/@stdlib/string/remove-utf8-bom/lib/index.js
@@ -32,9 +32,9 @@
 
 // MODULES //
 
-var removeUTF8BOM = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = removeUTF8BOM;
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/utf16-to-utf8-array/lib/index.js
+++ b/lib/node_modules/@stdlib/string/utf16-to-utf8-array/lib/index.js
@@ -33,9 +33,9 @@
 
 // MODULES //
 
-var utf16ToUTF8Array = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = utf16ToUTF8Array;
+module.exports = main;


### PR DESCRIPTION
## Description

This pull request:

-   Renames the internal variable in `lib/index.js` from a descriptive name to `main` in two `@stdlib/string` packages, matching the convention used in 54 of 56 (96.4%) sibling packages in the namespace. The change is local to `lib/index.js` and does not alter what is exported.

### `@stdlib/string/remove-utf8-bom`

`lib/index.js` declared `var removeUTF8BOM = require( './main.js' );` and `module.exports = removeUTF8BOM;`. Renamed both occurrences to `main` to match the namespace convention (96.4% conformance). No public-facing change.

### `@stdlib/string/utf16-to-utf8-array`

`lib/index.js` declared `var utf16ToUTF8Array = require( './main.js' );` and `module.exports = utf16ToUTF8Array;`. Renamed both occurrences to `main` to match the namespace convention (96.4% conformance). No public-facing change.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a cross-package drift-detection routine. The routine extracted structural and semantic features from every package in `@stdlib/string`, identified the majority pattern per feature, and validated the surviving correction with three independent review agents before applying.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01XTKE9JQJfeRYxmMZQNTCfo)_