### PR TITLE
docs: align `alpha` description in `blas/ext/base/gxsa`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gxsa/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxsa/lib/ndarray.js
@@ -35,7 +35,7 @@ var M = 5;
 * Subtracts a scalar constant from each element in a strided array.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NumericArray} x - input array
 * @param {integer} strideX - stride length
 * @param {NonNegativeInteger} offsetX - starting index


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-05-24 14:39 -0500 (`8fdaa49`) and 2026-05-25 03:04 -0700 (`86501b1`).

## Description

Sweep of the 13 commits merged to `develop` in the last 24 hours surfaced one objective, high-signal inconsistency in the newly added `blas/ext/base/gxsa` package.

### Fixes by package

- **`blas/ext/base/gxsa`** — In `blas/ext/base/gxsa/lib/ndarray.js` (`f8352cd`), the `@param alpha` description reads `scalar` but the sibling `main.js` and every analogous package (`gapx`, `capx`, `zapx`, `sapxsum`, etc.) use `scalar constant` — change `* @param {number} alpha - scalar` to `* @param {number} alpha - scalar constant` to restore consistency.

## Related Issues

None.

## Questions

None.

## Other

### Validation

Reviewed the union diff of all commits merged to `develop` between `8fdaa49^..86501b1` (13 commits, ~11k lines). Four parallel reviewers (two style, two bug) inspected the diff against the relevant style guides in `docs/style-guides` and against established peer packages (`gapx`, `dapx`, `sapxsum`).

Checked:
- stdlib code-style compliance across the three new packages (`capx`, `zapx`, `gxsa`) including README, `lib/*.js`, `docs/repl.txt`, `docs/types/`, examples, `src/`, `package.json`, `manifest.json`.
- The smaller doc-fix / refactor commits (`pcorrmat` `format` refactor, `@throws` annotation fixes, CDN URL fixes, eslint-disable propagation, REPL/namespace TOC updates, `assert` TS examples).
- Tests for the three new packages.
- Bug pass on the full diff for off-by-ones, swapped real/imag, stride sign handling, copy-paste leftovers between the sibling packages, doc/code contradictions, and broken example code.

Deliberately excluded:
- The 7-element `{{alias}}.ndarray` example in `gxsa/docs/repl.txt` — peer `gapx/docs/repl.txt` follows the exact same 8-vs-7-element pattern, so the truncation is established convention, not a typo.
- Missing `zapx` / `gxsa` entries in `blas/ext/base/README.md` — commit `c1be7ac` (the TOC sweep) landed minutes before the `zapx`/`gxsa` feat commits, so this is expected follow-up rather than a missed entry, and is left to the next periodic TOC commit.
- Style preferences, suggestions, and anything requiring interpretation or files outside the diff window to validate.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated post-merge review sweep of commits landed on `develop` in the last 24 hours. Findings were cross-checked by independent reviewer agents and verified against peer packages before applying.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvnHcn2VFF1hSZmzuQXpk1)_