### PR TITLE
bench: add benchmarks to `@stdlib/object/any-own-by`

### DIFF
--- a/lib/node_modules/@stdlib/object/any-own-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/object/any-own-by/benchmark/benchmark.js
@@ -1,0 +1,137 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var anyOwnBy = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var bool;
+	var obj;
+	var i;
+
+	function predicate( v ) {
+		return isnan( v );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		obj = {
+			'a': i,
+			'b': i+1,
+			'c': i+2,
+			'd': i+3,
+			'e': i+4,
+			'f': NaN
+		};
+		bool = anyOwnBy( obj, predicate );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::built-in', pkg ), function benchmark( b ) {
+	var bool;
+	var keys;
+	var obj;
+	var i;
+
+	function predicate( v ) {
+		return isnan( v );
+	}
+	function testPredicate( key ) {
+		return predicate( obj[ key ] );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		obj = {
+			'a': i,
+			'b': i+1,
+			'c': i+2,
+			'd': i+3,
+			'e': i+4,
+			'f': NaN
+		};
+		keys = Object.keys( obj );
+		bool = keys.some( testPredicate );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::loop', pkg ), function benchmark( b ) {
+	var bool;
+	var keys;
+	var obj;
+	var i;
+	var j;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		obj = {
+			'a': i,
+			'b': i+1,
+			'c': i+2,
+			'd': i+3,
+			'e': i+4,
+			'f': NaN
+		};
+		keys = Object.keys( obj );
+		bool = false;
+		for ( j = 0; j < keys.length; j++ ) {
+			if ( isnan( obj[ keys[j] ] ) ) {
+				bool = true;
+				break;
+			}
+		}
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should be a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/object/any-own-by/package.json
+++ b/lib/node_modules/@stdlib/object/any-own-by/package.json
@@ -15,6 +15,7 @@
   ],
   "main": "./lib",
   "directories": {
+    "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
     "lib": "./lib",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds a missing benchmark suite to `@stdlib/object/any-own-by`, the sole member of the `@stdlib/object` namespace that shipped no benchmarks. The package was surfaced by a cross-package drift sweep over all 26 namespace members.

### Namespace summary

-   **Namespace:** `@stdlib/object` — 26 members, none autogenerated.
-   **Features analyzed:** file tree, `package.json` shape, `README.md` section list and ordering, `manifest.json` shape, and test/benchmark/example file naming (structural); public signature, return kind, validation prologue, error-construction style, JSDoc shape, and dependency set (semantic).
-   **Features with a clear majority (≥75%):** presence of `benchmark/benchmark.js` (25/26) and `lib/main.js` (25/26); the seven universal files `README.md`, `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, `examples/index.js`, `lib/index.js`, `test/test.js` (26/26); the 18-key `package.json` top-level set (26/26); `README.md` sections `Usage`/`Examples` (26/26), `Notes` (21/26), `See Also` (20/26); `returnKind` = `value` (24/26); `errorConstruction` = `format` (23/26); `@example` present (26/26).
-   **Features without a clear majority (excluded):** public signature and validation prologue — genuinely heterogeneous across packages; the first-argument check alone splits `isObject` (8) / inline `typeof` (7) / `isObjectLike` (6), with no value reaching 75%. `README.md` section *order* showed no divergence.

### `@stdlib/object/any-own-by`

The package was the sole outlier in the `@stdlib/object` namespace lacking a `benchmark/` directory, which is present in 96% of non-tooling stdlib packages shipping a `lib/main.js` implementation. Added `benchmark/benchmark.js` modeled on the `@stdlib/object/any-in-by` sibling, timing the predicate path against an `Object.keys` + `Array#some` baseline and a manual-loop baseline over own enumerable properties. Added the corresponding `"benchmark": "./benchmark"` entry to the `directories` field in `package.json`, aligning with all 25 namespace siblings that ship benchmarks.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   Structural features were extracted from the filesystem and from `package.json`/`README.md` strings for all 26 members.
-   Semantic features (signature, return kind, validation prologue, error construction, JSDoc shape, dependencies) were extracted by one agent per package.
-   The single surviving outlier was put through three-agent drift validation (opus semantic-review, opus cross-reference, sonnet structural-review); all returned `confirmed-drift`. Cross-reference confirmed that no test or example references a benchmark, so adding the file changes nothing in the test/example/API surface.
-   The new `benchmark/benchmark.js` is structurally identical to the validated sibling `@stdlib/object/any-in-by` benchmark; the predicate logic was exercised directly. The full benchmark harness could not be run in the build environment because an external dependency (`debug`) is not installed — this affects every benchmark in the repository equally, including the existing sibling benchmarks.
-   Open-PR collision and 14-day cross-run dedup checks against `@stdlib/object` returned no hits.

Deliberately excluded:

-   `errorConstruction` outliers `common-keys` / `common-keys-in` (`plain-string` vs the namespace's `format` majority): intentional. Their only thrown error is a placeholder-free static "insufficient arguments" arity message; stdlib-wide, such static messages are thrown as a plain `new Error` (23 occurrences) far more often than wrapped in `format()` (2, both interpolating `%u`). Normalizing would add a needless dependency without changing behavior.
-   `ctor` (`plain-string`, no `@stdlib/string/format` dependency): a thin wrapper around the global `Object` constructor that throws nothing — there is no error path to normalize.
-   `assign` / `assign-in` (`returnKind` = `mutates-arg`): mutate-and-return-the-target is the defining, documented contract of an `assign` operation, not drift. `assign` also legitimately lacks `lib/main.js` owing to its builtin/polyfill architecture.
-   `README.md` `## See Also` sections: generator-owned, out of scope.
-   Missing `README.md` `## Notes` sections (5 packages): a majority exists (21/26), but the fix requires authored, package-specific prose rather than a mechanical change.
-   The `__stdlib__` key unique to `ctor`'s `package.json`: removal is not a supported additive correction and the key may be intentional metadata.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated cross-package API drift sweep run by Claude Code. Structural and semantic features were extracted from all 26 members of `@stdlib/object`, the per-feature majority pattern was computed at a 75% threshold, and the single surviving outlier was validated by three independent review agents before any file was created. The added `benchmark/benchmark.js` is modeled on the validated sibling `@stdlib/object/any-in-by`; no behavior, signatures, or test expectations changed. A maintainer should audit the change before promoting this PR from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GySEuVHeFe1WgohBinVeLK)_