### PR TITLE
chore: add Git note for broken commit message

### DIFF
--- a/docs/git-notes/c9560dedc2ebc61dc8eb2bba775555841f175eea.txt
+++ b/docs/git-notes/c9560dedc2ebc61dc8eb2bba775555841f175eea.txt
@@ -1,0 +1,8 @@
+---
+type: amend-message
+---
+docs: refactor to use `logEachMap` in examples
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/11454
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Reviewed-by: Neeraj Pathak <neerajrpathak710@gmail.com>


### PR DESCRIPTION
Resolves stdlib-js/todo#2761.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a Git note (`amend-message`) for commit `c9560dedc2ebc61dc8eb2bba775555841f175eea` to correct the commit type prefix from `bench:` to `docs:`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   stdlib-js/todo#2761

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md