### PR TITLE
feat: add `@stdlib/ndarray/nans-like`

### DIFF
--- a/.ralph/state.md
+++ b/.ralph/state.md
@@ -1,0 +1,97 @@
+# Ralph Loop State
+
+## Issue
+**Title**: Review `@stdlib/ndarray/nans-like`  
+**Source**: stdlib-js/todo#2771  
+**Task**: Implement the `@stdlib/ndarray/nans-like` package in the stdlib-js/stdlib repository.
+
+## Verbatim Issue Text
+"Review `@stdlib/ndarray/nans-like`."
+
+## Acceptance Criteria
+- [ ] Package `@stdlib/ndarray/nans-like` exists at `lib/node_modules/@stdlib/ndarray/nans-like/`
+- [ ] `lib/main.js` implements `nansLike(x[, options])` function
+- [ ] Function uses `dtypes('floating_point_and_generic')` (not integer types, since NaN is undefined for integers)
+- [ ] Function fills ndarray with `NaN`
+- [ ] Options: dtype, shape, order, mode, submode, readonly (same as ones-like)
+- [ ] `lib/index.js` module wrapper exists
+- [ ] `package.json` correct
+- [ ] `test/test.js` comprehensive (all dtypes, options, edge cases)
+- [ ] `examples/index.js` working example
+- [ ] `benchmark/benchmark.js` and per-dtype size benchmarks
+- [ ] `docs/repl.txt` correct REPL documentation
+- [ ] `docs/types/index.d.ts` TypeScript declarations (float types + generic only)
+- [ ] `docs/types/test.ts` TypeScript test file
+- [ ] `README.md` documentation
+- [ ] `nansLike` added to `@stdlib/ndarray` namespace (`lib/index.js`)
+- [ ] Tests pass
+- [ ] Lint passes
+
+## PR Template Sections
+- Description
+- Related Issues
+- Questions
+- Other
+- Checklist (contributing guidelines, AI assistance disclosure)
+
+## Make Commands
+- Test: `make test TESTS_FILTER="*/ndarray/nans-like/*"`
+- Lint JS: `make lint-javascript FILES="lib/node_modules/@stdlib/ndarray/nans-like/**/*.js"`
+- Examples: `node lib/node_modules/@stdlib/ndarray/nans-like/examples/index.js`
+
+## Branch
+`claude/vibrant-brahmagupta-9A236`
+
+## Key Design Decisions
+1. NaN only valid for floating-point and generic types → use `dtypes('floating_point_and_generic')`
+2. Complex types: `fill(out, NaN)` fills real=NaN, imag=0 (consistent with numpy behavior)
+3. TypeScript overloads: float64, float32, complex128, complex64, generic (no integer overloads)
+4. Fill mechanism: same as ones-like but with `NaN` instead of `1.0`
+
+## Hypothesis
+The package needs to be created from scratch following the pattern of `@stdlib/ndarray/ones-like`, with the key difference being the fill value (NaN) and the restricted set of supported dtypes (floating-point and generic only).
+
+## Iteration 1 - Implement
+
+### Primary Goal: Implement
+
+### Plan
+1. Create all package files for `@stdlib/ndarray/nans-like`
+2. Add `nansLike` to `@stdlib/ndarray` namespace
+3. Run tests and lint
+4. Dispatch review agents
+
+## Files Touched
+- `lib/node_modules/@stdlib/ndarray/nans-like/` (new)
+- `lib/node_modules/@stdlib/ndarray/lib/index.js` (modified - add nansLike)
+
+## Decisions Log
+- Using `floating_point_and_generic` dtype group (not `numeric_and_generic`) because NaN throws for integer dtypes in `ndarray/base/fill`
+- NaN for complex128/complex64: real=NaN, imag=0 (verified via test)
+- Pattern: follows `ones-like` exactly, substituting NaN fill and reduced dtype set
+
+## Iteration 1 - Review Findings (5 parallel agents)
+
+### Agent A: Correctness
+- ✅ Complex dtype imaginary parts test — fixed (assert real=NaN, imag=0.0)
+- ✅ `FloatingPointAndGenericDataType` import used in `docs/types/index.d.ts`
+- Minor: `float16`/`complex32` in dtype list but `buffer()` not implemented — pre-existing issue
+
+### Agent B: Test Quality
+- ✅ `bool`/`binary` added to dtype rejection tests
+- ✅ Column-major inferred test added
+- ✅ Buffer non-sharing test added
+- ✅ Isolated option override tests added (dtype, order, shape separately)
+- All 316 tests pass
+
+### Agent C: Convention
+- ✅ Removed `"numpy.full_like"` keyword from `package.json`
+- Naming, JSDoc, file structure all follow stdlib conventions
+
+### Agent D: Security/Robustness
+- No security concerns; proper validation mirrors ones-like pattern
+
+### Agent E: Issue-Scope
+- Implementation is complete; scope matches "Review `@stdlib/ndarray/nans-like`"
+
+## Final Test Count: 316 tests, 316 pass

--- a/lib/node_modules/@stdlib/ndarray/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/docs/types/index.d.ts
@@ -76,6 +76,7 @@ import maybeBroadcastArray = require( '@stdlib/ndarray/maybe-broadcast-array' );
 import maybeBroadcastArrays = require( '@stdlib/ndarray/maybe-broadcast-arrays' );
 import minDataType = require( '@stdlib/ndarray/min-dtype' );
 import mostlySafeCasts = require( '@stdlib/ndarray/mostly-safe-casts' );
+import nansLike = require( '@stdlib/ndarray/nans-like' );
 import ndarraylike2ndarray = require( '@stdlib/ndarray/ndarraylike2ndarray' );
 import ndims = require( '@stdlib/ndarray/ndims' );
 import nextDataType = require( '@stdlib/ndarray/next-dtype' );
@@ -2210,6 +2211,46 @@ interface Namespace {
 	* // returns [...]
 	*/
 	mostlySafeCasts: typeof mostlySafeCasts;
+
+	/**
+	* Creates an ndarray filled with NaNs and having the same shape and data type as a provided input ndarray.
+	*
+	* @param x - input array
+	* @param options - options
+	* @param options.dtype - output array data type
+	* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+	* @param options.shape - output array shape
+	* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+	* @param options.readonly - boolean indicating whether an array should be read-only
+	* @returns NaN-filled array
+	*
+	* @example
+	* var getShape = require( '@stdlib/ndarray/shape' );
+	* var getDType = require( '@stdlib/ndarray/dtype' );
+	* var zeros = require( '@stdlib/ndarray/zeros' );
+	*
+	* var x = zeros( [ 2, 2 ], {
+	*     'dtype': 'float64'
+	* });
+	* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+	*
+	* var sh = getShape( x );
+	* // returns [ 2, 2 ]
+	*
+	* var dt = String( getDType( x ) );
+	* // returns 'float64'
+	*
+	* var y = ns.nansLike( x );
+	* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+	*
+	* sh = getShape( y );
+	* // returns [ 2, 2 ]
+	*
+	* dt = String( getDType( y ) );
+	* // returns 'float64'
+	*/
+	nansLike: typeof nansLike;
 
 	/**
 	* Converts an ndarray-like object to an ndarray.

--- a/lib/node_modules/@stdlib/ndarray/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/lib/index.js
@@ -595,6 +595,15 @@ setReadOnly( ns, 'minDataType', require( '@stdlib/ndarray/min-dtype' ) );
 setReadOnly( ns, 'mostlySafeCasts', require( '@stdlib/ndarray/mostly-safe-casts' ) );
 
 /**
+* @name nansLike
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/ndarray/nans-like}
+*/
+setReadOnly( ns, 'nansLike', require( '@stdlib/ndarray/nans-like' ) );
+
+/**
 * @name ndarraylike2ndarray
 * @memberof ns
 * @readonly

--- a/lib/node_modules/@stdlib/ndarray/nans-like/README.md
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/README.md
@@ -1,0 +1,174 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# nansLike
+
+> Create an [ndarray][@stdlib/ndarray/ctor] filled with NaNs and having the same shape and [data type][@stdlib/ndarray/dtypes] as a provided ndarray.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var nansLike = require( '@stdlib/ndarray/nans-like' );
+```
+
+#### nansLike( x\[, options] )
+
+Creates an [ndarray][@stdlib/ndarray/ctor] filled with NaNs and having the same shape and [data type][@stdlib/ndarray/dtypes] as a provided ndarray.
+
+```javascript
+var getShape = require( '@stdlib/ndarray/shape' );
+var getDType = require( '@stdlib/ndarray/dtype' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+
+var x = zeros( [ 2, 2 ] );
+// returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+
+var y = nansLike( x );
+// returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+
+var sh = getShape( y );
+// returns [ 2, 2 ]
+
+var dt = String( getDType( y ) );
+// returns 'float64'
+```
+
+The function supports the following options:
+
+-   **dtype**: output [ndarray][@stdlib/ndarray/ctor] [data type][@stdlib/ndarray/dtypes]. Must be a floating-point or "generic" [data type][@stdlib/ndarray/dtypes]. Overrides the input ndarray's inferred [data type][@stdlib/ndarray/dtypes].
+-   **shape**: output [ndarray][@stdlib/ndarray/ctor] shape. Overrides the input ndarray's inferred shape.
+-   **order**: specifies whether the output [ndarray][@stdlib/ndarray/ctor] should be `'row-major'` (C-style) or `'column-major'` (Fortran-style). Overrides the input ndarray's inferred order.
+-   **mode**: specifies how to handle indices which exceed array dimensions (see [ndarray][@stdlib/ndarray/ctor]). Default: `'throw'`.
+-   **submode**: a mode array which specifies for each dimension how to handle subscripts which exceed array dimensions  (see [ndarray][@stdlib/ndarray/ctor]). If provided fewer modes than dimensions, the constructor recycles modes using modulo arithmetic. Default: `[ options.mode ]`.
+-   **readonly**: boolean indicating whether an array should be **read-only**. Default: `false`.
+
+To override either the `dtype`, `shape`, or `order`, specify the corresponding option. For example, to override the inferred [data type][@stdlib/ndarray/dtypes],
+
+```javascript
+var getShape = require( '@stdlib/ndarray/shape' );
+var getDType = require( '@stdlib/ndarray/dtype' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+
+var x = zeros( [ 2, 2 ] );
+// returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+
+var dt = String( getDType( x ) );
+// returns 'float64'
+
+var y = nansLike( x, {
+    'dtype': 'float32'
+});
+// returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+
+var sh = getShape( y );
+// returns [ 2, 2 ]
+
+dt = String( getDType( y ) );
+// returns 'float32'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   The function only supports floating-point and "generic" [data types][@stdlib/ndarray/dtypes], as NaN is not defined for integer data types.
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var zeros = require( '@stdlib/ndarray/zeros' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var nansLike = require( '@stdlib/ndarray/nans-like' );
+
+// Define a list of supported floating-point data types:
+var dt = [ 'float32', 'float64', 'complex64', 'complex128', 'generic' ];
+
+// Generate NaN-filled arrays...
+var x;
+var y;
+var i;
+for ( i = 0; i < dt.length; i++ ) {
+    x = zeros( [ 2, 2 ], {
+        'dtype': dt[ i ]
+    });
+    y = nansLike( x );
+    console.log( ndarray2array( y ) );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/ndarray/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/ctor
+
+[@stdlib/ndarray/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/dtypes
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.js
@@ -1,0 +1,151 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// MAIN //
+
+bench( format( '%s:dtype=float64', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = zeros( [ 0 ], {
+		'dtype': 'float64'
+	});
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:dtype=float32', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = zeros( [ 0 ], {
+		'dtype': 'float32'
+	});
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:dtype=complex128', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = zeros( [ 0 ], {
+		'dtype': 'complex128'
+	});
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:dtype=complex64', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = zeros( [ 0 ], {
+		'dtype': 'complex64'
+	});
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:dtype=generic', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = zeros( [ 0 ], {
+		'dtype': 'generic'
+	});
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.complex128.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.complex128.js
@@ -1,0 +1,98 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = zeros( [ len ], {
+		'dtype': 'complex128'
+	});
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=complex128,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.complex64.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.complex64.js
@@ -1,0 +1,98 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = zeros( [ len ], {
+		'dtype': 'complex64'
+	});
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=complex64,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.float32.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.float32.js
@@ -1,0 +1,98 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = zeros( [ len ], {
+		'dtype': 'float32'
+	});
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=float32,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.float64.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.float64.js
@@ -1,0 +1,98 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = zeros( [ len ], {
+		'dtype': 'float64'
+	});
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=float64,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.generic.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/benchmark/benchmark.size.generic.js
@@ -1,0 +1,98 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var zeros = require( '@stdlib/ndarray/zeros' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = zeros( [ len ], {
+		'dtype': 'generic'
+	});
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s:dtype=generic,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/nans-like/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/docs/repl.txt
@@ -1,0 +1,75 @@
+
+{{alias}}( x[, options] )
+    Returns an ndarray filled with NaNs and having the same shape and data type
+    as a provided input ndarray.
+
+    The function infers the following attributes from the input array:
+
+    - shape: array shape.
+    - dtype: underlying array data type.
+    - order: whether the array order is row-major (C-style) or column-major
+    (Fortran-style).
+
+    The function only supports floating-point and "generic" data types, as NaN
+    is not defined for integer data types.
+
+    Parameters
+    ----------
+    x: ndarray
+        Input array.
+
+    options: Object (optional)
+        Options.
+
+    options.shape: ArrayLikeObject<integer>|integer (optional)
+        Array shape. Overrides the input array's inferred shape.
+
+    options.dtype: string|DataType (optional)
+        Array data type. Must be a floating-point or "generic" data type.
+        Overrides the input array's inferred data type.
+
+    options.order: string (optional)
+        Array order (either 'row-major' (C-style) or 'column-major' (Fortran-
+        style)). Overrides the input array's inferred order.
+
+    options.mode: string (optional)
+        Specifies how to handle indices which exceed array dimensions. If equal
+        to 'throw', an ndarray instance throws an error when an index exceeds
+        array dimensions. If equal to 'normalize', an ndarray instance
+        normalizes negative indices and throws an error when an index exceeds
+        array dimensions. If equal to 'wrap', an ndarray instance wraps around
+        indices exceeding array dimensions using modulo arithmetic. If equal to
+        'clamp', an ndarray instance sets an index exceeding array dimensions
+        to either `0` (minimum index) or the maximum index. Default: 'throw'.
+
+    options.submode: Array<string> (optional)
+        Specifies how to handle subscripts which exceed array dimensions. If a
+        mode for a corresponding dimension is equal to 'throw', an ndarray
+        instance throws an error when a subscript exceeds array dimensions. If
+        equal to 'normalize', an ndarray instance normalizes negative
+        subscripts and throws an error when a subscript exceeds array
+        dimensions. If equal to 'wrap', an ndarray instance wraps around
+        subscripts exceeding array dimensions using modulo arithmetic. If equal
+        to 'clamp', an ndarray instance sets a subscript exceeding array
+        dimensions to either `0` (minimum index) or the maximum index. If the
+        number of modes is fewer than the number of dimensions, the function
+        recycles modes using modulo arithmetic. Default: [ options.mode ].
+
+    options.readonly: boolean (optional)
+        Boolean indicating whether an array should be read-only. Default: false.
+
+    Returns
+    -------
+    out: ndarray
+        Output array.
+
+    Examples
+    --------
+    > var x = {{alias:@stdlib/ndarray/zeros}}( [ 2, 2 ] )
+    <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+    > var y = {{alias}}( x )
+    <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/ndarray/nans-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/docs/types/index.d.ts
@@ -1,0 +1,430 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable max-lines */
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { ComplexLike } from '@stdlib/types/complex';
+import { Shape, Order, Mode, ndarray, typedndarray, float64ndarray, float32ndarray, genericndarray, complex128ndarray, complex64ndarray, Float64DataType, Float32DataType, Complex128DataType, Complex64DataType, GenericDataType } from '@stdlib/types/ndarray';
+
+/**
+* Interface describing function options.
+*/
+interface Options {
+	/**
+	* Array shape.
+	*
+	* ## Notes
+	*
+	* -   If provided, this option overrides the input array's inferred shape.
+	*/
+	shape?: Shape | number;
+
+	/**
+	* Array order (either 'row-major' (C-style) or 'column-major' (Fortran-style)).
+	*
+	* ## Notes
+	*
+	* -   If provided, this option overrides the input array's inferred order.
+	*/
+	order?: Order;
+
+	/**
+	* Specifies how to handle a linear index which exceeds array dimensions (default: 'throw').
+	*/
+	mode?: Mode;
+
+	/**
+	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw']).
+	*/
+	submode?: Array<Mode>;
+
+	/**
+	* Boolean indicating whether an array should be read-only (default: false).
+	*/
+	readonly?: boolean;
+}
+
+/**
+* Interface describing function options.
+*/
+interface Float64Options extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: Float64DataType;
+}
+
+/**
+* Interface describing function options.
+*/
+interface Float32Options extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: Float32DataType;
+}
+
+/**
+* Interface describing function options.
+*/
+interface Complex128Options extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: Complex128DataType;
+}
+
+/**
+* Interface describing function options.
+*/
+interface Complex64Options extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: Complex64DataType;
+}
+
+/**
+* Interface describing function options.
+*/
+interface GenericOptions extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: GenericDataType;
+}
+
+/**
+* Interface describing function options.
+*/
+interface OptionsWithDType extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: Float64DataType | Float32DataType | Complex128DataType | Complex64DataType | GenericDataType;
+}
+
+/**
+* Creates an ndarray filled with NaNs and having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var sh = getShape( x );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( x ) );
+* // returns 'float64'
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* dt = String( getDType( y ) );
+* // returns 'float64'
+*/
+declare function nansLike<T extends genericndarray<any> | typedndarray<number | ComplexLike>>( x: T, options?: Options ): T;
+
+/**
+* Creates an ndarray filled with NaNs and having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'generic'
+* });
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var sh = getShape( x );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( x ) );
+* // returns 'generic'
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* dt = String( getDType( y ) );
+* // returns 'generic'
+*/
+declare function nansLike( x: genericndarray<any>, options?: Options ): genericndarray<number>;
+
+/**
+* Creates a NaN-filled double-precision floating-point array having the same shape as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.dtype - output array data type
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'generic'
+* });
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var y = nansLike( x, {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'float64'
+*/
+declare function nansLike( x: ndarray, options: Float64Options ): float64ndarray;
+
+/**
+* Creates a NaN-filled single-precision floating-point array having the same shape as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.dtype - output array data type
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var y = nansLike( x, {
+*     'dtype': 'float32'
+* });
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'float32'
+*/
+declare function nansLike( x: ndarray, options: Float32Options ): float32ndarray;
+
+/**
+* Creates a NaN-filled double-precision complex floating-point array having the same shape as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.dtype - output array data type
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var y = nansLike( x, {
+*     'dtype': 'complex128'
+* });
+* // returns <ndarray>[ [ <Complex128>[ NaN, 0.0 ], <Complex128>[ NaN, 0.0 ] ], [ <Complex128>[ NaN, 0.0 ], <Complex128>[ NaN, 0.0 ] ] ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'complex128'
+*/
+declare function nansLike( x: ndarray, options: Complex128Options ): complex128ndarray;
+
+/**
+* Creates a NaN-filled single-precision complex floating-point array having the same shape as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.dtype - output array data type
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var y = nansLike( x, {
+*     'dtype': 'complex64'
+* });
+* // returns <ndarray>[ [ <Complex64>[ NaN, 0.0 ], <Complex64>[ NaN, 0.0 ] ], [ <Complex64>[ NaN, 0.0 ], <Complex64>[ NaN, 0.0 ] ] ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'complex64'
+*/
+declare function nansLike( x: ndarray, options: Complex64Options ): complex64ndarray;
+
+/**
+* Creates a NaN-filled generic array having the same shape as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.dtype - output array data type
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var y = nansLike( x, {
+*     'dtype': 'generic'
+* });
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'generic'
+*/
+declare function nansLike( x: ndarray, options: GenericOptions ): genericndarray<number>;
+
+/**
+* Creates an ndarray filled with NaNs and having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.dtype - output array data type
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'float64'
+*/
+declare function nansLike( x: ndarray, options?: Options | OptionsWithDType ): typedndarray<number>;
+
+
+// EXPORTS //
+
+export = nansLike;

