### PR TITLE
bench: replace `new Array(100)` with `zeros(100, 'generic')` in `assert/is-*-property` benchmarks

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-accessor-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-accessor-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isAccessorPropertyIn = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-accessor-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-accessor-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isAccessorProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-configurable-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-configurable-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isConfigurableProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-data-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-data-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isDataPropertyIn = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-data-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-data-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isDataProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-enumerable-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-enumerable-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isEnumerablePropertyIn = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-enumerable-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-enumerable-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isEnumerableProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-nonconfigurable-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-nonconfigurable-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isNonConfigurablePropertyIn = require( './../lib' ); // eslint-disable-line id-length
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-nonconfigurable-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-nonconfigurable-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isNonConfigurableProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-nonenumerable-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-nonenumerable-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isNonEnumerableProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-read-only-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-read-only-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isReadOnlyPropertyIn = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-read-only-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-read-only-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isReadOnlyProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-read-write-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-read-write-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isReadWritePropertyIn = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-read-write-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-read-write-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isReadWriteProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-readable-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-readable-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isReadablePropertyIn = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 ); // eslint-disable-line stdlib/no-new-array
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-writable-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-writable-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isWritablePropertyIn = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-writable-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-writable-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isWritableProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-write-only-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-write-only-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isWriteOnlyPropertyIn = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-write-only-property/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-write-only-property/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/zeros' );
 var pkg = require( './../package.json' ).name;
 var isWriteOnlyProperty = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = zeros( 100, 'generic' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-05-08 17:03 PDT and 2026-05-09 02:24 PDT to sibling packages with the same defect.

### `6f01b40` — replace `new Array(100)` with `zeros(100, 'generic')` in `assert/is-*-property` benchmarks

Mirrors `6f01b40` across 19 benchmark files: replaces `new Array( 100 )` with `zeros( 100, 'generic' )` and adds the corresponding `@stdlib/array/zeros` require after the `isBoolean` import, resolving `stdlib/no-new-array` violations. The `arr` variable serves only as a property-inspection target, so zero-initialization is semantically equivalent to uninitialized. For `is-readable-property-in`, the inline `// eslint-disable-line stdlib/no-new-array` suppression directive is also removed alongside the violation it masked.

-   `lib/node_modules/@stdlib/assert/is-accessor-property`
-   `lib/node_modules/@stdlib/assert/is-accessor-property-in`
-   `lib/node_modules/@stdlib/assert/is-configurable-property`
-   `lib/node_modules/@stdlib/assert/is-data-property`
-   `lib/node_modules/@stdlib/assert/is-data-property-in`
-   `lib/node_modules/@stdlib/assert/is-enumerable-property`
-   `lib/node_modules/@stdlib/assert/is-enumerable-property-in`
-   `lib/node_modules/@stdlib/assert/is-nonconfigurable-property`
-   `lib/node_modules/@stdlib/assert/is-nonconfigurable-property-in`
-   `lib/node_modules/@stdlib/assert/is-nonenumerable-property`
-   `lib/node_modules/@stdlib/assert/is-read-only-property`
-   `lib/node_modules/@stdlib/assert/is-read-only-property-in`
-   `lib/node_modules/@stdlib/assert/is-read-write-property`
-   `lib/node_modules/@stdlib/assert/is-read-write-property-in`
-   `lib/node_modules/@stdlib/assert/is-readable-property-in`
-   `lib/node_modules/@stdlib/assert/is-writable-property`
-   `lib/node_modules/@stdlib/assert/is-writable-property-in`
-   `lib/node_modules/@stdlib/assert/is-write-only-property`
-   `lib/node_modules/@stdlib/assert/is-write-only-property-in`

## Related Issues

None.

## Questions

No.

## Other

### Validation

-   **Search scope**: each source pattern was searched within `lib/node_modules/@stdlib/**/test/*.js` and `lib/node_modules/@stdlib/**/benchmark/*.js`. Originating packages already fixed by the source commits (`assert/is-readable-property`) were excluded.
-   **Independent validation**: two independent Opus validation agents reviewed every candidate site by reading each file in full; both returned `confirmed` for all 19 P2 sites. A separate Opus adaptation agent generated the per-site P2 patches (import-after-anchor + line replace), and a Sonnet style-consistency agent confirmed each replacement matches the source-commit precedent.
-   **Deliberately excluded**:
    -   The blank-line removals propagated from `41d54f5` and `6f01b40` (originally bundled with this PR) were dropped after reviewer feedback: the empty lines separating fixture import blocks are intentional logical-group separators (e.g., `column_major_*` vs `row_major_*`), not stray whitespace. See discussion at https://github.com/stdlib-js/stdlib/pull/12010#discussion_r3213891490.
    -   `01ddffb2` ("docs: propagate recent fixes across `stats/base/dists` and `lapack/base`") — itself a propagation commit; recent-merge dedup applies.
    -   `f7b9386` ("docs: place copy in codeblock") — one-off editorial fix to `docs/contributing/zen_of_stdlib.md` with no replicable search signature.
    -   88 files matched by the `new Array(N)` regex but rejected: `math/strided/special/*-by`, `math/strided/ops/*-by`, `strided/base/*-by`, and `stats/strided/*-by` test files use `new Array(5)` to construct **intentionally sparse** arrays — replacing with `zeros(5, 'generic')` would change test semantics (callbacks skip holes but would process zero-valued slots).
    -   `assert/is-prototype-of/benchmark.js` and `assert/is-arraybuffer-view/test/*.js` — `new Array(N)` used as a value in a heterogeneous-type-dispatch literal; replacement would change the runtime type observed by the type-checking function.
    -   `stats/{fligner,bartlett,kruskal}-test`, `stats/{ttest2,vartest,binomial-test,chi2gof}`, `blas/base/gasum`, `array/pool`, and several `utils/*` benchmark files — arrays fully overwritten in a fill loop before any read; the `Array` constructor here triggers the lint rule but the values are not semantically uninitialized.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a routine that scans recent `develop` commits for generalizable fixes and propagates them to sibling packages. Each propagation site was independently verified by two Opus validation agents, an Opus adaptation agent (for the `new Array` → `zeros` substitution), and a Sonnet style-consistency agent before patches were applied. The changes are mechanical analogs of the cited source commits and touch only benchmark setup.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_019qz8kssWMLenCUTsgngDXj)_
