### PR TITLE
chore: address JavaScript lint error

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/floorn/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/floorn/test/test.native.js
@@ -115,7 +115,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 });
 
 tape( 'rounding a numeric value to a desired number of decimals can result in unexpected behavior', opts, function test( t ) {
-	var x = -0.2 - 0.1; // => -0.30000000000000004
+	var x = -0.2 - 0.1; // returns -0.30000000000000004
 	t.strictEqual( floorn( x, -16 ), -0.3000000000000001, 'equals -0.3000000000000001 and not -0.3' );
 	t.end();
 });


### PR DESCRIPTION
Resolves #11983 
## Description

> What is the purpose of this pull request?
This pull request:

the javascript lint workflow was flagging an error in `lib/node_modules/@stdlib/math/base/special/floorn/test/test.native.js` at 118th line ,previously the comment was `// => -0.30000000000000004` ,and now i changed it to `// returns -0.30000000000000004` based on the linter's suggestion within the issue's description

## Related Issues

> Does this pull request have any related issues?
This pull request has the following related issues:
#11983 

## Questions

> Any questions for reviewers of this pull request?
No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.
No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.
-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
