### PR TITLE
docs: fix offset parameter wording in `blas/ext/base/*sort2*` READMEs

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dsort2ins/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsort2ins/README.md
@@ -122,7 +122,7 @@ The function has the following additional parameters:
 -   **offsetX**: `x` starting index.
 -   **offsetY**: `y` starting index.
 
-While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, the offset parameter supports indexing semantics based on a starting index. For example, to access only the last three elements of `x`
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, offset parameters support indexing semantics based on starting indices. For example, to access only the last three elements of `x`
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );

--- a/lib/node_modules/@stdlib/blas/ext/base/ssort2hp/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssort2hp/README.md
@@ -122,7 +122,7 @@ The function has the following additional parameters:
 -   **offsetX**: `x` starting index.
 -   **offsetY**: `y` starting index.
 
-While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, the offset parameter supports indexing semantics based on a starting index. For example, to access only the last three elements of `x`
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, offset parameters support indexing semantics based on starting indices. For example, to access only the last three elements of `x`
 
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );

--- a/lib/node_modules/@stdlib/blas/ext/base/ssort2sh/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssort2sh/README.md
@@ -122,7 +122,7 @@ The function has the following additional parameters:
 -   **offsetX**: `x` starting index.
 -   **offsetY**: `y` starting index.
 
-While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, the offset parameter supports indexing semantics based on a starting index. For example, to access only the last three elements of `x`
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, offset parameters support indexing semantics based on starting indices. For example, to access only the last three elements of `x`
 
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );


### PR DESCRIPTION
## Description

This pull request propagates a documentation fix merged to `develop` on 2026-05-20 to sibling packages exhibiting the same defect.

Source commit `618583c83` ("docs: update copy") corrected the `@stdlib/blas/ext/base/dediff` README, which referred to the package's multiple offset parameters in the singular ("the offset parameter ... a starting index"). The same wording is present in three `sort2` sibling packages, each of which documents two offset parameters (`offsetX` and `offsetY`):

-   `blas/ext/base/dsort2ins`
-   `blas/ext/base/ssort2hp`
-   `blas/ext/base/ssort2sh`

Each README is updated to the plural phrasing already used by sibling packages such as `dediff` and `ssort2ins`.

## Related Issues

None.

## Questions

No.

## Other

Search was scoped to `blas/ext/base`. Single-offset packages, where the singular phrasing is correct, were deliberately excluded; the three `sort2` packages above are the only siblings documenting multiple offset parameters that still used the singular wording. The change is a verbatim string replacement; two independent reviews confirmed each target package documents multiple offset parameters before the change was applied.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was prepared by an automated fix-propagation routine running with Claude Code. The routine identified the documentation fix in commit `618583c83`, located sibling packages with the same wording error, and applied the equivalent correction. Two independent reviews verified each target package documents multiple offset parameters before the change was applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018DFBWqSBUuSoS8tghunVsH)_