### PR TITLE
chore: rename internal variable to `main`

### DIFF
--- a/lib/node_modules/@stdlib/datasets/afinn-111/lib/index.js
+++ b/lib/node_modules/@stdlib/datasets/afinn-111/lib/index.js
@@ -31,9 +31,9 @@
 
 // MODULES //
 
-var afinn111 = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = afinn111;
+module.exports = main;

--- a/lib/node_modules/@stdlib/datasets/afinn-96/lib/index.js
+++ b/lib/node_modules/@stdlib/datasets/afinn-96/lib/index.js
@@ -31,9 +31,9 @@
 
 // MODULES //
 
-var afinn96 = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = afinn96;
+module.exports = main;

--- a/lib/node_modules/@stdlib/datasets/minard-napoleons-march/lib/index.js
+++ b/lib/node_modules/@stdlib/datasets/minard-napoleons-march/lib/index.js
@@ -42,9 +42,9 @@
 
 // MODULES //
 
-var minard = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = minard;
+module.exports = main;

--- a/lib/node_modules/@stdlib/datasets/month-names-en/lib/index.js
+++ b/lib/node_modules/@stdlib/datasets/month-names-en/lib/index.js
@@ -32,9 +32,9 @@
 
 // MODULES //
 
-var months = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = months;
+module.exports = main;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Renames the internal `lib/index.js` binding from a per-package name to `main` in four `@stdlib/datasets` packages, normalizing them to the canonical stdlib `lib/index.js` shape.

### Namespace summary

-   **Namespace**: `@stdlib/datasets` (57 packages, none autogenerated)
-   **Features analyzed (structural)**: file tree, `package.json` shape (top-level keys, scripts, stdlib), `datapackage.json` shape, `README.md` `##`/`###` heading set and ordering, presence of canonical files (`bin/cli`, `etc/cli_opts.json`, `test/test.js`, `test/test.cli.js`, `test/test.main.js`, `test/test.browser.js`, `benchmark/benchmark.js`, `benchmark/benchmark.browser.js`, `examples/index.js`, `docs/types/index.d.ts`, `docs/types/test.ts`, `docs/repl.txt`, `lib/index.js`, `lib/main.js`, `lib/browser.js`, `LICENSE`), `lib/index.js` redacted code shape.
-   **Features analyzed (semantic)**: public signature, `@returns` JSDoc type, `@throws` JSDoc type/count, `@example` presence, `lib/main.js` `require(...)` set, error-construction style (`format` vs concatenation vs template-literal vs plain), validation prologue, `lib/index.js` redacted code shape and binding name.
-   **Features with clear majority (≥75%)**: full top-level `package.json` key set (57/57), full `datapackage.json` key set (57/57), canonical file presence (57/57 except `lib/browser.js`/`benchmark/benchmark.browser.js`/`test/test.browser.js`/`test/test.main.js` at 56/57), `lib/index.js` redacted code shape with binding `main` (53/57), `lib/main.js` redacted code shape (52/57 static-loader form), arity-0 public signature (54/57), single `@throws {Error}` (55/57), `@example` presence (57/57).
-   **Features without clear majority (excluded)**: `@returns` type (content-driven; `StringArray`, `ObjectArray`, `Buffer`, `Object`, `ArrayArray`, `NumberArray`, etc.), `lib/main.js` exported function name (content-driven; `dataset`, `stopwords`, `words`, `table`, `names`, `data`, etc.), `README.md` `##` ordering (content-driven on `References`/`See Also`/`Notes` presence), keyword set beyond the universal four (`stdlib`, `datasets`, `dataset`, `data`).
-   **Drift surfaced for fix**: `lib/index.js` binding name. 53/57 (93%) within `@stdlib/datasets` and 4625/5028 (92%) stdlib-wide use `var main = require( './main.js' ); module.exports = main;`. Four packages use a per-package binding instead.

### `@stdlib/datasets/afinn-111`

Renames the internal variable in `lib/index.js` from `afinn111` to `main`. The change aligns with the convention used in 4625/5028 (92%) of `lib/index.js` files across the stdlib codebase, including 53/57 (93%) of `@stdlib/datasets/*/lib/index.js` files. The exported value and public API are unchanged.

### `@stdlib/datasets/afinn-96`

