### PR TITLE
chore: use `format` for error messages in `datasets/*` build scripts

### DIFF
--- a/lib/node_modules/@stdlib/datasets/berndt-cps-wages-1985/scripts/build_json.js
+++ b/lib/node_modules/@stdlib/datasets/berndt-cps-wages-1985/scripts/build_json.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
 var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
 
 
@@ -66,7 +67,7 @@ function main() {
 		} else {
 			tmp = file[ i ].split( ',' );
 			if ( tmp.length !== headers.length ) {
-				throw new Error( 'number of columns does not match number of columns for row '+i+'.' );
+				throw new Error( format( 'number of columns does not match number of columns for row %d.', i ) );
 			}
 			row = {};
 			for ( j = 0; j < headers.length; j++ ) {

--- a/lib/node_modules/@stdlib/datasets/cdc-nchs-us-births-1969-1988/scripts/build.js
+++ b/lib/node_modules/@stdlib/datasets/cdc-nchs-us-births-1969-1988/scripts/build.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
 
 
@@ -67,7 +68,7 @@ function main() {
 	for ( i = 0; i < data.length; i++ ) {
 		d = data[ i ].split( ',' );
 		if ( d.length !== fields.length ) {
-			throw new Error( 'unexpected error. Number of row values ('+d.length+') does not match the expected number of fields ('+fields.length+').' );
+			throw new Error( format( 'unexpected error. Number of row values (%d) does not match the expected number of fields (%d).', d.length, fields.length ) );
 		}
 		for ( j = 0; j < d.length; j++ ) {
 			d[ j ] = parseFloat( d[ j ] );

--- a/lib/node_modules/@stdlib/datasets/cdc-nchs-us-births-1994-2003/scripts/build.js
+++ b/lib/node_modules/@stdlib/datasets/cdc-nchs-us-births-1994-2003/scripts/build.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
 
 
@@ -67,7 +68,7 @@ function main() {
 	for ( i = 0; i < data.length; i++ ) {
 		d = data[ i ].split( ',' );
 		if ( d.length !== fields.length ) {
-			throw new Error( 'unexpected error. Number of row values ('+d.length+') does not match the expected number of fields ('+fields.length+').' );
+			throw new Error( format( 'unexpected error. Number of row values (%d) does not match the expected number of fields (%d).', d.length, fields.length ) );
 		}
 		for ( j = 0; j < d.length; j++ ) {
 			d[ j ] = parseFloat( d[ j ] );

--- a/lib/node_modules/@stdlib/datasets/emoji-code-picto/scripts/build.js
+++ b/lib/node_modules/@stdlib/datasets/emoji-code-picto/scripts/build.js
@@ -22,6 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var dataset = require( '@stdlib/datasets/emoji' );
 
 
@@ -63,7 +64,7 @@ function main() {
 		for ( j = 0; j < codes.length; j++ ) {
 			c = codes[ j ];
 			if ( json[ c ] ) {
-				throw new Error( 'unexpected error. Duplicate emoji code: `' + c + '`.' );
+				throw new Error( format( 'unexpected error. Duplicate emoji code: `%s`.', c ) );
 			}
 			json[ c ] = d.emoji;
 		}

--- a/lib/node_modules/@stdlib/datasets/fivethirtyeight-ffq/scripts/build.js
+++ b/lib/node_modules/@stdlib/datasets/fivethirtyeight-ffq/scripts/build.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
 var meta = require( './../datapackage.json' );
 
@@ -78,7 +79,7 @@ function main() {
 	for ( i = 0; i < data.length; i++ ) {
 		d = data[ i ];
 		if ( d.length !== fields.length ) {
-			throw new Error( 'unexpected error. Number of expected fields ('+fields.length+') does not match number of data fields ('+d.length+').' );
+			throw new Error( format( 'unexpected error. Number of expected fields (%d) does not match number of data fields (%d).', fields.length, d.length ) );
 		}
 		tmp = {};
 		for ( j = 0; j < fields.length; j++ ) {

--- a/lib/node_modules/@stdlib/datasets/frb-sf-wage-rigidity/scripts/build_json.js
+++ b/lib/node_modules/@stdlib/datasets/frb-sf-wage-rigidity/scripts/build_json.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
 var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
 
 
@@ -66,7 +67,7 @@ function main() {
 		} else {
 			tmp = file[ i ].split( ',' );
 			if ( tmp.length !== headers.length ) {
-				throw new Error( 'number of columns does not match number of columns for row '+i+'.' );
+				throw new Error( format( 'number of columns does not match number of columns for row %d.', i ) );
 			}
 			row = {};
 			for ( j = 0; j < headers.length; j++ ) {

--- a/lib/node_modules/@stdlib/datasets/moby-dick/scripts/to_json.js
+++ b/lib/node_modules/@stdlib/datasets/moby-dick/scripts/to_json.js
@@ -26,6 +26,7 @@
 var resolve = require( 'path' ).resolve;
 var readFileSync = require( '@stdlib/fs/read-file' ).sync;
 var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var replace = require( '@stdlib/string/replace' );
 var FILE_LIST = require( './../data/file_list.json' );
 
@@ -68,28 +69,28 @@ function main() {
 		} else if ( f === 'epilogue.txt' ) {
 			tmp = RE_TITLE.exec( file );
 			if ( !tmp ) {
-				throw new Error( 'Unexpected file content for file '+f+'.' );
+				throw new Error( format( 'Unexpected file content for file %s.', f ) );
 			}
 			out.chapter = 'Epilogue';
 			out.title = tmp[ 1 ];
 		} else if ( f === 'etymology.txt' ) {
 			tmp = RE_TITLE.exec( file );
 			if ( !tmp ) {
-				throw new Error( 'Unexpected file content for file '+f+'.' );
+				throw new Error( format( 'Unexpected file content for file %s.', f ) );
 			}
 			out.chapter = 'Etymology';
 			out.title = tmp[ 1 ];
 		} else if ( f === 'extracts.txt' ) {
 			tmp = RE_TITLE.exec( file );
 			if ( !tmp ) {
-				throw new Error( 'Unexpected file content for file '+f+'.' );
+				throw new Error( format( 'Unexpected file content for file %s.', f ) );
 			}
 			out.chapter = 'Extracts';
 			out.title = tmp[ 1 ];
 		} else {
 			tmp = RE_CHAPTER_TITLE.exec( file );
 			if ( !tmp ) {
-				throw new Error( 'Unexpected file content for file '+f+'.' );
+				throw new Error( format( 'Unexpected file content for file %s.', f ) );
 			}
 			out.chapter = tmp[ 1 ];
 			out.title = tmp[ 2 ];


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-05-15 and 2026-05-16 to sibling packages.

### `format` for error-message construction (`stdlib/no-error-string-concat`)

Commit `0205e0ada` ("chore: fix JavaScript lint errors", #12138) replaced string concatenation in a `throw new Error` message with `@stdlib/string/format` to resolve the `stdlib/no-error-string-concat` ESLint rule. Seven sibling dataset build scripts carry the identical violation. This pull request applies the same conversion at each site: it imports `@stdlib/string/format` and rewrites the error messages with `%d`/`%s` placeholders.

Source: `0205e0ada`

Target packages:

-   `datasets/cdc-nchs-us-births-1969-1988`
-   `datasets/cdc-nchs-us-births-1994-2003`
-   `datasets/fivethirtyeight-ffq`
-   `datasets/frb-sf-wage-rigidity`
-   `datasets/berndt-cps-wages-1985`
-   `datasets/emoji-code-picto`
-   `datasets/moby-dick` (four occurrences)

## Related Issues

This pull request does not have any related issues.

## Questions

No.

## Other

### Validation

Search scope: all `scripts/*.js` build scripts under `lib/node_modules/@stdlib/datasets/*`, scanned for `throw new Error` messages constructed via string concatenation.

-   Two independent reviews confirmed each site presents a genuine `stdlib/no-error-string-concat` violation and that placeholder types are correct (`%d` for integer array lengths and loop indices, `%s` for string values).
-   An adaptation pass produced per-site rewrites for the five scripts whose message text differs from the source; the two `cdc-nchs-us-births-*` scripts are byte-identical to the source's pre-fix line and take the fix verbatim.
-   A style pass confirmed `require` placement and `format` call formatting match each package and the source commit.
-   `datasets/cdc-nchs-us-infant-mortality-bw-1915-2013` already imports `@stdlib/string/format` and was excluded.

No sites required cross-package changes, new tests, or interpretation, and none were flagged for human review.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This pull request was prepared by Claude Code running an automated routine that propagates recently merged fixes to sibling packages. The routine identified the source commit, located the affected sibling scripts, validated each site with independent review passes, and applied the patches.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01C6LkMvn83yZvEHHahhfTJs)_