### PR TITLE
docs: correct scale parameter JSDoc type in `stats/base/dists/levy`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/lib/native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 * @private
 * @param {number} x - input value
 * @param {number} mu - location parameter
-* @param {number} c - scale parameter
+* @param {PositiveNumber} c - scale parameter
 * @returns {Probability} evaluated CDF
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/lib/factory.js
@@ -31,7 +31,7 @@ var erfcinv = require( '@stdlib/math/base/special/erfcinv' );
 * Returns a function for evaluating the quantile function for a Lévy distribution.
 *
 * @param {number} mu - location parameter
-* @param {NonNegativeNumber} c - scale parameter
+* @param {PositiveNumber} c - scale parameter
 * @returns {Function} quantile function
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/lib/main.js
@@ -31,7 +31,7 @@ var erfcinv = require( '@stdlib/math/base/special/erfcinv' );
 *
 * @param {Probability} p - input value
 * @param {number} mu - location parameter
-* @param {NonNegativeNumber} c - scale parameter
+* @param {PositiveNumber} c - scale parameter
 * @returns {number} evaluated quantile function
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/lib/native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 * @private
 * @param {Probability} p - input value
 * @param {number} mu - location parameter
-* @param {NonNegativeNumber} c - scale parameter
+* @param {PositiveNumber} c - scale parameter
 * @returns {number} evaluated quantile function
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request tightens the JSDoc `@param` annotation for the scale parameter `c` in two outlier packages within `@stdlib/stats/base/dists/levy/*` so that the documented type matches the runtime behavior and the rest of the namespace.

### Namespace summary

- Members analyzed: 12 non-autogenerated packages (`cdf`, `ctor`, `entropy`, `logcdf`, `logpdf`, `mean`, `median`, `mode`, `pdf`, `quantile`, `stdev`, `variance`).
- Features analyzed: file tree, `package.json` shape, README headings, `manifest.json` shape, test/benchmark/example file naming, public signatures, validation prologues, error construction, JSDoc shape, and source dependencies.
- Features with a clear majority (≥75%) producing actionable drift findings: JSDoc `@param` type for the scale parameter `c`.
- Features with no clear majority or where deviations were semantically justified (and excluded): native binding presence (the `ctor` package legitimately has no native addon), R benchmark files (present only in distribution-function packages), Julia test fixtures (varies by package; not mechanically synthesizable), `lib/factory.js` presence (only relevant for distribution-function packages), and `## Notes` README section (specific to packages with non-trivial domain notes).

### Per outlier package

### `@stdlib/stats/base/dists/levy/quantile`

Corrects the JSDoc `@param` annotation for the scale parameter `c` in `lib/main.js`, `lib/factory.js`, and `lib/native.js` from `NonNegativeNumber` to `PositiveNumber`. The runtime guard returns `NaN` for `c <= 0.0`, so zero is not a valid input and the looser annotation was incorrect. Brings this package into alignment with the 11 other Lévy distribution packages that already use `PositiveNumber` for `c` (92% conformance).

### `@stdlib/stats/base/dists/levy/cdf`

Corrects the JSDoc type annotation for the scale parameter `c` in `lib/native.js` from `{number}` to `{PositiveNumber}`, bringing the native binding wrapper into conformance with the 82% majority pattern across analogous wrappers and with `lib/main.js`, which already documents the parameter correctly. The looser `{number}` annotation is inaccurate: the runtime returns `NaN` for `c <= 0`, so `PositiveNumber` is the precise type. No logic changes.

### Validation

Checked via:

- Structural feature extraction across all 12 non-autogenerated namespace members (file trees, `package.json` shape, README headings, `manifest.json` shape, test/benchmark/example file naming).
- Per-package semantic feature extraction (public signature, validation prologue, error construction, JSDoc shape, dependencies).
- Three-agent drift validation: semantic review (confirmed the JSDoc type mismatch is a documentation oversight, not a behavioral difference), cross-reference review (confirmed no test, type-test, example, or sibling package depends on the deviating JSDoc text — `docs/types/index.d.ts` declarations use bare `number` and tests verify runtime behavior via `tape`), and structural review (n/a; the change is a JSDoc tag edit, not a structural addition).

Deliberately excluded:

- Outliers reflecting a genuine semantic difference (e.g., `ctor` lacking native binding files because it is a class constructor, not a math function).
- Drift requiring non-mechanical fixes (e.g., adding Julia test fixtures, which would require generating reference data).
- Features without a clear majority pattern.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Total diff: 4 lines across 4 files in 2 outlier packages. Each commit groups all corrections per outlier package.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via an automated cross-package API drift detection routine. The routine extracts structural and semantic features from every non-autogenerated package in a randomly selected stdlib namespace, identifies the majority pattern per feature, and flags deviating packages. Proposed corrections were validated by three independent agents (semantic review, cross-reference review, structural review) before being applied. All applied changes are mechanical JSDoc type corrections that preserve runtime behavior.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_012fYLDeTXb2JQV1GDxymFte)_