--- a/lib/node_modules/@stdlib/ndarray/nans-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 /// <reference types="@stdlib/types"/>
 
 import { ComplexLike } from '@stdlib/types/complex';
-import { Shape, Order, Mode, ndarray, typedndarray, float64ndarray, float32ndarray, genericndarray, complex128ndarray, complex64ndarray, Float64DataType, Float32DataType, Complex128DataType, Complex64DataType, GenericDataType } from '@stdlib/types/ndarray';
+import { Shape, Order, Mode, ndarray, typedndarray, float64ndarray, float32ndarray, genericndarray, complex128ndarray, complex64ndarray, FloatingPointAndGenericDataType, Float64DataType, Float32DataType, Complex128DataType, Complex64DataType, GenericDataType } from '@stdlib/types/ndarray';
 
 /**
 * Interface describing function options.
@@ -144,7 +144,7 @@ interface OptionsWithDType extends Options {
 	*
 	* -   This option overrides the input array's inferred data type.
 	*/
-	dtype: Float64DataType | Float32DataType | Complex128DataType | Complex64DataType | GenericDataType;
+	dtype: FloatingPointAndGenericDataType;
 }
 
 /**

--- a/lib/node_modules/@stdlib/ndarray/nans-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/docs/types/test.ts
@@ -1,0 +1,169 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import zeros = require( '@stdlib/ndarray/base/zeros' );
+import nansLike = require( './index' );
+
+
+// TESTS //
+
+// The function returns an ndarray...
+{
+	const sh = [ 2, 2 ];
+	const ord = 'row-major';
+
+	nansLike( zeros( 'float64', sh, ord ) ); // $ExpectType float64ndarray
+	nansLike( zeros( 'float32', sh, ord ) ); // $ExpectType float32ndarray
+	nansLike( zeros( 'complex128', sh, ord ) ); // $ExpectType complex128ndarray
+	nansLike( zeros( 'complex64', sh, ord ) ); // $ExpectType complex64ndarray
+	nansLike( zeros( 'generic', sh, ord ) ); // $ExpectType genericndarray<number>
+
+
+	nansLike( zeros( 'float64', sh, ord ), {} ); // $ExpectType float64ndarray
+	nansLike( zeros( 'float32', sh, ord ), {} ); // $ExpectType float32ndarray
+	nansLike( zeros( 'complex128', sh, ord ), {} ); // $ExpectType complex128ndarray
+	nansLike( zeros( 'complex64', sh, ord ), {} ); // $ExpectType complex64ndarray
+	nansLike( zeros( 'generic', sh, ord ), {} ); // $ExpectType genericndarray<number>
+
+
+	nansLike( zeros( 'float64', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType float64ndarray
+	nansLike( zeros( 'float32', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType float32ndarray
+	nansLike( zeros( 'complex128', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType complex128ndarray
+	nansLike( zeros( 'complex64', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType complex64ndarray
+	nansLike( zeros( 'generic', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType genericndarray<number>
+
+
+	nansLike( zeros( 'float64', sh, ord ), { 'order': 'column-major' } ); // $ExpectType float64ndarray
+	nansLike( zeros( 'float32', sh, ord ), { 'order': 'column-major' } ); // $ExpectType float32ndarray
+	nansLike( zeros( 'complex128', sh, ord ), { 'order': 'column-major' } ); // $ExpectType complex128ndarray
+	nansLike( zeros( 'complex64', sh, ord ), { 'order': 'column-major' } ); // $ExpectType complex64ndarray
+	nansLike( zeros( 'generic', sh, ord ), { 'order': 'column-major' } ); // $ExpectType genericndarray<number>
+
+
+	nansLike( zeros( 'generic', sh, ord ), { 'dtype': 'float64' } ); // $ExpectType float64ndarray
+	nansLike( zeros( 'generic', sh, ord ), { 'dtype': 'float32' } ); // $ExpectType float32ndarray
+	nansLike( zeros( 'generic', sh, ord ), { 'dtype': 'complex128' } ); // $ExpectType complex128ndarray
+	nansLike( zeros( 'generic', sh, ord ), { 'dtype': 'complex64' } ); // $ExpectType complex64ndarray
+	nansLike( zeros( 'generic', sh, ord ), { 'dtype': 'generic' } ); // $ExpectType genericndarray<number>
+}
+
+// The compiler throws an error if the function is provided a first argument is not an ndarray which has a recognized/supported data type...
+{
+	nansLike( '10' ); // $ExpectError
+	nansLike( 10 ); // $ExpectError
+	nansLike( false ); // $ExpectError
+	nansLike( true ); // $ExpectError
+	nansLike( null ); // $ExpectError
+	nansLike( [] ); // $ExpectError
+	nansLike( {} ); // $ExpectError
+	nansLike( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument is not an options object...
+{
+	const x = zeros( 'generic', [ 2, 2 ], 'row-major' );
+
+	nansLike( x, '10' ); // $ExpectError
+	nansLike( x, 10 ); // $ExpectError
+	nansLike( x, false ); // $ExpectError
+	nansLike( x, true ); // $ExpectError
+	nansLike( x, [] ); // $ExpectError
+	nansLike( x, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a `dtype` option which is not a valid data type...
+{
+	const x = zeros( 'generic', [ 2, 2 ], 'row-major' );
+
+	nansLike( x, { 'dtype': '10' } ); // $ExpectError
+	nansLike( x, { 'dtype': 10 } ); // $ExpectError
+	nansLike( x, { 'dtype': null } ); // $ExpectError
+	nansLike( x, { 'dtype': false } ); // $ExpectError
+	nansLike( x, { 'dtype': true } ); // $ExpectError
+	nansLike( x, { 'dtype': [] } ); // $ExpectError
+	nansLike( x, { 'dtype': {} } ); // $ExpectError
+	nansLike( x, { 'dtype': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an `order` option which is not a valid order...
+{
+	const x = zeros( 'generic', [ 2, 2 ], 'row-major' );
+
+	nansLike( x, { 'order': '10' } ); // $ExpectError
+	nansLike( x, { 'order': 10 } ); // $ExpectError
+	nansLike( x, { 'order': false } ); // $ExpectError
+	nansLike( x, { 'order': true } ); // $ExpectError
+	nansLike( x, { 'order': [] } ); // $ExpectError
+	nansLike( x, { 'order': {} } ); // $ExpectError
+	nansLike( x, { 'order': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a `shape` option which is not a valid shape...
+{
+	const x = zeros( 'generic', [ 2, 2 ], 'row-major' );
+
+	nansLike( x, { 'shape': '10' } ); // $ExpectError
+	nansLike( x, { 'shape': false } ); // $ExpectError
+	nansLike( x, { 'shape': true } ); // $ExpectError
+	nansLike( x, { 'shape': [ '5' ] } ); // $ExpectError
+	nansLike( x, { 'shape': {} } ); // $ExpectError
+	nansLike( x, { 'shape': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a `mode` option which is not a valid mode...
+{
+	const x = zeros( 'generic', [ 2, 2 ], 'row-major' );
+
+	nansLike( x, { 'mode': '5' } ); // $ExpectError
+	nansLike( x, { 'mode': 5 } ); // $ExpectError
+	nansLike( x, { 'mode': false } ); // $ExpectError
+	nansLike( x, { 'mode': true } ); // $ExpectError
+	nansLike( x, { 'mode': [ '5' ] } ); // $ExpectError
+	nansLike( x, { 'mode': {} } ); // $ExpectError
+	nansLike( x, { 'mode': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a `submode` option which is not valid...
+{
+	const x = zeros( 'generic', [ 2, 2 ], 'row-major' );
+
+	nansLike( x, { 'submode': '5' } ); // $ExpectError
+	nansLike( x, { 'submode': 5 } ); // $ExpectError
+	nansLike( x, { 'submode': false } ); // $ExpectError
+	nansLike( x, { 'submode': true } ); // $ExpectError
+	nansLike( x, { 'submode': [ '5' ] } ); // $ExpectError
+	nansLike( x, { 'submode': {} } ); // $ExpectError
+	nansLike( x, { 'submode': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a `readonly` option which is not a boolean...
+{
+	const x = zeros( 'generic', [ 2, 2 ], 'row-major' );
+
+	nansLike( x, { 'readonly': '5' } ); // $ExpectError
+	nansLike( x, { 'readonly': 5 } ); // $ExpectError
+	nansLike( x, { 'readonly': [ '5' ] } ); // $ExpectError
+	nansLike( x, { 'readonly': {} } ); // $ExpectError
+	nansLike( x, { 'readonly': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	nansLike(); // $ExpectError
+	nansLike( zeros( 'float64', [ 2, 2 ], 'row-major' ), {}, 1 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/ndarray/nans-like/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/examples/index.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var zeros = require( '@stdlib/ndarray/zeros' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var nansLike = require( './../lib' );
+
+// Define a list of supported floating-point data types:
+var dt = [ 'float32', 'float64', 'complex64', 'complex128', 'generic' ];
+
+// Generate NaN-filled arrays...
+var x;
+var y;
+var i;
+for ( i = 0; i < dt.length; i++ ) {
+	x = zeros( [ 2, 2 ], {
+		'dtype': dt[ i ]
+	});
+	y = nansLike( x );
+	console.log( ndarray2array( y ) );
+}

--- a/lib/node_modules/@stdlib/ndarray/nans-like/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/lib/index.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Create an ndarray filled with NaNs and having the same shape and data type as a provided ndarray.
+*
+* @module @stdlib/ndarray/nans-like
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+* var nansLike = require( '@stdlib/ndarray/nans-like' );
+*
+* var x = zeros( [ 2, 2 ] );
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'float64'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/ndarray/nans-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/lib/main.js
@@ -1,0 +1,167 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var isPlainObject = require( '@stdlib/assert/is-plain-object' );
+var isNonNegativeIntegerArray = require( '@stdlib/assert/is-nonnegative-integer-array' ).primitives;
+var isEmptyCollection = require( '@stdlib/assert/is-empty-collection' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var contains = require( '@stdlib/array/base/assert/contains' ).factory;
+var shape2strides = require( '@stdlib/ndarray/base/shape2strides' );
+var buffer = require( '@stdlib/ndarray/base/buffer' );
+var numel = require( '@stdlib/ndarray/base/numel' );
+var fill = require( '@stdlib/ndarray/base/fill' );
+var getDType = require( '@stdlib/ndarray/dtype' );
+var getShape = require( '@stdlib/ndarray/shape' );
+var getOrder = require( '@stdlib/ndarray/order' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var dtypes = require( '@stdlib/ndarray/dtypes' );
+var join = require( '@stdlib/array/base/join' );
+var format = require( '@stdlib/string/format' );
+
+
+// VARIABLES //
+
+var DTYPES = dtypes( 'floating_point_and_generic' );
+var isDataType = contains( DTYPES );
+
+
+// MAIN //
+
+/**
+* Creates an ndarray filled with NaNs and having the same shape and data type as a provided ndarray.
+*
+* @param {ndarray} x - input array
+* @param {Options} [options] - function options
+* @param {*} [options.dtype] - output array data type (overrides the input array's inferred data type)
+* @param {string} [options.order] - specifies whether the output array should be 'row-major' (C-style) or 'column-major' (Fortran-style) (overrides the input array's inferred order)
+* @param {(NonNegativeIntegerArray|NonNegativeInteger)} [options.shape] - output array shape (overrides the input array's inferred shape)
+* @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
+* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
+* @throws {TypeError} first argument must have a recognized data type
+* @throws {TypeError} options argument must be an object
+* @throws {TypeError} `dtype` option must be a supported data type
+* @throws {TypeError} `order` option must be a supported order
+* @throws {TypeError} `shape` option must be either a nonnegative integer or an array of nonnegative integers
+* @throws {TypeError} must provide valid options
+* @returns {ndarray} ndarray
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ] );
+* // returns <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'float64'
+*/
+function nansLike( x ) {
+	var options;
+	var dtype;
+	var order;
+	var ndims;
+	var opts;
+	var len;
+	var flg;
+	var out;
+	var st;
+	var sh;
+
+	if ( !isndarrayLike( x ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray-like object. Value: `%s`.', x ) );
+	}
+	flg = false;
+	opts = {};
+	if ( arguments.length > 1 ) {
+		options = arguments[ 1 ];
+		if ( !isPlainObject( options ) ) {
+			throw new TypeError( format( 'invalid argument. Options argument must be an object. Value: `%s`.', options ) );
+		}
+		if ( hasOwnProp( options, 'dtype' ) ) {
+			dtype = options.dtype;
+			if ( !isDataType( dtype ) ) {
+				throw new TypeError( format( 'invalid option. `%s` option must be one of the following: "%s". Option: `%s`.', 'dtype', join( DTYPES, '", "' ), dtype ) );
+			}
+			flg = true;
+		} else {
+			dtype = getDType( x );
+		}
+		if ( hasOwnProp( options, 'shape' ) ) {
+			sh = options.shape;
+			if ( isNonNegativeInteger( sh ) ) {
+				sh = [ sh ];
+			} else if ( !isNonNegativeIntegerArray( sh ) && !isEmptyCollection( sh ) ) { // eslint-disable-line max-len
+				throw new TypeError( format( 'invalid option. `%s` option must be a nonnegative integer or an array of nonnegative integers. Option: `%s`.', 'shape', sh ) );
+			}
+		} else {
+			sh = getShape( x );
+		}
+		if ( hasOwnProp( options, 'order' ) ) {
+			order = options.order;
+		} else {
+			order = getOrder( x );
+		}
+		if ( hasOwnProp( options, 'mode' ) ) {
+			opts.mode = options.mode;
+		}
+		if ( hasOwnProp( options, 'submode' ) ) {
+			opts.submode = options.submode;
+		}
+		if ( hasOwnProp( options, 'readonly' ) ) {
+			opts.readonly = options.readonly;
+		}
+	} else {
+		dtype = getDType( x );
+		sh = getShape( x );
+		order = getOrder( x );
+	}
+	if ( !flg && !isDataType( dtype ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must have one of the following data types: "%s". Value: `%s`.', join( DTYPES, '", "' ), dtype ) );
+	}
+	ndims = sh.length;
+	if ( ndims > 0 ) {
+		len = numel( sh );
+		st = shape2strides( sh, order );
+	} else {
+		// For 0-dimensional arrays, the buffer should contain a single element...
+		len = 1;
+		st = [ 0 ];
+	}
+	out = new ndarray( dtype, buffer( dtype, len ), sh, st, 0, order, opts );
+	fill( out, NaN );
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = nansLike;

--- a/lib/node_modules/@stdlib/ndarray/nans-like/package.json
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/package.json
@@ -60,7 +60,6 @@
     "fill",
     "filled",
     "nans",
-    "nan",
-    "numpy.full_like"
+    "nan"
   ]
 }

--- a/lib/node_modules/@stdlib/ndarray/nans-like/package.json
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@stdlib/ndarray/nans-like",
+  "version": "0.0.0",
+  "description": "Create an ndarray filled with NaNs and having the same shape and data type as a provided ndarray.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "types",
+    "data",
+    "structure",
+    "vector",
+    "ndarray",
+    "matrix",
+    "fill",
+    "filled",
+    "nans",
+    "nan",
+    "numpy.full_like"
+  ]
+}

