### PR TITLE
docs: add Git notes correcting recent commit messages

### DIFF
--- a/docs/git-notes/9330de700a97e4c3cdd6c0e4558f26e1e757178f.txt
+++ b/docs/git-notes/9330de700a97e4c3cdd6c0e4558f26e1e757178f.txt
@@ -1,0 +1,11 @@
+---
+type: amend-message
+---
+bench: refactor to use string interpolation in `ndarray/base`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/11430
+Co-authored-by: Athan Reines <kgryte@gmail.com>
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Signed-off-by: Athan Reines <kgryte@gmail.com>
+Ref: https://github.com/stdlib-js/metr-issue-tracker/issues/403
+Ref: https://github.com/stdlib-js/stdlib/issues/8647


### PR DESCRIPTION
## Summary

One commit from the last 24 hours was flagged for a malformed trailer.

## Flagged commits

- `9330de70`: missing `Signed-off-by` — commit has `Co-authored-by: Athan Reines <kgryte@gmail.com>` but no matching `Signed-off-by: Athan Reines <kgryte@gmail.com>`; every other commit in the same window that includes `Co-authored-by: Athan Reines` also carries the corresponding `Signed-off-by` (see `103392c9`, `f18c4cfb`, `7fab4532`).

## Not flagged

All 13 remaining non-merge commits in the window were inspected:
- All referenced PR numbers (12181, 12192, 12193, 12194, 12196, 12197, 12198, 12199, 12200, 11430, 11436) were verified to exist, match their commit subjects, and be merged.
- No spelling/grammar typos found in any subject line.
- No Conventional Commits style violations found.
- Commits by `stdlib-bot` and direct maintainer commits without `Signed-off-by` follow the established pattern for those commit types and were not flagged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeSUUpARdwDZvewx8qRWQw)_