### PR TITLE
test: use correct `float32` imports in `strided/base`

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/strided/base/docs/types/index.d.ts
@@ -251,8 +251,8 @@ interface Namespace {
 	*
 	* @example
 	* var Complex64Array = require( '@stdlib/array/complex64' );
-	* var real = require( '@stdlib/complex/float64/real' );
-	* var imag = require( '@stdlib/complex/float64/imag' );
+	* var real = require( '@stdlib/complex/float32/real' );
+	* var imag = require( '@stdlib/complex/float32/imag' );
 	* var Complex64 = require( '@stdlib/complex/float32/ctor' );
 	*
 	* function scale( x ) {
@@ -269,8 +269,8 @@ interface Namespace {
 	*
 	* @example
 	* var Complex64Array = require( '@stdlib/array/complex64' );
-	* var real = require( '@stdlib/complex/float64/real' );
-	* var imag = require( '@stdlib/complex/float64/imag' );
+	* var real = require( '@stdlib/complex/float32/real' );
+	* var imag = require( '@stdlib/complex/float32/imag' );
 	* var Complex64 = require( '@stdlib/complex/float32/ctor' );
 	*
 	* function scale( x ) {

--- a/lib/node_modules/@stdlib/strided/base/map-by2/test/test.main.js
+++ b/lib/node_modules/@stdlib/strided/base/map-by2/test/test.main.js
@@ -28,7 +28,7 @@ var cidentityf = require( '@stdlib/complex/float32/base/identity' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Float32Array = require( '@stdlib/array/float32' );
 var Complex64Array = require( '@stdlib/array/complex64' );
-var Complex64 = require( '@stdlib/complex/float64/ctor' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var mapBy2 = require( './../lib/main.js' );
 
 

--- a/lib/node_modules/@stdlib/strided/base/map-by2/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/strided/base/map-by2/test/test.ndarray.js
@@ -28,7 +28,7 @@ var cidentityf = require( '@stdlib/complex/float32/base/identity' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Float32Array = require( '@stdlib/array/float32' );
 var Complex64Array = require( '@stdlib/array/complex64' );
-var Complex64 = require( '@stdlib/complex/float64/ctor' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var mapBy2 = require( './../lib/ndarray.js' );
 
 

--- a/lib/node_modules/@stdlib/strided/base/reinterpret-complex64/examples/index.js
+++ b/lib/node_modules/@stdlib/strided/base/reinterpret-complex64/examples/index.js
@@ -19,8 +19,8 @@
 'use strict';
 
 var Complex64Array = require( '@stdlib/array/complex64' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
 var reinterpret = require( './../lib' );
 
 // Define a complex number array:


### PR DESCRIPTION
Progresses https://github.com/stdlib-js/metr-issue-tracker/issues/561

## Description

> What is the purpose of this pull request?

This pull request:

-   corrects imports in `strided/base`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- https://github.com/stdlib-js/metr-issue-tracker/issues/561

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used a Cursor driven Skill+Workflow to achieve this migration with manual and automated sanity checks.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md