### PR TITLE
docs: fix `@throws` annotation in `blas/ext/one-to` and `blas/ext/zero-to`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/one-to/lib/assign.js
+++ b/lib/node_modules/@stdlib/blas/ext/one-to/lib/assign.js
@@ -47,7 +47,7 @@ var base = require( './base.js' );
 * @throws {TypeError} first argument must be an ndarray-like object having at least one dimension
 * @throws {TypeError} first argument must have a supported data type
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {RangeError} dimension indices must not exceed input ndarray bounds
 * @throws {RangeError} number of dimension indices must not exceed the number of input ndarray dimensions
 * @returns {ndarray} input ndarray

--- a/lib/node_modules/@stdlib/blas/ext/one-to/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/one-to/lib/main.js
@@ -52,7 +52,7 @@ var base = require( './base.js' );
 * @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {RangeError} dimension indices must not exceed input ndarray bounds
 * @throws {RangeError} number of dimension indices must not exceed the number of input ndarray dimensions
 * @returns {ndarray} output ndarray

--- a/lib/node_modules/@stdlib/blas/ext/zero-to/lib/assign.js
+++ b/lib/node_modules/@stdlib/blas/ext/zero-to/lib/assign.js
@@ -47,7 +47,7 @@ var base = require( './base.js' );
 * @throws {TypeError} first argument must be an ndarray-like object having at least one dimension
 * @throws {TypeError} first argument must have a supported data type
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {RangeError} dimension indices must not exceed input ndarray bounds
 * @throws {RangeError} number of dimension indices must not exceed the number of input ndarray dimensions
 * @returns {ndarray} input ndarray

--- a/lib/node_modules/@stdlib/blas/ext/zero-to/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/zero-to/lib/main.js
@@ -52,7 +52,7 @@ var base = require( './base.js' );
 * @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {RangeError} dimension indices must not exceed input ndarray bounds
 * @throws {RangeError} number of dimension indices must not exceed the number of input ndarray dimensions
 * @returns {ndarray} output ndarray


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   normalizes the `@throws` JSDoc tag for the "must provide valid options" case in two `blas/ext/` packages whose `lib/main.js` and `lib/assign.js` deviate from the namespace convention (14 of 16 sibling packages document the case as `@throws {Error}`, and the same packages' own `lib/base.js` files already use `@throws {Error}`)

### Namespace summary

-   **Namespace:** `@stdlib/blas/ext`
-   **Members analyzed:** 16 (excluding `base`, which is a sub-namespace aggregator)
-   **Features with a clear majority (≥75%):** `package.json` shape, `manifest.json` shape, README section structure, `<section>` boilerplate, `errorConstruction == "format"`, `hasExample`, `@throws {Error} must provide valid options`
-   **Features excluded for no clear majority or for semantic differences:** `publicSignature`, `validationPrologue`, `dependencies`, keyword sets (each package's math/search semantics differ), `lib/assign.js` / `lib/base.js` presence (mutating-vs-non-mutating and factory-vs-manual architectures are intentional)

### `blas/ext/one-to`

Corrects the `@throws` annotation for the "invalid options" case in `lib/main.js` and `lib/assign.js` from `{TypeError}` to `{Error}`, aligning with `lib/base.js` within the same package and with 87.5% of sibling packages in `blas/ext/`. No runtime behavior changes; existing tests continue to assert on `TypeError` as thrown.

### `blas/ext/zero-to`

Corrects `@throws {TypeError}` to `@throws {Error}` for the "must provide valid options" JSDoc annotation in `lib/main.js` and `lib/assign.js`, bringing the package in line with `lib/base.js` and 14 of 16 sibling packages in `blas/ext/` (87.5%). The deviation was a documentation inconsistency only; no runtime behavior changes, and existing tests continue to assert the thrown `TypeError` as before.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   Structural feature extraction over all 16 members (file trees, `package.json` shapes, README sections, test/benchmark/example filenames, `manifest.json` shapes).
-   Semantic feature extraction via per-package agents (public signatures, validation prologues, error-construction style, JSDoc shapes, dependency sets).
-   Three-agent drift validation (semantic review, test/doc cross-reference, broader-codebase structural review) confirmed `confirmed-drift` for all four files. No outlier on this feature was marked `intentional-deviation` or `needs-human`.

### Deliberately excluded

-   Outliers on features without a clear ≥75% majority (e.g. `blas` keyword at 62.5%).
-   Architectural deviations driven by semantics: in-place mutating functions (`circshift`, `sort`, `sorthp`) correctly lack `.assign` infrastructure; `sum` correctly uses a factory that packages both forms; `to-sorted` / `to-sortedhp` correctly delegate to their mutating counterparts.
-   "Missing" math-keyword set on `find-index`, `find-last-index`, `index-of`, `last-index-of` — these are search functions, not math operations.
-   Auto-populated / generator-owned artifacts (`docs/repl.txt`, `docs/types/*.d.ts`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code as part of a cross-package API drift detection routine: structural and semantic features were extracted from every package in `@stdlib/blas/ext/`, the majority pattern per feature was computed (≥75% threshold), and outliers were validated by three independent review agents before the patches were applied.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wkg17ZrahaXCjXCmBLDv7B)_