### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ceilb/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceilb/test/test.js
@@ -163,7 +163,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 tape( 'due to floating-point rounding error, rounding a numeric value can result in unexpected behavior', function test( t ) {
 	var x;
 
-	x = 0.2 + 0.1; // => 0.30000000000000004
+	x = 0.2 + 0.1; // returns 0.30000000000000004
 	t.strictEqual( ceilb( x, -16, 10 ), 0.3000000000000001, 'equals 0.3000000000000001 and not 0.3' );
 
 	x = 24.616838129811768;

--- a/lib/node_modules/@stdlib/math/base/special/ceilb/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceilb/test/test.native.js
@@ -129,7 +129,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 tape( 'due to floating-point rounding error, rounding a numeric value can result in unexpected behavior', opts, function test( t ) {
 	var x;
 
-	x = 0.2 + 0.1; // => 0.30000000000000004
+	x = 0.2 + 0.1; // returns 0.30000000000000004
 	t.strictEqual( ceilb( x, -16, 10 ), 0.3000000000000001, 'equals 0.3000000000000001 and not 0.3' );
 
 	x = 24.616838129811768;


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #12121.

## Description

> What is the purpose of this pull request?

This pull request:

-   Replaces invalid doctest markers after assignment expressions in the `@stdlib/math/base/special/ceilb` JavaScript test files.
-   Updates `// =>` markers to `// returns` in both `test.js` and `test.native.js` to satisfy the `stdlib/doctest-marker` lint rule.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #12121

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

I ran the targeted Javascript test lint command: make eslint-tests TESTS_FILTER=".*/math/base/special/ceilb/.*"

i did not have any lint errors.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
