### PR TITLE
refactor: align `ndarray/*` errors and remove `namespace` self-ref

### DIFF
--- a/lib/node_modules/@stdlib/namespace/lib/namespace/u.js
+++ b/lib/node_modules/@stdlib/namespace/lib/namespace/u.js
@@ -588,8 +588,7 @@ ns.push({
 	'type': 'Function',
 	'related': [
 		'@stdlib/datasets/us-states-capitals',
-		'@stdlib/datasets/us-states-names',
-		'@stdlib/datasets/us-states-names-capitals'
+		'@stdlib/datasets/us-states-names'
 	]
 });
 

--- a/lib/node_modules/@stdlib/ndarray/base/fill-diagonal/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/fill-diagonal/lib/main.js
@@ -41,7 +41,7 @@ var fill = require( '@stdlib/ndarray/base/fill' );
 * @param {IntegerArray} dims - dimension indices defining the plane in which to fill the diagonal
 * @param {integer} k - diagonal offset
 * @throws {RangeError} must provide exactly two dimension indices
-* @throws {RangeError} input ndarray must have at least two dimensions
+* @throws {RangeError} input ndarray must have two or more dimensions
 * @throws {RangeError} must provide valid dimension indices
 * @throws {Error} must provide unique dimension indices
 * @throws {TypeError} second argument cannot be safely cast to the input array data type

--- a/lib/node_modules/@stdlib/ndarray/base/rot90/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/rot90/lib/main.js
@@ -47,7 +47,7 @@ var format = require( '@stdlib/string/format' );
 * @param {integer} k - number of times to rotate by 90 degrees
 * @param {boolean} writable - boolean indicating whether the returned ndarray should be writable
 * @throws {RangeError} must provide exactly two dimension indices
-* @throws {RangeError} input ndarray must have at least two dimensions
+* @throws {RangeError} input ndarray must have two or more dimensions
 * @throws {RangeError} must provide valid dimension indices
 * @throws {Error} must provide unique dimension indices
 * @returns {ndarray} ndarray view

--- a/lib/node_modules/@stdlib/ndarray/base/to-rot180/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/to-rot180/lib/main.js
@@ -37,7 +37,7 @@ var assign = require( '@stdlib/ndarray/base/assign' );
 * @param {ndarray} x - input array
 * @param {IntegerArray} dims - dimension indices defining the plane of rotation
 * @throws {RangeError} must provide exactly two dimension indices
-* @throws {RangeError} input ndarray must have at least two dimensions
+* @throws {RangeError} input ndarray must have two or more dimensions
 * @throws {RangeError} must provide valid dimension indices
 * @throws {Error} must provide unique dimension indices
 * @returns {ndarray} output array

--- a/lib/node_modules/@stdlib/ndarray/base/to-rot90/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/to-rot90/lib/main.js
@@ -40,7 +40,7 @@ var assign = require( '@stdlib/ndarray/base/assign' );
 * @param {IntegerArray} dims - dimension indices defining the plane of rotation
 * @param {integer} k - number of times to rotate by 90 degrees
 * @throws {RangeError} must provide exactly two dimension indices
-* @throws {RangeError} input ndarray must have at least two dimensions
+* @throws {RangeError} input ndarray must have two or more dimensions
 * @throws {RangeError} must provide valid dimension indices
 * @throws {Error} must provide unique dimension indices
 * @returns {ndarray} output array

--- a/lib/node_modules/@stdlib/ndarray/diagonal/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/diagonal/lib/main.js
@@ -49,7 +49,7 @@ var format = require( '@stdlib/string/format' );
 * @throws {TypeError} `k` option must be an integer
 * @throws {TypeError} `dims` option must be an array of integers
 * @throws {RangeError} must provide exactly two dimension indices
-* @throws {RangeError} input ndarray must have at least two dimensions
+* @throws {RangeError} input ndarray must have two or more dimensions
 * @throws {RangeError} must provide valid dimension indices
 * @throws {Error} must provide unique dimension indices
 * @returns {ndarray} ndarray view

--- a/lib/node_modules/@stdlib/ndarray/iter/column-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/column-entries/lib/main.js
@@ -45,7 +45,7 @@ var format = require( '@stdlib/string/format' );
 * @param {Options} [options] - function options
 * @param {boolean} [options.readonly=true] - boolean indicating whether returned views should be read-only
 * @throws {TypeError} first argument must be an ndarray
