### PR TITLE
fix: correct style deviations and Markdown lint variable references

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cindex-of/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cindex-of/README.md
@@ -113,7 +113,7 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var Complex64Vector = require( '@stdlib/ndarray/vector/complex64' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
-var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var cindexOf = require( '@stdlib/blas/ext/base/ndarray/cindex-of' );
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cindex-of/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cindex-of/examples/index.js
@@ -22,7 +22,7 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var Complex64Vector = require( '@stdlib/ndarray/vector/complex64' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
-var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var cindexOf = require( './../lib' );
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cindex-of/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cindex-of/package.json
@@ -59,11 +59,7 @@
     "index",
     "search",
     "get",
-    "ndarray",
-    "complex64",
-    "complex",
-    "single-precision",
-    "float32"
+    "ndarray"
   ],
   "__stdlib__": {}
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of/README.md
@@ -113,7 +113,7 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
-var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var zindexOf = require( '@stdlib/blas/ext/base/ndarray/zindex-of' );
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of/examples/index.js
@@ -22,7 +22,7 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
-var ndarraylike2scalar = require( '@stdlib/ndarray/ndarraylike2scalar' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var zindexOf = require( './../lib' );
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zindex-of/package.json
@@ -59,11 +59,7 @@
     "index",
     "search",
     "get",
-    "ndarray",
-    "complex128",
-    "complex",
-    "double-precision",
-    "float64"
+    "ndarray"
   ],
   "__stdlib__": {}
 }

--- a/tools/make/lib/lint/markdown/Makefile
+++ b/tools/make/lib/lint/markdown/Makefile
@@ -101,13 +101,13 @@ ifeq ($(FAIL_FAST), true)
 	$(QUIET) $(FIND_MARKDOWN_PKG_READMES_CMD) | grep '^[\/]\|^[a-zA-Z]:[/\]' | while read -r file; do \
 		echo ''; \
 		echo "Linting file: $$file"; \
-		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_PKG_READMES_FLAGS) $$file || exit 1; \
+		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_FLAGS_PKG_READMES) $$file || exit 1; \
 	done
 else
 	$(QUIET) $(FIND_MARKDOWN_PKG_READMES_CMD) | grep '^[\/]\|^[a-zA-Z]:[/\]' | while read -r file; do \
 		echo ''; \
 		echo "Linting file: $$file"; \
-		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_PKG_READMES_FLAGS) $$file || echo 'Linting failed.'; \
+		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_FLAGS_PKG_READMES) $$file || echo 'Linting failed.'; \
 	done
 endif
 
@@ -131,13 +131,13 @@ ifeq ($(FAIL_FAST), true)
 	$(QUIET) for file in $(FILES); do \
 		echo ''; \
 		echo "Linting file: $$file"; \
-		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_PKG_READMES_FLAGS) $$file || exit 1; \
+		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_FLAGS_PKG_READMES) $$file || exit 1; \
 	done
 else
 	$(QUIET) for file in $(FILES); do \
 		echo ''; \
 		echo "Linting file: $$file"; \
-		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_PKG_READMES_FLAGS) $$file || echo 'Linting failed.'; \
+		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_FLAGS_PKG_READMES) $$file || echo 'Linting failed.'; \
 	done
 endif
 
@@ -160,13 +160,13 @@ ifeq ($(FAIL_FAST), true)
 	$(QUIET) $(FIND_MARKDOWN_DOCS_CMD) | grep '^[\/]\|^[a-zA-Z]:[/\]' | while read -r file; do \
 		echo ''; \
 		echo "Linting file: $$file"; \
-		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_DOCS_FLAGS) $$file || exit 1; \
+		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_FLAGS_DOCS) $$file || exit 1; \
 	done
 else
 	$(QUIET) $(FIND_MARKDOWN_DOCS_CMD) | grep '^[\/]\|^[a-zA-Z]:[/\]' | while read -r file; do \
 		echo ''; \
 		echo "Linting file: $$file"; \
-		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_DOCS_FLAGS) $$file || echo 'Linting failed.'; \
+		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_FLAGS_DOCS) $$file || echo 'Linting failed.'; \
 	done
 endif
 
@@ -190,13 +190,13 @@ ifeq ($(FAIL_FAST), true)
 	$(QUIET) for file in $(FILES); do \
 		echo ''; \
 		echo "Linting file: $$file"; \
-		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_DOCS_FLAGS) $$file || exit 1; \
+		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_FLAGS_DOCS) $$file || exit 1; \
 	done
 else
 	$(QUIET) for file in $(FILES); do \
 		echo ''; \
 		echo "Linting file: $$file"; \
