### PR TITLE
docs: propagate fixes from `develop` across `stats`, `blas`, and `plot` siblings

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/gger/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/base/gger/test/test.main.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable max-len */
+/* eslint-disable max-len, stdlib/no-empty-lines-between-requires */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/blas/base/gger/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/base/gger/test/test.main.js
@@ -358,7 +358,7 @@ tape( 'the function throws an error if provided an invalid tenth argument (acces
 	}
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (row-major)', function test( t ) {
 	var expected;
 	var data;
 	var out;
@@ -380,7 +380,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', functi
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major) (accessors)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (row-major) (accessors)', function test( t ) {
 	var expected;
 	var data;
 	var abuf;
@@ -404,7 +404,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major) (accesso
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (column-major)', function test( t ) {
 	var expected;
 	var data;
 	var out;
@@ -426,7 +426,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major)', fun
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major) (accessors)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (column-major) (accessors)', function test( t ) {
 	var expected;
 	var data;
 	var abuf;

--- a/lib/node_modules/@stdlib/blas/base/gger/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/gger/test/test.ndarray.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable max-len */
+/* eslint-disable max-len, stdlib/no-empty-lines-between-requires */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/blas/base/gger/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/gger/test/test.ndarray.js
@@ -268,7 +268,7 @@ tape( 'the function throws an error if provided an invalid eighth argument (acce
 	}
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (row-major)', function test( t ) {
 	var expected;
 	var data;
 	var out;
@@ -290,7 +290,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', functi
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major) (accessors)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (row-major) (accessors)', function test( t ) {
 	var expected;
 	var data;
 	var abuf;
@@ -315,7 +315,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major) (accesso
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (column-major)', function test( t ) {
 	var expected;
 	var data;
 	var out;
@@ -337,7 +337,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major)', fun
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major) (accessors)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (column-major) (accessors)', function test( t ) {
 	var expected;
 	var data;
 	var abuf;

--- a/lib/node_modules/@stdlib/blas/base/sger/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sger/test/test.ndarray.js
@@ -170,7 +170,7 @@ tape( 'the function throws an error if provided an invalid eighth argument', fun
 	}
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (row-major)', function test( t ) {
 	var expected;
 	var data;
 	var out;
@@ -192,7 +192,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', functi
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (column-major)', function test( t ) {
 	var expected;
 	var data;
 	var out;

--- a/lib/node_modules/@stdlib/blas/base/sger/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sger/test/test.ndarray.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable max-len */
+/* eslint-disable max-len, stdlib/no-empty-lines-between-requires */
 
 'use strict';
 
@@ -44,6 +44,7 @@ var csa1nsa2n = require( './fixtures/column_major_sa1n_sa2n.json' );
 var ccap = require( './fixtures/column_major_complex_access_pattern.json' );
 var cx0 = require( './fixtures/column_major_x_zeros.json' );
 var cy0 = require( './fixtures/column_major_y_zeros.json' );
+
 var rm = require( './fixtures/row_major.json' );
 var roa = require( './fixtures/row_major_oa.json' );
 var rox = require( './fixtures/row_major_ox.json' );

