### PR TITLE
refactor: normalize error messages and descriptions

### DIFF
--- a/lib/node_modules/@stdlib/_tools/lint/namespace-aliases/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/lint/namespace-aliases/lib/async.js
@@ -45,7 +45,7 @@ var debug = logger( 'lint-namespace-aliases:async' );
 * @param {Callback} clbk - callback to invoke upon completion
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
-* @throws {TypeError} last argument must be a function
+* @throws {TypeError} callback argument must be a function
 *
 * @example
 * lint( onLint );
@@ -78,7 +78,7 @@ function lint( options, clbk ) {
 		cb = options;
 	}
 	if ( !isFunction( cb ) ) {
-		throw new TypeError( format( 'invalid argument. Last argument must be a function. Value: `%s`.', cb ) );
+		throw new TypeError( format( 'invalid argument. Callback argument must be a function. Value: `%s`.', cb ) );
 	}
 	debug( 'Options: %s', JSON.stringify( opts ) );
 

--- a/lib/node_modules/@stdlib/_tools/lint/pkg-json-names/docs/usage.txt
+++ b/lib/node_modules/@stdlib/_tools/lint/pkg-json-names/docs/usage.txt
@@ -1,3 +1,4 @@
+
 Usage: lint-pkg-json-names [options] [<dir>]
 
 Options:

--- a/lib/node_modules/@stdlib/_tools/lint/pkg-json-names/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/lint/pkg-json-names/lib/async.js
@@ -45,6 +45,7 @@ var debug = logger( 'lint:pkg-json-names:async' );
 * @param {string} [options.pattern] - glob pattern
 * @param {(string|StringArray)} [options.ignore] - glob pattern(s) to exclude
 * @param {Callback} clbk - callback to invoke upon completion
+* @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
 * @throws {TypeError} callback argument must be a function
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Normalizes two outlier packages in the `@stdlib/_tools/lint/*` namespace to the conventions used by the rest of the namespace, found via a cross-package drift sweep. No observable behavior changes — error type, JSDoc tag set, and CLI output are otherwise unchanged.

### Namespace summary

-   **Namespace:** `@stdlib/_tools/lint` (9 non-autogenerated packages)
-   **Features analyzed:** file tree, `package.json` shape, README section list, `lib/async.js` / `lib/main.js` JSDoc shape, error-construction style, validation prologue, `docs/usage.txt` formatting.
-   **Clear majority (≥75% conformance):** error-message phrasing for callback validation; presence of `@throws {TypeError} options argument must be an object` in the JSDoc of packages that accept an options object; leading newline in `docs/usage.txt`.
-   **No clear majority (excluded):** presence of `os` field in `package.json` (2/9 vs 7/9 split, intentional vs accidental unclear); the `cb` vs `clbk` callback parameter name; presence of `lib/sync.js` / `lib/async.js` / `lib/validate.js` (genuine API-shape differences across packages).

### `@stdlib/_tools/lint/namespace-aliases`

Replaces `"Last argument must be a function."` with `"Callback argument must be a function."` in the `TypeError` thrown by `lib/async.js`, and updates the matching `@throws` JSDoc tag. All 7 other sibling packages with a callback-arity validation use the `"Callback argument"` phrasing (87.5% conformance, 7/8 of comparable siblings); the function signature is `lint( options, clbk )` with `clbk` unambiguously the callback, so the `"Last argument"` wording is a copy-paste outlier with no semantic justification.

### `@stdlib/_tools/lint/pkg-json-names`

Two corrections in this package:

-   Adds the missing `* @throws {TypeError} options argument must be an object` line to the JSDoc for `lib/async.js`. The throw is already implemented in `lib/validate.js` but undocumented at the public entry. All 6 sibling packages that accept an `options` object document this throw (100% conformance).
-   Prepends a leading blank line to `docs/usage.txt`. The file is read at runtime into the CLI's `--help` output, and 8 of 8 sibling packages start their `docs/usage.txt` with `\n`; `pkg-json-names` was the only one starting on the `Usage:` line, which produced subtly different vertical spacing in `--help`.

### Validation

-   Structural extraction over file tree, `package.json` keys, README section list, and `docs/usage.txt` first byte across all 9 namespace members.
-   Semantic extraction of JSDoc shape, validation prologue, and error-construction style.
-   Three-agent drift validation (semantic, cross-reference, structural) confirmed each correction was a `confirmed-drift` rather than an intentional deviation. Cross-reference verified that tests in both packages assert only on `instanceof TypeError`, never on message text, and that the CLI's `test.cli.js` reads `docs/usage.txt` symmetrically against the produced `--help` output.
-   Deliberately excluded: the `os` field divergence (behavior-affecting, unclear majority), the `cb`/`clbk` naming difference (no 75% majority), and the empty `<section class="notes">` in `pkg-json/repl-txt` READMEs (requires authored content, not mechanical).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Each outlier package has its own commit so the audit trail is per-package. Conformance percentages for each item are quoted in the respective commit body.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by a cross-package API drift sweep run by Claude Code. The drift signals (majority error phrasing, missing JSDoc tag, missing leading newline in `docs/usage.txt`) were extracted automatically across the 9 packages in `@stdlib/_tools/lint`, then validated by three review passes before any file was modified. All edits are mechanical text substitutions in two packages; no behavior, signatures, or test expectations changed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01NL2s4uuPyNTRkcJ3g38gZb)_