### PR TITLE
chore: add `blas` and `extended` keywords to `nancount` packages in `blas/ext/base`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dnancount/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dnancount/package.json
@@ -59,6 +59,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "count",
     "nancount",
     "non-nan",

--- a/lib/node_modules/@stdlib/blas/ext/base/gnancount/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/gnancount/package.json
@@ -55,6 +55,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "count",
     "gnancount",
     "number",

--- a/lib/node_modules/@stdlib/blas/ext/base/snancount/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/snancount/package.json
@@ -59,6 +59,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "count",
     "nancount",
     "non-nan",

--- a/lib/node_modules/@stdlib/blas/ext/base/znancount/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/znancount/package.json
@@ -59,6 +59,8 @@
     "stats",
     "mathematics",
     "math",
+    "blas",
+    "extended",
     "count",
     "nancount",
     "non-nan",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds the missing `blas` and `extended` keywords to the `keywords` array in `package.json` for four `nancount` packages in `@stdlib/blas/ext/base`. Each keyword is inserted at index 6 (after `math`) to match the position used by all 28 sibling `nan*` packages in the same namespace.

### Namespace summary

-   **Namespace:** `@stdlib/blas/ext/base`
-   **Members analyzed:** 200 (no autogenerated packages excluded)
-   **Features with clear majority (≥75%):** package.json top-level keys, `os`, `engines`, `directories`, `license`, README section ordering (`Usage` / `Notes` / `Examples`), file tree (`README.md`, `package.json`, `lib/index.js`, `lib/main.js`, `lib/ndarray.js`, `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, `examples/index.js`, `test/test.js`, `test/test.ndarray.js`, `benchmark/benchmark.js`, `benchmark/benchmark.ndarray.js`), and the `stdlib` / `blas` / `extended` / `strided` / `array` / `math` / `mathematics` / `stdmath` keywords.
-   **Features without clear majority (excluded from drift analysis):** `browser` field (71%), `gypfile` field (71%), `__stdlib__` value shape (`{}` 53.5% vs `{"wasm": false}` 36% vs missing 10.5%), full README heading sequence (no single sequence reaches 75%).

### Per outlier package

### `blas/ext/base/dnancount`

Adds the missing `blas` and `extended` keywords to `package.json`. Operates on a double-precision (Float64) strided array, matching siblings `dnansum`, `dnannsum`, and `dnanasum`. The `blas` keyword is present in 196/200 (98%) of sibling packages and `extended` in 176/200 (88%, 100% within the `nan*` family).

### `blas/ext/base/snancount`

Adds the missing `blas` and `extended` keywords to `package.json`. Operates on a single-precision (Float32) strided array, matching siblings `snansum`, `snansumkbn`, and `snansumpw`. The `blas` keyword is present in 196/200 (98%) of sibling packages and `extended` in 176/200 (88%, 100% within the `nan*` family).

### `blas/ext/base/gnancount`

Adds the missing `blas` and `extended` keywords to `package.json`. Provides the generic counterpart for arbitrary strided arrays, matching siblings `gnansum`, `gnansumkbn`, and `gnannsum`. The `blas` keyword is present in 196/200 (98%) of sibling packages and `extended` in 176/200 (88%, 100% within the `nan*` family).

### `blas/ext/base/znancount`

Adds the missing `blas` and `extended` keywords to `package.json`. Operates on a double-precision complex (Complex128) strided array, matching siblings `dnannsum` and `dnanasum`; added recently in PR #11514 (April 2026). The `blas` keyword is present in 196/200 (98%) of sibling packages and `extended` in 176/200 (88%, 100% within the `nan*` family).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Each correction was filtered through:

-   **Structural extraction** of all 200 packages (file tree, `package.json` shape, README section list, manifest shape, test/benchmark/example file naming).
-   **Three-agent drift validation** on each outlier:
    -   *Semantic review:* confirmed each `nancount` package is a BLAS-extended strided-array operation with the same native-build layout (`gypfile`, `src/`, `include/`, `manifest.json`) as the `nan*sum` siblings — no semantic reason to omit the keywords.
    -   *Cross-reference:* verified no test, example, benchmark, README, or tooling under `tools/` or `_tools/` depends on the keyword list. Confirmed both new values satisfy the `keywords` lint regex defined in `_tools/package-json/schema/lib/schema.json` and do not duplicate existing entries.
    -   *Structural review:* confirmed the insertion index (6, after `math`) is uniform across `dnansum`, `gnansum`, `snansum`, `dnannsum`, `dnanasum`.

### Deliberately excluded

-   **`benchmark/benchmark.js` drift.** 23 packages lack the canonical `benchmark.js`. All 23 are sort variants (`dsort*`, `gsort*`, `ssort*`) carrying scenario-specific benchmark suites (`benchmark.unsorted_random.js`, `benchmark.sorted_random.js`, etc.); the deviation reflects the algorithmic need to benchmark across input distributions and is intentional.
-   **`__stdlib__` field absence.** 21 packages (the `*index-of*` family plus `ndarray` and `wasm`) lack a top-level `__stdlib__` field. Within the 179 packages that do carry it, the value is split between `{}` (60%) and `{"wasm": false}` (40%) with no clear correlation to `gypfile`, so there is no unambiguous value to apply.
-   **`math`/`mathematics`/`stdmath` keywords.** 20 packages omit these (the `*index-of*` family plus `gjoin-between`). These are search and string operations rather than mathematical operations; the omission is consistent with the keyword's semantic meaning.
-   **`docs/repl.txt`, `lib/main.js`, `lib/ndarray.js`, `test/test.ndarray.js` absences.** Missing only from `ndarray` and `wasm`, which are architectural meta-packages re-exporting variants and legitimately differ.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was produced by an automated cross-package API drift detection routine running under Claude Code. The routine extracts structural features from every package in a randomly selected stdlib namespace, identifies the majority pattern per feature, and proposes mechanical corrections to outliers. Three independent validation agents reviewed the proposed change for semantic appropriateness, downstream dependencies, and structural correctness before any file was modified. All edits and commit messages in this PR were generated by the routine; a maintainer should review before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017uyg18mApwuXon6gduGn5T)_