### PR TITLE
fix: update broken CMUdict link to GitHub mirror in datasets/cmudict README

### DIFF
--- a/lib/node_modules/@stdlib/datasets/cmudict/README.md
+++ b/lib/node_modules/@stdlib/datasets/cmudict/README.md
@@ -252,7 +252,7 @@ The data files (databases) and their contents are licensed under a [BSD-2-Clause
 
 <section class="links">
 
-[cmudict]: http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about
+[cmudict]: https://github.com/cmusphinx/cmudict
 
 [arpabet]: https://en.wikipedia.org/wiki/ARPABET
 


### PR DESCRIPTION
## Summary

Fixes #11868

The CMUdict README references `http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about`, a legacy URL that no longer resolves (HTTP status 0 — connection failure). The CMU Pronouncing Dictionary is now maintained as part of the CMU Sphinx project on GitHub.

## Root Cause

The `[cmudict]` reference link at the bottom of `lib/node_modules/@stdlib/datasets/cmudict/README.md` points to the old CMU Speech Group CGI endpoint, which has been decommissioned. The resource is permanently unavailable at that URL.

## Fix

Replaced the broken URL with the canonical GitHub mirror: `https://github.com/cmusphinx/cmudict`. This is the official upstream repository for the CMU Pronouncing Dictionary, actively maintained by the CMU Sphinx project.

## Changes

- `lib/node_modules/@stdlib/datasets/cmudict/README.md`: update reference link URL (`+1 -1` lines)

## Testing

- **Visit the new URL**: `https://github.com/cmusphinx/cmudict` resolves correctly and contains the dictionary data ✅
- **Old URL confirmed broken**: `http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about` still returns connection failure ✅
- **All other dataset README links**: unaffected (only cmudict reference changed) ✅
