### PR TITLE
docs: propagate recent doc-note and grammar fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/docs/types/index.d.ts
@@ -37,7 +37,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	*
 	* @param order - storage layout
 	* @param M - number of rows in `A`
@@ -62,7 +62,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	*
 	* @param M - number of rows in `A`
 	* @param N - number of columns in `A`
@@ -89,7 +89,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 *
 * @param order - storage layout
 * @param M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/lib/accessors.js
@@ -31,7 +31,7 @@ var ones = require( '@stdlib/array/base/ones' );
 *
 * ## Notes
 *
-* -   If the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 *
 * @private
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/lib/base.js
@@ -33,7 +33,7 @@ var accessors = require( './accessors.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 *
 * @private
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/lib/main.js
@@ -36,7 +36,7 @@ var base = require( './base.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 *
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-column/lib/ndarray.js
@@ -30,7 +30,7 @@ var base = require( './base.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 *
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/docs/types/index.d.ts
@@ -31,7 +31,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -63,7 +63,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -99,7 +99,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/lib/ndarray.js
@@ -32,7 +32,7 @@ var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/lib/sindex_of_column.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/lib/sindex_of_column.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/ndarray/empty-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/test/test.js
@@ -826,7 +826,7 @@ tape( 'the function returns a zero-filled array (dtype=generic, options)', funct
 	t.end();
 });
 
-tape( 'the function guards against array having shapes containing negative dimension sizes', function test( t ) {
+tape( 'the function guards against arrays having shapes containing negative dimension sizes', function test( t ) {
 	var x = {
 		'data': [ 1, 2, 3, 4 ],
 		'ndims': 3,


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Propagating fixes merged to `develop` between 2026-05-17 and 2026-05-18 to sibling packages carrying the same defect.

### `blas/ext/base/*index-of-column` — incorrect return-value note

Commit `a6856ed70` ("docs: update notes") corrected the `## Notes` bullet in `cindex-of-column` and `zindex-of-column`, which claimed the function returns `-1` when "unable to find a search vector". The search vector is a required input and is always present; the function returns `-1` when it cannot locate a *matching column*. The identical wording was present, verbatim, in the JSDoc and TypeScript declarations of two sibling packages:

-   `blas/ext/base/gindex-of-column`
-   `blas/ext/base/sindex-of-column`

`dindex-of-column` already carried the corrected wording and is left untouched.

### `ndarray/empty-like` — grammar in a test description

Commit `435de1206` ("test: fix grammar in description") fixed a singular/plural disagreement in a `nans-like` test description (`array having shapes` → `arrays having shapes`). One sibling package carried the identical defect:

-   `ndarray/empty-like`

Every other `*-like` ndarray package (`zeros-like`, `ones-like`, `trues-like`, `falses-like`, `nans-like`) already used the plural form.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

**Validation.** Each pattern was searched across its in-scope namespace (`blas/ext/base/*index-of-column` for the note wording; `ndarray/*-like` test descriptions for the grammar fix). Two independent reviewers verified every candidate site by reading the target files in full, confirming the defect is present and the corrected wording matches the source commit verbatim. The note-wording replacement is anchored on a trailing comma, so it cannot affect the legitimate "search vector" references in `@param` descriptions and algorithm comments.

**Deliberately excluded.** Test-description occurrences of "search vector" in the `*index-of-column` packages — the source commit `a6856ed70` scoped its change to JSDoc and TypeScript declarations only, and this PR mirrors that scope; `dindex-of-column`, already corrected; and `cindex-of-column` / `zindex-of-column`, the originating packages. No sites required cross-package changes or adaptive rework.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was authored by an automated fix-propagation routine running on Claude Code. The routine identifies recently merged fixes, locates sibling packages with the same defect, and applies the equivalent change; each propagation site was verified by independent automated review before inclusion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzdrbFU2hQ8K2PuZYASauH)_