### PR TITLE
refactor: use constants/float64/nan in math/base/special/fibonacci

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fibonacci/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fibonacci/manifest.json
@@ -38,6 +38,7 @@
       "dependencies": [
         "@stdlib/math/base/napi/unary",
         "@stdlib/constants/float64/max-safe-nth-fibonacci",
+        "@stdlib/constants/float64/nan",
         "@stdlib/math/base/assert/is-nonnegative-integer"
       ]
     },
@@ -53,6 +54,7 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/constants/float64/max-safe-nth-fibonacci",
+        "@stdlib/constants/float64/nan",
         "@stdlib/math/base/assert/is-nonnegative-integer"
       ]
     },
@@ -68,6 +70,7 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/constants/float64/max-safe-nth-fibonacci",
+        "@stdlib/constants/float64/nan",
         "@stdlib/math/base/assert/is-nonnegative-integer"
       ]
     }

--- a/lib/node_modules/@stdlib/math/base/special/fibonacci/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fibonacci/src/main.c
@@ -18,6 +18,7 @@
 
 #include "stdlib/math/base/special/fibonacci.h"
 #include "stdlib/constants/float64/max_safe_nth_fibonacci.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nonnegative_integer.h"
 #include <stdint.h>
 #include <stdlib.h>
@@ -116,7 +117,7 @@ static const int64_t fibonacci_value[ 79 ] = {
 */
 double stdlib_base_fibonacci( const double n ) {
 	if ( !stdlib_base_is_nonnegative_integer( n ) || n > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FIBONACCI ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	return fibonacci_value[ (size_t)n ];
 }


### PR DESCRIPTION
Resolves a part of https://github.com/stdlib-js/stdlib/issues/11743

## Description

This pull request:

-   Replaces inline `0.0 / 0.0` NaN generation in `math/base/special/fibonacci` with `STDLIB_CONSTANT_FLOAT64_NAN`.
-   Adds `@stdlib/constants/float64/nan` as a manifest dependency for build, benchmark, and examples tasks.

## Related Issues

This pull request has the following related issues:

-   No.

## Questions

No.

## Other

No.

## Verification

-   `make install-node-addons NODE_ADDONS_PATTERN='math/base/special/fibonacci'`
-   `make EXAMPLES_FILTER='.*/math/base/special/fibonacci/.*' examples-c`
-   `make BENCHMARKS_FILTER='.*/math/base/special/fibonacci/.*' benchmark-c`
-   `make test TESTS_FILTER='.*/math/base/special/fibonacci/.*'`

All package-specific checks passed.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

AI assistance helped identify the existing constant usage pattern and draft the small source/manifest refactor. The package-specific verification commands listed above were run locally.
