### PR TITLE
docs: align description openers in three `array/base/assert` cast packages

### DIFF
--- a/lib/node_modules/@stdlib/array/base/assert/is-mostly-safe-data-type-cast/README.md
+++ b/lib/node_modules/@stdlib/array/base/assert/is-mostly-safe-data-type-cast/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # isMostlySafeCast
 
-> Determine whether an array [data type][@stdlib/array/dtypes] can be safely cast or, for floating-point data types, downcast to another array [data type][@stdlib/array/dtypes].
+> Test if an array [data type][@stdlib/array/dtypes] can be safely cast or, for floating-point data types, downcast to another array [data type][@stdlib/array/dtypes].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 

--- a/lib/node_modules/@stdlib/array/base/assert/is-mostly-safe-data-type-cast/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/base/assert/is-mostly-safe-data-type-cast/docs/repl.txt
@@ -1,8 +1,7 @@
 
 {{alias}}( from, to )
-    Returns a boolean indicating whether a provided array data type can be
-    safely cast or, for floating-point data types, downcast to another array
-    data type.
+    Tests if a provided array data type can be safely cast or, for
+    floating-point data types, downcast to another array data type.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/array/base/assert/is-mostly-safe-data-type-cast/package.json
+++ b/lib/node_modules/@stdlib/array/base/assert/is-mostly-safe-data-type-cast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/array/base/assert/is-mostly-safe-data-type-cast",
   "version": "0.0.0",
-  "description": "Determine if an array data type can be safely cast or, for floating-point data types, downcast to another array data type.",
+  "description": "Test if an array data type can be safely cast or, for floating-point data types, downcast to another array data type.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/array/base/assert/is-safe-data-type-cast/README.md
+++ b/lib/node_modules/@stdlib/array/base/assert/is-safe-data-type-cast/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # isSafeCast
 
-> Determine whether an array [data type][@stdlib/array/dtypes] can be safely cast to another array [data type][@stdlib/array/dtypes].
+> Test if an array [data type][@stdlib/array/dtypes] can be safely cast to another array [data type][@stdlib/array/dtypes].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 

--- a/lib/node_modules/@stdlib/array/base/assert/is-safe-data-type-cast/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/base/assert/is-safe-data-type-cast/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( from, to )
-    Returns a boolean indicating whether a provided array data type can be
-    safely cast to another array data type.
+    Tests if a provided array data type can be safely cast to another array
+    data type.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/array/base/assert/is-safe-data-type-cast/package.json
+++ b/lib/node_modules/@stdlib/array/base/assert/is-safe-data-type-cast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/array/base/assert/is-safe-data-type-cast",
   "version": "0.0.0",
-  "description": "Determine if an array data type can be safely cast to another array data type.",
+  "description": "Test if an array data type can be safely cast to another array data type.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/array/base/assert/is-same-kind-data-type-cast/README.md
+++ b/lib/node_modules/@stdlib/array/base/assert/is-same-kind-data-type-cast/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # isSameKindCast
 
-> Determine whether an array [data type][@stdlib/array/dtypes] can be safely cast to, or is of the same "kind" as, another array [data type][@stdlib/array/dtypes].
+> Test if an array [data type][@stdlib/array/dtypes] can be safely cast to, or is of the same "kind" as, another array [data type][@stdlib/array/dtypes].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 

--- a/lib/node_modules/@stdlib/array/base/assert/is-same-kind-data-type-cast/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/base/assert/is-same-kind-data-type-cast/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( from, to )
-    Returns a boolean indicating whether a provided array data type can be
-    safely cast to, or is of the same "kind" as, another array data type.
+    Tests if a provided array data type can be safely cast to, or is of the
+    same "kind" as, another array data type.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/array/base/assert/is-same-kind-data-type-cast/package.json
+++ b/lib/node_modules/@stdlib/array/base/assert/is-same-kind-data-type-cast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/array/base/assert/is-same-kind-data-type-cast",
   "version": "0.0.0",
-  "description": "Determine if an array data type can be safely cast to, or is of the same kind as, another array data type.",
+  "description": "Test if an array data type can be safely cast to, or is of the same kind as, another array data type.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Reworks the leading phrase of three documentation surfaces in three sibling packages under `@stdlib/array/base/assert/` so that they read in the same voice as the rest of the namespace.

### Namespace summary

-   **Namespace:** `@stdlib/array/base/assert/`
-   **Members analyzed:** 26 non-autogenerated packages
-   **Features with a clear majority (≥75%):**
    -   `README.md` tagline opener — `Test if` (23/26 = 88.5%)
    -   `package.json` `description` opener — `Test if` (23/26 = 88.5%)
    -   `docs/repl.txt` first descriptive line opener — `Tests if` (23/26 = 88.5%)
-   **Features without a clear majority (excluded):** `lib/main.js` JSDoc opener (`Tests whether` 11 / `Tests if` 8 / `Returns a` 7), `lib/index.js` `@module` opener (12/11/3), `docs/types/index.d.ts` JSDoc opener (11/11/3), README section sequence (17/9 split on the optional `## Notes` section), and benchmark file naming (driven by single-value-vs-array function shape, not drift).

### Per outlier package

### `array/base/assert/is-mostly-safe-data-type-cast`

Rewrites the tagline, `package.json` description, and `docs/repl.txt` opening line to use `"Test if ..."` / `"Tests if ..."` phrasing, matching 23 of 26 sibling packages (88.5%). No code, signature, or behavioral changes.

-   `README.md` tagline: `"Determine whether ..."` → `"Test if ..."`
-   `package.json` description: `"Determine if ..."` → `"Test if ..."`
-   `docs/repl.txt` first line: `"Returns a boolean indicating whether ..."` → `"Tests if ..."`

### `array/base/assert/is-safe-data-type-cast`

Rewords documentation to use "Test if ..." / "Tests if ..." phrasing, consistent with 23 of 26 sibling packages (88.5%). No code, signatures, or behavior changed.

-   `README.md` tagline: "Determine whether ..." → "Test if ..."
-   `package.json` description: "Determine if ..." → "Test if ..."
-   `docs/repl.txt` opening line: "Returns a boolean indicating whether ..." → "Tests if ..."

### `array/base/assert/is-same-kind-data-type-cast`

Standardizes documentation phrasing to match the convention used by 23 of 26 sibling packages (88.5%), which prefix descriptions with "Test if" rather than "Determine whether/if". No code, signatures, or behavior changed.

-   `README.md` tagline: "Determine whether ..." → "Test if ..."
-   `package.json` description: "Determine if ..." → "Test if ..."
-   `docs/repl.txt` opening line: "Returns a boolean indicating whether ..." → "Tests if ..."

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   **Structural extraction:** file tree, `package.json` key sets, `README.md` section sequences, `manifest.json` shape, and test/benchmark/example filenames were collected for all 26 members; no structural outlier survived filtering (the `contains` package's `factory.js` is a legitimate semantic difference, and the `benchmark.js` vs `benchmark.length.js` split tracks single-value vs array-input function shape).
-   **Semantic extraction:** each package's `lib/main.js` and `lib/index.js` was parsed for public signature, return kind, validation prologue, error construction, JSDoc shape, and `@stdlib/*` source-level dependencies. All 26 members return `boolean` with no validation prologue (these are `base` internal helpers, by design).
-   **Three-pass review of each candidate:** a semantic review confirmed that all three cast packages genuinely return booleans and that the rewording carries no meaning loss; a cross-reference review (grep across `lib/node_modules/@stdlib/`) confirmed that the deviating phrases appear only in the three outliers' own files (no fixture, test, or sibling-package README embeds them); a structural review confirmed that the majority opener applies uniformly across 7 sampled conforming packages and reads naturally on the cast packages.
-   **Deliberately excluded:** opener style in `lib/main.js` JSDoc, `lib/index.js` `@module` block, and `docs/types/index.d.ts` (no clear majority opener in the namespace); the README `## Notes` section sequence split (no clear majority); per-package `keywords` arrays (intentionally diverge by package subject); `is-accessor-array` `@param {Object}` (the function dereferences `.get` and would crash on `null`/`undefined`, so the restrictive type hint is semantically appropriate for a `base` helper).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was prepared by Claude Code. It surveyed all 26 packages under `@stdlib/array/base/assert/`, identified the three documentation surfaces with a ≥75% majority opener, and rewrote the three outlier packages' leading phrases to match. Each correction was reviewed by independent semantic, cross-reference, and structural validation passes before any file was modified. No behavior, signatures, or test expectations were changed.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Do4t6YbTZAQqfx9wyixp2Y)_