### PR TITLE
docs: collapse double spaces in `strided/napi/{binary,smskmap,unary}`

### DIFF
--- a/lib/node_modules/@stdlib/strided/napi/binary/README.md
+++ b/lib/node_modules/@stdlib/strided/napi/binary/README.md
@@ -183,10 +183,10 @@ When used, this macro should be used **instead of** `NAPI_MODULE`. The macro inc
     -   **dtypeX**: `X` [data type][@stdlib/strided/dtypes] (enumeration constant).
     -   **X**: input [typed array][mdn-typed-array].
     -   **strideX**: `X` stride length.
-    -   **dtypeY**: `Y`  [data type][@stdlib/strided/dtypes] (enumeration constant).
+    -   **dtypeY**: `Y` [data type][@stdlib/strided/dtypes] (enumeration constant).
     -   **Y**: input [typed array][mdn-typed-array].
     -   **strideY**: `Y` stride length.
-    -   **dtypeZ**: `Z`  [data type][@stdlib/strided/dtypes] (enumeration constant).
+    -   **dtypeZ**: `Z` [data type][@stdlib/strided/dtypes] (enumeration constant).
     -   **Z**: destination [typed array][mdn-typed-array].
     -   **strideZ**: `Z` stride length.
 

--- a/lib/node_modules/@stdlib/strided/napi/smskmap/package.json
+++ b/lib/node_modules/@stdlib/strided/napi/smskmap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/strided/napi/smskmap",
   "version": "0.0.0",
-  "description": "C API for registering a Node-API module exporting a strided array interface for applying a unary callback  to a single-precision floating-point strided input array according to a strided mask array and assigning results to a single-precision floating-point strided output array.",
+  "description": "C API for registering a Node-API module exporting a strided array interface for applying a unary callback to a single-precision floating-point strided input array according to a strided mask array and assigning results to a single-precision floating-point strided output array.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/strided/napi/unary/README.md
+++ b/lib/node_modules/@stdlib/strided/napi/unary/README.md
@@ -183,7 +183,7 @@ When used, this macro should be used **instead of** `NAPI_MODULE`. The macro inc
     -   **dtypeX**: `X` [data type][@stdlib/strided/dtypes] (enumeration constant).
     -   **X**: input [typed array][mdn-typed-array].
     -   **strideX**: `X` stride length.
-    -   **dtypeY**: `Y`  [data type][@stdlib/strided/dtypes] (enumeration constant).
+    -   **dtypeY**: `Y` [data type][@stdlib/strided/dtypes] (enumeration constant).
     -   **Y**: destination [typed array][mdn-typed-array].
     -   **strideY**: `Y` stride length.
 


### PR DESCRIPTION
## Description

Removes three accidental double-space typos in documentation across `@stdlib/strided/napi` packages, restoring the single-space convention used uniformly by the other 12 sibling packages in the namespace.

### Namespace summary

-   Target namespace: `@stdlib/strided/napi` (15 members; 0 autogenerated)
-   Features analyzed: file tree, `package.json` key set, `manifest.json` key set, README section list/order, `lib/main.js` JSDoc shape, public signature, validation prologue, error construction, dependency set
-   Features with clear majority (≥75%): every formal feature reaches 100% conformance — these packages are an extremely uniform template family. Documentation-spacing convention reaches 80% (12/15 packages) for READMEs and 93% (14/15) for `package.json` descriptions
-   Features without clear majority: none

### `strided/napi/binary`

`README.md` lines 186 and 189 had double spaces between the backticked type letter and `[data type]` in the JavaScript-arguments bullet list under "Notes". The same file's `dtypeX` entry on line 183 already used the single-space form, and sibling packages (`mskunary`, `nullary`) are uniformly single-space. Collapses both to match.

### `strided/napi/unary`

`README.md` line 186 had a double space between `` `Y` `` and `[data type]` in the same bullet list, while line 183's `dtypeX` entry used single space. Collapses to match the in-file and cross-package convention.

### `strided/napi/smskmap`

`package.json` description had a stray double space between "callback" and "to". Collapses to match the single-space prose used across the other 14 descriptions in `@stdlib/strided/napi`.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

Drift was identified by enumerating the 15 packages under `@stdlib/strided/napi`, extracting structural and semantic features per package, computing the majority pattern per feature, and flagging deviations from the namespace majority.

Validation: three independent review agents — semantic, cross-reference, structural — each returned `confirmed-drift` for all three outliers. Tests and examples were checked and reference none of the modified strings; no observable behavior, signature, or test expectation changes.

Deliberately excluded: nothing. The namespace is template-uniform and surfaced only these three typo-level findings; every formal feature in the analysis (file tree, `package.json`/`manifest.json` keys, README section structure, JSDoc shape, public signature, validation prologue, error construction, dependency set) had 100% conformance.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift-detection routine over the `@stdlib/strided/napi` namespace. The routine extracted structural and semantic features from every package, identified deviations from the namespace-majority pattern, and applied mechanical typo corrections. Three independent agents validated each correction as `confirmed-drift` before commits were made. A human maintainer should promote the draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0127gvQ1oaoiV5Zvn65traEh)_