--- a/lib/node_modules/@stdlib/ndarray/nans-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/test/test.js
@@ -1,0 +1,794 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var Float32Array = require( '@stdlib/array/float32' );
+var Complex64Array = require( '@stdlib/array/complex64' );
+var Complex128Array = require( '@stdlib/array/complex128' );
+var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var instanceOf = require( '@stdlib/assert/instance-of' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
+var getShape = require( '@stdlib/ndarray/shape' );
+var getDType = require( '@stdlib/ndarray/dtype' );
+var getData = require( '@stdlib/ndarray/data-buffer' );
+var getOrder = require( '@stdlib/ndarray/order' );
+var getFlags = require( '@stdlib/ndarray/flags' );
+var nansLike = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nansLike, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided a first argument having an unrecognized data type', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {},
+		{
+			'data': true
+		}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument having an unrecognized data type (options)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {},
+		{
+			'data': true
+		}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( value, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a first argument having a non-floating-point data type', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		zeros( 'int8', [ 2, 2 ], 'row-major' ),
+		zeros( 'int16', [ 2, 2 ], 'row-major' ),
+		zeros( 'int32', [ 2, 2 ], 'row-major' ),
+		zeros( 'uint8', [ 2, 2 ], 'row-major' ),
+		zeros( 'uint8c', [ 2, 2 ], 'row-major' ),
+		zeros( 'uint16', [ 2, 2 ], 'row-major' ),
+		zeros( 'uint32', [ 2, 2 ], 'row-major' )
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided integer array' );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an options argument which is not an object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( zeros( 'generic', [ 2, 2 ], 'row-major' ), value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `dtype` option which is not a recognized data type', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		'int32',
+		'int16',
+		'int8',
+		'uint32',
+		'uint16',
+		'uint8',
+		'uint8c',
+		5,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( zeros( 'generic', [ 2, 2 ], 'row-major' ), {
+				'dtype': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an `order` option which is not a recognized order', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( zeros( 'generic', [ 2, 2 ], 'row-major' ), {
+				'order': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `shape` option which is not a valid shape', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		-1,
+		true,
+		false,
+		null,
+		void 0,
+		[ '5' ],
+		[ 3.14 ],
+		[ -1 ],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( zeros( 'generic', [ 2, 2 ], 'row-major' ), {
+				'shape': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `mode` option which is not a recognized mode', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		'beep',
+		'THROW',
+		5,
+		null,
+		true,
+		false,
+		[],
+		{}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( zeros( 'generic', [ 2, 2 ], 'row-major' ), {
+				'mode': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid `submode` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		'beep',
+		'THROW',
+		5,
+		null,
+		true,
+		false,
+		{}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( zeros( 'generic', [ 2, 2 ], 'row-major' ), {
+				'submode': [ value ]
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `readonly` option which is not a boolean', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		null,
+		void 0,
+		[],
+		{}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( zeros( 'generic', [ 2, 2 ], 'row-major' ), {
+				'readonly': value
+			});
+		};
+	}
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float64, inferred)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'float64', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float64, options)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'generic', [ 4 ], 'row-major' );
+	arr = nansLike( x, {
+		'shape': [ 2, 2 ],
+		'dtype': 'float64',
+		'order': 'column-major'
+	});
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float64, options, integer shape)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'generic', [ 0 ], 'row-major' );
+	arr = nansLike( x, {
+		'shape': 4,
+		'dtype': 'float64',
+		'order': 'column-major'
+	});
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 4 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float32, inferred)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'float32', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float32, options)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'generic', [ 4 ], 'row-major' );
+	arr = nansLike( x, {
+		'shape': [ 2, 2 ],
+		'dtype': 'float32',
+		'order': 'column-major'
+	});
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex128, inferred)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'complex128', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex128', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex128Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	buf = reinterpret128( getData( arr ), 0 );
+	for ( i = 0; i < buf.length; i += 2 ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'real part is NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex128, options)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'generic', [ 4 ], 'row-major' );
+	arr = nansLike( x, {
+		'shape': [ 2, 2 ],
+		'dtype': 'complex128',
+		'order': 'column-major'
+	});
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex128', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex128Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	buf = reinterpret128( getData( arr ), 0 );
+	for ( i = 0; i < buf.length; i += 2 ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'real part is NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex64, inferred)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'complex64', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	buf = reinterpret64( getData( arr ), 0 );
+	for ( i = 0; i < buf.length; i += 2 ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'real part is NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex64, options)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'generic', [ 4 ], 'row-major' );
+	arr = nansLike( x, {
+		'shape': [ 2, 2 ],
+		'dtype': 'complex64',
+		'order': 'column-major'
+	});
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	buf = reinterpret64( getData( arr ), 0 );
+	for ( i = 0; i < buf.length; i += 2 ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'real part is NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=generic, inferred)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'generic', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=generic, options)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'float64', [ 4 ], 'row-major' );
+	arr = nansLike( x, {
+		'shape': [ 2, 2 ],
+		'dtype': 'generic',
+		'order': 'column-major'
+	});
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function guards against array having shapes containing negative dimension sizes', function test( t ) {
+	var x = {
+		'data': [ 1, 2, 3, 4 ],
+		'ndims': 3,
+		'shape': [ 2, -1, 2 ],
+		'strides': [ -2, 2, 1 ],
+		'offset': 0,
+		'order': 'row-major',
+		'dtype': 'generic',
+		'length': 0,
+		'flags': {},
+		'get': noop,
+		'set': noop
+	};
+	t.throws( badValue, Error, 'throws an error' );
+
+	t.end();
+
+	function badValue() {
+		return nansLike( x );
+	}
+
+	function noop() {}
+});
+
+tape( 'the function supports zero-dimensional arrays', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+
+	x = {
+		'dtype': 'generic',
+		'ndims': 0,
+		'length': 0,
+		'data': [ 0 ],
+		'shape': [],
+		'strides': [ 0 ],
+		'offset': 0,
+		'order': 'row-major',
+		'flags': {},
+		'get': noop,
+		'set': noop
+	};
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( isnan( buf[ 0 ] ), true, 'returns NaN' );
+
+	t.end();
+
+	function noop() {}
+});
+
+tape( 'the function supports empty arrays', function test( t ) {
+	var arr;
+	var x;
+
+	x = {
+		'dtype': 'generic',
+		'ndims': 3,
+		'length': 0,
+		'data': [],
+		'shape': [ 2, 0, 2 ],
+		'strides': [ 0, 2, 1 ],
+		'offset': 0,
+		'order': 'row-major',
+		'flags': {},
+		'get': noop,
+		'set': noop
+	};
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 0, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.deepEqual( getData( arr ), [], 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+
+	function noop() {}
+});
+
+tape( 'the function supports returning read-only arrays', function test( t ) {
+	var opts;
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	opts = {
+		'order': 'row-major',
+		'readonly': true
+	};
+	x = zeros( 'generic', [ 2, 2, 2 ], 'row-major' );
+	arr = nansLike( x, opts );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.strictEqual( getFlags( arr ).READONLY, true, 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function supports returning writable arrays', function test( t ) {
+	var opts;
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	opts = {
+		'order': 'row-major',
+		'readonly': false
+	};
+	x = zeros( 'generic', [ 2, 2, 2 ], 'row-major' );
+	arr = nansLike( x, opts );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.strictEqual( getFlags( arr ).READONLY, false, 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function supports specifying array index modes and submodes', function test( t ) {
+	var opts;
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	opts = {
+		'mode': 'clamp',
+		'submode': [ 'wrap' ]
+	};
+	x = zeros( 'generic', [ 2, 2, 2 ], 'row-major' );
+	arr = nansLike( x, opts );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+
+	t.strictEqual( isnan( arr.iget( arr.length+10 ) ), true, 'returns expected value' );
+	arr.iset( arr.length+10, 2 );
+	t.strictEqual( arr.iget( arr.length+10 ), 2, 'returns expected value' );
+
+	t.strictEqual( isnan( arr.get( 2, 2, 2 ) ), true, 'returns expected value' );
+	arr.set( 2, 2, 2, 3 );
+	t.strictEqual( arr.get( 0, 0, 0 ), 3, 'returns expected value' );
+	t.strictEqual( arr.get( 2, 2, 2 ), 3, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/ndarray/nans-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/test/test.js
@@ -120,11 +120,13 @@ tape( 'the function throws an error if provided a first argument having a non-fl
 		zeros( 'uint8', [ 2, 2 ], 'row-major' ),
 		zeros( 'uint8c', [ 2, 2 ], 'row-major' ),
 		zeros( 'uint16', [ 2, 2 ], 'row-major' ),
-		zeros( 'uint32', [ 2, 2 ], 'row-major' )
+		zeros( 'uint32', [ 2, 2 ], 'row-major' ),
+		zeros( 'bool', [ 2, 2 ], 'row-major' ),
+		zeros( 'binary', [ 2, 2 ], 'row-major' )
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided integer array' );
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided non-floating-point array' );
 	}
 	t.end();
 
@@ -175,6 +177,8 @@ tape( 'the function throws an error if provided a `dtype` option which is not a 
 		'uint16',
 		'uint8',
 		'uint8c',
+		'bool',
+		'binary',
 		5,
 		true,
 		false,
@@ -487,6 +491,7 @@ tape( 'the function returns a NaN-filled array (dtype=complex128, inferred)', fu
 	buf = reinterpret128( getData( arr ), 0 );
 	for ( i = 0; i < buf.length; i += 2 ) {
 		t.strictEqual( isnan( buf[ i ] ), true, 'real part is NaN at index '+i );
+		t.strictEqual( buf[ i+1 ], 0.0, 'imaginary part is 0 at index '+(i+1) );
 	}
 	t.end();
 });
@@ -513,6 +518,7 @@ tape( 'the function returns a NaN-filled array (dtype=complex128, options)', fun
 	buf = reinterpret128( getData( arr ), 0 );
 	for ( i = 0; i < buf.length; i += 2 ) {
 		t.strictEqual( isnan( buf[ i ] ), true, 'real part is NaN at index '+i );
+		t.strictEqual( buf[ i+1 ], 0.0, 'imaginary part is 0 at index '+(i+1) );
 	}
 	t.end();
 });
@@ -535,6 +541,7 @@ tape( 'the function returns a NaN-filled array (dtype=complex64, inferred)', fun
 	buf = reinterpret64( getData( arr ), 0 );
 	for ( i = 0; i < buf.length; i += 2 ) {
 		t.strictEqual( isnan( buf[ i ] ), true, 'real part is NaN at index '+i );
+		t.strictEqual( buf[ i+1 ], 0.0, 'imaginary part is 0 at index '+(i+1) );
 	}
 	t.end();
 });
@@ -561,6 +568,7 @@ tape( 'the function returns a NaN-filled array (dtype=complex64, options)', func
 	buf = reinterpret64( getData( arr ), 0 );
 	for ( i = 0; i < buf.length; i += 2 ) {
 		t.strictEqual( isnan( buf[ i ] ), true, 'real part is NaN at index '+i );
+		t.strictEqual( buf[ i+1 ], 0.0, 'imaginary part is 0 at index '+(i+1) );
 	}
 	t.end();
 });
@@ -790,5 +798,104 @@ tape( 'the function supports specifying array index modes and submodes', functio
 	t.strictEqual( arr.get( 0, 0, 0 ), 3, 'returns expected value' );
 	t.strictEqual( arr.get( 2, 2, 2 ), 3, 'returns expected value' );
 
+	t.end();
+});
+
+tape( 'the function returns a new data buffer (not a view of the input)', function test( t ) {
+	var arr;
+	var x;
+
+	x = zeros( 'float64', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+	t.strictEqual( getData( arr ) === getData( x ), false, 'returns a new buffer' );
+	t.end();
+});
+
+tape( 'the function infers the order from the input array (column-major)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'float64', [ 2, 2 ], 'column-major' );
+	arr = nansLike( x );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	buf = getData( arr );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function supports overriding only the dtype option', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'float64', [ 2, 3 ], 'row-major' );
+	arr = nansLike( x, {
+		'dtype': 'float32'
+	});
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 3 ], 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( instanceOf( buf, Float32Array ), true, 'returns expected value' );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function supports overriding only the order option', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'float64', [ 2, 3 ], 'row-major' );
+	arr = nansLike( x, {
+		'order': 'column-major'
+	});
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 3 ], 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( instanceOf( buf, Float64Array ), true, 'returns expected value' );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
+	t.end();
+});
+
+tape( 'the function supports overriding only the shape option', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+	var i;
+
+	x = zeros( 'float64', [ 2, 3 ], 'row-major' );
+	arr = nansLike( x, {
+		'shape': [ 3, 2 ]
+	});
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 3, 2 ], 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( instanceOf( buf, Float64Array ), true, 'returns expected value' );
+	for ( i = 0; i < buf.length; i++ ) {
+		t.strictEqual( isnan( buf[ i ] ), true, 'returns NaN at index '+i );
+	}
 	t.end();
 });


