### PR TITLE
test: correct typos and errors in `blas/ext/base/dediff`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/README.md
@@ -59,8 +59,8 @@ The function has the following parameters:
 -   **prepend**: a [`Float64Array`][@stdlib/array/float64] containing values to prepend after computing differences.
 -   **strideP**: stride length for `prepend`.
 -   **N2**: number of indexed elements to `append`.
--   **append**: a [`Float64Array`][@stdlib/array/float64] containing values to append after computing differences..
--   **strideA**: strides length for `append`.
+-   **append**: a [`Float64Array`][@stdlib/array/float64] containing values to append after computing differences.
+-   **strideA**: stride length for `append`.
 -   **out**: output [`Float64Array`][@stdlib/array/float64]. Must have `N + N1 + N2 - 1` indexed elements.
 -   **strideOut**: stride length for `out`.
 
@@ -241,7 +241,7 @@ The function accepts the following arguments:
 -   **strideP**: `[in] CBLAS_INT` stride length for `Prepend`.
 -   **N2**: `[in] CBLAS_INT` number of indexed elements to append.
 -   **Append**: `[in] double` a [`Float64Array`][@stdlib/array/float64] containing values to append after computing differences.
--   **strideA**: `[in] CBLAS_INT` strides length for `Append`.
+-   **strideA**: `[in] CBLAS_INT` stride length for `Append`.
 -   **Out**: `[out] double` output [`Float64Array`][@stdlib/array/float64]. Must have `N + N1 + N2 - 1` indexed elements.
 -   **strideOut**: `[in] CBLAS_INT` stride length for `Out`.
 
