### PR TITLE
chore: propagate `ndarray/*` and `normal/*` fixes

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/to-transposed/README.md
+++ b/lib/node_modules/@stdlib/ndarray/to-transposed/README.md
@@ -69,7 +69,7 @@ The function accepts the following arguments:
 ## Notes
 
 -   The function operates on a stack of matrices, transposing the last two dimensions of the input ndarray.
--   The input ndarray must have at least two dimensions.
+-   The input ndarray must have two or more dimensions.
 
 </section>
 

--- a/lib/node_modules/@stdlib/ndarray/to-transposed/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/to-transposed/docs/repl.txt
@@ -6,7 +6,7 @@
     The function operates on a stack of matrices, transposing the last two
     dimensions of the input ndarray.
 
-    The input ndarray must have at least two dimensions.
+    The input ndarray must have two or more dimensions.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/ndarray/to-transposed/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/to-transposed/docs/types/index.d.ts
@@ -28,7 +28,7 @@ import { ndarray } from '@stdlib/types/ndarray';
 * ## Notes
 *
 * -   The function operates on a stack of matrices, transposing the last two dimensions of the input ndarray.
-* -   The input ndarray must have at least two dimensions.
+* -   The input ndarray must have two or more dimensions.
 *
 * @param x - input array
 * @returns output ndarray

--- a/lib/node_modules/@stdlib/ndarray/to-transposed/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/to-transposed/lib/main.js
@@ -37,7 +37,7 @@ var format = require( '@stdlib/string/format' );
 * ## Notes
 *
 * -   The function operates on a stack of matrices, transposing the last two dimensions of the input ndarray.
-* -   The input ndarray must have at least two dimensions.
+* -   The input ndarray must have two or more dimensions.
 *
 * @param {ndarray} x - input array
 * @throws {TypeError} must provide an ndarray

--- a/lib/node_modules/@stdlib/ndarray/transpose/README.md
+++ b/lib/node_modules/@stdlib/ndarray/transpose/README.md
@@ -69,7 +69,7 @@ The function accepts the following arguments:
 ## Notes
 
 -   The function operates on a stack of matrices, transposing the last two dimensions of the input ndarray.
--   The input ndarray must have at least two dimensions.
+-   The input ndarray must have two or more dimensions.
 
 </section>
 

--- a/lib/node_modules/@stdlib/ndarray/transpose/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/transpose/docs/repl.txt
@@ -6,7 +6,7 @@
     The function operates on a stack of matrices, transposing the last two
     dimensions of the input ndarray.
 
-    The input ndarray must have at least two dimensions.
+    The input ndarray must have two or more dimensions.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/ndarray/transpose/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/transpose/docs/types/index.d.ts
@@ -28,7 +28,7 @@ import { ndarray } from '@stdlib/types/ndarray';
 * ## Notes
 *
 * -   The function operates on a stack of matrices, transposing the last two dimensions of the input ndarray.
-* -   The input ndarray must have at least two dimensions.
+* -   The input ndarray must have two or more dimensions.
 *
 * @param x - input array
 * @returns output array

--- a/lib/node_modules/@stdlib/ndarray/transpose/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/transpose/lib/main.js
@@ -34,7 +34,7 @@ var format = require( '@stdlib/string/format' );
 * ## Notes
 *
 * -   The function operates on a stack of matrices, transposing the last two dimensions of the input ndarray.