### PR DESCRIPTION
## Description

This PR adds the `@stdlib/ndarray/nans-like` package, which creates an ndarray filled with NaN values having the same shape and data type as a provided input ndarray.

### Key design decisions

- **Restricted dtype support**: Only floating-point and `"generic"` data types are supported (via `dtypes('floating_point_and_generic')`), as NaN is not defined for integer types. Attempting to use an integer dtype throws a `TypeError`.
- **Complex NaN fill**: For `complex128` and `complex64`, `fill(out, NaN)` produces `real=NaN, imag=0.0` — consistent with NumPy's behavior for `np.full(..., np.nan, dtype=complex128)`.
- **Pattern**: Follows `@stdlib/ndarray/ones-like` exactly, substituting `NaN` as the fill value and restricting the dtype set accordingly.
- **Namespace**: Wired into `@stdlib/ndarray` alphabetically between `mostlySafeCasts` and `ndarraylike2ndarray`.

### Files added/modified

- `lib/node_modules/@stdlib/ndarray/nans-like/` — new package
  - `lib/main.js` — core implementation
  - `lib/index.js` — module entry point
  - `package.json`
  - `test/test.js` — 316 tests covering all dtypes, all option overrides, edge cases
  - `examples/index.js`
  - `benchmark/benchmark.js` and per-dtype size benchmarks
  - `docs/repl.txt`
  - `docs/types/index.d.ts` — TypeScript declarations using `FloatingPointAndGenericDataType`
  - `docs/types/test.ts`
  - `README.md`
- `lib/node_modules/@stdlib/ndarray/lib/index.js` — add `nansLike` to namespace
- `lib/node_modules/@stdlib/ndarray/docs/types/index.d.ts` — add `nansLike` type to namespace interface

## Related Issues

Closes stdlib-js/todo#2771

## Questions

None.

## Other

- All 316 tests pass.
- This implementation was developed with AI assistance (Claude Code / claude-sonnet-4-6).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).
- [x] I have followed the code style guidelines.
- [x] The implementation is based on an existing analogous package (`@stdlib/ndarray/ones-like`).
- [x] Tests cover all supported dtypes, all option overrides, error cases, and edge cases (zero-dim, empty arrays).
- [x] AI assistance disclosure: this PR was generated with Claude Code (claude-sonnet-4-6).

https://claude.ai/code/session_01THn379nEWg1u7YggFFBuFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01THn379nEWg1u7YggFFBuFQ)_