### PR TITLE
docs: normalize descriptions in `stats/base/dists/cosine/{ctor,logcdf}`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/ctor/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/ctor/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Cosine distribution constructor.
+* Raised cosine distribution constructor.
 *
 * @module @stdlib/stats/base/dists/cosine/ctor
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Cumulative Distribution Function
 
-> Evaluate the natural logarithm of the [cumulative distribution function][cdf] (CDF) for a [raised cosine][cosine-distribution] distribution.
+> [Raised cosine][cosine-distribution] distribution logarithm of [cumulative distribution function][cdf].
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Natural logarithm of cumulative distribution function (CDF) for a raised cosine distribution.
+* Raised cosine distribution logarithm of cumulative distribution function (CDF).
 *
 * @module @stdlib/stats/base/dists/cosine/logcdf
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/cosine/logcdf",
   "version": "0.0.0",
-  "description": "Natural logarithm of cumulative distribution function (CDF) for a raised cosine distribution.",
+  "description": "Raised cosine distribution logarithm of cumulative distribution function (CDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request brings two documentation outliers within the `@stdlib/stats/base/dists/cosine` namespace into agreement with the namespace-wide `Raised cosine distribution X.` description prefix used by the remaining sibling packages.

### Namespace summary

- **Namespace:** `@stdlib/stats/base/dists/cosine`
- **Members analyzed:** 14 non-autogenerated packages (`cdf`, `ctor`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `median`, `mgf`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`)
- **Majority threshold:** 75% (⌈14 × 0.75⌉ = 11)
- **Features with a clear majority (≥75%):** `package.json` top-level key set; `package.json` description prefix; `lib/index.js` module JSDoc title prefix; `README.md` one-liner template; per-feature validation prologue within the scalar-property sub-group; per-feature validation prologue within the factory sub-group; `lib/` file layout within each sub-group; test-file naming within each sub-group; error-construction canonicalization (`format`).
- **Features excluded (no clear majority):** none material; the `lib/` layouts of the factory sub-group (`cdf`, `logcdf`, `logpdf`, `mgf`, `pdf`, `quantile`) and the scalar-property sub-group (`kurtosis`, `mean`, `median`, `mode`, `skewness`, `stdev`, `variance`) are analyzed independently because their semantic shapes differ; `ctor` is sui generis (constructor; no native binding; no `gypfile`/`manifest.json`) and is excluded from features where it would otherwise be a single-package outlier on intentional grounds.

### Per outlier package

#### `@stdlib/stats/base/dists/cosine/ctor`

Align the `lib/index.js` module-level JSDoc title with the `package.json` description and `README.md` one-liner, both of which read `Raised cosine distribution constructor.`. 12 of 14 sibling packages under `stats/base/dists/cosine` already use the `Raised cosine distribution X.` prefix; prepend `Raised` to bring this package into conformance.

#### `@stdlib/stats/base/dists/cosine/logcdf`

Align the `package.json` description, `lib/index.js` JSDoc title, and `README.md` one-liner with the `Raised cosine distribution X.` prefix used by 13 of 14 siblings in `stats/base/dists/cosine`. Mirrors the `logpdf` analogue, substituting `cdf` for `pdf`; the README one-liner becomes `> [Raised cosine][cosine-distribution] distribution logarithm of [cumulative distribution function][cdf].`. Doc-only; no source behavior changes.

### Validation

Checked:

- Structural extraction across all 14 packages (file tree, `package.json` shape, `manifest.json` shape, README heading order, test/benchmark/example filenames).
- Semantic extraction of `lib/main.js`, `lib/index.js`, and `lib/factory.js` (where applicable) across all 14 packages: public signatures, validation prologues, return kinds, error-construction style, JSDoc shape, dependency sets.
- Per-outlier three-role review covering semantic justification, test/example cross-reference, and structural correctness of the proposed replacement strings.

Deliberately excluded:

- `ctor`'s absence of `gypfile`, `manifest.json`, `lib/factory.js`, `lib/native.js`, `benchmark/benchmark.native.js`, and `test/test.native.js`: intentional, as the package is a JavaScript constructor with no native binding.
- `logcdf` / `logpdf`'s `## Notes` README section (absent from the other 12 packages): intentional content for the log forms.
- The `s <= 0.0` validation in `mgf` versus `s < 0.0` in `cdf`/`pdf`/`logcdf`/`logpdf`/`quantile`: intentional — the MGF formula has `s*t` in the denominator, so `s = 0` is undefined.
- The factory sub-group's `lib/factory.js` and `lib/native.js` versus the scalar sub-group's flat `main.js` + `native.js`: intentional, reflecting that factory functions yield closures whereas scalar properties do not.
- README `## See Also` sections, REPL fixtures, and `docs/types/index.d.ts` files: auto-populated by the package generator.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Total diff: 6 lines across 4 files in 2 packages. One commit per package, per the namespace-drift correction routine. Each correction is mechanical and touches only description / JSDoc / README-one-liner strings; no `main.js`, `factory.js`, test, or example file is modified, and no public behavior changes.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was prepared with Claude Code under human supervision as part of a cross-package API-drift detection routine: an agent enumerated the 14 packages in the namespace, extracted structural and semantic features, identified the `Raised cosine distribution X.` description prefix as the majority pattern (≥85.7% conformance), flagged `ctor` and `logcdf` as outliers, and applied targeted single-string edits. A separate review-only agent independently verified that no test or example asserts against the changed strings and that the proposed replacements match the sibling `logpdf` template. All commits and the PR text were reviewed before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013cAQoeN5HVfjiM6EKwbWh2)_