### PR TITLE
docs: update notes

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/docs/types/index.d.ts
@@ -32,7 +32,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -64,7 +64,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -100,7 +100,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/lib/cindex_of_column.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/lib/cindex_of_column.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/lib/ndarray.js
@@ -33,7 +33,7 @@ var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/docs/types/index.d.ts
@@ -32,7 +32,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -64,7 +64,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -100,7 +100,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/lib/ndarray.js
@@ -33,7 +33,7 @@ var reinterpret = require( '@stdlib/strided/base/reinterpret-complex128' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/lib/zindex_of_column.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/lib/zindex_of_column.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-05-13 20:52 PDT (`360877d`) and 2026-05-14 02:11 PDT (`80b1ef7`).

## Description

Audit of the 15 first-parent commits merged to `develop` over the last 24 hours surfaced two high-signal items, grouped by package below. Each commit on this branch corresponds to a single package fix.

### `blas/ext/base/cindex-of-column`

-   Fixes incorrect JSDoc and TypeScript return descriptions introduced in `995d771` — `lib/cindex_of_column.js`, `lib/ndarray.js`, and `docs/types/index.d.ts` all said "unable to find a search vector" instead of "unable to find a matching column", contradicting both the README and the analogous `dindex-of-column` package.

### `blas/ext/base/zindex-of-column`

-   Fixes the copy-paste error introduced in `62dad13` where `lib/zindex_of_column.js`, `lib/ndarray.js`, and `docs/types/index.d.ts` described the no-match condition as "unable to find a search vector" rather than "matching column", replacing all 5 occurrences to match the README and `dindex-of-column` reference implementation.

## Related Issues

None.

## Questions

None.

## Other

### Validation

Audited the 15-commit window with two parallel style-compliance reviewers (compared each substantive new file against established reference packages — `dindex-of-column`/`sindex-of-column` for the new column-search packages, `transpose-operation-{str2enum,enum2str}` for the kmeans enum utilities, `ndarray/zeros`/`ndarray/ones` for `ndarray/nans`) and two parallel bug reviewers (one diff-only, one with full source-file context). Findings were de-duplicated and each surviving issue re-verified against the diff before applying.

Items raised during the audit but deliberately excluded from this PR:

-   Native C `_ndarray` routines in `cindex-of-column`/`zindex-of-column` use signed `strideA1 <= strideA2` for column-major detection while the JS path uses absolute-value `isColumnMajor`. The same divergence exists in the pre-existing `dindex-of-column`/`sindex-of-column`/`gindex-of-column` C sources, so addressing it would require a family-wide fix outside this window's scope.
-   "stride length for the first dimension" vs. "stride of the first dimension" wording in the new packages' JSDoc — the existing family is itself inconsistent (`sindex-of-column` uses "stride length for", `dindex-of-column` uses "stride of"); not a clear violation.
-   Re-adding the `numpy.nans` keyword to `ndarray/nans/package.json` — its removal in `65cbb12` is the explicit purpose of that commit.
-   Adding an `extended` keyword to the new `cindex-of-column`/`zindex-of-column` `package.json` files — the analogous `dindex-of-column` does not carry it, so no divergence exists.
-   `dnrm2` `@returns L2-norm` tag in `blas/base/ndarray/docs/types/index.d.ts` — matches the wording already used by the standalone `blas/base/dnrm2` and `blas/base/ndarray/dnrm2` declarations.

### Update

Originally this PR also proposed replacing the imported `isNumber`/`isString` guards in `ml/base/kmeans/algorithm-str2enum` and `algorithm-enum2str` with inline `typeof` checks to match the BLAS `*2enum` packages. Per review by @kgryte, the kmeans packages are correct as-is — it is the BLAS packages that should adopt the imported utility. Both commits have been dropped.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated daily review pass over commits merged to `develop`. Each finding was independently verified against the diff and the cited reference packages before applying. The PR is being opened as a **draft** for human audit; please do not promote to ready-for-review until the changes have been confirmed.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md