### PR TITLE
chore: fix JavaScript lint errors (issue #12222)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/gasum/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/gasum/test/test.ndarray.js
@@ -198,15 +198,15 @@ tape( 'if the stride equals `1`, the function efficiently sums the absolute valu
 	var y;
 	var i;
 
-	x = new Array( 100 );
-	for ( i = 0; i < x.length; i++ ) {
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
 		sign = randu();
 		if ( sign < 0.5 ) {
 			sign = -1.0;
 		} else {
 			sign = 1.0;
 		}
-		x[ i ] = sign * (i+1);
+		x.push( sign * (i+1) );
 	}
 
 	y = gasum( x.length, x, 1, 0 );
@@ -214,15 +214,15 @@ tape( 'if the stride equals `1`, the function efficiently sums the absolute valu
 	// Compare to closed-form formula:
 	t.strictEqual( y, x.length*(x.length+1)/2, 'returns expected value' );
 
-	x = new Array( 240 );
-	for ( i = 0; i < x.length; i++ ) {
+	x = [];
+	for ( i = 0; i < 240; i++ ) {
 		sign = randu();
 		if ( sign < 0.5 ) {
 			sign = -1.0;
 		} else {
 			sign = 1.0;
 		}
-		x[ i ] = sign * (i-5);
+		x.push( sign * (i-5) );
 	}
 
 	N = x.length - 6;
@@ -241,15 +241,15 @@ tape( 'if the stride equals `1`, the function efficiently sums the absolute valu
 	var y;
 	var i;
 
-	x = new Array( 100 );
-	for ( i = 0; i < x.length; i++ ) {
+	x = [];
+	for ( i = 0; i < 100; i++ ) {
 		sign = randu();
 		if ( sign < 0.5 ) {
 			sign = -1.0;
 		} else {
 			sign = 1.0;
 		}
-		x[ i ] = sign * (i+1);
+		x.push( sign * (i+1) );
 	}
 
 	y = gasum( x.length, toAccessorArray( x ), 1, 0 );
@@ -257,15 +257,15 @@ tape( 'if the stride equals `1`, the function efficiently sums the absolute valu
 	// Compare to closed-form formula:
 	t.strictEqual( y, x.length*(x.length+1)/2, 'returns expected value' );
 
-	x = new Array( 240 );
-	for ( i = 0; i < x.length; i++ ) {
+	x = [];
+	for ( i = 0; i < 240; i++ ) {
 		sign = randu();
 		if ( sign < 0.5 ) {
 			sign = -1.0;
 		} else {
 			sign = 1.0;
 		}
-		x[ i ] = sign * (i-5);
+		x.push( sign * (i-5) );
 	}
 
 	N = x.length - 6;


### PR DESCRIPTION
This is an independent contribution. I am not affiliated with the hackathon or any competition.

**Summary**

Replaces `new Array()` constructor calls with array literals and `.push()` in the `@stdlib/blas/base/gasum` test file to comply with the `stdlib/no-new-array` ESLint rule.

**Root Cause**

The automated JavaScript linting workflow detected 4 instances where `new Array( 100 )` and `new Array( 240 )` were used instead of array literals with `.push()`.

**Fix**

- Replaced `x = new Array( 100 )` with `x = []` and index-based assignment `x[ i ] = ...` with `x.push( ... )`.
- Replaced `x = new Array( 240 )` with `x = []` and index-based assignment `x[ i ] = ...` with `x.push( ... )`.
- Updated loop bounds from `x.length` to the explicit array size to maintain correctness after switching from pre-allocated arrays.

The same pattern was fixed in both test blocks (standard and accessor variants), resolving all 4 lint violations.

**Testing**

- Changes are limited to test file `test/test.ndarray.js`.
- Test logic is semantically identical — the same values are produced in the same order.
- Verified via manual inspection of the generated array contents.

Resolves #12222