### PR TITLE
chore: add Git note for broken commit message

### DIFF
--- a/docs/git-notes/822fadca5619ac17182fad841af43ec6d1cdd81e.txt
+++ b/docs/git-notes/822fadca5619ac17182fad841af43ec6d1cdd81e.txt
@@ -1,0 +1,10 @@
+---
+type: amend-message
+---
+bench: refactor to use string interpolation in `utils`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/11410
+Co-authored-by: Athan Reines <kgryte@gmail.com>
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Closes: https://github.com/stdlib-js/metr-issue-tracker/issues/376
+Ref: https://github.com/stdlib-js/stdlib/issues/8647


### PR DESCRIPTION
Resolves stdlib-js/todo#2764.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a Git note (`amend-message`) for commit `822fadca5619ac17182fad841af43ec6d1cdd81e` to fix a typo in the `Closes:` trailer (`githubs.com` → `github.com`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   stdlib-js/todo#2764

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md