### PR TITLE
docs: normalize description in `stats/base/dists/exponential/logcdf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Cumulative Distribution Function
 
-> Evaluate the natural logarithm of the [cumulative distribution function][cdf] for an [exponential][exponential-distribution] distribution.
+> [Exponential][exponential-distribution] distribution logarithm of [cumulative distribution function][cdf].
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Natural logarithm of the cumulative distribution function (CDF) for an exponential distribution.
+* Exponential distribution logarithm of cumulative distribution function (CDF).
 *
 * @module @stdlib/stats/base/dists/exponential/logcdf
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/exponential/logcdf",
   "version": "0.0.0",
-  "description": "Natural logarithm of the cumulative distribution function (CDF) for an exponential distribution.",
+  "description": "Exponential distribution logarithm of cumulative distribution function (CDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

Aligns the `package.json` description, `lib/index.js` JSDoc summary, and `README.md` blockquote intro for `@stdlib/stats/base/dists/exponential/logcdf` with the namespace majority pattern.

### `stats/base/dists/exponential/logcdf`

13 of 15 members of `@stdlib/stats/base/dists/exponential` describe themselves in the form "Exponential distribution X." (86.7% conformance); `logcdf` and `logpdf` carry the older "Natural logarithm of X (Y) for an exponential distribution." phrasing. Normalized `logcdf` to "Exponential distribution logarithm of cumulative distribution function (CDF)." across `package.json` (description), `lib/index.js` (JSDoc summary), and `README.md` (blockquote intro). Same change shape as 5e6cc5227 for `cosine/{ctor,logcdf}`. Metadata only; no source, test, or behavioral change.

### Validation

Checked:

- structural feature extraction (file tree, `package.json` shape, README section list, `manifest.json` shape, test/benchmark/example filenames) across all 15 members.
- semantic feature extraction (public signature, validation prologue, error construction, JSDoc shape, dependency set) across all 15 members by reading each `lib/main.js` directly.
- three-agent drift validation:
  - opus semantic-review confirmed the deviation is unintentional and the proposed rephrasing preserves all meaning.
  - opus cross-reference confirmed no test, example, sibling-package documentation, or REPL fixture references the original description string.
  - sonnet structural-review confirmed the proposed text exactly matches the namespace majority and the `cosine/logcdf` maintainer precedent (5e6cc5227).

Deliberately excluded:

- `logpdf` was a candidate outlier for the same normalization, but the cross-reference agent returned `needs-human`: `logpdf/docs/types/index.d.ts` line 89 reads "Exponential distribution natural logarithm of probability density function (logPDF)." — a partial-migration phrasing that diverges from both the proposed text and the cosine template. Updating only the three precedent files would leave the package internally inconsistent; resolving the type-def expands scope beyond the precedent's shape. Dropped from this run.
- `ctor` (no native bindings, JS-only constructor) and `logcdf`/`logpdf` (only members with `## Notes` README sections) reflect intentional semantic groupings and were excluded from drift detection.
- Native-bindings file group, `gypfile` `package.json` key, `lib/factory.js` (factory-equipped vs not), and `PositiveNumber` vs `NonNegativeNumber` JSDoc typing — each below 75% within-namespace conformance or reflective of genuine semantic differences (e.g. `ctor` lacks all native bindings).

## Related Issues

None.

## Questions

No.

## Other

Random namespace pick from 122 eligible namespaces in `lib/node_modules/@stdlib/` with ≥8 direct child packages (seed `17786601871205`, index 54/122). This is the second drift run on `@stdlib/stats/base/dists/exponential`; the first (#11996, merged 2026-05-08) fixed a C API heading typo in `logcdf`. Description normalization was not yet a recognized pattern at that time — commit 5e6cc5227 (cosine, 2026-05-12) established the precedent.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: structural and semantic features were extracted from every member of `@stdlib/stats/base/dists/exponential`, majority patterns were computed at a 75% conformance threshold, and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed the correction was high-signal mechanical drift before any file was edited. The proposed `logpdf` correction was dropped because the cross-reference agent returned `needs-human` over a pre-existing type-def inconsistency. All edits are docs/metadata; no source, test, or behavioral change.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTvKp9QgRWAJYMjNHY7Yhf)_