Renames the internal variable binding in `lib/index.js` from `afinn96` to `main`. The change aligns with the convention used in 53/57 (93%) of `@stdlib/datasets/*/lib/index.js` files and 4625/5028 (92%) of stdlib `lib/index.js` files more broadly. The exported value and public API are unchanged.

### `@stdlib/datasets/minard-napoleons-march`

Renames the internal variable in `lib/index.js` from `minard` to `main` to align with the convention used in 93% of `@stdlib/datasets/*/lib/index.js` files and 92% of stdlib `lib/index.js` files more broadly. The exported value and public API are unchanged.

### `@stdlib/datasets/month-names-en`

Renames the internal variable in `lib/index.js` from `months` to `main` to match the convention used in 4625/5028 (92%) of stdlib `lib/index.js` files, including 53/57 (93%) of `@stdlib/datasets/*/lib/index.js` files. The exported value and public API are unchanged.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   **Structural extraction** over all 57 `@stdlib/datasets` members covered the full file tree, `package.json` and `datapackage.json` key shapes, `README.md` `##`/`###` heading set and ordering, canonical file presence, and `lib/index.js`/`lib/main.js` redacted code shapes (string and JSDoc redaction; whitespace-collapsed).
-   **Semantic extraction** covered public signature and arity, JSDoc tag set (`@param`, `@returns`, `@throws`, `@example`), `require()` set, and error-construction style.
-   **Three-agent drift validation** was run on the surfaced outliers: an opus semantic-review agent confirmed the local binding has no observable effect on the public API; an opus cross-reference agent confirmed no test, example, benchmark, REPL fixture, TypeScript declaration, or `bin/cli` outside `lib/index.js` reaches into the file's local variable name; a sonnet structural-review agent confirmed `var main = require( './main.js' );` is the canonical stdlib `lib/index.js` shape (sampled `math/base/special/sin`, `math/base/special/cos`, `string/replace`, `array/float64`, `utils/copy`).
-   **Stdlib-wide presence check** (≥90% gate): 4625/5028 (92.0%) of stdlib `lib/index.js` files use the `var main = require( './main.js' )` form, comfortably above the 90% threshold for treating absence as drift.
-   **Open-PR collision check**: GitHub search for open PRs touching `datasets/afinn-111`, `datasets/afinn-96`, `datasets/minard-napoleons-march`, or `datasets/month-names-en` returned zero hits; recent merged PRs touching `@stdlib/datasets` (#11892, #11904) reference vendored data files only.
-   **Precedent**: directly mirrors `b72a90bca` (`chore: rename internal variable to `main` in two `string` packages`).

### Deliberately excluded

-   **`@stdlib/datasets/sotu`** — the only structural outlier on `lib/browser.js`, `benchmark/benchmark.browser.js`, `test/test.browser.js`, and `test/test.main.js` (56/57 each). The deviation is intentional: `sotu` is a query library (`browser_db.js`, `browser_file_list.js`, `browser_get_file.js`, `db.js`, `file_list.js`, `get_file.js`, `index_year.js`, `index_name.js`, `index_party.js`, `union.js`, `validate.js`) with a richer browser surface and per-component tests, not a static data export.
-   **`@stdlib/datasets/cmudict`, `@stdlib/datasets/minard-napoleons-march`, `@stdlib/datasets/sotu`** options-bearing public signatures (arity 1 vs. namespace-majority arity 0). The arity, validation prologue, and `format`-based error construction in these three packages reflect documented optional `data`/query semantics, not drift.
-   **`README.md` heading order**, **`@returns` type**, **`lib/main.js` exported function name**, and **per-dataset keywords** — content-driven. No clear majority above the 75% threshold; excluded from drift analysis.
-   **Auto-populated sections** (`## See Also`, `repl.txt`, `<package>.d.ts`, generator-owned files) — out of scope per the routine.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated cross-package drift-detection routine: extracting structural and semantic features from every `@stdlib/datasets` member, computing the per-feature majority pattern at the 75% threshold, validating each surfaced outlier through three independent agents (opus semantic-review, opus cross-reference, sonnet structural-review), and applying only the corrections that survived all three verdicts plus the open-PR collision and ecosystem-presence gates. The four `lib/index.js` renames are mechanical (2 lines per file, local variable only, no public-API change). A maintainer should audit each site before promoting from draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1WYGBF8SU4PcTpoBaSqzi)_