### PR TITLE
fix: propagate recent develop fixes to sibling packages (2026-05-20)

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
@@ -342,7 +342,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -385,7 +385,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -1191,7 +1191,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -1265,7 +1265,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -3293,7 +3293,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	*
 	* @param order - storage layout
 	* @param M - number of rows in `A`
@@ -3325,7 +3325,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	*
 	* @param order - storage layout
 	* @param M - number of rows in `A`
@@ -3435,7 +3435,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -4893,7 +4893,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -4936,7 +4936,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -5010,7 +5010,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -5894,7 +5894,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout
@@ -5937,7 +5937,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   If the function is provided an empty matrix or if the function is unable to find a search vector, the function returns `-1` (i.e., an invalid index).
+	* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
 	* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
 	*
 	* @param order - storage layout

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape/benchmark/c/benchmark.c
@@ -96,7 +96,7 @@ static double benchmark( void ) {
 	double t;
 	int i;
 
-	int64_t ndims = 3;
+	const int64_t ndims = 3;
 	int64_t shape[] = { 10, 10, 10 };
 
 	t = tic();

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible/benchmark/c/benchmark.c
@@ -100,7 +100,7 @@ static double benchmark( void ) {
 	int64_t shape[] = { 10, 10, 10 };
 	int64_t strides[] = { 100, 10, -1 };
 	int64_t offset = 0;
-	int64_t ndims = 3;
+	const int64_t ndims = 3;
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major-contiguous/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major-contiguous/benchmark/c/benchmark.c
@@ -100,7 +100,7 @@ static double benchmark( void ) {
 	int64_t shape[] = { 10, 10, 10 };
 	int64_t strides[] = { 1, 10, 100 };
 	int64_t offset = 0;
-	int64_t ndims = 3;
+	const int64_t ndims = 3;
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major/benchmark/c/benchmark.c
@@ -96,7 +96,7 @@ static double benchmark( void ) {
 	double t;
 	int i;
 
-	int64_t ndims = 3;
+	const int64_t ndims = 3;
 	int64_t strides[] = { 1, 10, 100 };
 
 	t = tic();

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-contiguous/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-contiguous/benchmark/c/benchmark.c
@@ -100,7 +100,7 @@ static double benchmark( void ) {
 	int64_t shape[] = { 10, 10, 10 };
 	int64_t strides[] = { 1, 10, 100 };
 	int64_t offset = 0;
-	int64_t ndims = 3;
+	const int64_t ndims = 3;
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major-contiguous/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major-contiguous/benchmark/c/benchmark.c
@@ -100,7 +100,7 @@ static double benchmark( void ) {
 	int64_t shape[] = { 10, 10, 10 };
 	int64_t strides[] = { 100, 10, 1 };
 	int64_t offset = 0;
-	int64_t ndims = 3;
+	const int64_t ndims = 3;
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major/benchmark/c/benchmark.c
@@ -96,7 +96,7 @@ static double benchmark( void ) {
 	double t;
 	int i;
 
-	int64_t ndims = 3;
+	const int64_t ndims = 3;
 	int64_t strides[] = { 100, 10, 1 };
 
 	t = tic();

--- a/lib/node_modules/@stdlib/ndarray/ndarraylike2ndarray/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/ndarraylike2ndarray/lib/main.js
@@ -33,7 +33,7 @@ var defaults = require( '@stdlib/ndarray/defaults' );
 
 // VARIABLES //
 
-var DEFAULT_ORDER = defaults( 'order' );
+var DEFAULT_ORDER = defaults.get( 'order' );
 
 
 // MAIN //


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between `9559de0` (2026-05-19 18:52 -0400) and `8c6dabd` (2026-05-20 03:14 -0700) to sibling packages with the same underlying defect.

### Pattern: correct default order resolution via `defaults.get()` accessor

`62d6dcc0b` fixed a bug in `@stdlib/ndarray/base/ndarraylike2ndarray/lib/main.js` where `defaults( 'order' )` ignores its argument and returns the full defaults object rather than the order string, so `DEFAULT_ORDER` held an object instead of a string, breaking the fallback path when `getOrder( x )` returns falsy. The identical defect exists in `@stdlib/ndarray/ndarraylike2ndarray`, which receives the same single-line fix: `defaults( 'order' )` → `defaults.get( 'order' )`. The remaining changes from `62d6dcc0b` — switching inner calls to base APIs to avoid redundant validation — do not apply here, as `@stdlib/ndarray/ndarraylike2ndarray` is the validating public wrapper and must retain those calls.

- `62d6dcc0b` ([`fix: avoid duplicate validation overhead and fix default order resolution`](https://github.com/stdlib-js/stdlib/commit/62d6dcc0bd4c36e07c629811ab23831bfe65bf7a))
  - `@stdlib/ndarray/ndarraylike2ndarray`

### Pattern: const-qualify compile-time `ndims` scalar in `ndarray/base/assert/*` benchmarks

Propagated from `ffbae8968`, which added `const` to compile-time-constant arrays and scalars in the benchmark loop of `is-single-segment-compatible` while leaving mutated variables (e.g., `offset`) unqualified. The `ndims` const addition is propagated to seven sibling packages (the `shape[]`/`strides[]` array-const additions were deliberately deferred — see Validation below). `ndims` is passed by value, so the local-only `const` addition is warning-free across all targets.

- `ffbae8968` ([`chore: fix C lint errors`](https://github.com/stdlib-js/stdlib/commit/ffbae8968bd9c767c100864a4c638037e517b734))
  - `@stdlib/ndarray/base/assert/is-row-major`
  - `@stdlib/ndarray/base/assert/is-row-major-contiguous`
  - `@stdlib/ndarray/base/assert/is-column-major`
  - `@stdlib/ndarray/base/assert/is-contiguous`
  - `@stdlib/ndarray/base/assert/is-column-major-contiguous`
  - `@stdlib/ndarray/base/assert/is-buffer-length-compatible`
  - `@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape`

### Pattern: correct "find a search vector" phrasing in `blas/ext/base` umbrella declarations

Commit `9559de0` corrected the misleading phrase "find a search vector" across per-package `lib/*.js` and `docs/types/index.d.ts` files for the row-finding APIs in `blas/ext/base`, but the umbrella namespace declarations file at `blas/ext/base/docs/types/index.d.ts` was missed. This patch replaces all 12 occurrences: 10 with "find a matching row" for the row-finding APIs (`cindexOfRow`, `clastIndexOfRow`, `dindexOfRow`, `dlastIndexOfRow`, `gindexOfRow`, `glastIndexOfRow`, `sindexOfRow`, `slastIndexOfRow`, `zindexOfRow`, `zlastIndexOfRow`) and 2 with "find a matching column" for the column-finding APIs (`gindexOfColumn`, `sindexOfColumn`), matching the wording already present in those packages' own declaration files.

- `9559de093` ([`chore: propagate typo and doc-note fixes across blas sibling packages`](https://github.com/stdlib-js/stdlib/commit/9559de093ed0c43ba65c7b6829be61a5967cd2f4))
  - `@stdlib/blas/ext/base` (umbrella `docs/types/index.d.ts`)

## Related Issues

None.

## Questions

No.

## Other

### Validation

Reviewed all 37 commits merged to `develop` in the 24-hour window. Three propagatable source patterns advanced to the patch stage; per-pattern search scope and validation procedure:

- Search scope: scoped to the source commit's namespace first (`ndarray/base/assert/*` for the `const` lint fix, `ndarray/*` for the `defaults.get()` fix, `blas/ext/base/*` for the typo correction), widened only when warranted by the pattern signature.
- Two independent opus validation passes confirmed (a) the defect is present at each candidate site, (b) surrounding context does not change the semantics, and (c) the proposed patch matches the source commit's exact fix shape.
- An adaptation pass produced the row-vs-column per-occurrence replacements for the umbrella `blas/ext/base` declarations file.
- A style-consistency pass confirmed `const` placement, JS `var`-style, JSDoc indentation, and wording match the source-commit canonical form.

Deliberately excluded:

- `shape[]`/`strides[]` `const` additions in `ndarray/base/assert/*/benchmark/c/benchmark.c` siblings: five of the seven target sibling C headers still declare the pointer parameters as `int64_t *shape`/`int64_t *strides`. Adding `const` to the local arrays would emit `-Wdiscarded-qualifiers` at the call sites — directly at odds with the source commit's "fix C lint errors" intent. A complete fix needs accompanying header/implementation patches, which exceeds single-file propagation scope.
- The bench-string-interpolation pattern from `ad8f9b59d` (`bench: refactor to use string interpolation in ndarray/base`): open PRs #11411, #11341, and #11437 already propagate this pattern to other namespaces; dropped per the open-PR collision gate.
- Autogenerated namespace-TOC and related-packages docs updates from `050cabae` and `2dd6ec1c` (stdlib-bot commits): generator-owned files.
- Sites where applying the local-only patch would require touching multiple files in the same package (cascade rule) or interpretive judgment about whether the fix applies (e.g., `3df93b0c`'s `Last argument` → `Callback argument` error-message normalization, where "last argument" is intentional in many signatures).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two opus validation passes plus a style-consistency pass) before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01K2ubeWf6THJRSV3QSxvryf)_