### PR TITLE
style: add missing section comments

### DIFF
--- a/lib/node_modules/@stdlib/constants/float16/half-pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/half-pi/lib/index.js
@@ -29,6 +29,9 @@
 * // returns 1.5703125
 */
 
+
+// MAIN //
+
 /**
 * One half times the mathematical constant `π`.
 *

--- a/lib/node_modules/@stdlib/constants/float16/pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/pi/lib/index.js
@@ -29,6 +29,9 @@
 * // returns 3.140625
 */
 
+
+// MAIN //
+
 /**
 * The mathematical constant `π`.
 *

--- a/lib/node_modules/@stdlib/constants/float16/two-pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/two-pi/lib/index.js
@@ -29,6 +29,9 @@
 * // returns 6.28125
 */
 
+
+// MAIN //
+
 /**
 * The mathematical constant `π` times `2`.
 *


### PR DESCRIPTION
Resolves none.

## Description

This pull request normalizes the `lib/index.js` source layout of three members of the `@stdlib/constants/float16` namespace — `pi`, `half-pi`, and `two-pi` — by adding the `// MAIN //` section-comment marker.

stdlib source files delimit regions with section comments (`// MODULES //`, `// MAIN //`, `// EXPORTS //`). In a `@stdlib/constants/float16` constant package, `// MAIN //` separates the module-level JSDoc from the constant implementation. 50 of 53 namespace members (94%) carry the marker; `pi`, `half-pi`, and `two-pi` were the three that omitted it. All three already carry the trailing `// EXPORTS //` marker, so the convention was partially applied and `// MAIN //` was the missing piece. The change adds a non-semantic source comment only — no exported value, signature, or test expectation changes.

### Namespace summary

- **Members analyzed:** 53 (all non-autogenerated; `@stdlib/constants/float16` has no generated members).
- **Structural features:** file tree, `package.json` shape (top-level / `scripts` / `stdlib` keys), README section list and order, `manifest.json` shape, test/benchmark/example file naming.
- **Semantic features:** `lib/index.js` structure — `'use strict';`, JSDoc block shapes, section markers, `require()` dependencies, export form. These members are constant packages with no `lib/main.js` or `lib/validate.js`, so the routine's public-signature / validation-prologue / error-construction fields are not applicable.
- **Features with a clear majority (≥75%):** universal 8-file layout (100%), `package.json` top-level keys (100%), empty `scripts` (100%), README `## Usage` / `#### <NAME>` / `## Examples` (100%), `test/test.js` and `examples/index.js` naming (100%), `'use strict';` (100%), module-level JSDoc tag sequence (100%), `// EXPORTS //` marker (100%), **`// MAIN //` marker (94%)**.
- **Features without a clear majority (excluded):** constant-level JSDoc `@see` tag count (mode 55%, content-driven by how many external references a constant has); `manifest.json` + C header + `## C APIs` section (28%, the C-enabled bit/exponent constants — an intentional bimodal split, not drift); `## See Also` section (25%, auto-populated).

## Related Issues

None.

## Questions

No.

## Other

Each outlier is a separate commit.

### `@stdlib/constants/float16/pi`

`pi` omitted the `// MAIN //` section comment present in 94% of namespace siblings. The marker now separates the module documentation from the constant implementation in `lib/index.js`. Comment-only change; the exported value `3.140625` is untouched.

### `@stdlib/constants/float16/half-pi`

`half-pi` omitted the `// MAIN //` section comment present in 94% of namespace siblings. The marker now separates the module documentation from the constant implementation in `lib/index.js`. Comment-only change; the exported value `1.5703125` is untouched.

### `@stdlib/constants/float16/two-pi`

`two-pi` omitted the `// MAIN //` section comment present in 94% of namespace siblings. The marker now separates the module documentation from the constant implementation in `lib/index.js`. Comment-only change; the exported value `6.28125` is untouched.

### Validation

- **Structural extraction** — file tree, `package.json` / `manifest.json` shape, README section structure, and test/example/benchmark file naming were extracted across all 53 members. No structural drift: every member carries the same 8-file layout and identical `package.json` key set.
- **Semantic extraction** — `lib/index.js` structure was extracted for all 53 members (`'use strict';`, JSDoc blocks/tags, section markers, dependencies, export form). The only majority feature with outliers was the `// MAIN //` marker.
- **Three-agent drift validation** — the finding was reviewed by three independent agents: a semantic-review agent (intentional vs. unintentional deviation), a cross-reference agent (test / example / API-contract dependence), and a structural-review agent (correctness of the majority pattern). All three returned `confirmed-drift` for all three outliers.
- **Deliberately excluded** — the constant-level `@see` tag-count variation (content-driven, no majority); the `manifest.json` / `## C APIs` C-binding split (intentional, 28%); the auto-populated `## See Also` section; and `docs/repl.txt` / `docs/types/*.d.ts` (generator-owned). No outlier's tests or examples depend on the change.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code running an automated cross-package drift-detection routine. The `@stdlib/constants/float16` namespace was selected at random; structural and semantic features were extracted from all 53 members; the majority pattern per feature was computed at a 75% threshold; and the single drift finding (the `// MAIN //` marker) was validated by three independent review agents before any change was applied. A maintainer should audit the diff before promoting this draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wc7aZYa8kTwjKRyRfFTM1K)_