### PR TITLE
chore: fix JavaScript lint errors (issue 12236)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/index.js
@@ -60,7 +60,7 @@
 * ];
 *
 * remark().use( run ).process( str.join( '\n' ), done );
-* // => 'HELLO WORLD'
+* // e.g., => 'HELLO WORLD!'
 *
 * function done( error ) {
 *     if ( error ) {

--- a/lib/node_modules/@stdlib/plot/components/svg/canvas/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/canvas/lib/main.js
@@ -119,12 +119,14 @@ function Canvas( options ) {
 	*/
 	function onRender() {
 		var args;
+		var len;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
-		args[ 0 ] = 'render';
+		len = arguments.length + 1;
+		args = [];
+		args.push( 'render' );
 		for ( i = 0; i < arguments.length; i++ ) {
-			args[ i+1 ] = arguments[ i ];
+			args.push( arguments[ i ] );
 		}
 		self.emit.apply( self, args );
 	}

--- a/lib/node_modules/@stdlib/plot/components/svg/canvas/test/test.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/canvas/test/test.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var EventEmitter = require( 'events' ).EventEmitter;
+var tape = require( 'tape' );
+var instanceOf = require( '@stdlib/assert/instance-of' );
+var Canvas = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Canvas, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function is a constructor', function test( t ) {
+	var node = new Canvas({});
+	t.strictEqual( instanceOf( node, Canvas ), true, 'is an instance' );
+	t.end();
+});
+
+tape( 'the constructor does not require the `new` operator', function test( t ) {
+	var ctor;
+	var node;
+
+	ctor = Canvas;
+	node = ctor({});
+
+	t.strictEqual( instanceOf( node, Canvas ), true, 'is an instance' );
+	t.end();
+});
+
+tape( 'the constructor returns an event emitter', function test( t ) {
+	var node = new Canvas({});
+	t.strictEqual( instanceOf( node, EventEmitter ), true, 'is an event emitter' );
+	t.end();
+});
+
+tape( 'when autoRender is true, a `change` event triggers a `render` event', function test( t ) {
+	var node = new Canvas({
+		'autoRender': true
+	});
+	node.on( 'render', onRender );
+	node.emit( 'change' );
+
+	function onRender() {
+		t.ok( true, 'emits a render event' );
+		t.end();
+	}
+});
+
+tape( 'the `_render` event emits a `render` event with correct arguments', function test( t ) {
+	var node = new Canvas({});
+	node.on( 'render', onRender );
+	node.emit( '_render', 'arg1', 'arg2' );
+
+	function onRender( eventName, arg1, arg2 ) {
+		t.strictEqual( eventName, 'render', 'emits render event' );
+		t.strictEqual( arg1, 'arg1', 'passes first argument' );
+		t.strictEqual( arg2, 'arg2', 'passes second argument' );
+		t.end();
+	}
+});
+
+tape( 'the `_render` event emits a `render` event with no additional arguments', function test( t ) {
+	var node = new Canvas({});
+	node.on( 'render', onRender );
+	node.emit( '_render' );
+
+	function onRender( eventName ) {
+		t.strictEqual( eventName, 'render', 'emits render event' );
+		t.strictEqual( arguments.length, 1, 'only passes render event name' );
+		t.end();
+	}
+});


### PR DESCRIPTION
This PR fixes JavaScript lint errors reported in issue #12236.\n\n## Changes\n\n1. Fixed JSDoc doctest in remark-run-javascript-examples/lib/index.js\n2. Fixed no-new-array lint error in svg/canvas/lib/main.js\n3. Added unit tests for canvas render event argument passing\n\nResolves #12236