### PR TITLE
test: fix typo in test description

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gaxpb/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gaxpb/test/test.main.js
@@ -140,7 +140,7 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function retu
 	t.end();
 });
 
-tape( 'when `alpha` equals `1.0`, the function add `beta` to each element', function test( t ) {
+tape( 'when `alpha` equals `1.0`, the function adds `beta` to each element', function test( t ) {
 	var expected;
 	var x;
 


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-05-16 23:58:43 -0700 and 2026-05-17 01:31:08 -0700.

That window contained 11 first-parent commits: two new BLAS packages (`blas/ext/base/gaxpb`, `blas/base/ndarray/snrm2`) plus their namespace registrations, an ESLint forward-compatibility fix (`context.getFilename()` → `context.filename`), a Makefile lint-variable rename, an EditorConfig whitespace fix, `format`-based error messages across several `datasets/*` build scripts, and auto-generated TypeScript/docs updates. Reviewing the diff surfaced one validated, high-signal issue.

Fixes, grouped by package:

### `blas/ext/base/gaxpb`

-   Fix subject-verb agreement typo in `lib/node_modules/@stdlib/blas/ext/base/gaxpb/test/test.main.js` (line 143, introduced in b28f7b8): test description read "the function add `beta`" but should read "the function adds `beta`", matching the parallel phrasing already present in `test.ndarray.js`.

## Related Issues

None.

## Questions

No.

## Other

### Validation

-   **Style-guide compliance:** all changed/new files were audited against `docs/style-guides` and compared to established reference packages (`blas/ext/base/gapx`, `blas/base/ndarray/sdot`, and siblings) by two independent reviewers.
-   **Bug scan:** all `gaxpb`/`snrm2` worked examples, test expectations, and core logic (`N <= 0` guard, `alpha === 1.0`/`beta === 0.0` fast paths, 5x unit-stride loop unrolling, ndarray delegation) were verified arithmetically by two independent reviewers; no runtime bugs found.
-   **Deliberately excluded:** observations requiring interpretation or out-of-diff validation were not acted on — the `snrm2` `package.json` `"squared"` keyword (judgment call, not corroborated by the second reviewer), comment-backtick stylistic preferences, an alternative `repl.txt` example phrasing, and the auto-generated `chebyshevSeries` JSDoc example (`// returns 0.75`) whose correctness cannot be confirmed without inspecting the source package outside the diff window.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code. An automated multi-agent review of the last 24 hours of commits to `develop` flagged the typo; the one-line fix was applied and verified by Claude Code.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_016KrBEH2L2UfC4vtfzz91Cm)_