### PR TITLE
refactor: use floating-point zero literals in `stats/base/dists/rayleigh`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/stdev/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/stdev/lib/main.js
@@ -56,7 +56,7 @@ var SQRT4MPI = sqrt( 4.0-PI );
 * // returns NaN
 */
 function stdev( sigma ) {
-	if ( isnan( sigma ) || sigma < 0 ) {
+	if ( isnan( sigma ) || sigma < 0.0 ) {
 		return NaN;
 	}
 	return SQRT4MPI * sigma / SQRT2;

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/lib/main.js
@@ -49,7 +49,7 @@ var PI = require( '@stdlib/constants/float64/pi' );
 * // returns NaN
 */
 function variance( sigma ) {
-	if ( isnan( sigma ) || sigma < 0 ) {
+	if ( isnan( sigma ) || sigma < 0.0 ) {
 		return NaN;
 	}
 	return ( 4.0-PI ) * sigma*sigma / 2.0;


### PR DESCRIPTION
## Description

This pull request normalizes the `sigma` scale-parameter validation guard in two `@stdlib/stats/base/dists/rayleigh` packages to compare the scale parameter against `0.0` (an explicit floating-point zero literal) rather than `0` (a bare integer literal). The explicit floating-point form is used by 12 of the 14 numeric-function packages in the namespace (86%) and is the sole form used elsewhere in `@stdlib/stats/base/dists`: `variance` and `stdev` were the only two `lib/main.js` parameter guards in the entire distribution namespace using a bare integer literal (~94% ecosystem conformance). The change is behavior-preserving, since `0` and `0.0` denote the same IEEE 754 value.

### `stats/base/dists/rayleigh/variance`

`variance/lib/main.js` guarded the `sigma` scale parameter against a bare integer `0`. The parameter is a float64 `NonNegativeNumber`, and the function body already uses floating-point literals throughout (`4.0`, `2.0`); the bare integer was incidental. The guard now compares against `0.0`.

### `stats/base/dists/rayleigh/stdev`

`stdev/lib/main.js` carried the same bare-integer guard. It now compares against `0.0`, consistent with sibling packages including `mean`, `median`, and `kurtosis`.

## Related Issues

No.

## Questions

No.

## Other

The change touches only the JavaScript validation guard in each package; tests, examples, REPL fixtures, and TypeScript declarations are unaffected, and the native (C) implementations were not modified.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by Claude Code running an automated cross-package consistency check. The routine extracted structural and semantic features from every package in the `rayleigh` namespace, identified the explicit floating-point parameter-guard literal as the majority convention, flagged `variance` and `stdev` as the outliers, and applied the two-line normalization. The change was independently reviewed for behavior preservation and for the absence of any dependent tests or documentation.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md