### PR TITLE
docs: add `C APIs` placeholder section to four `lapack/base` package READMEs

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/clacgv/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/clacgv/README.md
@@ -149,6 +149,76 @@ console.log( cx.get( cx.length-1 ).toString() );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/lapack/base/crot/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/crot/README.md
@@ -184,6 +184,76 @@ logEach( '(%s,%s) => (%s,%s)', cxc, cyc, cx, cy );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/lapack/base/zlacgv/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/zlacgv/README.md
@@ -149,6 +149,76 @@ console.log( zx.get( zx.length-1 ).toString() );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/lapack/base/zrot/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/zrot/README.md
@@ -184,6 +184,76 @@ logEach( '(%s,%s) => (%s,%s)', zxc, zyc, zx, zy );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the standard `## C APIs` placeholder section to the READMEs of four `@stdlib/lapack/base` packages that were missing it: `clacgv`, `crot`, `zlacgv`, and `zrot`. The section is present in 26 of 30 `lapack/base` packages (87% conformance), and the inserted block is byte-identical to the template used by sibling packages such as `claset`, `claswp`, `zlacpy`, and `zlaset`.

### Namespace summary

-   Namespace: `@stdlib/lapack/base`
-   Members analyzed: 30 (`shared`, `xerbla`, `dlamch`, `dlapy2`, `dlapy3` retained in the structural pass but recognized as non-array/utility packages for which several majority features are intentionally inapplicable).
-   Features with clear majority (≥75%): presence of `## C APIs` README section (87%), presence of `## Notes` README section (93%), presence of `lib/ndarray.js` (83%), presence of `test/test.ndarray.js` (83%), presence of `benchmark/benchmark.js` (93%), keyword set including `algebra`/`linear`/`math`/`stdmath`/`subroutines` (97%).
-   Features without clear majority (excluded): `browser` field in `package.json` (20%), `__stdlib__` field (20%), `lib/base.js` (70%), `gypfile` (7%).
-   Findings advanced: missing `## C APIs` section in `clacgv`, `crot`, `zlacgv`, `zrot` (4 outliers).
-   Findings dropped: missing `ndarray.js`/`test.ndarray.js`/`benchmark.ndarray.js` in `dlamch`/`dlapy2`/`dlapy3` (these are scalar operations and have no array variant by design); missing `lib/base.js` in `clacgv`/`crot`/`zlacgv`/`zrot` (these are 1D vector operations whose stride variants delegate directly to ndarray, no shared base implementation is warranted); structural differences in `shared` (types-only) and `xerbla` (LAPACK error handler) — intentional special-purpose packages.

### `lapack/base/clacgv`

The README was missing the `## C APIs` placeholder section present in 26 of 30 `lapack/base` packages (87% conformance). The standard placeholder block was inserted between `<!-- /.examples -->` and the `Related stdlib packages` comment, matching the byte-identical template used by `claset`, `claswp`, `zlacpy`, `zlaset`, and 22 other siblings. Net change is +70 lines, README only.

### `lapack/base/crot`

Adds the missing `## C APIs` placeholder section to the README. The section is absent in 4 of 30 `lapack/base` packages (87% conformance); this patch brings `crot` in line with the other 26. Inserted between `<!-- /.examples -->` and the `Related stdlib packages` comment, byte-identical to the standard template. No code or test changes.

### `lapack/base/zlacgv`

The README was missing the `## C APIs` placeholder section present in 26 of 30 `lapack/base` packages (87% conformance). The standard placeholder block was inserted between `<!-- /.examples -->` and the `Related stdlib packages` comment. Change is +70 lines, README only.

### `lapack/base/zrot`

The README for `@stdlib/lapack/base/zrot` is missing the `## C APIs` placeholder section present in 26 of 30 `lapack/base` packages (87% conformance). The fix inserts the standard C APIs placeholder block between `<!-- /.examples -->` and the `Related stdlib packages` comment. The change is +70 lines, README-only, with no code or test modifications.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   Structural extraction across all 30 packages (file tree, `package.json` keys, README section lists, `manifest.json` shape, `test/`/`benchmark/`/`examples/` file naming).
-   Semantic spot-checks for error-construction patterns (none — LAPACK base routines defer error handling to `xerbla`) and JSDoc shape (JSDoc lives on per-function files, not `main.js`).
-   Three-agent drift validation: semantic review (intentional vs. drift), cross-reference (tests/examples or sibling docs depending on the absence), structural review (template byte-identity and insertion-point unambiguity). All three agents returned `confirmed-drift` for the four outliers; the inserted block was verified byte-identical to four reference packages (`claset`, `claswp`, `zlacpy`, `zlaset`).

### Deliberate exclusions

-   `shared` and `xerbla` are excluded from drift corrections (special-purpose packages — `shared` exports include-path metadata; `xerbla` is the LAPACK error handler).
-   `dlamch`, `dlapy2`, `dlapy3` are excluded from "missing ndarray variant" findings (these operate on scalars and legitimately lack array variants).
-   `lib/base.js` was not propagated to the 4 outliers — its presence reflects 2D matrix-layout factoring, not a universal convention, and adding it would constitute a refactor rather than a mechanical drift correction.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was prepared by Claude Code as a cross-package drift detection run over the `@stdlib/lapack/base` namespace. Claude extracted structural and semantic features across all 30 packages, computed majority conformance per feature, applied three-agent validation to the surfaced outliers, and inserted a byte-identical placeholder template into the four outliers' READMEs. The inserted block matches the standard already used by 26 sibling packages — no code, tests, or examples were modified.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01TH6EFMnCnowjzMJyjtsVJD)_