### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/datasets/ssa-us-births-2000-2014/scripts/build.js
+++ b/lib/node_modules/@stdlib/datasets/ssa-us-births-2000-2014/scripts/build.js
@@ -68,11 +68,7 @@ function main() {
 	for ( i = 0; i < data.length; i++ ) {
 		d = data[ i ].split( ',' );
 		if ( d.length !== fields.length ) {
-			throw new Error( format(
-				'unexpected error. Number of row values (%d) does not match the expected number of fields (%d).',
-				d.length,
-				fields.length
-			) );
+			throw new Error( format( 'unexpected error. Number of row values (%d) does not match the expected number of fields (%d).', d.length, fields.length ) );
 		}
 		for ( j = 0; j < d.length; j++ ) {
 			d[ j ] = parseFloat( d[ j ] );

--- a/lib/node_modules/@stdlib/datasets/ssa-us-births-2000-2014/scripts/build.js
+++ b/lib/node_modules/@stdlib/datasets/ssa-us-births-2000-2014/scripts/build.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
 
 
@@ -67,7 +68,11 @@ function main() {
 	for ( i = 0; i < data.length; i++ ) {
 		d = data[ i ].split( ',' );
 		if ( d.length !== fields.length ) {
-			throw new Error( 'unexpected error. Number of row values ('+d.length+') does not match the expected number of fields ('+fields.length+').' );
+			throw new Error( format(
+				'unexpected error. Number of row values (%d) does not match the expected number of fields (%d).',
+				d.length,
+				fields.length
+			) );
 		}
 		for ( j = 0; j < d.length; j++ ) {
 			d[ j ] = parseFloat( d[ j ] );


### PR DESCRIPTION
## Summary
- replace string concatenation in the SSA births dataset build script error message with `@stdlib/string/format`

## Related Issues
- resolves #12137

## Verification
- `node --check lib/node_modules/@stdlib/datasets/ssa-us-births-2000-2014/scripts/build.js`
- `git diff --check`

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)