### PR TITLE
fix: replace deprecated `context.getFilename()` with `context.filename` in ESLint rules

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/doctest/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/doctest/lib/main.js
@@ -129,7 +129,7 @@ function main( context ) {
 	}
 	sourceCode = replace( source.text, RE_JSDOC, '' );
 	sourceCode = replace( sourceCode, RE_ESLINT_INLINE, '\n' );
-	filename = context.getFilename();
+	filename = context.filename;
 	dir = dirname( filename );
 	/**
 	* Requires modules after converting relative to absolute paths.

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/first-unit-test/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/first-unit-test/lib/main.js
@@ -75,7 +75,7 @@ function main( context ) {
 
 		hasMainExportTest = false;
 		tOkExists = false;
-		filename = context.getFilename();
+		filename = context.filename;
 		if (
 			contains( filename, '/test/' ) &&
 			contains( filename, 'test.' ) &&

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-doctest/lib/main.js
@@ -136,7 +136,7 @@ function main( context ) {
 		// Do not lint executable Node.js script files:
 		return {};
 	}
-	filename = context.getFilename();
+	filename = context.filename;
 	dir = dirname( filename );
 	opts = {
 		'includeDecimal': false

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-license-header-year/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-license-header-year/lib/main.js
@@ -39,7 +39,7 @@ var rule;
 * @returns {Object} validators
 */
 function main( context ) {
-	var filename = context.getFilename();
+	var filename = context.filename;
 	var source = context.sourceCode;
 
 	return {

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-main-export/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-main-export/lib/main.js
@@ -64,7 +64,7 @@ function main( context ) {
 	var source;
 
 	source = context.sourceCode;
-	modulePath = context.getFilename();
+	modulePath = context.filename;
 
 	// Get the part starting with `@stdlib`, shift by one to avoid leading `@`:
 	modulePath = modulePath.substr( modulePath.indexOf( '@stdlib' )+1 );

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/namespace-export-all/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/namespace-export-all/lib/main.js
@@ -103,7 +103,7 @@ function main( context ) {
 	} else {
 		excludes = EXCLUDE_LIST;
 	}
-	filename = context.getFilename();
+	filename = context.filename;
 	if ( !filename || !endsWith( filename, 'index.js' ) ) {
 		return {};
 	}

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-self-require/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-self-require/lib/main.js
@@ -59,7 +59,7 @@ function main( context ) {
 	* @param {string} id - module identifier
 	*/
 	function isSelfRequire( context, node, id ) {
-		var filePath = context.getFilename();
+		var filePath = context.filename;
 		if ( filePath && id && filePath === resolve( id ) ) {
 			report( node );
 		}

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/require-file-extensions/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/require-file-extensions/lib/main.js
@@ -112,7 +112,7 @@ function main( context ) {
 		if ( node.callee.name === 'require' ) {
 			requirePath = node.arguments[ 0 ].value;
 			if ( isString( requirePath ) ) {
-				filename = context.getFilename();
+				filename = context.filename;
 				dir = dirname( filename );
 				if ( startsWith( requirePath, '.' ) ) {
 					requirePath = path.resolve( dir, requirePath );

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/tsdoc-declarations-doctest/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/tsdoc-declarations-doctest/lib/main.js
@@ -351,7 +351,7 @@ function main( context ) {
 	var dir;
 
 	sourceCode = context.sourceCode;
-	filename = context.getFilename();
+	filename = context.filename;
 
 	// Only process TypeScript declaration files:
 	if ( !endsWith( filename, '.d.ts' ) ) {


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/583

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces deprecated `context.getFilename()` with `context.filename` in ESLint rules

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- https://github.com/stdlib-js/metr-issue-tracker/issues/583

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used Cursor+VS Code code-generation tools to help assist with the feature.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md