### PR TITLE
chore: fix JavaScript lint errors (issue #11867)

### DIFF
--- a/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
@@ -40,7 +40,7 @@ var Symbol = require( '@stdlib/symbol/ctor' );
 *     console.log( 'Environment does support Symbol.asyncIterator.' );
 * }
 */
-var AsyncIteratorSymbol = ( hasAsyncIteratorSymbolSupport() ) ? Symbol.asyncIterator : null; // eslint-disable-line max-len, n/no-unsupported-features/es-builtins
+var AsyncIteratorSymbol = ( hasAsyncIteratorSymbolSupport() ) ? Symbol.asyncIterator : null; // eslint-disable-line max-len
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/async-iterator/lib/main.js
@@ -40,7 +40,7 @@ var Symbol = require( '@stdlib/symbol/ctor' );
 *     console.log( 'Environment does support Symbol.asyncIterator.' );
 * }
 */
-var AsyncIteratorSymbol = ( hasAsyncIteratorSymbolSupport() ) ? Symbol.asyncIterator : null; // eslint-disable-line max-len
+var AsyncIteratorSymbol = ( hasAsyncIteratorSymbolSupport() ) ? Symbol.asyncIterator : null; // eslint-disable-line max-len, n/no-unsupported-features/es-builtins
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
@@ -148,7 +148,7 @@ console.log( constructorName( new Float64Array() ) );
 console.log( constructorName( new ArrayBuffer() ) );
 // => 'ArrayBuffer'
 
-console.log( constructorName( new Buffer( 'beep' ) ) ); // eslint-disable-line no-buffer-constructor
+console.log( constructorName( new Buffer( 'beep' ) ) );
 // => 'Buffer'
 
 console.log( constructorName( Math ) );

--- a/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/constructor-name/examples/index.js
@@ -35,11 +35,8 @@ var Uint32Array = require( '@stdlib/array/uint32' );
 var ArrayBuffer = require( '@stdlib/array/buffer' );
 var Buffer = require( '@stdlib/buffer/ctor' );
 var Symbol = require( '@stdlib/symbol/ctor' );
+var noop = require( '@stdlib/utils/noop' );
 var constructorName = require( './../lib' );
-
-function noop() {
-	// Do nothing...
-}
 
 console.log( constructorName( 'a' ) );
 // => 'String'


### PR DESCRIPTION
Resolves #11867.

## Description

This pull request:

-   adds an inline lint exception for `Symbol.asyncIterator`, which is gated by feature detection but still flagged by `n/no-unsupported-features/es-builtins`;
-   removes an unused `no-buffer-constructor` disable comment from the `constructor-name` example.

## Related Issues

This pull request has the following related issues:

-   resolves #11867

## Questions

No.

## Other

I ran the focused checks below locally:

-   `git diff --check`
-   `node node_modules\\eslint\\bin\\eslint.js --report-unused-disable-directives --rule "linebreak-style: off" --rule "stdlib/jsdoc-linebreak-style: off" lib\\node_modules\\@stdlib\\utils\\constructor-name\\examples\\index.js`
-   `node -e "require('./lib/node_modules/@stdlib/utils/constructor-name/examples/index.js')"`

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

I used Codex to help identify the relevant lint failures, make the small edits, and run local checks. I reviewed the diff and verification output before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md