-* -   The input ndarray must have at least two dimensions.
+* -   The input ndarray must have two or more dimensions.
 *
 * @param {ndarray} x - input array
 * @throws {TypeError} must provide an ndarray

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_entropy( mu, sigma );
 		printf( "µ: %.4f, σ: %.4f, h(X;µ,σ): %.4f\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_kurtosis( mu, sigma );
 		printf( "µ: %.4f, σ: %.4f, Kurt(X;µ,σ): %.4f\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/examples/c/example.c
@@ -35,7 +35,7 @@ int main( void ) {
 	for ( i = 0; i < 10; i++ ) {
 		x = random_uniform( 0.0, 10.0 );
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_logcdf( x, mu, sigma );
 		printf( "x: %lf, µ: %lf, σ: %lf, ln(F(x;µ,σ)): %lf\n", x, mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/examples/c/example.c
@@ -36,7 +36,7 @@ int main( void ) {
 	for ( i = 0; i < 10; i++ ) {
 		x = random_uniform( 0.0, 10.0 );
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_logpdf( x, mu, sigma );
 		printf( "x: %lf, µ: %lf, σ: %lf, ln(f(x;µ,σ)): %lf\n", x, mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_median( mu, sigma );
 		printf( "µ: %.4f, σ: %.4f, Median(X;µ,σ): %.4f\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_mode( mu, sigma );
 		printf("µ: %.4f, σ: %.4f, mode(X;µ,σ): %.4f\n", mu, sigma, y);
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_skewness( mu, sigma );
 		printf( "µ: %.4f, σ: %.4f, skew(X;µ,σ): %.4f\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_stdev( mu, sigma );
 		printf( "µ: %.4f, σ: %.4f, SD(X;µ,σ): %.4f\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/variance/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 25; i++ ) {
 		mu = random_uniform( 0.0, 10.0 ) - 5.0;
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_variance( mu, sigma );
 		printf( "µ: %lf, σ: %lf, Var(X;µ,σ): %lf\n", mu, sigma, y );
 	}


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-05-12 10:16 PDT and 2026-05-13 01:16 PDT to sibling packages with the same defect.

### `65f9d6f` — align dimension-constraint prose in remaining `ndarray/transpose`/`ndarray/to-transposed` artifacts

Commit `65f9d6f` standardized `@throws` tags and runtime error messages across `ndarray/*` packages to read "two or more dimensions" rather than "at least two dimensions". The `transpose` and `to-transposed` packages had their `@throws` lines updated in that pass, but prose Notes in `lib/main.js`, `docs/types/index.d.ts`, `docs/repl.txt`, and `README.md` retained the old phrasing; this PR brings those eight lines into alignment.

**Affected packages:**

-   `lib/node_modules/@stdlib/ndarray/transpose`
-   `lib/node_modules/@stdlib/ndarray/to-transposed`

### `bac6704` — ensure positive sigma in remaining `stats/base/dists/normal/*` C examples

`bac6704` corrected `stats/base/dists/normal/mean` to sample `sigma` from `random_uniform( 0.1, 20.0 )` rather than `random_uniform( 0.0, 20.0 )`, since the normal distribution requires `sigma > 0` and a zero lower bound risks producing NaN output. The same defect was present verbatim in nine sibling packages, each now updated to match the corrected lower bound already used by `stats/base/dists/normal/cdf`.

**Affected packages:**

-   `lib/node_modules/@stdlib/stats/base/dists/normal/entropy`
-   `lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis`
-   `lib/node_modules/@stdlib/stats/base/dists/normal/logcdf`
-   `lib/node_modules/@stdlib/stats/base/dists/normal/logpdf`
-   `lib/node_modules/@stdlib/stats/base/dists/normal/median`
-   `lib/node_modules/@stdlib/stats/base/dists/normal/mode`
-   `lib/node_modules/@stdlib/stats/base/dists/normal/skewness`
-   `lib/node_modules/@stdlib/stats/base/dists/normal/stdev`
-   `lib/node_modules/@stdlib/stats/base/dists/normal/variance`

## Related Issues

None.

## Questions

No.

## Other

### Validation

-   **Search scope:** for `65f9d6f`, `lib/node_modules/@stdlib/ndarray/**` excluding the packages already fixed by the source commit; for `bac6704`, `lib/node_modules/@stdlib/stats/base/dists/normal/*/examples/c/example.c` excluding `normal/mean`.
-   **Independent validation:** two independent Opus validation agents reviewed every candidate site by reading each file in full; both returned `confirmed` for all 17 sites. An Opus adaptation agent classified every site as MECHANICAL (source patch applies verbatim). A Sonnet style-consistency agent approved each replacement with no rewrites.
-   **Deliberately excluded:**
    -   `stats/base/dists/cosine/mgf` `s < 0` → `s <= 0` pattern from `1d12a90` — the sibling `cosine/{pdf,cdf,logpdf,logcdf,quantile}` packages would each require per-package verification that their runtime code actually returns NaN for `s == 0` (rather than only `s < 0`), which falls outside this routine's mechanical scope.
    -   `stats/base/dists/cosine/{ctor,logcdf}` "raised cosine" terminology normalization from `5e6cc52` — all other `cosine/*` subpackages already use the canonical phrasing.
    -   `random_uniform( 0.0, ... )` lower-bound fixes for `lambda`, `alpha`, `beta`, `k`, `scale` parameters across `lognormal`, `rayleigh`, `weibull`, `gamma`, `erlang`, `poisson`, `chi`, `chisquare`, `frechet`, `betaprime`, `invgamma`, `laplace` C examples — the source commit's scope was `stats/base/dists/normal/*`; widening parameter-name scope is adaptive (the safe lower bound differs per parameter) and belongs in a separate run.
    -   Autogenerated commits (`docs: update ToC`, `docs: update REPL namespace documentation`, `docs: update namespace table of contents`, `docs: update related packages sections`, `docs: update descriptions` by `stdlib-bot`) — outputs of generator scripts, not propagation candidates.
    -   `feat:` commits adding new namespace entries (`reinterpretFloat16`, `nansLike`, `onesLike`, etc.) — out of scope for fix propagation.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a routine that scans recent `develop` commits for generalizable fixes and propagates them to sibling packages. Each propagation site was independently verified by two Opus validation agents, classified by an Opus adaptation agent, and approved by a Sonnet style-consistency agent before patches were applied; the changes are pure mechanical text replacements drawn verbatim from the cited source commits.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeVxHHpEZykNmwWBNvfHYU)_