### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/set-topics/lib/factory.js
+++ b/lib/node_modules/@stdlib/_tools/github/set-topics/lib/factory.js
@@ -90,21 +90,22 @@ function factory( options, clbk ) {
 			throw new TypeError( format( 'invalid argument. Topics argument must be an array of strings. Value: `%s`.', topics ) );
 		}
 		query( slug, topics, opts, done );
-		/**
-		* Callback invoked after receiving an API response.
-		*
-		* @private
-		* @param {(Error|null)} error - error object
-		* @param {Object} data - response data
-		* @param {Object} info - response info
-		* @returns {void}
-		*/
-		function done( error, data, info ) {
-			error = error || null;
-			data = data || null;
-			info = info || null;
-			clbk( error, data, info );
-		}
+	}
+
+	/**
+	* Callback invoked after receiving an API response.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Object} data - response data
+	* @param {Object} info - response info
+	* @returns {void}
+	*/
+	function done( error, data, info ) {
+		error = error || null;
+		data = data || null;
+		info = info || null;
+		clbk( error, data, info );
 	}
 }
 


### PR DESCRIPTION
## Summary

- move the `done` callback out of `setTopics` so the callback is no longer an unnecessary nested function
- keep `done` inside `factory` so it can continue to close over the user callback

## Validation

- `node --check lib/node_modules/@stdlib/_tools/github/set-topics/lib/factory.js`
- `node_modules\.bin\eslint --ignore-path .eslintignore --config etc/eslint/.eslintrc.js lib/node_modules/@stdlib/_tools/github/set-topics/lib/factory.js`
- `git diff --check`

## Related Issues

- resolves #12086

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)