### PR TITLE
chore: add Git note for broken commit message

### DIFF
--- a/docs/git-notes/8a0bdab18b22e650ce6ec73b87f347846774890f.txt
+++ b/docs/git-notes/8a0bdab18b22e650ce6ec73b87f347846774890f.txt
@@ -1,0 +1,50 @@
+---
+type: amend-message
+---
+feat: add `stats/strided/distances/dchebyshev`
+
+---
+type: pre_commit_static_analysis_report
+description: Results of running static analysis checks when committing changes.
+report:
+  - task: lint_filenames
+    status: passed
+  - task: lint_editorconfig
+    status: passed
+  - task: lint_markdown
+    status: passed
+  - task: lint_package_json
+    status: passed
+  - task: lint_repl_help
+    status: passed
+  - task: lint_javascript_src
+    status: passed
+  - task: lint_javascript_cli
+    status: na
+  - task: lint_javascript_examples
+    status: passed
+  - task: lint_javascript_tests
+    status: passed
+  - task: lint_javascript_benchmarks
+    status: passed
+  - task: lint_python
+    status: na
+  - task: lint_r
+    status: na
+  - task: lint_c_src
+    status: missing_dependencies
+  - task: lint_c_examples
+    status: missing_dependencies
+  - task: lint_c_benchmarks
+    status: missing_dependencies
+  - task: lint_c_tests_fixtures
+    status: na
+  - task: lint_shell
+    status: na
+  - task: lint_typescript_declarations
+    status: passed
+  - task: lint_typescript_tests
+    status: passed
+  - task: lint_license_headers
+    status: passed
+---


### PR DESCRIPTION
Resolves stdlib-js/todo#2745.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a Git note (`amend-message`) for commit `8a0bdab18b22e650ce6ec73b87f347846774890f` to add the missing closing backtick in the subject (`` `stats/strided/distances/dchebyshev `` → `` `stats/strided/distances/dchebyshev` ``).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   stdlib-js/todo#2745

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md