### PR TITLE
chore: normalize `main` field to `./lib` in `array/base` and `array/float16` package.json

### DIFF
--- a/lib/node_modules/@stdlib/array/base/package.json
+++ b/lib/node_modules/@stdlib/array/base/package.json
@@ -13,7 +13,7 @@
       "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
     }
   ],
-  "main": "lib/index.js",
+  "main": "./lib",
   "directories": {
     "doc": "./docs",
     "example": "./examples",

--- a/lib/node_modules/@stdlib/array/float16/package.json
+++ b/lib/node_modules/@stdlib/array/float16/package.json
@@ -13,7 +13,7 @@
       "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
     }
   ],
-  "main": "./lib/index.js",
+  "main": "./lib",
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Normalizes the `main` field in two `@stdlib/array` packages to the canonical `"./lib"` form used by 101 of the 103 packages in the namespace (98% conformance). Node's module resolution treats `"./lib"`, `"lib/index.js"`, and `"./lib/index.js"` identically — all three resolve to `./lib/index.js` — so the change is purely metadata normalization with no behavioral impact.

### `@stdlib/array/base`

`main` was `"lib/index.js"` (missing leading `./` and full path). Changed to `"./lib"`. 98% namespace conformance.

### `@stdlib/array/float16`

`main` was `"./lib/index.js"` (full path rather than directory). Changed to `"./lib"`. 98% namespace conformance.

## Related Issues

> Does this pull request have any related issues?

This pull request has no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verified post-edit with `require.resolve()`: both packages still resolve to `./lib/index.js`. No test, source file, or stdlib tooling compares the literal `main` value as a string — `tools/.../create_namespace_types.js` operates on the resolved absolute path from `require.resolve()`, which is unaffected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by Claude Code running a namespace drift-detection routine: extract structural and semantic features from every package in a randomly selected `@stdlib` namespace, compute per-feature majority patterns at a 75% threshold, and propose corrections for outliers. Both deviations were independently verified by separate sonnet validation agents (structural-review and cross-reference) before any edits were made.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoYXVaFzXZAXJQZrZQX482)_