### PR TITLE
docs: propagate lint and example fixes to `math` and `stats` siblings

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cceiln/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceiln/test/test.js
@@ -164,7 +164,7 @@ tape( 'rounding components to a desired number of decimals can result in unexpec
 	var x;
 	var v;
 
-	x = 0.2 + 0.1; // => 0.30000000000000004
+	x = 0.2 + 0.1; // returns 0.30000000000000004
 	v = cceiln( new Complex128( x, x ), -16 );
 
 	t.strictEqual( real( v ), 0.3000000000000001, 'returns 0.3000000000000001 and not 0.3' );

--- a/lib/node_modules/@stdlib/math/base/special/cceiln/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceiln/test/test.native.js
@@ -155,7 +155,7 @@ tape( 'rounding components to a desired number of decimals can result in unexpec
 	var x;
 	var v;
 
-	x = 0.2 + 0.1; // => 0.30000000000000004
+	x = 0.2 + 0.1; // returns 0.30000000000000004
 	v = cceiln( new Complex128( x, x ), -16 );
 
 	t.strictEqual( real( v ), 0.3000000000000001, 'returns 0.3000000000000001 and not 0.3' );

--- a/lib/node_modules/@stdlib/math/base/special/ceiln/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceiln/test/test.js
@@ -124,7 +124,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 });
 
 tape( 'rounding a numeric value to a desired number of decimals can result in unexpected behavior', function test( t ) {
-	var x = 0.2 + 0.1; // => 0.30000000000000004
+	var x = 0.2 + 0.1; // returns 0.30000000000000004
 	t.strictEqual( ceiln( x, -16 ), 0.3000000000000001, 'equals 0.3000000000000001 and not 0.3' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ceiln/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceiln/test/test.native.js
@@ -115,7 +115,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 });
 
 tape( 'rounding a numeric value to a desired number of decimals can result in unexpected behavior', opts, function test( t ) {
-	var x = 0.2 + 0.1; // => 0.30000000000000004
+	var x = 0.2 + 0.1; // returns 0.30000000000000004
 	t.strictEqual( ceiln( x, -16 ), 0.3000000000000001, 'equals 0.3000000000000001 and not 0.3' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/test/test.js
@@ -161,7 +161,7 @@ tape( 'rounding components to a desired number of decimals can result in unexpec
 	var x;
 	var v;
 
-	x = -0.2 - 0.1; // => -0.30000000000000004
+	x = -0.2 - 0.1; // returns -0.30000000000000004
 	v = cfloorn( new Complex128( x, x ), -16 );
 	t.strictEqual( real( v ), -0.3000000000000001, 'returns -0.3000000000000001 and not -0.3' );
 	t.strictEqual( imag( v ), -0.3000000000000001, 'returns -0.3000000000000001 and not -0.3' );

--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/test/test.native.js
@@ -133,7 +133,7 @@ tape( 'rounding components to a desired number of decimals can result in unexpec
 	var x;
 	var v;
 
-	x = -0.2 - 0.1; // => -0.30000000000000004
+	x = -0.2 - 0.1; // returns -0.30000000000000004
 	v = cfloorn( new Complex128( x, x ), -16 );
 	t.strictEqual( real( v ), -0.3000000000000001, 'returns -0.3000000000000001 and not -0.3' );
 	t.strictEqual( imag( v ), -0.3000000000000001, 'returns -0.3000000000000001 and not -0.3' );

--- a/lib/node_modules/@stdlib/math/base/special/croundn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundn/test/test.js
@@ -160,7 +160,7 @@ tape( 'rounding components to a desired number of decimals can result in unexpec
 	var x;
 	var v;
 
-	x = 0.2 + 0.1; // => 0.30000000000000004
+	x = 0.2 + 0.1; // returns 0.30000000000000004
 
 	v = croundn( new Complex128( x, x ), -16 );
 	t.strictEqual( real( v ), 0.3000000000000001, 'returns expected value' );

--- a/lib/node_modules/@stdlib/math/base/special/croundn/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundn/test/test.native.js
@@ -153,7 +153,7 @@ tape( 'rounding components to a desired number of decimals can result in unexpec
 	var x;
 	var v;
 
-	x = 0.2 + 0.1; // => 0.30000000000000004
+	x = 0.2 + 0.1; // returns 0.30000000000000004
 
 	v = croundn( new Complex128( x, x ), -16 );
 	t.strictEqual( real( v ), 0.3000000000000001, 'returns expected value' );

--- a/lib/node_modules/@stdlib/math/base/special/floorb/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/floorb/test/test.js
@@ -163,7 +163,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 tape( 'due to floating-point rounding error, rounding a numeric value can result in unexpected behavior', function test( t ) {
 	var x;
 
-	x = -0.2 - 0.1; // => -0.30000000000000004
+	x = -0.2 - 0.1; // returns -0.30000000000000004
 	t.strictEqual( floorb( x, -16, 10 ), -0.3000000000000001, 'equals -0.3000000000000001 and not -0.3' );
 
 	x = -24.616838129811768;

--- a/lib/node_modules/@stdlib/math/base/special/floorb/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/floorb/test/test.native.js
@@ -129,7 +129,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 tape( 'due to floating-point rounding error, rounding a numeric value can result in unexpected behavior', opts, function test( t ) {
 	var x;
 
-	x = -0.2 - 0.1; // => -0.30000000000000004
+	x = -0.2 - 0.1; // returns -0.30000000000000004
 	t.strictEqual( floorb( x, -16, 10 ), -0.3000000000000001, 'equals -0.3000000000000001 and not -0.3' );
 
 	x = -24.616838129811768;

--- a/lib/node_modules/@stdlib/math/base/special/floorn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/floorn/test/test.js
@@ -124,7 +124,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 });
 
 tape( 'rounding a numeric value to a desired number of decimals can result in unexpected behavior', function test( t ) {
-	var x = -0.2 - 0.1; // => -0.30000000000000004
+	var x = -0.2 - 0.1; // returns -0.30000000000000004
 	t.strictEqual( floorn( x, -16 ), -0.3000000000000001, 'equals -0.3000000000000001 and not -0.3' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/floornf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/floornf/test/test.js
@@ -124,7 +124,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 });
 
 tape( 'rounding a numeric value to a desired number of decimals can result in unexpected behavior', function test( t ) {
-	var x = f32( f32( -0.2 ) - f32( 0.1 ) ); // => -0.30000001192092896
+	var x = f32( f32( -0.2 ) - f32( 0.1 ) ); // returns -0.30000001192092896
 	t.strictEqual( floornf( x, -8 ), f32( -0.30000000 ), 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/floornf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/floornf/test/test.native.js
@@ -115,7 +115,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 });
 
 tape( 'rounding a numeric value to a desired number of decimals can result in unexpected behavior', opts, function test( t ) {
-	var x = f32( f32( -0.2 ) - f32( 0.1 ) ); // => -0.30000001192092896
+	var x = f32( f32( -0.2 ) - f32( 0.1 ) ); // returns -0.30000001192092896
 	t.strictEqual( floornf( x, -8 ), f32( -0.30000000 ), 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/roundb/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/test/test.native.js
@@ -128,7 +128,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 tape( 'due to floating-point rounding error, rounding a numeric value can result in unexpected behavior', opts, function test( t ) {
 	var x;
 
-	x = 0.2 + 0.1; // => 0.30000000000000004
+	x = 0.2 + 0.1; // returns 0.30000000000000004
 	t.strictEqual( roundb( x, -16, 10 ), 0.3000000000000001, 'equals 0.3000000000000001 and not 0.3' );
 
 	x = 24.616838129811768;

--- a/lib/node_modules/@stdlib/math/base/special/roundn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/test/test.js
@@ -124,7 +124,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 });
 
 tape( 'rounding a numeric value to a desired number of decimals can result in unexpected behavior', function test( t ) {
-	var x = 0.2 + 0.1; // => 0.30000000000000004
+	var x = 0.2 + 0.1; // returns 0.30000000000000004
 	t.strictEqual( roundn( x, -16 ), 0.3000000000000001, 'equals 0.3000000000000001 and not 0.3' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/roundn/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/test/test.native.js
@@ -115,7 +115,7 @@ tape( 'the function supports rounding a numeric value to a desired number of dec
 });
 
 tape( 'rounding a numeric value to a desired number of decimals can result in unexpected behavior', opts, function test( t ) {
-	var x = 0.2 + 0.1; // => 0.30000000000000004
+	var x = 0.2 + 0.1; // returns 0.30000000000000004
 	t.strictEqual( roundn( x, -16 ), 0.3000000000000001, 'equals 0.3000000000000001 and not 0.3' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/skewness/examples/c/example.c
@@ -31,7 +31,7 @@ int main( void ) {
 	int i;
 
 	for ( i = 0; i < 25; i++ ) {
-		sigma = random_uniform( 0 , 10.0 );
+		sigma = random_uniform( 0.1, 10.0 );
 		y = stdlib_base_dists_rayleigh_skewness( sigma );
 		printf( "σ: %lf, skew(X;σ): %lf\n", sigma, y );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/stdev/examples/c/example.c
@@ -31,7 +31,7 @@ int main( void ) {
 	int i;
 
 	for ( i = 0; i < 25; i++ ) {
-		sigma = random_uniform( 0 , 10.0 );
+		sigma = random_uniform( 0.1, 10.0 );
 		y = stdlib_base_dists_rayleigh_stdev( sigma );
 		printf( "σ: %lf, SD(X;σ): %lf\n", sigma, y );
 	}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Propagating fixes merged to `develop` between 2026-05-14 and 2026-05-15 to sibling packages exhibiting the same defect.

### `stdlib/doctest-marker` lint violations

Commit f797ee08 ("chore: fix JavaScript lint errors") replaced `// =>` value markers flagged by the `stdlib/doctest-marker` ESLint rule, which requires `// returns` after variable declarations and assignment expressions. The identical violation is present in the test files of nine sibling `math/base/special` rounding packages; left unaddressed, each fails linting the next time the file is touched. This pull request applies the same `// =>` → `// returns` correction:

-   `@stdlib/math/base/special/ceiln`
-   `@stdlib/math/base/special/roundn`
-   `@stdlib/math/base/special/cceiln`
-   `@stdlib/math/base/special/floornf`
-   `@stdlib/math/base/special/roundb`
-   `@stdlib/math/base/special/floorb`
-   `@stdlib/math/base/special/cfloorn`
-   `@stdlib/math/base/special/croundn`
-   `@stdlib/math/base/special/floorn`

### Invalid scale parameter in Rayleigh C examples

Commit b517ce16 ("docs: propagate description and example fixes in `stats/base/dists/*`") raised the lower sampling bound of the Rayleigh scale parameter `sigma` from `0` to `0.1` across ten `rayleigh` C examples, since `sigma` must be strictly positive. The `stdev` and `skewness` C examples were missed and still sample `sigma` from a zero lower bound. This pull request applies the same correction:

-   `@stdlib/stats/base/dists/rayleigh/stdev`
-   `@stdlib/stats/base/dists/rayleigh/skewness`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Each candidate site was located by searching for the source pattern's structural signature within the originating namespace, then validated by two independent reviews of each target file in full, an adaptation pass confirming the fix applies verbatim, and a style-consistency pass.

Sites where a textual match did not correspond to the same defect were deliberately excluded: the six `lapack/base/dlassq` test annotations and the one `ml/incr/sgd-regression` annotation use `// =>` to describe a hand-computed derivation rather than a returned value, and `math/base/special/roundnf` annotates a discarded `float64` intermediate — `// returns` would misrepresent all eight. The `sigma` correction was scoped to the Rayleigh scale parameter only; strictly-positive parameters in other distributions were left untouched, as confirming their domain constraints requires per-distribution review beyond the scope of this propagation.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was authored by Claude Code as part of an automated routine that propagates recently merged fixes to sibling packages sharing the same defect. Every propagation site was independently validated before inclusion; nothing was applied on a textual match alone.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01676ZXHFdSpqLLN9weHRcsj)_