### PR TITLE
docs: propagate description and example fixes in `stats/base/dists/*`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Cumulative Distribution Function
 
-> Evaluate the natural logarithm of the [cumulative distribution function][cdf] for a [discrete uniform][discrete-uniform-distribution] distribution.
+> [Discrete uniform][discrete-uniform-distribution] distribution logarithm of [cumulative distribution function][cdf].
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Natural logarithm of the cumulative distribution function (CDF) for a discrete uniform distribution.
+* Discrete uniform distribution logarithm of cumulative distribution function (CDF).
 *
 * @module @stdlib/stats/base/dists/discrete-uniform/logcdf
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/discrete-uniform/logcdf",
   "version": "0.0.0",
-  "description": "Natural logarithm of the cumulative distribution function (CDF)for a discrete uniform distribution.",
+  "description": "Discrete uniform distribution logarithm of cumulative distribution function (CDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/gamma/pdf",
   "version": "0.0.0",
-  "description": "Gamma  distribution probability density function (PDF).",
+  "description": "Gamma distribution probability density function (PDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_entropy( mu, sigma );
 		printf( "µ: %.4f, σ: %.4f, h(X;µ,σ): %.4f\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_mean( mu, sigma );
 		printf( "µ: %.4f, σ: %.4f, E(X;µ,σ): %.4f\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_median( mu, sigma );
 		printf( "µ: %.4f, σ: %.4f, Median(X;µ,σ): %.4f\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_mode( mu, sigma );
 		printf( "µ: %.4f, σ: %.4f, Mode(X;µ,σ): %.4f\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/skewness/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_skewness( mu, sigma );
 		printf("µ: %.4f, σ: %.4f, skew(X;µ,σ): %.4f\n", mu, sigma, y);
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_stdev( mu, sigma );
 		printf("µ: %.4f, σ: %.4f, SD(X; µ, σ): %.4f\n", mu, sigma, y);
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 25; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_variance( mu, sigma );
 		printf( "µ: %lf, σ: %lf, Var(X;µ,σ): %lf\n", mu, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Cumulative Distribution Function
 
-> Evaluate the natural logarithm of the [cumulative distribution function][cdf] for a [Pareto (Type I)][pareto-distribution] distribution.
+> [Pareto (Type I)][pareto-distribution] distribution logarithm of [cumulative distribution function][cdf].
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Natural logarithm of the cumulative distribution function (CDF) for a Pareto (Type I) distribution.
+* Pareto (Type I) distribution logarithm of cumulative distribution function (CDF).
 *
 * @module @stdlib/stats/base/dists/pareto-type1/logcdf
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/pareto-type1/logcdf",
   "version": "0.0.0",
-  "description": "Natural logarithm of the cumulative distribution function (CDF)for a Pareto (Type I) distribution.",
+  "description": "Pareto (Type I) distribution logarithm of cumulative distribution function (CDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/pareto-type1/pdf",
   "version": "0.0.0",
-  "description": "Pareto  distribution (Type I) probability density function (PDF).",
+  "description": "Pareto distribution (Type I) probability density function (PDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 25; i++ ) {
 		x = random_uniform( 0.0, 10.0 );
-		sigma = random_uniform( 0.0, 10.0 );
+		sigma = random_uniform( 0.1, 10.0 );
 		y = stdlib_base_dists_rayleigh_cdf( x, sigma );
 		printf( "x: %lf, σ: %lf, F(x;σ): %lf\n", x, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/entropy/examples/c/example.c
@@ -31,7 +31,7 @@ int main( void ) {
 	int i;
 
 	for ( i = 0; i < 25; i++ ) {
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_rayleigh_entropy( sigma );
 		printf( "σ: %lf, h(σ): %lf\n", sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/kurtosis/examples/c/example.c
@@ -31,7 +31,7 @@ int main( void ) {
 	int i;
 
 	for ( i = 0; i < 25; i++ ) {
-		sigma = random_uniform( 0.0, 10.0 );
+		sigma = random_uniform( 0.1, 10.0 );
 		y = stdlib_base_dists_rayleigh_kurtosis( sigma );
 		printf( "σ: %lf, Kurt(X,σ): %lf\n", sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logcdf/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 25; i++ ) {
 		x = random_uniform( 0.0, 10.0 );
-		sigma = random_uniform( 0.0, 10.0 );
+		sigma = random_uniform( 0.1, 10.0 );
 		y = stdlib_base_dists_rayleigh_logcdf( x, sigma );
 		printf( "x: %lf, σ: %lf, F(x;σ): %lf\n", x, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logpdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logpdf/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 25; i++ ) {
 		x = random_uniform( 0.0, 10.0 );
-		sigma = random_uniform( 0.0, 10.0 );
+		sigma = random_uniform( 0.1, 10.0 );
 		y = stdlib_base_dists_rayleigh_logpdf( x, sigma );
 		printf( "x: %lf, σ: %lf, ln(f(x;σ)): %lf\n", x, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mean/examples/c/example.c
@@ -31,7 +31,7 @@ int main( void ) {
 	int i;
 
 	for ( i = 0; i < 25; i++ ) {
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_rayleigh_mean( sigma );
 		printf( "σ: %lf, E(X;σ): %lf\n", sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/median/examples/c/example.c
@@ -31,7 +31,7 @@ int main( void ) {
 	int i;
 
 	for ( i = 0; i < 25; i++ ) {
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_rayleigh_median( sigma );
 		printf( "σ: %lf, Median(X;σ): %lf\n", sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mode/examples/c/example.c
@@ -31,7 +31,7 @@ int main( void ) {
 	int i;
 
 	for ( i = 0; i < 25; i++ ) {
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_rayleigh_mode( sigma );
 		printf( "σ: %lf, mode(X;σ): %lf\n", sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/examples/c/example.c
@@ -33,7 +33,7 @@ int main( void ) {
 
 	for ( i = 0; i < 25; i++ ) {
 		x = random_uniform( 0.0, 10.0 );
-		sigma = random_uniform( 0.0, 10.0 );
+		sigma = random_uniform( 0.1, 10.0 );
 		y = stdlib_base_dists_rayleigh_pdf( x, sigma );
 		printf( "x: %lf, σ: %lf, f(x;σ): %lf\n", x, sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/examples/c/example.c
@@ -31,7 +31,7 @@ int main( void ) {
 	int i;
 
 	for ( i = 0; i < 25; i++ ) {
-		sigma = random_uniform( 0.0, 20.0 );
+		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_rayleigh_variance( sigma );
 		printf( "σ: %lf, Var(X;σ): %lf\n", sigma, y );
 	}


### PR DESCRIPTION
Propagating fixes merged to `develop` between 2026-05-13 20:52 PDT (`360877d`) and 2026-05-14 02:11 PDT (`80b1ef7`) to sibling packages.

## Description

### `stats/base/dists/{gamma,pareto-type1}/pdf`

Propagates the double-space collapse from 4728aa8 to two additional `package.json` description fields that contain the same defect: an errant double space between the distribution name and the word "distribution". Both packages are updated to be consistent with the fix applied in the source commit.

-   `lib/node_modules/@stdlib/stats/base/dists/gamma/pdf`
-   `lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf`

### `stats/base/dists/{lognormal,rayleigh}/*`

Propagates the sigma lower-bound fix from 3220a54 to 17 sibling C example files. Prior to that fix, sigma was generated from `[0.0, upper]`, allowing a value of `0.0` which falls outside the strictly-positive support required by both `lognormal` and `rayleigh` distributions; the lower bound is raised to `0.1` to guarantee a valid scale parameter.

-   `lognormal/{mode,variance,skewness,mean,stdev,entropy,median}`
-   `rayleigh/{pdf,mode,variance,kurtosis,cdf,mean,entropy,logcdf,logpdf,median}`

### `stats/base/dists/{discrete-uniform,pareto-type1}/logcdf`

Propagates the description normalization from f2c2f39 to two sibling `logcdf` packages, aligning the README tagline, JSDoc `@module` summary, and `package.json` description to the canonical form `"<DistName> distribution logarithm of cumulative distribution function (CDF)."`. As a side effect, this fixes the pre-existing `CDF)for` missing-space typo in both `package.json` files.

-   `lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf`
-   `lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf`

## Related Issues

None.

## Questions

None.

## Other

### Validation

Audited the 24-hour window (`360877d`..`80b1ef7`, 15 first-parent commits) for propagable fix patterns. Three patterns surfaced: the double-space collapse from 4728aa8, the sigma lower-bound fix from 3220a54, and the `logcdf` description normalization from f2c2f39. Search was scoped to sibling packages under `stats/base/dists/*`. Two independent validators read each candidate site in full and confirmed the defect; an adaptation pass produced per-site patches for the description-normalization pattern; a style-consistency pass reviewed each proposed patch.

Items deliberately excluded:

-   Four `logcdf` packages (`t`, `normal`, `lognormal`, `kumaraswamy`) where the source rewrite is not a clean substitution — `t/logcdf` and `kumaraswamy/logcdf` introduce extra phrasing ("(CDF)" parenthetical, leading "Evaluate" verb), and `normal/logcdf` / `lognormal/logcdf` READMEs do not wrap "cumulative distribution function" in a reference link. Flagged for human review by the validation pass.
-   Sigma-bound propagation to non-positive-scale distributions (no sites — `normal` was the source; `lognormal` and `rayleigh` are the only siblings whose C examples generate `sigma = random_uniform( 0.0, ... )`).
-   The `numpy.nans` keyword removal from 65cbb12 — no sibling `package.json` files reference `numpy.nans`.
-   Source commits classified as feature additions (`feat:`), namespace/ToC updates, or chores touching only `package.json` keywords (`00769bf`) — none carry a propagable defect pattern.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated daily propagation pass over commits merged to `develop`. Each propagation site was independently verified by two validators reading the target file in full, an adaptation pass produced per-site patches where the source fix was not verbatim-applicable, and a style-consistency pass reviewed the resulting changes before they were applied. The PR is being opened as a **draft** for human audit; please do not promote to ready-for-review until the changes have been confirmed.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjNwtyjkpXcJd8FarLid5C)_