### PR TITLE
refactor: use `main` as require alias in `stats/base/dists/frechet`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;


### PR DESCRIPTION
## Description

Normalizes the `require( './main.js' )` alias in three `lib/index.js` files under `stats/base/dists/frechet` from the package-name form (e.g. `var mean = ...`) to the canonical `var main = ...` form, with matching `module.exports` updates. Internal-only rename: the exported value is unchanged.

### Namespace summary

- **Target namespace:** `@stdlib/stats/base/dists/frechet`
- **Members:** 14, all hand-written (no autogenerated packages)
- **Features analyzed:** file tree, `package.json` shape, README sections, `lib/` file set, `lib/index.js` require-alias variable, error-construction shape
- **Features with clear majority (≥75%):** `lib/index.js` require-alias variable (11/14 = 78.6% use `var main`)
- **Features without clear majority:** none material; native-binding presence (12/14) was excluded because adding a native binding is not a mechanical fix and the absences (`ctor`, `pdf`) are intentional (constructor; trivial `exp(logpdf(...))` wrapper)

### Per outlier package

#### `stats/base/dists/frechet/mean`

Renames the local alias in `lib/index.js` from `mean` to `main` to match the canonical wrapper-module convention used by the remaining sibling packages under `stats/base/dists/frechet` and throughout the `stats/base/dists` ecosystem. No functional changes; export behavior is unchanged.

#### `stats/base/dists/frechet/median`

Renames the local alias in `lib/index.js` from `median` to `main` to match the canonical wrapper-module convention used across the `stats/base/dists` ecosystem. Purely cosmetic and does not affect the exported API or runtime behavior.

#### `stats/base/dists/frechet/mode`

Renames the local alias in `lib/index.js` from `mode` to `main` to align with the canonical wrapper-module convention used by 11 of 14 sibling packages under `stats/base/dists/frechet` and approximately 78% of packages across the `stats/base/dists` ecosystem. No functional changes; export behavior is unchanged.

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural extraction:** filesystem walk and string-level scan of every member's `package.json`, README headings, `lib/`, `test/`, `benchmark/`, `examples/`, and `docs/` trees.
- **Semantic extraction:** error-construction pattern (uniformly `format` for the one package that throws — `ctor`; the distribution functions return `NaN` on invalid input).
- **Three-agent drift validation:** semantic-review, cross-reference, and structural-review agents independently confirmed the rename is mechanical, the `var main` alias is the canonical convention, and no test / example / downstream consumer reads the exports via a named property (`.mean` / `.median` / `.mode`).
- **Ecosystem cross-check:** 398 / 505 (78%) of `stats/base/dists/*/*/lib/index.js` files already use `var main`, confirming this is the canonical convention and not a frechet-local style choice.

### Deliberately excluded

- **`pdf` package** lacks native bindings and a `## C APIs` README section: intentional — the implementation is `exp(logpdf(x, ...))`, a one-line wrapper around `logpdf`, so a native binding adds no value.
- **`ctor` package** has a distinct file tree (no native binding, no `factory.js`, different README): legitimately different — it is a stateful distribution constructor, not a scalar function.
- **Outliers whose drift would require touching tests or examples:** none in this run.
- **Features without a clear ≥75% majority:** none in this namespace beyond those documented above.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running a cross-package drift-detection routine: extract structural/semantic features from every package in a randomly chosen namespace, identify a ≥75% majority pattern per feature, validate with three independent review agents, and apply mechanical fixes to outliers. The scope here is a purely internal `var` rename in three `lib/index.js` files. A human maintainer should confirm and promote out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pmru3jqutaMnVXjPQKFrG5)_