### PR TITLE
docs: use correct `s` predicate in `stats/base/dists/cosine/mgf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/docs/types/index.d.ts
@@ -35,7 +35,7 @@ interface MGF {
 	*
 	* ## Notes
 	*
-	* -   If provided `s < 0`, the function returns `NaN`.
+	* -   If provided `s <= 0`, the function returns `NaN`.
 	*
 	* @param t - input value
 	* @param mu - location parameter


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   In `stats/base/dists/cosine/mgf`, corrects the TypeScript declaration's Notes section from `If provided \`s < 0\`, the function returns \`NaN\`.` to `If provided \`s <= 0\`, the function returns \`NaN\`.` so it matches the actual validation. The implementation in `lib/main.js`, `lib/factory.js`, and `src/main.c` all reject `s <= 0.0`; the JSDoc declares `s` as `PositiveNumber`; and both the README and `docs/repl.txt` already document `s <= 0`. The d.ts was the lone artifact in the package that disagreed with the source predicate (92.9% conformance across the namespace's d.ts Notes prior to this change, 100% after).

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Detected via a cross-package consistency sweep of the `stats/base/dists/cosine` namespace (14 packages). The declaration was templated from an eval-function declaration (`cdf`/`pdf`/`logcdf`/`logpdf` all use `s < 0` because they accept `s = 0` as a degenerate distribution), but `mgf`'s implementation correctly rejects `s = 0` since the raised cosine MGF requires a positive scale; only the d.ts wording was not updated to reflect that.

See: https://github.com/stdlib-js/stdlib/blob/30d9788e9ed67a8a6fc403b344966e0ea76074c1/lib/node_modules/%40stdlib/stats/base/dists/cosine/mgf/lib/main.js#L70

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was produced end-to-end by Claude Code as part of an automated cross-package API drift detection run scoped to the `stats/base/dists/cosine` namespace. The drift (d.ts Notes section disagreeing with the source's `s <= 0` validation predicate) was identified by majority vote across the 14 sibling packages and confirmed by three independent review passes (semantic, cross-reference, structural) before applying the one-line fix.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_015Tv7BPJLxQQQGkz9ZCKL7F)_