@@ -263,7 +263,7 @@ const double p[] = { 1.0 };
 const double a[] = { 11.0 };
 double out[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
-stdlib_strided_dediff_ndarray( 5, 1, x, 1, 0, 1, p, 1, 0, 1, a, 1, 0, out, 1, 0 );
+stdlib_strided_dediff_ndarray( 5, x, 1, 0, 1, p, 1, 0, 1, a, 1, 0, out, 1, 0 );
 ```
 
 The function accepts the following arguments:
@@ -278,7 +278,7 @@ The function accepts the following arguments:
 -   **offsetP**: `[in] CBLAS_INT` starting index for `Prepend`.
 -   **N2**: `[in] CBLAS_INT` number of indexed elements to append.
 -   **Append**: `[in] double` a [`Float64Array`][@stdlib/array/float64] containing values to append after computing differences.
--   **strideA**: `[in] CBLAS_INT` strides length for `Append`.
+-   **strideA**: `[in] CBLAS_INT` stride length for `Append`.
 -   **offsetA**: `[in] CBLAS_INT` starting index for `Append`.
 -   **Out**: `[out] double` output [`Float64Array`][@stdlib/array/float64]. Must have `N + N1 + N2 - 1` indexed elements.
 -   **strideOut**: `[in] CBLAS_INT` stride length for `Out`.

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/docs/repl.txt
@@ -132,7 +132,7 @@
         Stride length for `Out`.
 
     oo: integer
-        Stride length for `Out`.
+        Starting index for `Out`.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/docs/types/index.d.ts
@@ -82,7 +82,7 @@ interface Routine {
 	* dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, 1, 0, out, 1, 0 );
 	* // out => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 22.0 ]
 	*/
-	ndarray	( N: number, x: Float64Array, strideX: number, offsetX: number, N1: number, prepend: Float64Array, strideP: number, offsetP: number, N2: number, append: Float64Array, strideA: number, offsetA: number, out: Float64Array, strideOut: number, offsetOut: number ): Float64Array;
+	ndarray( N: number, x: Float64Array, strideX: number, offsetX: number, N1: number, prepend: Float64Array, strideP: number, offsetP: number, N2: number, append: Float64Array, strideA: number, offsetA: number, out: Float64Array, strideOut: number, offsetOut: number ): Float64Array;
 }
 
 /**

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/docs/types/test.ts
@@ -149,7 +149,7 @@ import dediff = require( './index' );
 	dediff( x.length, x, 1, 1, p, 1, ( x: number ): number => x, a, 1, out, 1 ); // $ExpectError
 }
 
-// The compiler throws an error if the function is provided an eigth argument which is not a Float64Array...
+// The compiler throws an error if the function is provided an eighth argument which is not a Float64Array...
 {
 	const x = new Float64Array( 10 );
 	const p = new Float64Array( 1 );
@@ -243,7 +243,7 @@ import dediff = require( './index' );
 	const a = new Float64Array( 1 );
 	const out = new Float64Array( 11 );
 
-	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, 1, 0, out, 1 ); // $ExpectType Float64Array
+	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, 1, 0, out, 1, 0 ); // $ExpectType Float64Array
 }
 
 // The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
@@ -364,7 +364,7 @@ import dediff = require( './index' );
 	dediff.ndarray( x.length, x, 1, 0, 1, p, ( x: number ): number => x, 0, 1, a, 1, 0, out, 1, 0 ); // $ExpectError
 }
 
-// The compiler throws an error if the `ndarray` method is provided an eigth argument which is not a number...
+// The compiler throws an error if the `ndarray` method is provided an eighth argument which is not a number...
 {
 	const x = new Float64Array( 10 );
 	const p = new Float64Array( 1 );
@@ -431,7 +431,7 @@ import dediff = require( './index' );
 	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, ( x: number ): number => x, 0, out, 1, 0 ); // $ExpectError
 }
 
-// The compiler throws an error if the `ndarray` method is provided a twelveth argument which is not a number...
+// The compiler throws an error if the `ndarray` method is provided a twelfth argument which is not a number...
 {
 	const x = new Float64Array( 10 );
 	const p = new Float64Array( 1 );
@@ -509,15 +509,15 @@ import dediff = require( './index' );
 	dediff.ndarray( x.length ); // $ExpectError
 	dediff.ndarray( x.length, x ); // $ExpectError
 	dediff.ndarray( x.length, x, 1 ); // $ExpectError
-	dediff.ndarray( x.length, x, 1 ); // $ExpectError
+	dediff.ndarray( x.length, x, 1, 0 ); // $ExpectError
 	dediff.ndarray( x.length, x, 1, 0, 1 ); // $ExpectError
 	dediff.ndarray( x.length, x, 1, 0, 1, p ); // $ExpectError
 	dediff.ndarray( x.length, x, 1, 0, 1, p, 1 ); // $ExpectError
-	dediff.ndarray( x.length, x, 1, 0, 1, p, 1 ); // $ExpectError
+	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0 ); // $ExpectError
 	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1 ); // $ExpectError
 	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a ); // $ExpectError
 	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, 1 ); // $ExpectError
-	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, 1 ); // $ExpectError
+	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, 1, 0 ); // $ExpectError
 	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, 1, 0, out ); // $ExpectError
 	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, 1, 0, out, 1 ); // $ExpectError
 	dediff.ndarray( x.length, x, 1, 0, 1, p, 1, 0, 1, a, 1, 0, out, 1, 0, {} ); // $ExpectError

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/test/test.dediff.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/test/test.dediff.js
@@ -38,7 +38,7 @@ tape( 'the function has an arity of 11', function test( t ) {
 	t.end();
 });
 
-tape( 'the function calculate differences between consecutive elements of a double-precision floating-point strided array', function test( t ) {
+tape( 'the function calculates differences between consecutive elements of a double-precision floating-point strided array', function test( t ) {
 	var expected;
 	var out;
 	var x;
@@ -63,7 +63,7 @@ tape( 'the function calculate differences between consecutive elements of a doub
 		35.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -93,7 +93,7 @@ tape( 'if the sum of the `N`, `N1`, and `N2` parameters is less than or equal to
 		0.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -126,7 +126,7 @@ tape( 'the function supports stride parameters', function test( t ) {
 		45.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -159,7 +159,7 @@ tape( 'the function supports negative stride parameters', function test( t ) {
 		25.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/test/test.dediff.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/test/test.dediff.native.js
@@ -47,7 +47,7 @@ tape( 'the function has an arity of 11', opts, function test( t ) {
 	t.end();
 });
 
-tape( 'the function calculate differences between consecutive elements of a double-precision floating-point strided array', opts, function test( t ) {
+tape( 'the function calculates differences between consecutive elements of a double-precision floating-point strided array', opts, function test( t ) {
 	var expected;
 	var out;
 	var x;
@@ -72,7 +72,7 @@ tape( 'the function calculate differences between consecutive elements of a doub
 		35.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -102,7 +102,7 @@ tape( 'if the sum of the `N`, `N1`, and `N2` parameters is less than or equal to
 		0.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -135,7 +135,7 @@ tape( 'the function supports stride parameters', opts, function test( t ) {
 		45.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -168,7 +168,7 @@ tape( 'the function supports negative stride parameters', opts, function test( t
 		25.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/test/test.ndarray.js
@@ -38,7 +38,7 @@ tape( 'the function has an arity of 15', function test( t ) {
 	t.end();
 });
 
-tape( 'the function calculate differences between consecutive elements of a double-precision floating-point strided array', function test( t ) {
+tape( 'the function calculates differences between consecutive elements of a double-precision floating-point strided array', function test( t ) {
 	var expected;
 	var out;
 	var x;
@@ -63,7 +63,7 @@ tape( 'the function calculate differences between consecutive elements of a doub
 		35.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -93,7 +93,7 @@ tape( 'if the sum of the `N`, `N1`, and `N2` parameters is less than or equal to
 		0.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -126,7 +126,7 @@ tape( 'the function supports stride parameters', function test( t ) {
 		45.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -159,7 +159,7 @@ tape( 'the function supports negative stride parameters', function test( t ) {
 		25.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/test/test.ndarray.native.js
@@ -47,7 +47,7 @@ tape( 'the function has an arity of 15', opts, function test( t ) {
 	t.end();
 });
 
-tape( 'the function calculate differences between consecutive elements of a double-precision floating-point strided array', opts, function test( t ) {
+tape( 'the function calculates differences between consecutive elements of a double-precision floating-point strided array', opts, function test( t ) {
 	var expected;
 	var out;
 	var x;
@@ -72,7 +72,7 @@ tape( 'the function calculate differences between consecutive elements of a doub
 		35.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -102,7 +102,7 @@ tape( 'if the sum of the `N`, `N1`, and `N2` parameters is less than or equal to
 		0.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -135,7 +135,7 @@ tape( 'the function supports stride parameters', opts, function test( t ) {
 		45.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });
@@ -168,7 +168,7 @@ tape( 'the function supports negative stride parameters', opts, function test( t
 		25.0
 	]);
 	t.deepEqual( o, expected, 'returns expected value' );
-	t.strictEqual( out, o, 'return expected value' );
+	t.strictEqual( out, o, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-05-20 12:04 and 2026-05-20 21:06 (PDT).

This pull request is the output of an automated review of the 18 commits merged to `develop` in that window (`24639c346`…`e1dd43fdd`). Every validated, high-signal issue was grouped by package and committed separately. All findings landed in a single package — `blas/ext/base/dediff`, added in `e46390e26`:

### `blas/ext/base/dediff`

-   Removed a stray trailing period from the `append` parameter description in `README.md` (`differences..` → `differences.`). [`e46390e26`]
-   Corrected the `strideA` parameter description in `README.md`: three occurrences read "strides length" (plural) — one in the JS API list and two in the C API lists — inconsistent with the singular "stride length" used by every other stride parameter; changed all three. [`e46390e26`]
-   Fixed the `stdlib_strided_dediff_ndarray` C usage example in `README.md`, which passed 16 arguments — a stray `1` immediately after `N` — for a 15-parameter function; removed the stray argument to match the signature and the sibling `sediff` example. [`e46390e26`]
-   Corrected the `oo` parameter in `docs/repl.txt`, documented as "Stride length for `Out`" (a copy of the `so` stride entry); it is the output starting index, so changed it to "Starting index for `Out`". [`e46390e26`]
-   Removed a stray tab between the `ndarray` method name and its parameter list in the interface declaration in `docs/types/index.d.ts`. [`e46390e26`]
-   Corrected the misspelling "eigth" → "eighth" in two test comments in `docs/types/test.ts`. [`e46390e26`]
-   Corrected the misspelling "twelveth" → "twelfth" in a test comment in `docs/types/test.ts`. [`e46390e26`]
-   Fixed the positive (`$ExpectType`) declaration test for `dediff.ndarray` in `docs/types/test.ts`, which passed only 14 arguments and omitted the required final `offsetOut`; added the missing argument to match the 15-parameter signature. [`e46390e26`]
-   Replaced three duplicated stubs in the `ndarray` "unsupported number of arguments" `$ExpectError` block in `docs/types/test.ts`, which left the 4-, 8-, and 12-argument cases untested; the block now steps through every arity, consistent with the sibling `sediff` and `ddiff` test files. [`e46390e26`]
-   Fixed subject-verb disagreement in a test description ("the function calculate" → "calculates") across the four `dediff` test files (`test/test.dediff.js`, `test.ndarray.js`, `test.dediff.native.js`, `test.ndarray.native.js`). [`e46390e26`]
-   Corrected 16 `t.strictEqual` assertion messages across the four `dediff` test files from "return expected value" to "returns expected value", matching the adjacent `t.deepEqual` messages. [`e46390e26`]

## Related Issues

None.

## Questions

No.

## Other

### Validation

**Reviewed:** all 18 commits merged to `develop` in the window (`24639c346`…`e1dd43fdd`), via the union diff and per-commit diffs. Four independent review passes were run — two stdlib code-style compliance audits (changed code compared against the established sibling packages `ddiff`/`sdiff`/`gdiff` and the guidelines under `docs/style-guides`), one diff-only bug scan, and one correctness/security pass over the introduced code (C source, JS lib, declarations, tests).

**Checked:**

-   stdlib code-style compliance for every changed file.
-   Objective runtime bugs and copy-paste artifacts across the three new BLAS extension packages (`dediff`, `sediff`, `zdiff`), plus the `ndarray/base/order` logic fix.
-   The mechanical benchmark `format(...)` refactor (~80 files) for specifier/argument mismatches — none found.

**Deliberately excluded:**

-   Subjective concerns, style preferences not mandated by a style guide, and "might be" issues requiring interpretation.
-   One candidate flagged by a single reviewer — an unguarded `X[offsetX]` read in the new `dediff`/`sediff` C `*_ndarray` routines when `N == 0` — was dropped. `N == 0` is not a valid input under the package's `N + N1 + N2 - 1` output-size contract, the second bug reviewer cleared the same code, and a complete fix would require redesigning the package, outside the scope of this window's diff.

This PR is intentionally left in **draft** for a maintainer to audit and promote.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was produced end-to-end by an automated Claude Code review routine. Claude enumerated the 24-hour commit window on `develop`, ran four independent review passes, validated every finding against the affected files and sibling packages, applied the fixes, and drafted this description. All changes are mechanical typo, documentation, and test corrections confined to a single package. A human maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01EggYBTRpKyCrCRdvMq9fvC)_