--- a/lib/node_modules/@stdlib/blas/base/sger/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sger/test/test.ndarray.native.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable max-len */
+/* eslint-disable max-len, stdlib/no-empty-lines-between-requires */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/blas/base/sger/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sger/test/test.ndarray.native.js
@@ -180,7 +180,7 @@ tape( 'the function throws an error if provided an invalid eighth argument', opt
 	}
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', opts, function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (row-major)', opts, function test( t ) {
 	var expected;
 	var data;
 	var out;
@@ -202,7 +202,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', opts, 
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major)', opts, function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (column-major)', opts, function test( t ) {
 	var expected;
 	var data;
 	var out;

--- a/lib/node_modules/@stdlib/blas/base/sger/test/test.sger.js
+++ b/lib/node_modules/@stdlib/blas/base/sger/test/test.sger.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable max-len */
+/* eslint-disable max-len, stdlib/no-empty-lines-between-requires */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/blas/base/sger/test/test.sger.js
+++ b/lib/node_modules/@stdlib/blas/base/sger/test/test.sger.js
@@ -208,7 +208,7 @@ tape( 'the function throws an error if provided an invalid tenth argument', func
 	}
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (row-major)', function test( t ) {
 	var expected;
 	var data;
 	var out;
@@ -230,7 +230,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', functi
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major)', function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (column-major)', function test( t ) {
 	var expected;
 	var data;
 	var out;

--- a/lib/node_modules/@stdlib/blas/base/sger/test/test.sger.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sger/test/test.sger.native.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable max-len */
+/* eslint-disable max-len, stdlib/no-empty-lines-between-requires */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/blas/base/sger/test/test.sger.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sger/test/test.sger.native.js
@@ -217,7 +217,7 @@ tape( 'the function throws an error if provided an invalid tenth argument', opts
 	}
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', opts, function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (row-major)', opts, function test( t ) {
 	var expected;
 	var data;
 	var out;
@@ -239,7 +239,7 @@ tape( 'the function the rank 1 operation `A = α*x*y^T + A` (row-major)', opts, 
 	t.end();
 });
 
-tape( 'the function the rank 1 operation `A = α*x*y^T + A` (column-major)', opts, function test( t ) {
+tape( 'the function performs the rank 1 operation `A = α*x*y^T + A` (column-major)', opts, function test( t ) {
 	var expected;
 	var data;
 	var out;

--- a/lib/node_modules/@stdlib/plot/components/svg/annotations/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/annotations/lib/main.js
@@ -24,6 +24,7 @@ var EventEmitter = require( 'events' ).EventEmitter;
 var logger = require( 'debug' );
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var inherit = require( '@stdlib/utils/inherit' );
+var zeros = require( '@stdlib/array/zeros' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var render = require( './render.js' );
 
@@ -75,7 +76,7 @@ function Annotations() {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = zeros( arguments.length+1, 'generic' );
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/axis/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/axis/lib/main.js
@@ -28,6 +28,7 @@ var linear = require( 'd3-scale' ).scaleLinear; // TODO: remove
 var defineProperty = require( '@stdlib/utils/define-property' );
 var setReadOnly = require( '@stdlib/utils/define-read-only-property' );
 var copy = require( '@stdlib/utils/copy' );
+var zeros = require( '@stdlib/array/zeros' );
 var defaults = require( './defaults.json' );
 var validate = require( './validate.js' );
 var setScale = require( './props/scale/set.js' );
@@ -198,7 +199,7 @@ function Axis( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = zeros( arguments.length+1, 'generic' );
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/background/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/background/lib/main.js
@@ -25,6 +25,7 @@ var logger = require( 'debug' );
 var defineProperty = require( '@stdlib/utils/define-property' );
 var setReadOnly = require( '@stdlib/utils/define-read-only-property' );
 var copy = require( '@stdlib/utils/copy' );
+var zeros = require( '@stdlib/array/zeros' );
 var defaults = require( './defaults.json' );
 var validate = require( './validate.js' );
 var setWidth = require( './props/width/set.js' );
@@ -121,7 +122,7 @@ function Background( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = zeros( arguments.length+1, 'generic' );
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/canvas/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/canvas/lib/main.js
@@ -25,6 +25,7 @@ var logger = require( 'debug' );
 var defineProperty = require( '@stdlib/utils/define-property' );
 var setReadOnly = require( '@stdlib/utils/define-read-only-property' );
 var copy = require( '@stdlib/utils/copy' );
+var zeros = require( '@stdlib/array/zeros' );
 var defaults = require( './defaults.json' );
 var validate = require( './validate.js' );
 var setWidth = require( './props/width/set.js' );
@@ -121,7 +122,7 @@ function Canvas( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = zeros( arguments.length+1, 'generic' );
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/graph/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/graph/lib/main.js
@@ -25,6 +25,7 @@ var logger = require( 'debug' );
 var defineProperty = require( '@stdlib/utils/define-property' );
 var setReadOnly = require( '@stdlib/utils/define-read-only-property' );
 var copy = require( '@stdlib/utils/copy' );
+var zeros = require( '@stdlib/array/zeros' );
 var defaults = require( './defaults.json' );
 var validate = require( './validate.js' );
 var setTranslateX = require( './props/translate-x/set.js' );
@@ -121,7 +122,7 @@ function Graph( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = zeros( arguments.length+1, 'generic' );
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/path/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/path/lib/main.js
@@ -32,6 +32,7 @@ var format = require( '@stdlib/string/format' );
 var copy = require( '@stdlib/utils/copy' );
 var merge = require( '@stdlib/utils/merge' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
+var zeros = require( '@stdlib/array/zeros' );
 var isDefined = require( './accessors/is_defined.js' );
 var defaults = require( './defaults.json' );
 var setX = require( './props/x/set.js' );
@@ -176,7 +177,7 @@ function Path( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = zeros( arguments.length+1, 'generic' );
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/rug/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/rug/lib/main.js
@@ -32,6 +32,7 @@ var merge = require( '@stdlib/utils/merge' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var inherit = require( '@stdlib/utils/inherit' );
+var zeros = require( '@stdlib/array/zeros' );
 var isDefined = require( './accessors/is_defined.js' );
 var defaults = require( './defaults.json' );
 var setAutoRender = require( './props/auto-render/set.js' );
@@ -166,7 +167,7 @@ function Rug( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = zeros( arguments.length+1, 'generic' );
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/symbols/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/symbols/lib/main.js
@@ -32,6 +32,7 @@ var format = require( '@stdlib/string/format' );
 var copy = require( '@stdlib/utils/copy' );
 var merge = require( '@stdlib/utils/merge' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
+var zeros = require( '@stdlib/array/zeros' );
 var isDefined = require( './accessors/is_defined.js' );
 var defaults = require( './defaults.json' );
 var setSymbol = require( './props/symbol/set.js' );
@@ -175,7 +176,7 @@ function Symbols( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = zeros( arguments.length+1, 'generic' );
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/title/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/title/lib/main.js
@@ -25,6 +25,7 @@ var logger = require( 'debug' );
 var defineProperty = require( '@stdlib/utils/define-property' );
 var setReadOnly = require( '@stdlib/utils/define-read-only-property' );
 var copy = require( '@stdlib/utils/copy' );
+var zeros = require( '@stdlib/array/zeros' );
 var defaults = require( './defaults.json' );
 var validate = require( './validate.js' );
 var setText = require( './props/text/set.js' );
@@ -111,7 +112,7 @@ function Title( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = zeros( arguments.length+1, 'generic' );
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/docs/types/index.d.ts
@@ -70,7 +70,7 @@ interface Namespace {
 	Levy: typeof Levy;
 
 	/**
-	* Returns the differential entropy for a Lévy distribution with location `mu` and scale `s`.
+	* Returns the differential entropy for a Lévy distribution with location `mu` and scale `c`.
 	*
 	* ## Notes
 	*


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between `f8a43f95` (2026-05-24 01:23 -0700) and `40dad68e` (2026-05-24 02:54 -0700) to sibling packages with the same underlying defect.

### Pattern: propagate parameter-name fixes to umbrella namespace declarations

Commit `47f803ef` corrected a stale scale parameter reference (`s` → `c`) in the `entropy` JSDoc and per-function TypeScript declaration for `@stdlib/stats/base/dists/levy/entropy`. The umbrella namespace `docs/types/index.d.ts` carries a duplicate of that description and requires the same correction at line 73.

- `47f803ef` ([`docs: fix scale parameter reference in @stdlib/stats/base/dists/levy/entropy`](https://github.com/stdlib-js/stdlib/commit/47f803efb7e6e84fb26a7ded647b9a398b29a226))
  - `@stdlib/stats/base/dists/levy` (umbrella `docs/types/index.d.ts`)

### Pattern: propagate missing-verb fix in BLAS rank-1 update test descriptions

Test description strings in `gger` and `sger` read `'the function the rank 1 operation ...'`, omitting `performs` — the same defect fixed in `dger`. Corrects 16 sites across 6 test files.

- `7800c9a7` ([`test: fix grammar of test descriptions in blas/base/dger`](https://github.com/stdlib-js/stdlib/commit/7800c9a717853e6fc12795832bc4c34c06b2ef95))
  - `@stdlib/blas/base/gger`
  - `@stdlib/blas/base/sger`

### Pattern: replace `new Array` allocations with `zeros` in SVG plot component `onRender` re-emit callbacks

Nine sibling SVG plot components share the same `onRender` re-emit pattern as `plot/components/svg/defs`, each allocating an argument array via `new Array( arguments.length+1 )`. Replace each allocation with `zeros( arguments.length+1, 'generic' )` and add the corresponding `@stdlib/array/zeros` require.

- `40dad68e` ([`chore: fix JavaScript lint errors`](https://github.com/stdlib-js/stdlib/commit/40dad68e605aadfb8380e25d3b8f9dc1a0a3389a))
  - `@stdlib/plot/components/svg/annotations`
  - `@stdlib/plot/components/svg/axis`
  - `@stdlib/plot/components/svg/background`
  - `@stdlib/plot/components/svg/canvas`
  - `@stdlib/plot/components/svg/graph`
  - `@stdlib/plot/components/svg/path`
  - `@stdlib/plot/components/svg/rug`
  - `@stdlib/plot/components/svg/symbols`
  - `@stdlib/plot/components/svg/title`

## Related Issues

None.

## Questions

No.

## Other

### Validation

Reviewed all 12 commits merged to `develop` in the 24-hour window. Three source patterns advanced to the patch stage; per-pattern search scope and validation procedure:

- **Search scope**: scoped to the source commit's namespace first (`stats/base/dists/levy/*` for the scale parameter fix; `blas/base/*` for the test-description grammar fix; `plot/components/svg/*` for the `new Array` allocation pattern). Originating packages already fixed by the source commits were excluded.
- **Independent validation**: two opus validation agents independently reviewed every candidate site by reading each file in full; both returned `confirmed` for all 26 sites.
- An adaptation pass confirmed each `@stdlib/array/zeros` require insertion point for the nine SVG plot components (placement determined per-file: between `inherit` and `instanceOf` where present, otherwise after the last `@stdlib/utils/*` or `@stdlib/assert/*` require and before the first local require, mirroring the source commit's placement convention).
- A sonnet style-consistency pass confirmed JSDoc indentation, single-quoted string form, and require-block ordering match the source-commit canonical form.

Deliberately excluded:

- `91a6a85e` (multi-offset README wording): the source commit was comprehensive — no remaining multi-offset README sites carry the old singular phrasing.
- `f345dd63` (incorrect `logEach` argument in `cgemv` example): the defect (logging `x` where `y` is the output vector) has no grep-able textual signature distinguishing wrong from correct call sites; would require per-site semantic interpretation.
- `c17ecc0d` (separate `@example` tags in `time/day-of-quarter`): no remaining `time/*` packages exhibit the malformed-`@example` continuation pattern.
- `a2fcfdb2` (ndarray-instance doctest improvement): single-package documentation improvement without a generalizable propagation signature.
- `ac45b111` (refactor: `main` require alias in `stats/base/dists/frechet`): refactor commit, not a defect fix; out of scope for this routine.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two opus validation passes plus a sonnet style-consistency pass) before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFVC2QpmVDSaWiZ6BXDCWW)_