### PR TITLE
fix(@stdlib/plot/components/svg): replace `new Array()` with array literal in `defs`, `background`, and `path`

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/background/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/background/lib/main.js
@@ -121,10 +121,9 @@ function Background( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
-		args[ 0 ] = 'render';
+		args = [ 'render' ];
 		for ( i = 0; i < arguments.length; i++ ) {
-			args[ i+1 ] = arguments[ i ];
+			args.push( arguments[ i ] );
 		}
 		self.emit.apply( self, args );
 	}

--- a/lib/node_modules/@stdlib/plot/components/svg/defs/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/defs/lib/main.js
@@ -76,10 +76,9 @@ function Defs() {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
-		args[ 0 ] = 'render';
+		args = [ 'render' ];
 		for ( i = 0; i < arguments.length; i++ ) {
-			args[ i+1 ] = arguments[ i ];
+			args.push( arguments[ i ] );
 		}
 		self.emit.apply( self, args );
 	}

--- a/lib/node_modules/@stdlib/plot/components/svg/path/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/path/lib/main.js
@@ -176,10 +176,9 @@ function Path( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
-		args[ 0 ] = 'render';
+		args = [ 'render' ];
 		for ( i = 0; i < arguments.length; i++ ) {
-			args[ i+1 ] = arguments[ i ];
+			args.push( arguments[ i ] );
 		}
 		self.emit.apply( self, args );
 	}


### PR DESCRIPTION
Resolves <!-- no linked issue -->.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes `stdlib/no-new-array` lint violations in three SVG plot component files by replacing `new Array( arguments.length+1 )` constructor calls with array literal plus `push()` in the `onRender` callback of each constructor

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #12244 (sibling fix for `@stdlib/plot/components/svg/canvas`)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/26260926243 (`lint_random_files`, branch `develop`, 2026-05-22T00:33:27Z)

**Symptom:** `stdlib/no-new-array` reported at error severity in three files:

-   `lib/node_modules/@stdlib/plot/components/svg/defs/lib/main.js` (line 79)
-   `lib/node_modules/@stdlib/plot/components/svg/background/lib/main.js` (line 124)
-   `lib/node_modules/@stdlib/plot/components/svg/path/lib/main.js` (line 179)

**Root cause:** Each `onRender` closure pre-allocated `args = new Array( arguments.length+1 )`, assigned `args[0] = 'render'`, and filled subsequent indices by position before calling `self.emit.apply( self, args )`. The pattern is semantically correct but violates the project rule prohibiting the `Array` constructor.

**Fix:** Replace `new Array( arguments.length+1 )` and positional index assignment with an array literal `[ 'render' ]` and a `push()` call inside the loop body. The resulting array is equivalent for all values of `arguments.length`, including zero. Total diff: 3 files, +6/-9 lines.

**Validation:** Three independent review passes confirmed correctness and no regression; the `fix:` commit type is correct (rule is set to `error`, causing CI failure); the pattern matches the fix applied to `clip-path` and mirrors PR #12244.

**Reviewer notes:** Additional sibling components (`annotations`, `axis`, `graph`, `rug`, `symbols`, `title`) contain the same `new Array` pattern and require follow-up PRs. The `clip-path` and `marks` siblings do not require changes — `clip-path` already uses the corrected pattern and `marks` does not have the violation.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated CI-fix routine. The fix was validated by three independent review agents (two opus, one sonnet) before committing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAuriKaqYCGnC2jvsaqFGW)_