### PR TITLE
chore: fix EditorConfig lint errors

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/axis/lib/etc/orientations.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/axis/lib/etc/orientations.json
@@ -1,6 +1,6 @@
 [
-	"left",
-	"right",
-	"top",
-	"bottom"
+  "left",
+  "right",
+  "top",
+  "bottom"
 ]


### PR DESCRIPTION
## Summary
- Replace tab indentation with two-space indentation in `orientations.json` to satisfy the JSON EditorConfig rule.

## Related Issues
- resolves #12161

## Validation
- git diff --check
- `LC_ALL=C grep -n $'\t' lib/node_modules/@stdlib/plot/components/svg/axis/lib/etc/orientations.json` (no output)

## Checklist
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)