### PR TITLE
docs: improve doctests for ndarray instances in `ndarray/fill`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/fill/README.md
+++ b/lib/node_modules/@stdlib/ndarray/fill/README.md
@@ -42,20 +42,16 @@ Fills an input [`ndarray`][@stdlib/ndarray/ctor] with a specified value.
 
 ```javascript
 var zeros = require( '@stdlib/ndarray/zeros' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 var x = zeros( [ 3, 1, 2 ], {
     'dtype': 'float64'
 });
 
 var y = fill( x, 10.0 );
-// returns <ndarray>
+// returns <ndarray>[ [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ] ]
 
 var bool = ( y === x );
 // returns true
-
-var arr = ndarray2array( x );
-// returns [ [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ], [ [ 10.0, 10.0 ] ] ]
 ```
 
 The function accepts the following arguments:


### PR DESCRIPTION
Progresses #9329

## Summary

- Replace the `ndarray/fill` usage doctest's explicit `ndarray2array` conversion with ndarray instance notation.
- Remove the now-unused `@stdlib/ndarray/to-array` import from that doctest.

## Impact

This keeps the example focused on the returned ndarray while preserving the existing `fill` identity check.

## Validation

- `git diff --check` - passed
- `NODE_PATH=lib/node_modules node -e "const fill=require('@stdlib/ndarray/fill'); const zeros=require('@stdlib/ndarray/zeros'); const ndarray2array=require('@stdlib/ndarray/to-array'); const x=zeros([3,1,2], {'dtype':'float64'}); const y=fill(x,10.0); if (y !== x) { throw new Error('fill did not return input ndarray'); } const expected=[[[10,10]],[[10,10]],[[10,10]]]; const actual=ndarray2array(x); if (JSON.stringify(actual)!==JSON.stringify(expected)) { throw new Error('unexpected filled values: '+JSON.stringify(actual)); }"` - passed

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)