### PR TITLE
chore: correct issues found during recent `develop` commit review

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -38,7 +38,7 @@ sign-git-commit = true
 sign-git-tag = true
 
 # Run Git commit hooks when using `npm version`:
-commits-hooks = true
+commit-hooks = true
 
 # Require that dependencies within the dependency tree have a minimum release age (in days) in order to guard against supply chain attacks:
-min-release-age: 90
+min-release-age = 90

--- a/lib/node_modules/@stdlib/blas/ext/base/saxpb/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/saxpb/lib/ndarray.native.js
@@ -28,7 +28,6 @@ var addon = require( './../src/addon.node' );
 /**
 * Multiplies each element in a single-precision floating-point strided array by a scalar constant and adds a scalar constant to each result using alternative indexing semantics.
 *
-* @private
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} alpha - first scalar constant
 * @param {number} beta - second scalar constant

--- a/lib/node_modules/@stdlib/blas/ext/base/saxpb/lib/saxpb.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/saxpb/lib/saxpb.native.js
@@ -28,7 +28,6 @@ var addon = require( './../src/addon.node' );
 /**
 * Multiplies each element in a single-precision floating-point strided array by a scalar constant and adds a scalar constant to each result.
 *
-* @private
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} alpha - first scalar constant
 * @param {number} beta - second scalar constant


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-05-18 16:46:06 -0700 and 2026-05-19 04:22:25 -0700.

## Description

> What is the purpose of this pull request?

This pull request applies follow-up corrections for validated, high-signal issues identified while reviewing the 13 commits merged to `develop` in the window above (`7fab4532`...`e1d7dc74`).

That window covered: two new BLAS extension packages (`blas/ext/base/daxpb`, `blas/ext/base/saxpb`) with their namespace and TypeScript wiring; a `blas/base/cgemv` bug-and-typo fix; added `α`/`β` tests for `blas/base/ggemm`; doc/grammar propagation across the `gindex-of-column`/`sindex-of-column` siblings; an `ndarray/base` benchmark refactor to string interpolation (~200 files); and an `.npmrc` configuration update.

This pull request fixes the following, grouped by package. Each group is a separate commit (`fix:` for the configuration bugs, `style:` for the JSDoc tag removal):

### `.npmrc`

-   `commit-hooks` was misspelled as `commits-hooks` (`e1d7dc74`). npm silently ignores the unrecognized key, so git commit hooks would not run during `npm version`. Corrected the spelling.
-   `min-release-age` used a colon separator — `min-release-age: 90` (`e1d7dc74`). `.npmrc` is INI-format and requires `=`; every other directive uses it, and with a colon npm does not parse the directive, so the minimum release-age supply-chain guard never takes effect. Changed to `min-release-age = 90`.

### `blas/ext/base/saxpb`

-   `lib/saxpb.native.js` (`103392c9`) carried a spurious `@private` JSDoc tag on the exported native function — a public entry point, not an internal helper. Removed the tag to match the sibling `daxpb` package and the `dapx` reference.
-   `lib/ndarray.native.js` (`103392c9`) likewise tagged the exported native ndarray interface `@private`. Removed the tag to match `daxpb` and `dapx`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This pull request is the output of an automated review of the last 24 hours of `develop`. Four reviewer agents — two for stdlib code-style compliance, two for bugs/correctness — independently audited the window's diff; findings were cross-checked, and only issues re-verifiable directly against the diff (and the relevant stdlib reference packages) were retained.

**Validation — checked, no action required:**

-   `blas/base/cgemv` (`c606f03c`): the `LDA < v` → `LDA < vala` correction, the `cfill_ndarray` `zero`-argument fix, and the `strideA2` JSDoc/grammar fixes are all genuine and correct.
-   `blas/base/ggemm` tests (`fc3275c0`): the new fixtures' `C_out` values verified arithmetically (`α*A*B + β*C`).
-   `daxpb`/`saxpb`: README, REPL, and JSDoc numeric examples verified (`x[i] = α*x[i] + β`); C sources, addons, and manifests internally consistent.
-   `ndarray/base` benchmark refactor (`7fab4532`, `9330de70`): the `format()` conversions preserve the original concatenated strings; format-specifier counts match argument counts.

**Deliberately excluded** (out of scope / requires interpretation): the `daxpb`/`saxpb` ndarray JSDoc descriptions differ slightly in whether they include the phrase "using alternative indexing semantics" — a wording inconsistency with no governing style-guide rule, left for maintainer judgment. Auto-generated bot commits (REPL data, namespace ToC, TypeScript declarations) were not line-reviewed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was generated by an automated multi-agent review of commits merged to `develop` over the preceding 24 hours, run with Claude Code. Reviewer agents flagged candidate issues; each retained fix was independently verified against the diff and the relevant stdlib reference packages before being applied. This is a draft — a human maintainer should audit before promoting it.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_018QmMKaq9vdyE4GsoS5Pzw2)_