### PR TITLE
fix: use correct `Complex64` import in `math/base/special/cceilf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cceilf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceilf/lib/native.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var Complex64 = require( '@stdlib/complex/float64/ctor' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var addon = require( './../src/addon.node' );
 
 


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes `Complex64` import in `math/base/special/cceilf`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md