### PR TITLE
docs: use separate `@example` tags in `time/day-of-quarter`

### DIFF
--- a/lib/node_modules/@stdlib/time/day-of-quarter/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/time/day-of-quarter/docs/types/index.d.ts
@@ -39,10 +39,12 @@
 * var day = dayOfQuarter();
 * // returns <number>
 *
-* day = dayOfQuarter( new Date() );
+* @example
+* var day = dayOfQuarter( new Date() );
 * // returns <number>
 *
-* day = dayOfQuarter( 12, 31, 2017 );
+* @example
+* var day = dayOfQuarter( 12, 31, 2017 );
 * // returns 92
 */
 declare function dayOfQuarter( month?: string | number | Date, day?: number, year?: number ): number;

--- a/lib/node_modules/@stdlib/time/day-of-quarter/lib/main.js
+++ b/lib/node_modules/@stdlib/time/day-of-quarter/lib/main.js
@@ -56,10 +56,12 @@ var LEAP_YEAR = [ 0, 91, 182, 274 ];
 * var day = dayOfQuarter();
 * // returns <number>
 *
-* day = dayOfQuarter( new Date() );
+* @example
+* var day = dayOfQuarter( new Date() );
 * // returns <number>
 *
-* day = dayOfQuarter( 12, 31, 2017 );
+* @example
+* var day = dayOfQuarter( 12, 31, 2017 );
 * // returns 92
 */
 function dayOfQuarter( month, day, year ) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   splits the grouped JSDoc `@example` block in `@stdlib/time/day-of-quarter` (`lib/main.js` and `docs/types/index.d.ts`) into three discrete `@example` tags, matching the convention used by the rest of the `@stdlib/time/*` namespace.

### Namespace summary

-   Members analyzed: 19 (all non-autogenerated packages directly under `lib/node_modules/@stdlib/time/`).
-   Features extracted: file tree, `package.json` shape, README section sequence, test/benchmark/example file naming, public signature, validation prologue, error construction, JSDoc shape, dependencies.
-   Features with a clear majority (≥75%): universal file set (`README.md`, `lib/index.js`, `package.json`, `docs/types/{index.d.ts,test.ts}`, `examples/index.js`, `test/test.js`), uniform `package.json` shape, exclusive use of `@stdlib/string/format` for error construction (100% of packages that throw), one-`@example`-per-call-site JSDoc convention (12/13 of packages with multi-example main JSDoc).
-   Features without a clear majority (excluded): README `Notes` (14/19) and `See Also` (14/19) section presence; JSDoc `@param` type order for the polymorphic `month` parameter (split across `(string|Date|integer)`, `(string|integer|Date)`, and `(integer|string|Date)` orderings without a clear winner).

### `time/day-of-quarter`

The JSDoc above `dayOfQuarter` in `lib/main.js` and the `declare function` in `docs/types/index.d.ts` collapses three distinct call sites under a single `@example` tag. The sibling `day-of-year` (same shape, same copyright year, paired implementation) and every other multi-example package in the namespace — `days-in-month`, `hours-in-month`, `minutes-in-month`, `seconds-in-month`, `days-in-year`, `hours-in-year`, `minutes-in-year`, `seconds-in-year`, `iso-weeks-in-year`, `quarter-of-year`, `duration2ms`, `ms2duration` — emits one `@example` tag per call site (12/13 = 92% conformance among multi-example packages; the broader stdlib convention is the same). Reformatted to match.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Three-stage drift validation was applied before producing this patch:

-   **Semantic review** — confirmed the deviation is not tied to anything `day-of-quarter`-specific; the paired sibling `day-of-year` uses the separate-tag style.
-   **Cross-reference** — confirmed nothing in `day-of-quarter/test/`, `day-of-quarter/examples/`, or any sibling package relies on the grouped JSDoc structure; the change is purely cosmetic.
-   **Structural review** — sampled `math/base/special/{sin,cos}`, `string/{lowercase,uppercase}`, `array/from-iterator`, `utils/{index-of,zip}` and confirmed the one-tag-per-example pattern is the broader stdlib convention.

Deliberately excluded from this PR:

-   `lib/node_modules/@stdlib/time/docs/types/index.d.ts` re-documents `dayOfQuarter` with the same grouped block — out of scope for this run since it sits in the parent `@stdlib/time` package, not the outlier package. Worth a follow-up.
-   `Notes` and `See Also` README section absence in some packages (no clear majority).
-   Benchmark directory absence (only 2/19 — far below stdlib-wide presence; not drift).
-   `bin/cli` and CLI-related files missing in `base`, `tic`, `toc` (semantically justified — sub-namespace and high-resolution-timing primitives).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a cross-package drift detection run over the `@stdlib/time` namespace: structural and semantic features were extracted per package, the majority pattern per feature identified, deviations triaged via a three-agent validation pass, and a mechanical JSDoc reformatting applied to the surviving outlier.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018xTwM6mXSFWfhfKNNcFwBp)_