### PR TITLE
docs: fix broken Markdown link (issue #11868)

### DIFF
--- a/lib/node_modules/@stdlib/datasets/cmudict/README.md
+++ b/lib/node_modules/@stdlib/datasets/cmudict/README.md
@@ -252,7 +252,7 @@ The data files (databases) and their contents are licensed under a [BSD-2-Clause
 
 <section class="links">
 
-[cmudict]: http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about
+[cmudict]: http://www.speech.cs.cmu.edu/cgi-bin/cmudict
 
 [arpabet]: https://en.wikipedia.org/wiki/ARPABET
 


### PR DESCRIPTION
## Summary

Fixes #11868

The reference link for CMUdict in `lib/node_modules/@stdlib/datasets/cmudict/README.md` pointed to a URL with the `#about` fragment anchor (`http://www.speech.cs.cmu.edu/cgi-bin/cmudict#about`), which the automated link checker flagged as broken (HTTP status 0).

## Root Cause

The `#about` anchor on the CMUdict page no longer exists. The base URL (`http://www.speech.cs.cmu.edu/cgi-bin/cmudict`) returns HTTP 200, but the fragment `#about` does not resolve to a valid target on the page.

## Fix

Removed the `#about` fragment from the reference link definition. The link now points to the main CMUdict page which is accessible and provides the same context about the Carnegie Mellon Pronouncing Dictionary.

## Changes

- `lib/node_modules/@stdlib/datasets/cmudict/README.md`: removed `#about` fragment from cmudict reference link (`+1 -1`)

## Testing

- **Base URL accessible**: `http://www.speech.cs.cmu.edu/cgi-bin/cmudict` returns HTTP 200 ✅
- **No other cmudict links affected**: only one reference link definition in the file ✅
- **Link still points to the relevant resource**: the base page provides the same dictionary context ✅

---

resolves #11868