### PR TITLE
docs: add `stdmath` keyword to `chebyshev-series` and `chebyshev-seriesf` in `math/base/tools`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/tools/chebyshev-series/package.json
+++ b/lib/node_modules/@stdlib/math/base/tools/chebyshev-series/package.json
@@ -50,8 +50,9 @@
   ],
   "keywords": [
     "stdlib",
-    "math",
+    "stdmath",
     "mathematics",
+    "math",
     "chebyshev",
     "series",
     "polynomial",

--- a/lib/node_modules/@stdlib/math/base/tools/chebyshev-seriesf/package.json
+++ b/lib/node_modules/@stdlib/math/base/tools/chebyshev-seriesf/package.json
@@ -50,8 +50,9 @@
   ],
   "keywords": [
     "stdlib",
-    "math",
+    "stdmath",
     "mathematics",
+    "math",
     "chebyshev",
     "series",
     "polynomial",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

- Inserts the `stdmath` keyword and reorders the leading `keywords` entries in two `math/base/tools` packages so the prefix matches the rest of the namespace: `["stdlib", "stdmath", "mathematics", "math", ...]`.

### Namespace summary

- `@stdlib/math/base/tools`: 17 non-autogenerated members.
- Features analyzed: file tree, `package.json` shape (top-level keys, `scripts`, `keywords`), `manifest.json` shape, README section list/order, test/benchmark/example file naming, and (inline) semantic surface — public signature, validation prologue, error construction, JSDoc shape, dependencies.
- Features with a clear (≥75%) majority that produced an actionable correction: `keywords` prefix sequence (15/17 = 88.2%).
- Features with a clear majority but no actionable outliers: every universal file (`README.md`, `lib/index.js`, `package.json`, `test/test.js`, `benchmark/benchmark.js`, `examples/index.js`, `docs/types/index.d.ts`, `docs/types/test.ts`); 18 universal `package.json` top-level keys.
- Features without a clear majority (excluded): README h2 set order (Notes 12/17 = 71%; See Also 6/17), test/benchmark file naming (multiple sub-majority subsets corresponding to the namespace's three sub-architectures: polynomial evaluators, compile helpers, series tools).
- Features with majority deviations gated out: `lib/main.js` absent in `continued-fraction` and `sum-series` (intentional `basic.js` + `generators.js` architecture for generator/non-generator paths); `docs/repl.txt` absent in the four `*-compile*` packages (88.1% stdlib-wide presence — below the 90% gate).

### `math/base/tools/chebyshev-series`

The `keywords` array begins `["stdlib", "math", "mathematics", "chebyshev", ...]` — the rest of `@stdlib/math/base/tools` (15/17 = 88.2%; `@stdlib/math/*` overall: 665/684 = 97.2%) leads with `stdlib`/`stdmath`/`mathematics`/`math`. Package was added in #11470 and the `stdmath` discoverability marker was missed at authoring; aligning the prefix here matches what every sibling already does. No source, tests, examples, or REPL fixtures touched.

### `math/base/tools/chebyshev-seriesf`

Single-precision sibling carries the same omission verbatim — same rationale, same fix. The two packages were authored together; the divergence is mechanical, not intentional.

### Validation

- Structural extraction over 17 packages: file tree, `package.json` shape, README sections, test/bench/example names.
- Semantic surface inspected inline (no per-package agent fan-out needed): every package in the namespace carries no `throw` and no `@stdlib/assert/*` validation imports — `math/base/*` is the unvalidated fast-path tier — so `validationPrologue`, `errorConstruction`, and related semantic features are trivially universal-empty.
- Three-agent advance criteria: structural-review agent (sonnet) returned `confirmed-drift` for both outliers; cross-reference agent verified that no test, example, README claim, or `_tools/lint/pkg-json` schema constrains keyword content/order beyond presence-of-`stdlib` and the global character-set rule, and that the files are not generator output.
- Cross-run dedup: no open PR proposes this fix; #11470 (the package add) and #11584 (a follow-up doc fix on `chebyshev-seriesf`) merged outside the 14-day window.

### Deliberately excluded

- Intentional architecture deviations (`continued-fraction`, `sum-series` lacking `lib/main.js`).
- The four `*-compile*` packages lacking `docs/repl.txt` — below the ≥90% stdlib-wide gate.
- README `Notes` and `See Also` sections — sub-threshold in this namespace; the `See Also` block is auto-populated regardless and outside the routine's scope.
- All non-`keywords` features that already conform on every member.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Total diff: 4 insertions / 2 deletions across 2 files, both `package.json`. Each outlier receives a single `keywords` prefix change and no other modifications. No commits touch source, tests, examples, types, or generated artifacts.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored by Claude (Opus 4.7) running a cross-package drift-detection routine: a randomly-picked namespace (`@stdlib/math/base/tools`, seed `1818300874`) was scanned for structural and semantic drift against a 75% majority threshold, candidate corrections went through pre-validation gates and a multi-agent advance check (sonnet structural-review and cross-reference review, both `confirmed-drift`), and only the surviving mechanical metadata fix was applied. I reviewed the verdict, the gating decisions, and the diff before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01TQsrwfGFWZiHk2QHgjmqFy)_