### PR TITLE
docs: follow-up fixes for commits merged to `develop` on 2026-05-24

### DIFF
--- a/lib/node_modules/@stdlib/array/float64/README.md
+++ b/lib/node_modules/@stdlib/array/float64/README.md
@@ -1432,7 +1432,7 @@ console.log( arr );
 ## See Also
 
 -   <span class="package-name">[`@stdlib/array/buffer`][@stdlib/array/buffer]</span><span class="delimiter">: </span><span class="description">ArrayBuffer.</span>
--   <span class="package-name">[`@stdlib/array/float16`][@stdlib/array/float16]</span><span class="delimiter">: </span><span class="description">float16Array.</span>
+-   <span class="package-name">[`@stdlib/array/float16`][@stdlib/array/float16]</span><span class="delimiter">: </span><span class="description">Float16Array.</span>
 -   <span class="package-name">[`@stdlib/array/float32`][@stdlib/array/float32]</span><span class="delimiter">: </span><span class="description">Float32Array.</span>
 -   <span class="package-name">[`@stdlib/array/int16`][@stdlib/array/int16]</span><span class="delimiter">: </span><span class="description">Int16Array.</span>
 -   <span class="package-name">[`@stdlib/array/int32`][@stdlib/array/int32]</span><span class="delimiter">: </span><span class="description">Int32Array.</span>

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dznrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dznrm2/README.md
@@ -33,7 +33,7 @@ The [L2-norm][l2-norm] is defined as
 ```
 
 <!-- <div class="equation" align="center" data-raw-text="\|\mathbf{x}\|_2 = \sqrt{x_0^2 + x_1^2 + \ldots + x_{N-1}^2}" data-equation="eq:l2_norm">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/dznrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/ndarray/dznrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
     <br>
 </div> -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/scnrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/scnrm2/README.md
@@ -33,7 +33,7 @@ The [L2-norm][l2-norm] is defined as
 ```
 
 <!-- <div class="equation" align="center" data-raw-text="\|\mathbf{x}\|_2 = \sqrt{x_0^2 + x_1^2 + \ldots + x_{N-1}^2}" data-equation="eq:l2_norm">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/scnrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/ndarray/scnrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
     <br>
 </div> -->
 


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-05-24 01:23 PT (`f8a43f95e`) and 2026-05-24 05:54 ET (`40dad68e6`).

## Description

This pull request:

-   Cleans up three high-signal documentation defects introduced by commits merged to `develop` in the last 24 hours. Two are broken equation image paths in the new `blas/base/ndarray/dznrm2` and `blas/base/ndarray/scnrm2` packages, and one is a typed-array constructor capitalization typo in `array/float64`'s See Also block.

### Fixes by package

**`array/float64`**

-   Fix capitalization of `Float16Array` in the `@stdlib/array/float16` See Also entry in `lib/node_modules/@stdlib/array/float64/README.md`; introduced in `da0bf4e0`, the description used `float16Array.` instead of `Float16Array.`, inconsistent with every other typed-array sibling in the list.

**`blas/base/ndarray/dznrm2`**

-   Fixes a broken equation image in `lib/node_modules/@stdlib/blas/base/ndarray/dznrm2/README.md` (introduced in `0c071d9e`) where the `<img src>` path incorrectly references `@stdlib/blas/base/dznrm2/docs/img/equation_l2_norm.svg` instead of the correct `@stdlib/blas/base/ndarray/dznrm2/docs/img/equation_l2_norm.svg`.

**`blas/base/ndarray/scnrm2`**

-   Fixes broken equation image in `lib/node_modules/@stdlib/blas/base/ndarray/scnrm2/README.md` (introduced in `0c071d9e`): the `<img src>` path pointed to `@stdlib/blas/base/scnrm2/docs/img/equation_l2_norm.svg` instead of `@stdlib/blas/base/ndarray/scnrm2/docs/img/equation_l2_norm.svg`.

## Related Issues

None.

## Questions

No.

## Other

### Validation

What was checked across the 12 commits in the window (`f8a43f95e..40dad68e6`):

-   stdlib JavaScript style-guide compliance for changed `lib/`, `test/`, `benchmark/`, `examples/`, `docs/`, and `.d.ts` files.
-   Obvious-bug scan over each diff (wrong variable, off-by-one, mismatched argument count, mislabelled parameter, broken identifier resolution).
-   Logic/security scan over the changed code (wrong formula, swapped arguments, broken invariants, demonstrably wrong examples).
-   Verification of every surviving finding by re-reading the file at the merged SHA before applying a fix.

Deliberately excluded:

-   Anything requiring interpretation, judgement calls, or context outside the window's diff.
-   Style suggestions not codified in `docs/style-guides`.
-   Findings reported by only one reviewer that could not be independently re-verified from the diff.
-   The `blas/base/drotm/test/test.ndarray.js` whitespace change was flagged but rejected: that change is the deliberate intent of upstream commit `dc7c32d50` (`style: fix spacing in multiline arrays`).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was prepared by Claude Code. Multiple reviewer agents independently audited the last 24 hours of merges to `develop`; only findings that survived cross-agent corroboration and direct file re-verification were applied. Each fix is a one-line edit; the maintainer should still audit before promoting out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtHHX2nNYsqdLTv6FKFFxX)_