-		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_DOCS_FLAGS) $$file || echo 'Linting failed.'; \
+		NODE_PATH="$(NODE_PATH)" $(MARKDOWN_LINT) $(MARKDOWN_LINT_FLAGS_DOCS) $$file || echo 'Linting failed.'; \
 	done
 endif
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Provides follow-up fixes for commits merged to `develop` between 2026-05-15 13:29 PDT and 2026-05-16 00:22 PDT (SHA range `822b65687^..bfb2f6e19`, 10 commits).
-   That window added two new packages — `blas/ext/base/ndarray/zindex-of` (complex128) and `blas/ext/base/ndarray/cindex-of` (complex64) — plus namespace wiring, a dispatch-table update in `blas/ext/index-of`, scoped Markdown lint tooling, and bot-generated docs updates. The fixes below address style deviations in the two new packages and one build-tooling bug in the new Markdown lint rules.

Fixes, grouped by package:

**`blas/ext/base/ndarray/zindex-of`**

-   Fixed incorrect require path in `examples/index.js` and the `## Examples` block of `README.md` (commit `822b65687`): both imported `@stdlib/ndarray/ndarraylike2scalar` instead of `@stdlib/ndarray/base/ndarraylike2scalar`, diverging from `lib/main.js` and the sibling `dindex-of`, `sindex-of`, and `gindex-of` packages, which all use the base package.
-   Commit `822b65687` introduced the package with four spurious dtype-specific keywords (`complex128`, `complex`, `double-precision`, `float64`) in `package.json` that no sibling package (`dindex-of`, `sindex-of`, `gindex-of`, `zsum`, `csum`) carries; removed them so the `keywords` array terminates at `ndarray`, consistent with family convention.

**`blas/ext/base/ndarray/cindex-of`**

-   Fixed incorrect require path in `examples/index.js` and the `## Examples` block of `README.md` (commit `ca72b065a`): both imported the higher-level `@stdlib/ndarray/ndarraylike2scalar` wrapper instead of `@stdlib/ndarray/base/ndarraylike2scalar`, which is what `lib/main.js` and every sibling package (`dindex-of`, `sindex-of`, `gindex-of`) use.
-   Commit `ca72b065a` introduced the package with four spurious dtype-specific keywords (`complex64`, `complex`, `single-precision`, `float32`) in `package.json` that no sibling package (`dindex-of`, `sindex-of`, `gindex-of`, `zsum`, `csum`) carries; removed them so the `keywords` array terminates at `ndarray`, consistent with family convention.

**`tools/make/lib/lint/markdown`**

-   Fixed variable name mismatches introduced in `ec3ccdf7b` in `tools/make/lib/lint/markdown/Makefile`: the four new lint rules referenced `MARKDOWN_LINT_PKG_READMES_FLAGS` and `MARKDOWN_LINT_DOCS_FLAGS`, but `remark.mk` defines those variables as `MARKDOWN_LINT_FLAGS_PKG_READMES` and `MARKDOWN_LINT_FLAGS_DOCS`. The wrong names expanded to empty, so `remark` ran without `--rc-path` and the scoped `.remarkrc.pkg_readmes.js` / `.remarkrc.docs.js` configs were never applied. Renamed all eight references to match the definitions in `remark.mk`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Each commit in the window was reviewed for typos, bugs, and stdlib style-guide compliance. Checks performed:

-   Style-guide compliance: the two new packages were audited against the established reference packages `dindex-of`, `sindex-of`, and `gindex-of` (and the complex analogs `zsum` / `csum`).
-   Bug scan over the union diff and per-commit diffs, plus a security/logic review of the introduced code.

Each fix above was independently re-verified before inclusion. Deliberately excluded (require interpretation, not objective defects):

-   The new package examples and benchmarks import `@stdlib/random/array/discrete-uniform` / `@stdlib/random/array/uniform` rather than the ndarray-returning forms used by the real-valued reference packages. The array-returning form wrapped in a complex vector is the legitimate pattern for complex-typed packages, so this is intentional, not a defect.
-   The new benchmark files omit a `// VARIABLES //` section present in the reference benchmarks. The new benchmarks have no module-level variables; adding the section would be a structural refactor rather than a defect fix.
-   Bot-generated docs commits (`bfb2f6e19`, `66ec9de8d`) and the git-notes commit (`8995b6e57`) are documentation/text only and were left untouched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code. It reviewed the commits merged to `develop` over the preceding 24 hours, identified style deviations and one build-tooling bug, and applied the fixes. Every finding was verified against existing reference packages and the affected files before inclusion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01RFVi3wWuwpZGvJmAncjQG4)_