### PR TITLE
docs(remark-run-javascript-examples): correct jsdoc example

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/index.js
@@ -28,24 +28,6 @@
 * var run = require( '@stdlib/_tools/remark/plugins/remark-run-javascript-examples' );
 *
 * var str = [
-*     '<section class="usage">',
-*     '',
-*     '## Usage',
-*     '',
-*     '```javascript',
-*     'var path = require( "path" );',
-*     '```',
-*     '',
-*     '#### path.posix.join( [...paths] )',
-*     '',
-*     '```javascript',
-*     'var p = path.posix.join( "foo", "bar" );',
-*     '```',
-*     '',
-*     '</section>',
-*     '',
-*     '<!-- /.usage -->',
-*     '',
 *     '<section class="examples">',
 *     '',
 *     '## Examples',
@@ -60,7 +42,6 @@
 * ];
 *
 * remark().use( run ).process( str.join( '\n' ), done );
-* // => 'HELLO WORLD'
 *
 * function done( error ) {
 *     if ( error ) {


### PR DESCRIPTION
Resolves #12236.

## Description

> What is the purpose of this pull request?

This pull request:

-   Removes a spurious `<section class="usage">` block from the `@example` JSDoc tag in `remark-run-javascript-examples/lib/index.js` that caused `stdlib/jsdoc-main-export` to fire a false positive by placing a `require( "path" )` string literal after the main export's actual `require()` call.
-   Removes the `// => 'HELLO WORLD'` return-value annotation from the same example, which caused `stdlib/jsdoc-doctest` to assert the processor call returns a string rather than the remark processor object.

## Related Issues

> Does this pull request have any related issues?

-   #12236

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

**Failing CI:** [workflow run 26260926243](https://github.com/stdlib-js/stdlib/actions/runs/26260926243) (2026-05-22T00:33:27Z, branch `develop`).

**Error 1 — `stdlib/jsdoc-main-export`**

Symptom: "Example code of main export should require itself last."

Root cause: The `str` array in the example contained the string literal `'var path = require( "path" );'`. The lint rule locates the main export's `require()` by calling `lastIndexOf('require(')` on the raw tag description. That substring appeared inside the string literal at a higher offset than the actual `require()` call for the main export, so `match.index !== lastIndexOf('require(')` evaluated to `true` and the rule erroneously flagged the file.

Fix: Removed the 14-line `<section class="usage">` block containing the offending string literal.

**Error 2 — `stdlib/jsdoc-doctest`**

Symptom: "Displayed return value is `'HELLO WORLD'`, but expected `function processor() {...}`."

Root cause: The `// => 'HELLO WORLD'` annotation asserted that `remark().use(run).process()` returns the string `'HELLO WORLD'`. The call actually returns the remark processor object.

Fix: Removed the `// => 'HELLO WORLD'` line.

**Validation:** Three independent review agents (two opus, one sonnet) approved the diff or returned non-blocking findings only.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code as part of an automated CI-fix routine. The fix was validated by three independent review agents (two opus, one sonnet) before committing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018kNewQxiXkenYZgV9YhaEc)_