### PR TITLE
style: fix spacing in multiline arrays

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/drotm/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/drotm/test/test.ndarray.js
@@ -287,20 +287,20 @@ tape( 'the function applies a plane rotation', function test( t ) {
 
 	drotm( 3, x, 2, 0, y, 2, 0, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		-18.0, // 0
 		2.0,
 		-24.0, // 1
 		4.0,
 		-30.0  // 2
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		2.0, // 0
 		7.0,
 		6.0, // 1
 		9.0,
 		10.0 // 2
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -323,20 +323,20 @@ tape( 'the function applies a plane rotation', function test( t ) {
 
 	drotm( 2, x, 3, 0, y, 3, 0, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		6.0, // 0
 		2.0,
 		3.0,
 		9.0, // 1
 		5.0
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		-1.0, // 0
 		7.0,
 		8.0,
 		-4.0, // 1
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -370,20 +370,20 @@ tape( 'the function supports an `x` stride', function test( t ) {
 
 	drotm( 2, x, 2, 0, y, 1, 0, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		-17.0, // 0
 		2.0,
 		-18.0, // 1
 		4.0,
 		5.0
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		8.0,  // 0
 		13.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -406,20 +406,20 @@ tape( 'the function supports an `x` stride', function test( t ) {
 
 	drotm( 2, x, 3, 0, y, 1, 0, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		-18.0, // 0
 		2.0,
 		3.0,
 		-21.0, // 1
 		5.0
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		2.0, // 0
 		8.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -477,20 +477,20 @@ tape( 'the function supports an `x` offset', function test( t ) {
 
 	drotm( 2, x, -2, 2, y, 1, 0, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		-21.0, // 1
 		2.0,
 		-18.0, // 0
 		4.0,
 		5.0
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		6.0,  // 0
 		2.0, // 1
 		8.0,
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -513,20 +513,20 @@ tape( 'the function supports an `x` offset', function test( t ) {
 
 	drotm( 3, x, -2, 4, y, 1, 0, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		8.0, // 2
 		2.0,
 		7.0, // 1
 		4.0,
 		6.0  // 0
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		-5.0, // 0
 		-3.0, // 1
 		-1.0, // 2
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -559,20 +559,20 @@ tape( 'the function supports a `y` stride', function test( t ) {
 
 	drotm( 3, x, 1, 0, y, 2, 0, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		-17.0, // 0
 		-22.0, // 1
 		-27.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		8.0,  // 0
 		7.0,
 		12.0, // 1
 		9.0,
 		16.0  // 2
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -595,20 +595,20 @@ tape( 'the function supports a `y` stride', function test( t ) {
 
 	drotm( 2, x, 1, 0, y, 3, 0, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		-18.0, // 0
 		-27.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		2.0, // 0
 		7.0,
 		8.0,
 		4.0, // 1
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 1.0 );
 	isApprox( t, y, ye, 1.0 );
@@ -666,20 +666,20 @@ tape( 'the function supports a `y` offset', function test( t ) {
 
 	drotm( 2, x, 1, 0, y, -2, 2, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		8.0, // 0
 		6.0, // 1
 		3.0,
 		4.0,
 		5.0
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		-2.0, // 1
 		7.0,
 		-1.0, // 0
 		9.0,
 		10.0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );
@@ -702,20 +702,20 @@ tape( 'the function supports a `y` offset', function test( t ) {
 
 	drotm( 3, x, 1, 0, y, -2, 4, param );
 
-	xe = new Float64Array( [
+	xe = new Float64Array([
 		-30.0, // 0
 		-24.0, // 1
 		-18.0, // 2
 		4.0,
 		5.0
-	] );
-	ye = new Float64Array( [
+	]);
+	ye = new Float64Array([
 		6.0, // 2
 		7.0,
 		4.0, // 1
 		9.0,
 		2.0  // 0
-	] );
+	]);
 
 	isApprox( t, x, xe, 2.0 );
 	isApprox( t, y, ye, 2.0 );


### PR DESCRIPTION
Resolves #12222.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes 40 ESLint violations in `@stdlib/blas/base/drotm` `test/test.ndarray.js` reported by the lint CI workflow (run 26197800347) on the `develop` branch

The violations were:

-   20 `stdlib/eol-open-bracket-spacing` errors — multiline `xe`/`ye` expected-value arrays used `new Float64Array( [` (space before `[` at end of line), which the rule disallows
-   20 `stdlib/line-closing-bracket-spacing` errors — the corresponding closing lines used `] );` (space before `)` at start of line), which the companion rule disallows

The fix removes the spaces so the bracket style matches the `x`/`y` input arrays already present in the same file, which already used the correct no-space multiline form.

**Note for reviewers:** Three sibling test files (`test.drotm.js`, `test.drotm.native.js`, `test.ndarray.native.js`) contain approximately 60 identical latent violations using the same wrong pattern. Those files are out of scope for this PR but may be worth addressing in a follow-up.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #12222

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

CI workflow run that surfaced the failures: https://github.com/stdlib-js/stdlib/actions/runs/26197800347

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code. An automated CI-fix routine identified the lint failures from issue #12222, read the ESLint rule source to confirm the correct bracket-spacing semantics for multiline arrays, applied a targeted regex substitution to remove only the 40 offending spaces in the xe/ye expected-value arrays, and validated the change via three independent review passes before committing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtJ3Y6dGfAHY1CSxwhTSu8)_