-* @throws {TypeError} first argument must have at least two dimensions
+* @throws {TypeError} first argument must have two or more dimensions
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
 * @throws {Error} cannot write to a read-only array
@@ -120,7 +120,7 @@ function nditerColumnEntries( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least two dimensions.' );
+		throw new TypeError( 'invalid argument. First argument must be an ndarray having two or more dimensions.' );
 	}
 
 	// Check whether the input array is empty...

--- a/lib/node_modules/@stdlib/ndarray/iter/columns/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/columns/lib/main.js
@@ -45,7 +45,7 @@ var format = require( '@stdlib/string/format' );
 * @param {Options} [options] - function options
 * @param {boolean} [options.readonly=true] - boolean indicating whether returned views should be read-only
 * @throws {TypeError} first argument must be an ndarray
-* @throws {TypeError} first argument must have at least two dimensions
+* @throws {TypeError} first argument must have two or more dimensions
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
 * @throws {Error} cannot write to a read-only array
@@ -120,7 +120,7 @@ function nditerColumns( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least two dimensions.' );
+		throw new TypeError( 'invalid argument. First argument must be an ndarray having two or more dimensions.' );
 	}
 	// Check whether the input array is empty...
 	N = numel( shape );

--- a/lib/node_modules/@stdlib/ndarray/iter/row-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/row-entries/lib/main.js
@@ -45,7 +45,7 @@ var format = require( '@stdlib/string/format' );
 * @param {Options} [options] - function options
 * @param {boolean} [options.readonly=true] - boolean indicating whether returned views should be read-only
 * @throws {TypeError} first argument must be an ndarray
-* @throws {TypeError} first argument must have at least two dimensions
+* @throws {TypeError} first argument must have two or more dimensions
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
 * @throws {Error} cannot write to a read-only array
@@ -120,7 +120,7 @@ function nditerRowEntries( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least two dimensions.' );
+		throw new TypeError( 'invalid argument. First argument must be an ndarray having two or more dimensions.' );
 	}
 
 	// Check whether the input array is empty...

--- a/lib/node_modules/@stdlib/ndarray/iter/rows/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/rows/lib/main.js
@@ -45,7 +45,7 @@ var format = require( '@stdlib/string/format' );
 * @param {Options} [options] - function options
 * @param {boolean} [options.readonly=true] - boolean indicating whether returned views should be read-only
 * @throws {TypeError} first argument must be an ndarray
-* @throws {TypeError} first argument must have at least two dimensions
+* @throws {TypeError} first argument must have two or more dimensions
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
 * @throws {Error} cannot write to a read-only array
@@ -120,7 +120,7 @@ function nditerRows( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least two dimensions.' );
+		throw new TypeError( 'invalid argument. First argument must be an ndarray having two or more dimensions.' );
 	}
 	// Check whether the input array is empty...
 	N = numel( shape );

--- a/lib/node_modules/@stdlib/ndarray/rot180/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/rot180/lib/main.js
@@ -44,7 +44,7 @@ var format = require( '@stdlib/string/format' );
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} `dims` option must be an array of integers
 * @throws {RangeError} must provide exactly two dimension indices
-* @throws {RangeError} input ndarray must have at least two dimensions
+* @throws {RangeError} input ndarray must have two or more dimensions
 * @throws {RangeError} must provide valid dimension indices
 * @throws {Error} must provide unique dimension indices
 * @returns {ndarray} ndarray view

--- a/lib/node_modules/@stdlib/ndarray/rot90/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/rot90/lib/main.js
@@ -49,7 +49,7 @@ var format = require( '@stdlib/string/format' );
 * @throws {TypeError} `k` option must be an integer
 * @throws {TypeError} `dims` option must be an array of integers
 * @throws {RangeError} must provide exactly two dimension indices
-* @throws {RangeError} input ndarray must have at least two dimensions
+* @throws {RangeError} input ndarray must have two or more dimensions
 * @throws {RangeError} must provide valid dimension indices
 * @throws {Error} must provide unique dimension indices
 * @returns {ndarray} ndarray view

--- a/lib/node_modules/@stdlib/ndarray/to-rot180/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/to-rot180/lib/main.js
@@ -44,7 +44,7 @@ var base = require( '@stdlib/ndarray/base/to-rot180' );
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} `dims` option must be an array of integers
 * @throws {RangeError} must provide exactly two dimension indices
