### PR TITLE
chore: propagate typo and doc-note fixes across `blas` sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dgemv/README.md
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/README.md
@@ -236,7 +236,7 @@ void c_dgemv( const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE trans, const CBLA
 
 #### c_dgemv_ndarray( trans, M, N, alpha, \*A, sa1, sa2, oa, \*X, sx, ox, beta, \*Y, sy, oy )
 
-Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y`, using indexing alternative semantics and where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
+Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y`, using alternative indexing semantics and where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
 
 ```c
 #include "stdlib/blas/base/shared.h"

--- a/lib/node_modules/@stdlib/blas/base/dsyr/src/dsyr_ndarray.c
+++ b/lib/node_modules/@stdlib/blas/base/dsyr/src/dsyr_ndarray.c
@@ -60,7 +60,7 @@ void API_SUFFIX(c_dsyr_ndarray)( const CBLAS_UPLO uplo, const CBLAS_INT N, const
 		return;
 	}
 	if ( strideX == 0 ) {
-		c_xerbla( 5, "c_dsyr_ndarray", "Error: invalid argument. Fifth argument must be a nonzero. Value: `%d`.", strideX );
+		c_xerbla( 5, "c_dsyr_ndarray", "Error: invalid argument. Fifth argument must be nonzero. Value: `%d`.", strideX );
 		return;
 	}
 	// Check whether we can avoid computation altogether...

--- a/lib/node_modules/@stdlib/blas/base/sgemv/README.md
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/README.md
@@ -236,7 +236,7 @@ void c_sgemv( const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE trans, const CBLA
 
 #### c_sgemv_ndarray( trans, M, N, alpha, \*A, sa1, sa2, oa, \*X, sx, ox, beta, \*Y, sy, oy )
 
-Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y`, using indexing alternative semantics and where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
+Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y`, using alternative indexing semantics and where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
 
 ```c
 #include "stdlib/blas/base/shared.h"

--- a/lib/node_modules/@stdlib/blas/base/ssyr/src/ssyr_ndarray.c
+++ b/lib/node_modules/@stdlib/blas/base/ssyr/src/ssyr_ndarray.c
@@ -60,7 +60,7 @@ void API_SUFFIX(c_ssyr_ndarray)( const CBLAS_UPLO uplo, const CBLAS_INT N, const
 		return;
 	}
 	if ( strideX == 0 ) {
-		c_xerbla( 5, "c_ssyr_ndarray", "Error: invalid argument. Fifth argument must be a nonzero. Value: `%d`.", strideX );
+		c_xerbla( 5, "c_ssyr_ndarray", "Error: invalid argument. Fifth argument must be nonzero. Value: `%d`.", strideX );
 		return;
 	}
 	// Check whether we can avoid computation altogether...

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/docs/types/index.d.ts
@@ -32,7 +32,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -64,7 +64,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -100,7 +100,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/lib/cindex_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/lib/cindex_of_row.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/lib/ndarray.js
@@ -33,7 +33,7 @@ var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/docs/types/index.d.ts
@@ -32,7 +32,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -65,7 +65,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -102,7 +102,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/lib/clast_index_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/lib/clast_index_of_row.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/lib/ndarray.js
@@ -33,7 +33,7 @@ var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/docs/types/index.d.ts
@@ -31,7 +31,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -63,7 +63,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -99,7 +99,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/lib/dindex_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/lib/dindex_of_row.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/lib/ndarray.js
@@ -32,7 +32,7 @@ var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/docs/types/index.d.ts
@@ -31,7 +31,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -63,7 +63,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -99,7 +99,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/lib/dlast_index_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/lib/dlast_index_of_row.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/lib/ndarray.js
@@ -32,7 +32,7 @@ var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/docs/types/index.d.ts
@@ -37,7 +37,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	*
 	* @param order - storage layout
 	* @param M - number of rows in `A`
@@ -62,7 +62,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	*
 	* @param M - number of rows in `A`
 	* @param N - number of columns in `A`
@@ -89,7 +89,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 *
 * @param order - storage layout
 * @param M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/lib/accessors.js
@@ -31,7 +31,7 @@ var ones = require( '@stdlib/array/base/ones' );
 *
 * ## Notes
 *
-* -   If the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 *
 * @private
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/lib/base.js
@@ -33,7 +33,7 @@ var accessors = require( './accessors.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 *
 * @private
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/lib/main.js
@@ -36,7 +36,7 @@ var base = require( './base.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 *
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-row/lib/ndarray.js
@@ -30,7 +30,7 @@ var base = require( './base.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 *
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/docs/types/index.d.ts
@@ -42,7 +42,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -71,7 +71,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -104,7 +104,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/accessors.js
@@ -32,7 +32,7 @@ var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 *
 * ## Notes
 *
-* -   If the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @private

--- a/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/main.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/glast-index-of-row/lib/ndarray.js
@@ -34,7 +34,7 @@ var accessors = require( './accessors.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/docs/types/index.d.ts
@@ -31,7 +31,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -63,7 +63,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -99,7 +99,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/lib/ndarray.js
@@ -32,7 +32,7 @@ var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/lib/sindex_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/lib/sindex_of_row.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/docs/types/index.d.ts
@@ -31,7 +31,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -63,7 +63,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -99,7 +99,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/ndarray.js
@@ -32,7 +32,7 @@ var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/docs/types/index.d.ts
@@ -32,7 +32,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -64,7 +64,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -100,7 +100,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/lib/ndarray.js
@@ -33,7 +33,7 @@ var reinterpret = require( '@stdlib/strided/base/reinterpret-complex128' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/lib/zindex_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/lib/zindex_of_row.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/docs/types/index.d.ts
@@ -32,7 +32,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -65,7 +65,7 @@ interface Routine {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param M - number of rows in `A`
@@ -102,7 +102,7 @@ interface Routine {
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param order - storage layout

--- a/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/lib/ndarray.js
@@ -33,7 +33,7 @@ var reinterpret = require( '@stdlib/strided/base/reinterpret-complex128' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {PositiveInteger} M - number of rows in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/lib/zlast_index_of_row.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/lib/zlast_index_of_row.js
@@ -36,7 +36,7 @@ var ndarray = require( './ndarray.js' );
 *
 * ## Notes
 *
-* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 * -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 *
 * @param {string} order - storage layout


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-05-18 and 2026-05-19 to sibling packages.

### Error-message grammar typo (`fix:`)

`c606f03c3` ("fix: correct bugs and typos in `blas/base/cgemv`") removed an ungrammatical article from a stride-validation error message. The same defect — `must be a nonzero` in place of `must be nonzero` — is present in the `strideX == 0` guard of two sibling ndarray C implementations:

-   `@stdlib/blas/base/dsyr`
-   `@stdlib/blas/base/ssyr`

### Transposed words in ndarray interface description (`fix:`)

`c606f03c3` also corrected a word-order error in the `cgemv` README. The `*_ndarray` interface description in two sibling READMEs reads `using indexing alternative semantics` rather than `using alternative indexing semantics`:

-   `@stdlib/blas/base/dgemv`
-   `@stdlib/blas/base/sgemv`

### Return-value doc-note phrasing (`docs:`)

`238446093` ("docs: propagate recent doc-note and grammar fixes to sibling packages") fixed the `## Notes` block of the `*index-of-column` packages, which claimed the function returns `-1` when "unable to find a search vector". The search vector is the caller-provided query, not the value being located; the function returns `-1` when unable to find a *matching* column. The analogous `*index-of-row` and `*last-index-of-row` packages carry the identical defect, corrected here to "unable to find a matching row" across `lib/` implementations and TypeScript declaration files:

-   `@stdlib/blas/ext/base/cindex-of-row`, `dindex-of-row`, `gindex-of-row`, `sindex-of-row`, `zindex-of-row`
-   `@stdlib/blas/ext/base/clast-index-of-row`, `dlast-index-of-row`, `glast-index-of-row`, `slast-index-of-row`, `zlast-index-of-row`

## Related Issues

None.

## Questions

No.

## Other

Validation: each pattern was located by searching the originating commit's defect signature across sibling packages under the same namespace. Candidate sites were verified by two independent reviews — each reading every target file in full to confirm the defect is present and the surrounding context does not change the semantics — followed by a style-consistency pass confirming each edit is a pure phrase substitution introducing no formatting drift.

Deliberately excluded:

-   Test files (`test/*.js`) and the `blas/ext/base` namespace declaration barrel, mirroring the file scope of source commit `238446093` (`lib/` and per-package `docs/types/` only).
-   The `cgemv` logic fixes from `c606f03c3` (`LDA < v` → `LDA < vala`; the `beta == 0` zero-fill argument; the duplicate `@param strideA1`): the `dgemv`/`sgemv`/`ggemv` siblings were inspected and are already correct — those defects were unique to the newly added `cgemv`.
-   The `bench:` string-interpolation refactors and the `test:` coverage additions merged in the same window: stylistic and additive changes, not defect corrections.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated fix-propagation routine run with Claude Code. The routine identified generalizable fixes among commits merged to `develop` in the preceding 24 hours, located sibling packages exhibiting the same defect, and applied the equivalent change at each validated site. Every site was confirmed by independent automated review passes before inclusion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01SQDKGocTPJxMb6aExkYoqx)_