### PR TITLE
fix: correct bugs and typos in `blas/base/cgemv`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/cgemv/README.md
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/README.md
@@ -292,7 +292,7 @@ void c_cgemv( const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE trans, const CBLA
 
 #### c_cgemv_ndarray( trans, M, N, alpha, \*A, sa1, sa2, oa, \*X, sx, ox, beta, \*Y, sy, oy )
 
-Performs one of the matrix-vector operations `Y = α*A*X + β*Y` or `Y = α*A^T*X + β*Y` or `Y = α*A^H*X + β*Y` using indexing alternative semantics and where `α` and `β` are scalars, `X` and `Y` are vectors, and `A` is an `M` by `N` matrix.
+Performs one of the matrix-vector operations `Y = α*A*X + β*Y` or `Y = α*A^T*X + β*Y` or `Y = α*A^H*X + β*Y` using alternative indexing semantics and where `α` and `β` are scalars, `X` and `Y` are vectors, and `A` is an `M` by `N` matrix.
 
 ```c
 #include "stdlib/blas/base/shared.h"

--- a/lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv.c
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv.c
@@ -88,7 +88,7 @@ void API_SUFFIX(c_cgemv)( const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE trans
 	} else {
 		vala = v;
 	}
-	if ( LDA < v ) {
+	if ( LDA < vala ) {
 		c_xerbla( 7, "c_cgemv", "Error: invalid argument. Seventh argument must be greater than or equal to max(1,%d). Value: `%d`.", vala, LDA );
 		return;
 	}

--- a/lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv.c
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv.c
@@ -70,11 +70,11 @@ void API_SUFFIX(c_cgemv)( const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE trans
 		return;
 	}
 	if ( strideX == 0 ) {
-		c_xerbla( 9, "c_cgemv", "Error: invalid argument. Ninth argument must be a nonzero. Value: `%d`.", strideX );
+		c_xerbla( 9, "c_cgemv", "Error: invalid argument. Ninth argument must be nonzero. Value: `%d`.", strideX );
 		return;
 	}
 	if ( strideY == 0 ) {
-		c_xerbla( 12, "c_cgemv", "Error: invalid argument. Twelfth argument must be a nonzero. Value: `%d`.", strideY );
+		c_xerbla( 12, "c_cgemv", "Error: invalid argument. Twelfth argument must be nonzero. Value: `%d`.", strideY );
 		return;
 	}
 	if ( layout == CblasColMajor ) {

--- a/lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv_ndarray.c
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv_ndarray.c
@@ -37,7 +37,7 @@
 * @param alpha     scalar constant
 * @param A         input matrix
 * @param strideA1  stride of the first dimension of `A`
-* @param strideA1  stride of the second dimension of `A`
+* @param strideA2  stride of the second dimension of `A`
 * @param offsetA   starting index for `A`
 * @param X         first input vector
 * @param strideX   `X` stride length
@@ -84,11 +84,11 @@ void API_SUFFIX(c_cgemv_ndarray)( const CBLAS_TRANSPOSE trans, const CBLAS_INT M
 		return;
 	}
 	if ( strideX == 0 ) {
-		c_xerbla( 10, "c_cgemv_ndarray", "Error: invalid argument. Tenth argument must be a nonzero. Value: `%d`.", strideX );
+		c_xerbla( 10, "c_cgemv_ndarray", "Error: invalid argument. Tenth argument must be nonzero. Value: `%d`.", strideX );
 		return;
 	}
 	if ( strideY == 0 ) {
-		c_xerbla( 14, "c_cgemv_ndarray", "Error: invalid argument. Fourteenth argument must be a nonzero. Value: `%d`.", strideY );
+		c_xerbla( 14, "c_cgemv_ndarray", "Error: invalid argument. Fourteenth argument must be nonzero. Value: `%d`.", strideY );
 		return;
 	}
 	ap = (stdlib_complex64_t *)A;

--- a/lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv_ndarray.c
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv_ndarray.c
@@ -113,7 +113,7 @@ void API_SUFFIX(c_cgemv_ndarray)( const CBLAS_TRANSPOSE trans, const CBLAS_INT M
 	}
 	// Y = beta * Y
 	if ( stdlib_base_complex64_is_equal( beta, zero ) ) {
-		API_SUFFIX(stdlib_strided_cfill_ndarray)( ylen, alpha, Y, strideY, offsetY );
+		API_SUFFIX(stdlib_strided_cfill_ndarray)( ylen, zero, Y, strideY, offsetY );
 	} else if ( !stdlib_base_complex64_is_equal( beta, one ) ) {
 		API_SUFFIX(c_cscal_ndarray)( ylen, beta, Y, strideY, offsetY );
 	}


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-05-17 14:08:37 -0700 and 2026-05-18 04:45:04 -0700 (39 commits, `fbf2d918`..`adb3e6a9b`).

All validated issues originate from `2a0b1a1` (*feat: add `C` implementation for `blas/base/cgemv`*).

### `blas/base/cgemv`

Bug fixes (`8b47c41`):

-   Fix `c_cgemv_ndarray` incorrectly passing `alpha` instead of `zero` to `stdlib_strided_cfill_ndarray` during the `beta == 0` pre-scaling branch (`2a0b1a1`, `lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv_ndarray.c`, line ~116), causing all `beta = 0` calls to return `alpha + alpha*A*X` rather than `alpha*A*X`; sibling `sgemv_ndarray.c`/`dgemv_ndarray.c` handle this correctly.
-   Fix leading-dimension validation in `c_cgemv` (`2a0b1a1`, `lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv.c`, line ~91): the guard `LDA < v` fails to catch an invalid `LDA` when `M`/`N` is zero because it tests the raw dimension rather than `vala = max(1, v)`, which is computed precisely for this purpose and is already cited in the accompanying `xerbla` message; changed to `LDA < vala`, consistent with the sibling `sgemv.c` and `dgemv.c` implementations.

Typo fixes (`2dbfbfc`):

-   Fix typo in `c_cgemv_ndarray` doc comment (`2a0b1a1`, `lib/node_modules/@stdlib/blas/base/cgemv/src/cgemv_ndarray.c:40`): duplicate `@param strideA1` entry renamed to `@param strideA2` to match the function signature.
-   Fix typo in `xerbla` error messages in `cgemv.c` and `cgemv_ndarray.c` (`2a0b1a1`): dropped the erroneous article "a" from four "must be a nonzero" strings to match the phrasing in sibling `sgemv.c`/`dgemv.c`.
-   Fix word-order typo in `blas/base/cgemv` docs (`2a0b1a1`): `lib/node_modules/@stdlib/blas/base/cgemv/README.md` line 295 described `c_cgemv_ndarray` as "using indexing alternative semantics"; corrected to "using alternative indexing semantics" to match every other occurrence in the README and the C sources.

## Related Issues

No.

## Questions

No.

## Other

**Review scope.** Audited all 39 commits merged to `develop` in the 24-hour window (`fbf2d918`..`adb3e6a9b`) — roughly 14k insertions across 390 files: four new `ndarray` packages (`trues`, `falses`, `trues-like`, `falses-like`), the new `blas/base/cgemv` C implementation, two large benchmark string-interpolation refactors, and assorted docs/test/style commits.

**Style-guide compliance + bug scan.** Validated five high-signal issues — two runtime bugs and three typos, all in `blas/base/cgemv` (`2a0b1a1`). Each was independently re-verified by re-reading the diff and comparing against the established `sgemv`/`dgemv` reference implementations.

Checked, no action required:

-   Benchmark string-interpolation refactors (`d660241`, `9451399`) and the "fix missing arguments" commits (`d400b65`, `8e2d42f`): `format()` placeholder/argument counts verified to match.
-   New `trues`/`falses`/`trues-like`/`falses-like` packages: implementations fill the correct boolean value; READMEs, REPL help, and TypeScript declarations are consistent with the code.
-   `cgemv` complex arithmetic, stride/offset handling, and addon argument parsing: verified correct.

Deliberately excluded (require interpretation; no explicit backing rule):

-   Missing space inside two `if` conditions, and `@return` annotations on `void` functions, in the `cgemv` C sources — `docs/style-guides/c` is a stub, so neither is an explicit style-guide violation.
-   A `package.json` keyword-list inconsistency between `trues`/`falses` and their `*-like` siblings — cosmetic, not a defect.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code. An automated multi-agent review audited every commit merged to `develop` over the preceding 24 hours; each finding was cross-verified against the diff and the `sgemv`/`dgemv` reference implementations before any change was applied. All fixes are mechanical corrections scoped to the reviewed window.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01TSEHKgS4iExWRieEZUJTbw)_