### PR TITLE
style: replace `new Array()` with `[]`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/lint/namespace-aliases/lib/resolve.js
+++ b/lib/node_modules/@stdlib/_tools/lint/namespace-aliases/lib/resolve.js
@@ -57,10 +57,10 @@ function getPkgs( pkgs, dir, clbk ) {
 		opts = {
 			'basedir': dir
 		};
-		out[ i ] = {
+		out.push({
 			'id': pkgs[ i ],
 			'main': null
-		};
+		});
 		resolve( pkgs[ i ], opts, createClbk( i ) );
 	}
 	/**

--- a/lib/node_modules/@stdlib/_tools/lint/namespace-aliases/lib/resolve.js
+++ b/lib/node_modules/@stdlib/_tools/lint/namespace-aliases/lib/resolve.js
@@ -50,7 +50,7 @@ function getPkgs( pkgs, dir, clbk ) {
 	len = pkgs.length;
 	debug( 'Resolving %d packages...', len );
 
-	out = new Array( len );
+	out = [];
 	count = 0;
 	for ( i = 0; i < len; i++ ) {
 		debug( 'Resolving package: %s (%d of %d).', pkgs[ i ], i+1, len );


### PR DESCRIPTION
## Description

This PR fixes a `stdlib/no-new-array` ESLint violation in
`@stdlib/_tools/lint/namespace-aliases/lib/resolve.js`.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/25976689223
**Symptom:** `lint_random_files` / `Lint JavaScript files` — `53:8 error Using the \`new Array()\` constructor is not allowed`
**Root cause:** `out = new Array( len )` at line 53 pre-dates the `stdlib/no-new-array` rule. The synchronous for-loop fills every index `0..len-1` before any async `resolve` callback fires, so `out = []` is functionally equivalent.
**Fix:** Replace `new Array( len )` with `[]` at line 53 of `resolve.js`.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated CI failure investigation routine. Three independent AI reviewer agents (correctness, regression scope, style) validated the fix before submission.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_011nfhfnUY4R1mfXSJRKPxZy)_