-* @throws {RangeError} input ndarray must have at least two dimensions
+* @throws {RangeError} input ndarray must have two or more dimensions
 * @throws {RangeError} must provide valid dimension indices
 * @throws {Error} must provide unique dimension indices
 * @returns {ndarray} output ndarray

--- a/lib/node_modules/@stdlib/ndarray/to-rot90/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/to-rot90/lib/main.js
@@ -49,7 +49,7 @@ var format = require( '@stdlib/string/format' );
 * @throws {TypeError} `k` option must be an integer
 * @throws {TypeError} `dims` option must be an array of integers
 * @throws {RangeError} must provide exactly two dimension indices
-* @throws {RangeError} input ndarray must have at least two dimensions
+* @throws {RangeError} input ndarray must have two or more dimensions
 * @throws {RangeError} must provide valid dimension indices
 * @throws {Error} must provide unique dimension indices
 * @returns {ndarray} output ndarray


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Propagating fixes merged to `develop` between 2026-05-11T13:56:05-07:00 and 2026-05-12T01:42:58-07:00 to sibling packages.

This pull request:

-   Propagates the error-message wording introduced in c77fbd9a across thirteen `ndarray/*` packages, replacing `"at least two dimensions"` with `"two or more dimensions"` in `@throws` JSDoc annotations and, for `ndarray/iter/rows`, `ndarray/iter/columns`, `ndarray/iter/row-entries`, and `ndarray/iter/column-entries`, in the corresponding runtime `TypeError` messages as well. `ndarray/base/rot90` required only a JSDoc update, as its runtime throw already carried the aligned phrasing. This brings the full set of dimension-arity error messages into conformance with the wording established by `ndarray/transpose`, `ndarray/vconcat`, and `ndarray/base/diagonal`.

    Source: c77fbd9a

    Target packages:
    -   `ndarray/diagonal`
    -   `ndarray/rot90`
    -   `ndarray/rot180`
    -   `ndarray/to-rot90`
    -   `ndarray/to-rot180`
    -   `ndarray/base/rot90`
    -   `ndarray/base/to-rot90`
    -   `ndarray/base/to-rot180`
    -   `ndarray/base/fill-diagonal`
    -   `ndarray/iter/rows`
    -   `ndarray/iter/columns`
    -   `ndarray/iter/row-entries`
    -   `ndarray/iter/column-entries`

-   Propagates c77fbd9a across the remaining namespace entries. Scans all 3,201 `ns.push` blocks in 91 files under `lib/node_modules/@stdlib/namespace/lib/namespace/` and removes the one outstanding self-reference: the `US_STATES_NAMES_CAPITALS` entry in `u.js`, whose `path` (`@stdlib/datasets/us-states-names-capitals`) appeared in its own `related` array. As with the source commit, the self-ref was the last element, so the preceding entry's trailing comma is also removed to maintain consistent style.

    Source: c77fbd9a

    Target package:
    -   `namespace` (entry: `US_STATES_NAMES_CAPITALS` in `lib/namespace/u.js`)

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** For each propagation pattern, scope was determined by the search signature derived from the source commit: for the dimension-error pattern, `rg`-scanned `lib/node_modules/@stdlib/ndarray/**/lib/*.js` for the substring `at least two dimensions` in `@throws` JSDoc lines and `throw new` statements (descriptive text and `.d.ts`/README/repl.txt files were excluded as not error-message sites); for the namespace pattern, every `ns.push({...})` block under `lib/node_modules/@stdlib/namespace/lib/namespace/` was parsed for entries listing their own `path` in their `related` array. Two independent validation agents confirmed every site by reading the surrounding code; an adaptation pass produced exact diffs; a style-consistency pass approved the resulting wording. Sites that would have cascaded into tests, READMEs, or `.d.ts` were deliberately excluded — the source commit did not touch those classes of file, so they are out of scope. No site was flagged `needs-human`; none were dropped during patch application.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was generated by Claude Code as part of an automated fix-propagation routine. The routine identifies generalizable fix patterns in recent `develop` commits, searches for sibling sites with the same defect, runs multi-agent validation (two independent validators, one adaptation reviewer, one style-consistency reviewer) against each candidate site, and produces a draft PR applying the equivalent fix at every validated location.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_012rvNkv5BDrjyNPNssYxf2g)_