### PR TITLE
feat: add `@stdlib/ndarray/base/nans-like`

### DIFF
--- a/.ralph/state.md
+++ b/.ralph/state.md
@@ -1,0 +1,82 @@
+# Ralph Loop State
+
+## Issue
+**Reference**: stdlib-js/todo#2772  
+**Title**: Review `@stdlib/ndarray/base/nans-like`  
+**Body**: Review `@stdlib/ndarray/base/nans-like`. This package does not yet exist and must be created.
+
+## Acceptance Criteria
+- [x] `lib/main.js` — implements `nansLike(x)`, returns NaN-filled ndarray with same shape/dtype/order as input
+- [x] `lib/index.js` — module wiring
+- [x] `test/test.js` — tests covering all floating-point+generic dtypes (base and non-base), zero-dimensional arrays, empty arrays, and error case for unrecognized dtypes and integer dtypes
+- [x] `examples/index.js` — runnable example iterating over supported dtypes
+- [x] `benchmark/benchmark.js` — per-dtype benchmarks (float64, float32, complex128, complex64, generic)
+- [x] `benchmark/benchmark.size.float64.js` through `*.generic.js` — size-varying benchmarks for each supported dtype
+- [x] `docs/repl.txt` — REPL documentation
+- [x] `docs/types/index.d.ts` — TypeScript declarations with overloads for each supported dtype
+- [x] `docs/types/test.ts` — TypeScript type tests
+- [x] `README.md` — package documentation
+- [x] `package.json` — correct package metadata
+- [x] All sanity checks pass (tape not installed; verified with direct node execution)
+- [x] Namespace index.js and types/index.d.ts updated
+
+## Key Design Decisions
+- Only supports floating-point and generic dtypes (float64, float32, complex128, complex64, generic)
+- Complex types use `CNAN` from `@stdlib/constants/complex128/nan`; others use `NaN`
+- Uses `emptyLike` + `fill` pattern (like `ones-like`)
+- Integer dtypes throw at runtime (fill throws TypeError for NaN + integer types)
+- TypeScript uses per-dtype overloads (not generic pattern) since integer types throw
+- No `@throws` annotation in JSDoc (match `ones-like` convention)
+
+## Branch
+`claude/vibrant-brahmagupta-jUurQ`
+
+## Files Touched
+- `lib/node_modules/@stdlib/ndarray/base/nans-like/` (new package, all files)
+- `lib/node_modules/@stdlib/ndarray/base/lib/index.js` (added nansLike export)
+- `lib/node_modules/@stdlib/ndarray/base/docs/types/index.d.ts` (added nansLike declaration)
+
+## Iteration 1 — Plan: Implement
+Created all package files for `@stdlib/ndarray/base/nans-like`.
+
+## Iteration 1 — Review Findings
+
+### Agent A (Correctness): Running
+### Agent B (Test Quality): Completed
+- BLOCKER F-9: Tests used pre-NaN inputs — aliasing bug would pass → FIXED: now use zeros() as input + buffer identity assertions
+- BLOCKER F-5: Integer dtypes not tested → FIXED: added tests for int32/uint32/int16/uint16/int8/uint8/uint8c (all throw)
+- MAJOR F-2: Buffer length not asserted → FIXED
+- MAJOR F-3: Complex buffer length missing in non-base → FIXED
+- MAJOR F-6: 0-dim only tested with generic → FIXED: added float64/float32/complex128/complex64
+- MAJOR F-7: Empty array only tested with generic → FIXED: added float64 base test
+- MINOR F-1: allNaN helper vacuously true for empty → FIXED: added guard
+- MINOR F-12: Dead `expected` var in complex128 base test → FIXED (removed unused var)
+
+### Agent C (Code Quality): Completed
+- BLOCKER: @throws annotation incorrect (delegates to emptyLike, not direct throw) → FIXED: removed @throws, matches ones-like pattern
+- MAJOR: TypeScript should use generic pattern `<T extends typedndarray<...>>` → DISPUTED: per-overload is correct because integer types throw (runtime verified)
+- MINOR: getDType import "extra" compared to ones-like → ACCEPTED: needed for complex check, not a bug
+
+### Agent D (Security): Running
+### Agent E (Issue-Scope): Completed — No issues (everything is in scope)
+
+## Triage
+
+### Fixed
+- Removed @throws from JSDoc (was inaccurate for "unrecognized dtype" framing; matches ones-like)
+- Test rewrites: non-NaN inputs, buffer identity, buffer length, integer dtypes, 0-dim for all types
+- allNaN helper guards empty arrays
+
+### Disputed
+- TypeScript generic vs per-overload: Per-overload KEPT. Reason: integer ndarray inputs to nansLike throw TypeError at runtime (fill rejects NaN for int types). The per-overload pattern correctly documents supported types. Generic `<T extends typedndarray<number | ComplexLike>>` would incorrectly accept integer ndarrays at the TypeScript level. The reviewer's pattern applies to ones-like which supports ALL dtypes; nans-like is more restrictive.
+
+## Decision Log
+1. Used emptyLike + fill pattern (like ones-like), not manual buffer pattern (like zeros-like)
+2. No @throws in JSDoc — removed to match ones-like convention
+3. TypeScript: per-dtype overloads (5 overloads) not generic — correctly restricts to NaN-capable types
+4. Integer dtype tests: verified they DO throw (TypeError from fill), added throw tests
+5. Tests use zeros() as input, not nans(), to make NaN filling visible
+
+## Make Commands
+- Tests: node script with NODE_PATH=/home/user/stdlib/lib/node_modules
+- Examples: NODE_PATH=... node examples/index.js

