### PR TITLE
chore: address JavaScript lint error

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ssyr/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr/test/test.ndarray.js
@@ -40,7 +40,6 @@ var rsa1nsa2 = require( './fixtures/row_major_sa1n_sa2.json' );
 var rsa1sa2n = require( './fixtures/row_major_sa1_sa2n.json' );
 var rsa1nsa2n = require( './fixtures/row_major_sa1n_sa2n.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/plot/components/svg/defs/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/defs/lib/main.js
@@ -76,10 +76,9 @@ function Defs() {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
-		args[ 0 ] = 'render';
-		for ( i = 0; i < arguments.length; i++ ) {
-			args[ i+1 ] = arguments[ i ];
+		args = [ 'render' ];
+		for ( i = 0 ; i < arguments.length; i++ ) {
+			args.push( arguments[ i ] );
 		}
 		self.emit.apply( self, args );
 	}


### PR DESCRIPTION
Resolves #12208

## Description

> What is the purpose of this pull request?
This pull request:

-  The Javascript lint workflow was flagging an error at 2 places
- 1st one at `lib/node_modules/@stdlib/plot/components/svg/defs/lib/main.js` at 79th line , were previously there was a preallocated size array using 
`args = new Array ( arguments.length + 1 ); args[0] = 'render' ; for ( i = 0; i<arguments.length;i++ ){ 
args[i+1] = arguments[i] }`  -> the lint workflow was flagging it because of presize allocation of array, i changed it to 
`args = [ 'render' ]; for( i = 0; i<arguments.length; i++ ){ args.push( arguments[ i ] ); }`
- 2nd one at ` lib/node_modules/@stdlib/blas/base/ssyr/test/test.ndarray.js` where there was an unexpected blank line at line 43, so the lint workflow was flagging it too --> removed it.

## Related Issues

> Does this pull request have any related issues?
This pull request has the following related issues:
-   #12208 

## Questions

> Any questions for reviewers of this pull request?
No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.
No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.
-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
