### PR TITLE
docs: fix scale parameter reference in `@stdlib/stats/base/dists/levy/entropy`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Returns the differential entropy for a Lévy distribution with location `mu` and scale `s`.
+* Returns the differential entropy for a Lévy distribution with location `mu` and scale `c`.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/lib/main.js
@@ -35,7 +35,7 @@ var PI_TIMES_SIXTEEN = 16.0 * PI;
 // MAIN //
 
 /**
-* Returns the differential entropy for a Lévy distribution with location `mu` and scale `s`.
+* Returns the differential entropy for a Lévy distribution with location `mu` and scale `c`.
 *
 * @param {number} mu - location parameter
 * @param {PositiveNumber} c - scale parameter


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   corrects the JSDoc description in `@stdlib/stats/base/dists/levy/entropy` to reference the scale parameter as `c`, matching the function signature and the convention used by the other 10 of 11 sibling packages under `@stdlib/stats/base/dists/levy/*` (91% conformance).

### `entropy`

The description in `lib/main.js` and `docs/types/index.d.ts` referenced the scale parameter as `s`, but the function signature names it `c`. The `s` is a copy-paste artifact from sibling distributions whose scale parameter is genuinely named `s` (e.g., `logistic`, `frechet`). Two-line fix; no behavior, signature, or test change.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The same typo is propagated into the parent aggregator `lib/node_modules/@stdlib/stats/base/dists/levy/docs/types/index.d.ts` (line 73). That file is outside this PR's scope (sibling-package drift only); leaving as a separate follow-up.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via an automated cross-package drift-detection routine: structural and semantic features were extracted across the 12 child packages of `@stdlib/stats/base/dists/levy/`, the majority pattern per feature was identified, and `entropy`'s JSDoc description was flagged as the lone deviator (1 of 11) on the scale-parameter reference. The fix was applied mechanically and validated against sibling source.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhLrSkm3do4bbQmtEhpYGU)_