### PR TITLE
chore: use `format` for error messages in strided build scripts

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/ops/add/scripts/addon.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/add/scripts/addon.js
@@ -25,6 +25,7 @@
 var resolve = require( 'path' ).resolve;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var replace = require( '@stdlib/string/replace' );
 var resolveStr = require( '@stdlib/strided/base/dtype-resolve-str' );
 var dtypeChar = require( '@stdlib/ndarray/base/dtype-char' );
@@ -124,7 +125,7 @@ function main() {
 	for ( i = 0; i < fcns.length; i++ ) {
 		parts = fcns[ i ].match( RE_IO_ARGS );
 		if ( parts === null ) {
-			throw new Error( 'unexpected error. Unable to resolve signature dtypes. Function: `' + fcns[ i ] + '`.' );
+			throw new Error( format( 'unexpected error. Unable to resolve signature dtypes. Function: `%s`.', fcns[ i ] ) );
 		}
 		tmp = [];
 		t1 = parts[ 1 ];
@@ -140,13 +141,13 @@ function main() {
 	for ( i = 0; i < fcns.length; i++ ) {
 		parts = fcns[ i ].match( RE_CLBK_ARGS );
 		if ( parts === null ) {
-			throw new Error( 'unexpected error. Unable to resolve signature dtypes. Function: `' + fcns[ i ] + '`.' );
+			throw new Error( format( 'unexpected error. Unable to resolve signature dtypes. Function: `%s`.', fcns[ i ] ) );
 		}
 		t1 = parts[ 1 ];
 		t2 = parts[ 2 ];
 		t3 = parts[ 3 ];
 		if ( t1 !== t2 || t2 !== t3 ) {
-			throw new Error( 'unexpected error. Callback arguments must all be the same. Function: `' + fcns[ i ] + '`.' );
+			throw new Error( format( 'unexpected error. Callback arguments must all be the same. Function: `%s`.', fcns[ i ] ) );
 		}
 		if ( t1 === FLOAT64_CHAR ) {
 			f = 'stdlib_base_float64_'+FCN_BASENAME;

--- a/lib/node_modules/@stdlib/math/strided/ops/mul/scripts/addon.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul/scripts/addon.js
@@ -25,6 +25,7 @@
 var resolve = require( 'path' ).resolve;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var replace = require( '@stdlib/string/replace' );
 var resolveStr = require( '@stdlib/strided/base/dtype-resolve-str' );
 var dtypeChar = require( '@stdlib/ndarray/base/dtype-char' );
@@ -124,7 +125,7 @@ function main() {
 	for ( i = 0; i < fcns.length; i++ ) {
 		parts = fcns[ i ].match( RE_IO_ARGS );
 		if ( parts === null ) {
-			throw new Error( 'unexpected error. Unable to resolve signature dtypes. Function: `' + fcns[ i ] + '`.' );
+			throw new Error( format( 'unexpected error. Unable to resolve signature dtypes. Function: `%s`.', fcns[ i ] ) );
 		}
 		tmp = [];
 		t1 = parts[ 1 ];
@@ -140,13 +141,13 @@ function main() {
 	for ( i = 0; i < fcns.length; i++ ) {
 		parts = fcns[ i ].match( RE_CLBK_ARGS );
 		if ( parts === null ) {
-			throw new Error( 'unexpected error. Unable to resolve signature dtypes. Function: `' + fcns[ i ] + '`.' );
+			throw new Error( format( 'unexpected error. Unable to resolve signature dtypes. Function: `%s`.', fcns[ i ] ) );
 		}
 		t1 = parts[ 1 ];
 		t2 = parts[ 2 ];
 		t3 = parts[ 3 ];
 		if ( t1 !== t2 || t2 !== t3 ) {
-			throw new Error( 'unexpected error. Callback arguments must all be the same. Function: `' + fcns[ i ] + '`.' );
+			throw new Error( format( 'unexpected error. Callback arguments must all be the same. Function: `%s`.', fcns[ i ] ) );
 		}
 		if ( t1 === FLOAT64_CHAR ) {
 			f = 'stdlib_base_float64_'+FCN_BASENAME;

--- a/lib/node_modules/@stdlib/math/strided/ops/sub/scripts/addon.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub/scripts/addon.js
@@ -25,6 +25,7 @@
 var resolve = require( 'path' ).resolve;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var replace = require( '@stdlib/string/replace' );
 var resolveStr = require( '@stdlib/strided/base/dtype-resolve-str' );
 var dtypeChar = require( '@stdlib/ndarray/base/dtype-char' );
@@ -124,7 +125,7 @@ function main() {
 	for ( i = 0; i < fcns.length; i++ ) {
 		parts = fcns[ i ].match( RE_IO_ARGS );
 		if ( parts === null ) {
-			throw new Error( 'unexpected error. Unable to resolve signature dtypes. Function: `' + fcns[ i ] + '`.' );
+			throw new Error( format( 'unexpected error. Unable to resolve signature dtypes. Function: `%s`.', fcns[ i ] ) );
 		}
 		tmp = [];
 		t1 = parts[ 1 ];
@@ -140,13 +141,13 @@ function main() {
 	for ( i = 0; i < fcns.length; i++ ) {
 		parts = fcns[ i ].match( RE_CLBK_ARGS );
 		if ( parts === null ) {
-			throw new Error( 'unexpected error. Unable to resolve signature dtypes. Function: `' + fcns[ i ] + '`.' );
+			throw new Error( format( 'unexpected error. Unable to resolve signature dtypes. Function: `%s`.', fcns[ i ] ) );
 		}
 		t1 = parts[ 1 ];
 		t2 = parts[ 2 ];
 		t3 = parts[ 3 ];
 		if ( t1 !== t2 || t2 !== t3 ) {
-			throw new Error( 'unexpected error. Callback arguments must all be the same. Function: `' + fcns[ i ] + '`.' );
+			throw new Error( format( 'unexpected error. Callback arguments must all be the same. Function: `%s`.', fcns[ i ] ) );
 		}
 		if ( t1 === FLOAT64_CHAR ) {
 			f = 'stdlib_base_float64_'+FCN_BASENAME;

--- a/lib/node_modules/@stdlib/strided/base/binary/scripts/loops.js
+++ b/lib/node_modules/@stdlib/strided/base/binary/scripts/loops.js
@@ -29,6 +29,7 @@ var unlink = require( '@stdlib/fs/unlink' ).sync;
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var readJSON = require( '@stdlib/fs/read-json' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var format = require( '@stdlib/string/format' );
 var replace = require( '@stdlib/string/replace' );
 var substringBefore = require( '@stdlib/string/substring-before' );
 var substringAfter = require( '@stdlib/string/substring-after' );
@@ -453,7 +454,7 @@ function createSourceFile( signature ) {
 		if ( isComplexChar( ch1 ) ) {
 			// WARNING: we assume that the callback signature has the same complex number dtype for all input and output values and that the output array dtype is a complex number dtype...
 			if ( !isComplexChar( match1[ 3 ] ) ) {
-				throw new Error( 'unexpected error. Unable to process signature: '+signature+'.' );
+				throw new Error( format( 'unexpected error. Unable to process signature: %s.', signature ) );
 			}
 			macro = MACROS.acast;
 			if ( ch1 === 'z' ) {
@@ -470,7 +471,7 @@ function createSourceFile( signature ) {
 				args.push( 'stdlib_complex64_from_'+t3 );
 			}
 		} else if ( isComplexChar( ch2 ) || isComplexChar( ch3 ) ) {
-			throw new Error( 'unexpected error. Unable to process callback signature: '+ch1+ch2+'_'+ch3+'.' );
+			throw new Error( format( 'unexpected error. Unable to process callback signature: %s%s_%s.', ch1, ch2, ch3 ) );
 		} else {
 			macro = MACROS.cast;
 			args.push( ct1, ct2 );
@@ -478,7 +479,7 @@ function createSourceFile( signature ) {
 	} else if ( /[cz]/.test( signature ) ) {
 		// E.g., zz_z, cc_c, cc_z, ff_c, dd_z, uu_z, ##_(c|z), etc. For all these signatures, the callback signature is expected to be ##_#, meaning all the same dtype (e.g., uu_u).
 		if ( ch1 !== ch2 ) {
-			throw new Error( 'unexpected error. Unable to process signature: '+ch1+ch2+'_'+ch3+'.' );
+			throw new Error( format( 'unexpected error. Unable to process signature: %s%s_%s.', ch1, ch2, ch3 ) );
 		}
 		if ( ch1 === ch2 && ch2 === ch3 ) { // e.g., zz_z, cc_c
 			macro = MACROS.nocast;


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-05-16 23:58:43 -0700 and 2026-05-17 01:31:08 -0700 to sibling packages.

### `format` for error messages in build scripts

Propagates `dca1108ec`, which replaced `+`-concatenated `throw new Error` messages with `format()` calls from `@stdlib/string/format` in dataset build scripts, applying the same transformation to code-generation build scripts that retained the old pattern. Each affected script gains a `var format = require( '@stdlib/string/format' );` declaration and uses `%s` specifiers for all interpolated string values.

Affected packages:

-   `strided/base/binary` — `scripts/loops.js`
-   `math/strided/ops/add` — `scripts/addon.js`
-   `math/strided/ops/sub` — `scripts/addon.js`
-   `math/strided/ops/mul` — `scripts/addon.js`

## Related Issues

None.

## Questions

No.

## Other

### Validation

-   **Search scope:** all `*/scripts/` build scripts under `lib/node_modules/@stdlib/` were searched for `throw new Error` messages assembled by `+` concatenation without an existing `@stdlib/string/format` import.
-   **Independent confirmation:** two independent reviewers read each of the four target files in full and confirmed the defect, the string-typed interpolants (`%s` specifiers), the absence of any `format` identifier collision, and that each change is self-contained within its file.
-   **Adaptation and style:** an adaptation pass produced the per-site patches; a style-consistency pass verified require ordering, spacing, format specifiers, and tab indentation against `docs/style-guides`. `node --check` and a `format()` output-equivalence check were run on all four files.
-   **Deliberately excluded:**
    -   `dff4820f3` (dtslint `AccessorArray` type expectations) and `e31cdb769` (`context.getFilename()` → `context.filename`) — repository-wide searches returned zero remaining sites.
    -   `87731b41d` (markdown-lint Makefile variable rename) — no dangling references to the old names and no sibling Makefiles with the analogous misnaming.
    -   `10cef3dde` (EditorConfig indentation) — formatting conformance with no behavioral or user-visible defect; out of scope for fix propagation.
    -   `b2eb5da5b` (stale `is-typed-array` "See Also" description) — the candidate text resides in the auto-populated `<section class="related">` block marked "Do not manually edit"; the fix belongs to the related-packages generator, not manual edits.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated fix-propagation routine: it reviewed the last 24 hours of commits merged to `develop`, identified `dca1108ec` as a generalizable fix, located sibling build scripts carrying the same defect, validated each candidate site with independent review agents, and applied the equivalent change.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kww5t5k6o8RFbQYevNvgZL)_