### PR TITLE
docs: add notes content to `blas/ext/base/ndarray/gjoin` README

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gjoin/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gjoin/README.md
@@ -67,6 +67,11 @@ The function has the following parameters:
 
 <section class="notes">
 
+## Notes
+
+-   If provided an empty one-dimensional ndarray, the function returns an empty string.
+-   If an array element is either `null` or `undefined`, the function will serialize the element as an empty string.
+
 </section>
 
 <!-- /.notes -->


### PR DESCRIPTION
## Description

This pull request:

-   Populates the empty `<section class="notes">` wrapper in `blas/ext/base/ndarray/gjoin/README.md`. The package previously shipped the wrapper without a `## Notes` heading or any bullets — 86 of 87 sibling packages in `blas/ext/base/ndarray` ship populated Notes content (98.9% conformance).

### `blas/ext/base/ndarray/gjoin`

The README's `<section class="notes">` block was empty. Two bullets were added, derived from the underlying `@stdlib/blas/ext/base/gjoin` Notes (the strided base this package wraps) and adapted to ndarray phrasing using the same translation pattern other ndarray wrappers in the namespace already follow (e.g., `dnansum`, `dindex-of`):

-   `If provided an empty one-dimensional ndarray, the function returns an empty string.` — the wrapper passes `numelDimension(x, 0)` as `N` to the strided implementation, which returns `''` when `N <= 0`.
-   `If an array element is either null or undefined, the function will serialize the element as an empty string.` — matches the strided implementation's element handling via `isUndefinedOrNull`.

The strided base's third bullet (array-like accessor support) is intentionally omitted: it does not surface to ndarray callers, who pass ndarrays rather than array-like objects.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a cross-package API drift detection routine across the `blas/ext/base/ndarray` namespace. The Notes content was derived mechanically from the underlying `@stdlib/blas/ext/base/gjoin` Notes section, with the proposed correction reviewed by three independent validation agents (semantic, cross-reference, structural) before application.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRwaS3nAY14Ubs8pwxfdM1)_