--- a/lib/node_modules/@stdlib/ndarray/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/docs/types/index.d.ts
@@ -105,6 +105,7 @@ import minUnsignedIntegerDataType = require( '@stdlib/ndarray/base/min-unsigned-
 import minViewBufferIndex = require( '@stdlib/ndarray/base/min-view-buffer-index' );
 import minmaxViewBufferIndex = require( '@stdlib/ndarray/base/minmax-view-buffer-index' );
 import nans = require( '@stdlib/ndarray/base/nans' );
+import nansLike = require( '@stdlib/ndarray/base/nans-like' );
 import ndarraylike2ndarray = require( '@stdlib/ndarray/base/ndarraylike2ndarray' );
 import ndarraylike2object = require( '@stdlib/ndarray/base/ndarraylike2object' );
 import ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
@@ -2781,6 +2782,31 @@ interface Namespace {
 	* // returns 'float64'
 	*/
 	nans: typeof nans;
+
+	/**
+	* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+	*
+	* @param x - input array
+	* @returns NaN-filled array
+	*
+	* @example
+	* var getShape = require( '@stdlib/ndarray/shape' );
+	* var getDType = require( '@stdlib/ndarray/dtype' );
+	* var nans = require( '@stdlib/ndarray/base/nans' );
+	*
+	* var x = nans( 'float64', [ 2, 2 ], 'row-major' );
+	* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+	*
+	* var y = ns.nansLike( x );
+	* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+	*
+	* var sh = getShape( y );
+	* // returns [ 2, 2 ]
+	*
+	* var dt = String( getDType( y ) );
+	* // returns 'float64'
+	*/
+	nansLike: typeof nansLike;
 
 	/**
 	* Converts an ndarray-like object to an ndarray.

--- a/lib/node_modules/@stdlib/ndarray/base/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/lib/index.js
@@ -905,6 +905,15 @@ setReadOnly( ns, 'minmaxViewBufferIndex', require( '@stdlib/ndarray/base/minmax-
 setReadOnly( ns, 'nans', require( '@stdlib/ndarray/base/nans' ) );
 
 /**
+* @name nansLike
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/ndarray/base/nans-like}
+*/
+setReadOnly( ns, 'nansLike', require( '@stdlib/ndarray/base/nans-like' ) );
+
+/**
 * @name ndarraylike2ndarray
 * @memberof ns
 * @readonly

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/README.md
@@ -1,0 +1,139 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# nansLike
+
+> Create a NaN-filled [ndarray][@stdlib/ndarray/base/ctor] having the same shape and [data type][@stdlib/ndarray/dtypes] as a provided ndarray.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var nansLike = require( '@stdlib/ndarray/base/nans-like' );
+```
+
+#### nansLike( x )
+
+Creates a NaN-filled [ndarray][@stdlib/ndarray/base/ctor] having the same shape and [data type][@stdlib/ndarray/dtypes] as a provided ndarray.
+
+```javascript
+var getShape = require( '@stdlib/ndarray/shape' );
+var nans = require( '@stdlib/ndarray/base/nans' );
+
+var x = nans( 'float64', [ 2, 2 ], 'row-major' );
+// returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+
+var y = nansLike( x );
+// returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+
+var sh = getShape( y );
+// returns [ 2, 2 ]
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   Along with data type, shape, and order, the function infers the "class" of the returned ndarray from the provided ndarray. For example, if provided a "base" [ndarray][@stdlib/ndarray/base/ctor], the function returns a base [ndarray][@stdlib/ndarray/base/ctor]. If provided a non-base [ndarray][@stdlib/ndarray/ctor], the function returns a non-base [ndarray][@stdlib/ndarray/ctor].
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var nans = require( '@stdlib/ndarray/base/nans' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var nansLike = require( '@stdlib/ndarray/base/nans-like' );
+
+var dt = [
+    'float64',
+    'float32',
+    'complex128',
+    'complex64',
+    'generic'
+];
+
+// Generate NaN-filled arrays...
+var x;
+var i;
+for ( i = 0; i < dt.length; i++ ) {
+    x = nansLike( nans( dt[ i ], [ 2, 2 ], 'row-major' ) );
+    console.log( ndarray2array( x ) );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/ndarray/base/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/base/ctor
+
+[@stdlib/ndarray/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/ctor
+
+[@stdlib/ndarray/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/dtypes
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.js
@@ -1,0 +1,141 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var nans = require( '@stdlib/ndarray/base/nans' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// MAIN //
+
+bench( format( '%s::base:dtype=float64', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = nans( 'float64', [ 0 ], 'row-major' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::base:dtype=float32', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = nans( 'float32', [ 0 ], 'row-major' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::base:dtype=complex128', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = nans( 'complex128', [ 0 ], 'row-major' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::base:dtype=complex64', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = nans( 'complex64', [ 0 ], 'row-major' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::base:dtype=generic', pkg ), function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = nans( 'generic', [ 0 ], 'row-major' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = nansLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.complex128.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.complex128.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var nans = require( '@stdlib/ndarray/base/nans' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = nans( 'complex128', [ len ], 'row-major' );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::base:dtype=complex128,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.complex64.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.complex64.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var nans = require( '@stdlib/ndarray/base/nans' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = nans( 'complex64', [ len ], 'row-major' );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::base:dtype=complex64,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.float32.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.float32.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var nans = require( '@stdlib/ndarray/base/nans' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = nans( 'float32', [ len ], 'row-major' );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::base:dtype=float32,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.float64.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.float64.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var nans = require( '@stdlib/ndarray/base/nans' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = nans( 'float64', [ len ], 'row-major' );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::base:dtype=float64,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.generic.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.generic.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var nans = require( '@stdlib/ndarray/base/nans' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = nans( 'generic', [ len ], 'row-major' );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = nansLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( format( '%s::base:dtype=generic,size=%d', pkg, len ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/repl.txt
@@ -1,0 +1,30 @@
+
+{{alias}}( x )
+    Returns a NaN-filled ndarray having the same shape and data type as a
+    provided input ndarray.
+
+    Along with data type, shape, and order, the function infers the "class" of
+    the returned ndarray from the provided ndarray. For example, if provided a
+    "base" ndarray, the function returns a base ndarray. If provided a non-base
+    ndarray, the function returns a non-base ndarray.
+
+    Parameters
+    ----------
+    x: ndarray
+        Input array.
+
+    Returns
+    -------
+    out: ndarray
+        Output array.
+
+    Examples
+    --------
+    > var x = {{alias:@stdlib/ndarray/base/nans}}( 'float64', [ 2, 2 ], 'row-major' )
+    <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+    > var y = {{alias}}( x )
+    <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/types/index.d.ts
@@ -1,0 +1,183 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { float64ndarray, float32ndarray, complex128ndarray, complex64ndarray, genericndarray } from '@stdlib/types/ndarray';
+
+/**
+* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var nans = require( '@stdlib/ndarray/base/nans' );
+*
+* var x = nans( 'float64', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var sh = getShape( x );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( x ) );
+* // returns 'float64'
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* dt = String( getDType( y ) );
+* // returns 'float64'
+*/
+declare function nansLike( x: float64ndarray ): float64ndarray;
+
+/**
+* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var nans = require( '@stdlib/ndarray/base/nans' );
+*
+* var x = nans( 'float32', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var sh = getShape( x );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( x ) );
+* // returns 'float32'
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* dt = String( getDType( y ) );
+* // returns 'float32'
+*/
+declare function nansLike( x: float32ndarray ): float32ndarray;
+
+/**
+* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var nans = require( '@stdlib/ndarray/base/nans' );
+*
+* var x = nans( 'complex128', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>
+*
+* var sh = getShape( x );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( x ) );
+* // returns 'complex128'
+*
+* var y = nansLike( x );
+* // returns <ndarray>
+*
+* sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* dt = String( getDType( y ) );
+* // returns 'complex128'
+*/
+declare function nansLike( x: complex128ndarray ): complex128ndarray;
+
+/**
+* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var nans = require( '@stdlib/ndarray/base/nans' );
+*
+* var x = nans( 'complex64', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>
+*
+* var sh = getShape( x );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( x ) );
+* // returns 'complex64'
+*
+* var y = nansLike( x );
+* // returns <ndarray>
+*
+* sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* dt = String( getDType( y ) );
+* // returns 'complex64'
+*/
+declare function nansLike( x: complex64ndarray ): complex64ndarray;
+
+/**
+* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @returns NaN-filled array
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var nans = require( '@stdlib/ndarray/base/nans' );
+*
+* var x = nans( 'generic', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var sh = getShape( x );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( x ) );
+* // returns 'generic'
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* dt = String( getDType( y ) );
+* // returns 'generic'
+*/
+declare function nansLike( x: genericndarray<number> ): genericndarray<number>;
+
+
+// EXPORTS //
+
+export = nansLike;

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/types/test.ts
@@ -1,0 +1,53 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import nans = require( '@stdlib/ndarray/base/nans' );
+import nansLike = require( './index' );
+
+
+// TESTS //
+
+// The function returns an ndarray...
+{
+	const sh = [ 2, 2 ];
+	const ord = 'row-major';
+
+	nansLike( nans( 'float64', sh, ord ) ); // $ExpectType float64ndarray
+	nansLike( nans( 'float32', sh, ord ) ); // $ExpectType float32ndarray
+	nansLike( nans( 'complex128', sh, ord ) ); // $ExpectType complex128ndarray
+	nansLike( nans( 'complex64', sh, ord ) ); // $ExpectType complex64ndarray
+	nansLike( nans( 'generic', sh, ord ) ); // $ExpectType genericndarray<number>
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an ndarray...
+{
+	nansLike( '10' ); // $ExpectError
+	nansLike( 10 ); // $ExpectError
+	nansLike( false ); // $ExpectError
+	nansLike( true ); // $ExpectError
+	nansLike( null ); // $ExpectError
+	nansLike( [] ); // $ExpectError
+	nansLike( {} ); // $ExpectError
+	nansLike( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	nansLike(); // $ExpectError
+	nansLike( nans( 'float64', [ 2, 2 ], 'row-major' ), 1 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/examples/index.js
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var nans = require( '@stdlib/ndarray/base/nans' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var nansLike = require( './../lib' );
+
+var dt = [
+	'float64',
+	'float32',
+	'complex128',
+	'complex64',
+	'generic'
+];
+
+// Generate NaN-filled arrays...
+var x;
+var i;
+for ( i = 0; i < dt.length; i++ ) {
+	x = nansLike( nans( dt[ i ], [ 2, 2 ], 'row-major' ) );
+	console.log( ndarray2array( x ) );
+}

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/index.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Create a NaN-filled ndarray having the same shape and data type as a provided ndarray.
+*
+* @module @stdlib/ndarray/base/nans-like
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var nans = require( '@stdlib/ndarray/base/nans' );
+* var nansLike = require( '@stdlib/ndarray/base/nans-like' );
+*
+* var x = nans( 'float32', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'float32'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/main.js
@@ -33,7 +33,6 @@ var CNAN = require( '@stdlib/constants/complex128/nan' );
 * Creates a NaN-filled ndarray having the same shape and data type as a provided ndarray.
 *
 * @param {ndarray} x - input array
-* @throws {TypeError} first argument must have a recognized data type
 * @returns {ndarray} ndarray
 *
 * @example

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/main.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isComplexFloatingPointDataType = require( '@stdlib/ndarray/base/assert/is-complex-floating-point-data-type' ); // eslint-disable-line id-length
+var emptyLike = require( '@stdlib/ndarray/base/empty-like' );
+var getDType = require( '@stdlib/ndarray/base/dtype' );
+var fill = require( '@stdlib/ndarray/base/fill' );
+var CNAN = require( '@stdlib/constants/complex128/nan' );
+
+
+// MAIN //
+
+/**
+* Creates a NaN-filled ndarray having the same shape and data type as a provided ndarray.
+*
+* @param {ndarray} x - input array
+* @throws {TypeError} first argument must have a recognized data type
+* @returns {ndarray} ndarray
+*
+* @example
+* var getShape = require( '@stdlib/ndarray/shape' );
+* var getDType = require( '@stdlib/ndarray/dtype' );
+* var nans = require( '@stdlib/ndarray/base/nans' );
+*
+* var x = nans( 'float32', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var y = nansLike( x );
+* // returns <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]
+*
+* var sh = getShape( y );
+* // returns [ 2, 2 ]
+*
+* var dt = String( getDType( y ) );
+* // returns 'float32'
+*/
+function nansLike( x ) {
+	if ( isComplexFloatingPointDataType( getDType( x ) ) ) {
+		return fill( emptyLike( x ), CNAN );
+	}
+	return fill( emptyLike( x ), NaN );
+}
+
+
+// EXPORTS //
+
+module.exports = nansLike;

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/package.json
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@stdlib/ndarray/base/nans-like",
+  "version": "0.0.0",
+  "description": "Create a NaN-filled ndarray having the same shape and data type as a provided ndarray.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "types",
+    "base",
+    "data",
+    "structure",
+    "vector",
+    "ndarray",
+    "matrix",
+    "fill",
+    "filled",
+    "nans",
+    "nan"
+  ]
+}

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/test/test.js
@@ -1,0 +1,348 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var Float32Array = require( '@stdlib/array/float32' );
+var Complex64Array = require( '@stdlib/array/complex64' );
+var Complex128Array = require( '@stdlib/array/complex128' );
+var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var instanceOf = require( '@stdlib/assert/instance-of' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var base = require( '@stdlib/ndarray/base/ctor' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var array = require( '@stdlib/ndarray/array' );
+var nans = require( '@stdlib/ndarray/base/nans' );
+var getShape = require( '@stdlib/ndarray/shape' );
+var getDType = require( '@stdlib/ndarray/dtype' );
+var getData = require( '@stdlib/ndarray/data-buffer' );
+var getOrder = require( '@stdlib/ndarray/order' );
+var nansLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Tests whether all elements in an array are NaN.
+*
+* @private
+* @param {Collection} arr - input array
+* @returns {boolean} boolean indicating whether all elements are NaN
+*/
+function allNaN( arr ) {
+	var i;
+	for ( i = 0; i < arr.length; i++ ) {
+		if ( !isnan( arr[ i ] ) ) {
+			return false;
+		}
+	}
+	return true;
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nansLike, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided a value having an unrecognized data type', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {},
+		{
+			'data': true
+		},
+		{
+			'shape': [ 1, 2, 3 ],
+			'order': 'row-major',
+			'dtype': 'foo_bar_beep_boop'
+		}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			nansLike( value );
+		};
+	}
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float64, base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = nans( 'float64', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float64, non-base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = array( new Float64Array( 4 ), {
+		'shape': [ 2, 2 ],
+		'dtype': 'float64',
+		'order': 'column-major'
+	});
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float32, base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = nans( 'float32', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=float32, non-base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = array( new Float32Array( 4 ), {
+		'shape': [ 2, 2 ],
+		'dtype': 'float32',
+		'order': 'column-major'
+	});
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex128, base)', function test( t ) {
+	var expected;
+	var arr;
+	var buf;
+	var x;
+
+	x = nans( 'complex128', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex128', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex128Array ), true, 'returns expected value' );
+
+	buf = reinterpret128( getData( arr ), 0 );
+	expected = new Float64Array( [ NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN ] );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+	t.strictEqual( buf.length, expected.length, 'returns expected value' );
+
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex128, non-base)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+
+	x = array( new Complex128Array( 4 ), {
+		'shape': [ 2, 2 ],
+		'dtype': 'complex128',
+		'order': 'column-major'
+	});
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex128', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex128Array ), true, 'returns expected value' );
+
+	buf = reinterpret128( getData( arr ), 0 );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex64, base)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+
+	x = nans( 'complex64', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex64Array ), true, 'returns expected value' );
+
+	buf = reinterpret64( getData( arr ), 0 );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=complex64, non-base)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+
+	x = array( new Complex64Array( 4 ), {
+		'shape': [ 2, 2 ],
+		'dtype': 'complex64',
+		'order': 'column-major'
+	});
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex64Array ), true, 'returns expected value' );
+
+	buf = reinterpret64( getData( arr ), 0 );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=generic, base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = nans( 'generic', [ 2, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a NaN-filled array (dtype=generic, non-base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = array( [ NaN, NaN, NaN, NaN ], {
+		'shape': [ 2, 2 ],
+		'dtype': 'generic',
+		'order': 'column-major'
+	});
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports zero-dimensional arrays', function test( t ) {
+	var arr;
+	var x;
+
+	x = new ndarray( 'generic', [ NaN ], [], [ 0 ], 0, 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports empty arrays', function test( t ) {
+	var arr;
+	var x;
+
+	x = new ndarray( 'generic', [], [ 2, 0, 2 ], [ 0, 2, 1 ], 0, 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 0, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
+	t.deepEqual( getData( arr ), [], 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/test/test.js
@@ -23,6 +23,13 @@
 var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Float32Array = require( '@stdlib/array/float32' );
+var Int32Array = require( '@stdlib/array/int32' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var Int16Array = require( '@stdlib/array/int16' );
+var Uint16Array = require( '@stdlib/array/uint16' );
+var Int8Array = require( '@stdlib/array/int8' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -32,7 +39,8 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var base = require( '@stdlib/ndarray/base/ctor' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var array = require( '@stdlib/ndarray/array' );
-var nans = require( '@stdlib/ndarray/base/nans' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
+var ones = require( '@stdlib/ndarray/base/ones' );
 var getShape = require( '@stdlib/ndarray/shape' );
 var getDType = require( '@stdlib/ndarray/dtype' );
 var getData = require( '@stdlib/ndarray/data-buffer' );
@@ -43,7 +51,7 @@ var nansLike = require( './../lib' );
 // FUNCTIONS //
 
 /**
-* Tests whether all elements in an array are NaN.
+* Tests whether all elements in a non-empty array are NaN.
 *
 * @private
 * @param {Collection} arr - input array
@@ -51,6 +59,9 @@ var nansLike = require( './../lib' );
 */
 function allNaN( arr ) {
 	var i;
+	if ( arr.length === 0 ) {
+		return false;
+	}
 	for ( i = 0; i < arr.length; i++ ) {
 		if ( !isnan( arr[ i ] ) ) {
 			return false;
@@ -104,28 +115,84 @@ tape( 'the function throws an error if provided a value having an unrecognized d
 	}
 });
 
+tape( 'the function throws an error when provided an ndarray with an integer data type (int32)', function test( t ) {
+	t.throws( function throwit() {
+		nansLike( ones( 'int32', [ 2, 2 ], 'row-major' ) );
+	}, TypeError, 'throws for int32' );
+	t.end();
+});
+
+tape( 'the function throws an error when provided an ndarray with an integer data type (uint32)', function test( t ) {
+	t.throws( function throwit() {
+		nansLike( ones( 'uint32', [ 2, 2 ], 'row-major' ) );
+	}, TypeError, 'throws for uint32' );
+	t.end();
+});
+
+tape( 'the function throws an error when provided an ndarray with an integer data type (int16)', function test( t ) {
+	t.throws( function throwit() {
+		nansLike( ones( 'int16', [ 2, 2 ], 'row-major' ) );
+	}, TypeError, 'throws for int16' );
+	t.end();
+});
+
+tape( 'the function throws an error when provided an ndarray with an integer data type (uint16)', function test( t ) {
+	t.throws( function throwit() {
+		nansLike( ones( 'uint16', [ 2, 2 ], 'row-major' ) );
+	}, TypeError, 'throws for uint16' );
+	t.end();
+});
+
+tape( 'the function throws an error when provided an ndarray with an integer data type (int8)', function test( t ) {
+	t.throws( function throwit() {
+		nansLike( ones( 'int8', [ 2, 2 ], 'row-major' ) );
+	}, TypeError, 'throws for int8' );
+	t.end();
+});
+
+tape( 'the function throws an error when provided an ndarray with an integer data type (uint8)', function test( t ) {
+	t.throws( function throwit() {
+		nansLike( ones( 'uint8', [ 2, 2 ], 'row-major' ) );
+	}, TypeError, 'throws for uint8' );
+	t.end();
+});
+
+tape( 'the function throws an error when provided an ndarray with an integer data type (uint8c)', function test( t ) {
+	t.throws( function throwit() {
+		nansLike( ones( 'uint8c', [ 2, 2 ], 'row-major' ) );
+	}, TypeError, 'throws for uint8c' );
+	t.end();
+});
+
 tape( 'the function returns a NaN-filled array (dtype=float64, base)', function test( t ) {
 	var arr;
+	var buf;
 	var x;
 
-	x = nans( 'float64', [ 2, 2 ], 'row-major' );
+	x = zeros( 'float64', [ 2, 2 ], 'row-major' );
 	arr = nansLike( x );
 
 	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
 	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
 	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
-	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( buf.length, 4, 'returns expected value' );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
 	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
 
 tape( 'the function returns a NaN-filled array (dtype=float64, non-base)', function test( t ) {
 	var arr;
+	var buf;
 	var x;
 
-	x = array( new Float64Array( 4 ), {
+	x = array( new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] ), {
 		'shape': [ 2, 2 ],
 		'dtype': 'float64',
 		'order': 'column-major'
@@ -136,34 +203,46 @@ tape( 'the function returns a NaN-filled array (dtype=float64, non-base)', funct
 	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
 	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
-	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( buf.length, 4, 'returns expected value' );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
 	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
 
 tape( 'the function returns a NaN-filled array (dtype=float32, base)', function test( t ) {
 	var arr;
+	var buf;
 	var x;
 
-	x = nans( 'float32', [ 2, 2 ], 'row-major' );
+	x = zeros( 'float32', [ 2, 2 ], 'row-major' );
 	arr = nansLike( x );
 
 	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
 	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
 	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
-	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( buf.length, 4, 'returns expected value' );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
 	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
 
 tape( 'the function returns a NaN-filled array (dtype=float32, non-base)', function test( t ) {
 	var arr;
+	var buf;
 	var x;
 
-	x = array( new Float32Array( 4 ), {
+	x = array( new Float32Array( [ 1.0, 2.0, 3.0, 4.0 ] ), {
 		'shape': [ 2, 2 ],
 		'dtype': 'float32',
 		'order': 'column-major'
@@ -174,19 +253,23 @@ tape( 'the function returns a NaN-filled array (dtype=float32, non-base)', funct
 	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
 	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
-	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( buf.length, 4, 'returns expected value' );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
 	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
 
 tape( 'the function returns a NaN-filled array (dtype=complex128, base)', function test( t ) {
-	var expected;
 	var arr;
 	var buf;
 	var x;
 
-	x = nans( 'complex128', [ 2, 2 ], 'row-major' );
+	x = zeros( 'complex128', [ 2, 2 ], 'row-major' );
 	arr = nansLike( x );
 
 	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
@@ -195,11 +278,11 @@ tape( 'the function returns a NaN-filled array (dtype=complex128, base)', functi
 	t.strictEqual( instanceOf( getData( arr ), Complex128Array ), true, 'returns expected value' );
 
 	buf = reinterpret128( getData( arr ), 0 );
-	expected = new Float64Array( [ NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN ] );
+	t.strictEqual( buf.length, 8, 'returns expected value' );
 	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
-	t.strictEqual( buf.length, expected.length, 'returns expected value' );
 
 	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
@@ -222,9 +305,11 @@ tape( 'the function returns a NaN-filled array (dtype=complex128, non-base)', fu
 	t.strictEqual( instanceOf( getData( arr ), Complex128Array ), true, 'returns expected value' );
 
 	buf = reinterpret128( getData( arr ), 0 );
+	t.strictEqual( buf.length, 8, 'returns expected value' );
 	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
 
 	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
@@ -234,7 +319,7 @@ tape( 'the function returns a NaN-filled array (dtype=complex64, base)', functio
 	var buf;
 	var x;
 
-	x = nans( 'complex64', [ 2, 2 ], 'row-major' );
+	x = zeros( 'complex64', [ 2, 2 ], 'row-major' );
 	arr = nansLike( x );
 
 	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
@@ -243,9 +328,11 @@ tape( 'the function returns a NaN-filled array (dtype=complex64, base)', functio
 	t.strictEqual( instanceOf( getData( arr ), Complex64Array ), true, 'returns expected value' );
 
 	buf = reinterpret64( getData( arr ), 0 );
+	t.strictEqual( buf.length, 8, 'returns expected value' );
 	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
 
 	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
@@ -268,35 +355,44 @@ tape( 'the function returns a NaN-filled array (dtype=complex64, non-base)', fun
 	t.strictEqual( instanceOf( getData( arr ), Complex64Array ), true, 'returns expected value' );
 
 	buf = reinterpret64( getData( arr ), 0 );
+	t.strictEqual( buf.length, 8, 'returns expected value' );
 	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
 
 	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
 
 tape( 'the function returns a NaN-filled array (dtype=generic, base)', function test( t ) {
 	var arr;
+	var buf;
 	var x;
 
-	x = nans( 'generic', [ 2, 2 ], 'row-major' );
+	x = zeros( 'generic', [ 2, 2 ], 'row-major' );
 	arr = nansLike( x );
 
 	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
 	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
-	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( buf.length, 4, 'returns expected value' );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
 	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
 
 tape( 'the function returns a NaN-filled array (dtype=generic, non-base)', function test( t ) {
 	var arr;
+	var buf;
 	var x;
 
-	x = array( [ NaN, NaN, NaN, NaN ], {
+	x = array( [ 1.0, 2.0, 3.0, 4.0 ], {
 		'shape': [ 2, 2 ],
 		'dtype': 'generic',
 		'order': 'column-major'
@@ -307,30 +403,117 @@ tape( 'the function returns a NaN-filled array (dtype=generic, non-base)', funct
 	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( arr ), [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
-	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+
+	buf = getData( arr );
+	t.strictEqual( buf.length, 4, 'returns expected value' );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
 	t.strictEqual( getOrder( arr ), 'column-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
 
-tape( 'the function supports zero-dimensional arrays', function test( t ) {
+tape( 'the function supports zero-dimensional arrays (dtype=generic)', function test( t ) {
 	var arr;
 	var x;
 
-	x = new ndarray( 'generic', [ NaN ], [], [ 0 ], 0, 'row-major' );
+	x = new ndarray( 'generic', [ 0.0 ], [], [ 0 ], 0, 'row-major' );
 	arr = nansLike( x );
 
 	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
 	t.strictEqual( String( getDType( arr ) ), 'generic', 'returns expected value' );
 	t.deepEqual( getShape( arr ), [], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
-	t.strictEqual( allNaN( getData( arr ) ), true, 'returns expected value' );
+	t.strictEqual( getData( arr ).length, 1, 'returns expected value' );
+	t.strictEqual( isnan( getData( arr )[ 0 ] ), true, 'returns expected value' );
 	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
 
 	t.end();
 });
 
-tape( 'the function supports empty arrays', function test( t ) {
+tape( 'the function supports zero-dimensional arrays (dtype=float64, base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = zeros( 'float64', [], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( getData( arr ).length, 1, 'returns expected value' );
+	t.strictEqual( isnan( getData( arr )[ 0 ] ), true, 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
+
+	t.end();
+});
+
+tape( 'the function supports zero-dimensional arrays (dtype=float32, base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = zeros( 'float32', [], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float32', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float32Array ), true, 'returns expected value' );
+	t.strictEqual( getData( arr ).length, 1, 'returns expected value' );
+	t.strictEqual( isnan( getData( arr )[ 0 ] ), true, 'returns expected value' );
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
+
+	t.end();
+});
+
+tape( 'the function supports zero-dimensional arrays (dtype=complex128, base)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+
+	x = zeros( 'complex128', [], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex128', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex128Array ), true, 'returns expected value' );
+
+	buf = reinterpret128( getData( arr ), 0 );
+	t.strictEqual( buf.length, 2, 'returns expected value' );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
+
+	t.end();
+});
+
+tape( 'the function supports zero-dimensional arrays (dtype=complex64, base)', function test( t ) {
+	var arr;
+	var buf;
+	var x;
+
+	x = zeros( 'complex64', [], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'complex64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Complex64Array ), true, 'returns expected value' );
+
+	buf = reinterpret64( getData( arr ), 0 );
+	t.strictEqual( buf.length, 2, 'returns expected value' );
+	t.strictEqual( allNaN( buf ), true, 'returns expected value' );
+
+	t.notEqual( getData( arr ), getData( x ), 'returns a new data buffer' );
+
+	t.end();
+});
+
+tape( 'the function supports empty arrays (dtype=generic, non-base)', function test( t ) {
 	var arr;
 	var x;
 
@@ -342,6 +525,23 @@ tape( 'the function supports empty arrays', function test( t ) {
 	t.deepEqual( getShape( arr ), [ 2, 0, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( getData( arr ), Array ), true, 'returns expected value' );
 	t.deepEqual( getData( arr ), [], 'returns expected value' );
+	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports empty arrays (dtype=float64, base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = zeros( 'float64', [ 2, 0, 2 ], 'row-major' );
+	arr = nansLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( String( getDType( arr ) ), 'float64', 'returns expected value' );
+	t.deepEqual( getShape( arr ), [ 2, 0, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( getData( arr ), Float64Array ), true, 'returns expected value' );
+	t.strictEqual( getData( arr ).length, 0, 'returns expected value' );
 	t.strictEqual( getOrder( arr ), 'row-major', 'returns expected value' );
 
 	t.end();


### PR DESCRIPTION
Resolves #2772 (in stdlib-js/todo).

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds `@stdlib/ndarray/base/nans-like`, a new package that creates a NaN-filled ndarray having the same shape and data type as a provided ndarray.
-   Supports floating-point and generic data types (`float64`, `float32`, `complex128`, `complex64`, `generic`). Complex types are filled using `CNAN` from `@stdlib/constants/complex128/nan`; all others use `NaN`.
-   Integer data types (`int32`, `uint32`, `int16`, `uint16`, `int8`, `uint8`, `uint8c`) are not supported and throw a `TypeError` (via `@stdlib/ndarray/base/fill`).
-   Wires the new package into the `@stdlib/ndarray/base` namespace index (`lib/index.js`) and TypeScript declarations (`docs/types/index.d.ts`).

### Implementation notes

-   Uses the `emptyLike` + `fill` pattern (consistent with `@stdlib/ndarray/base/ones-like`).
-   TypeScript declarations use per-dtype overloads (not the generic `<T extends typedndarray<...>>` pattern used by `ones-like`/`zeros-like`) because `nans-like` is restricted to NaN-capable types. This correctly prevents integer-typed ndarrays from being passed at compile time.

## Related Issues

> Does this pull request have any related issues?

-   stdlib-js/todo#2772

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_015jQ1FqbZbBX2N2ZXE73Azf)_