### PR TITLE
docs: propagate fixes across `_tools` and `blas/base/ndarray` siblings

### DIFF
--- a/lib/node_modules/@stdlib/_tools/docs/www/readme-database/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/docs/www/readme-database/lib/main.js
@@ -50,7 +50,7 @@ var debug = logger( 'readme-database:async' );
 * @param {string} [options.base="/docs/api/develop/"] - base path for internal URLs
 * @param {Function} clbk - callback
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {TypeError} last argument must be a callback function
 *

--- a/lib/node_modules/@stdlib/_tools/docs/www/readme-fragment-file-tree/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/docs/www/readme-fragment-file-tree/lib/main.js
@@ -52,7 +52,7 @@ var debug = logger( 'readme-fragment-file-tree:async' );
 * @param {Function} clbk - callback
 * @throws {TypeError} first argument must be a string
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {TypeError} last argument must be a callback function
 *

--- a/lib/node_modules/@stdlib/_tools/github/create-issue/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/github/create-issue/lib/main.js
@@ -56,7 +56,7 @@ var DEFAULT_HTTPS_PORT = 443;
 * @throws {TypeError} first argument must be a string
 * @throws {TypeError} second argument must be a string
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {TypeError} last argument must be a function
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/github/dispatch-workflow/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/github/dispatch-workflow/lib/main.js
@@ -54,7 +54,7 @@ var DEFAULT_HTTPS_PORT = 443;
 * @throws {TypeError} first argument must be a string
 * @throws {TypeError} second argument must be a string
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {TypeError} last argument must be a function
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/lint/pkg-json/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/lint/pkg-json/lib/async.js
@@ -49,7 +49,7 @@ var debug = logger( 'lint:pkg-json:async' );
 * @param {Callback} clbk - callback to invoke after completion
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/lint/pkg-json/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/lint/pkg-json/lib/sync.js
@@ -46,7 +46,7 @@ var debug = logger( 'lint:pkg-json:sync' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @returns {(ObjectArray|null)} lint errors or `null`
 *

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/async.js
@@ -43,7 +43,7 @@ var inspect = require( './inspect.js' );
 * @param {Callback} clbk - callback to invoke after finding add-ons
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/sync.js
@@ -40,7 +40,7 @@ var validate = require( './validate.js' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {Error} unable to parse `package.json` as JSON
 * @returns {(EmptyArray|StringArray)} list of add-ons

--- a/lib/node_modules/@stdlib/_tools/pkgs/browser-compatible/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/browser-compatible/lib/async.js
@@ -48,7 +48,7 @@ var debug = logger( 'browser-compatible:async' );
 * @param {Callback} clbk - callback to invoke after finding packages
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/browser-compatible/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/browser-compatible/lib/sync.js
@@ -44,7 +44,7 @@ var debug = logger( 'browser-compatible:sync' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {Error} unexpected error
 * @returns {StringArray} list of names

--- a/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/async.js
@@ -43,7 +43,7 @@ var readPkgs = require( './read_pkgs.js' );
 * @param {Callback} clbk - callback to invoke after finding package CLIs
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/sync.js
@@ -43,7 +43,7 @@ var validate = require( './validate.js' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {Error} unable to parse `package.json` as JSON
 * @returns {(EmptyArray|StringArray)} list of command-line interfaces

--- a/lib/node_modules/@stdlib/_tools/pkgs/cmds/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/cmds/lib/async.js
@@ -43,7 +43,7 @@ var readPkgs = require( './read_pkgs.js' );
 * @param {Callback} clbk - callback to invoke after finding package CLI commands
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/cmds/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/cmds/lib/sync.js
@@ -42,7 +42,7 @@ var validate = require( './validate.js' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {Error} unable to parse `package.json` as JSON
 * @returns {(EmptyArray|StringArray)} list of command-line interface commands

--- a/lib/node_modules/@stdlib/_tools/pkgs/includes/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/includes/lib/main.js
@@ -43,7 +43,7 @@ var inspect = require( './inspect.js' );
 * @param {Callback} clbk - callback to invoke after finding directories
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/includes/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/includes/lib/sync.js
@@ -40,7 +40,7 @@ var validate = require( './validate.js' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {Error} unable to parse `package.json` as JSON
 * @returns {(EmptyArray|StringArray)} list of directories

--- a/lib/node_modules/@stdlib/_tools/pkgs/names/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/names/lib/async.js
@@ -42,7 +42,7 @@ var getRoot = require( './root.js' );
 * @param {Callback} clbk - callback to invoke after finding packages
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/names/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/names/lib/sync.js
@@ -38,7 +38,7 @@ var getRoot = require( './root.js' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @returns {StringArray} list of names
 *

--- a/lib/node_modules/@stdlib/_tools/pkgs/namespace-readmes/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/namespace-readmes/lib/main.js
@@ -44,7 +44,7 @@ var find = require( './find.js' ); // eslint-disable-line stdlib/no-redeclare
 * @param {Callback} clbk - callback to invoke after finding namespace package READMEs
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/namespace-readmes/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/namespace-readmes/lib/sync.js
@@ -41,7 +41,7 @@ var getRoot = require( './root.js' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @returns {(EmptyArray|StringArray)} list of READMEs
 *

--- a/lib/node_modules/@stdlib/_tools/pkgs/namespaces/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/namespaces/lib/async.js
@@ -41,7 +41,7 @@ var defaults = require( './defaults.json' );
 * @param {Callback} clbk - callback to invoke after finding namespaces
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/namespaces/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/namespaces/lib/sync.js
@@ -37,7 +37,7 @@ var defaults = require( './defaults.json' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @returns {StringArray} list of names
 *

--- a/lib/node_modules/@stdlib/_tools/pkgs/readmes/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/readmes/lib/main.js
@@ -43,7 +43,7 @@ var find = require( './find.js' ); // eslint-disable-line stdlib/no-redeclare
 * @param {Callback} clbk - callback to invoke after finding package READMEs
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/readmes/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/readmes/lib/sync.js
@@ -41,7 +41,7 @@ var validate = require( './validate.js' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @returns {(EmptyArray|StringArray)} list of READMEs
 *

--- a/lib/node_modules/@stdlib/_tools/pkgs/repl-help/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/repl-help/lib/main.js
@@ -44,7 +44,7 @@ var find = require( './find.js' ); // eslint-disable-line stdlib/no-redeclare
 * @param {Callback} clbk - callback to invoke after finding package REPL help files
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/repl-help/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/repl-help/lib/sync.js
@@ -42,7 +42,7 @@ var validate = require( './validate.js' );
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @param {string} [options.filename='docs/repl.txt'] - REPL help filename
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @returns {(EmptyArray|StringArray)} list of REPL help files
 *

--- a/lib/node_modules/@stdlib/_tools/pkgs/standalones/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/standalones/lib/async.js
@@ -41,7 +41,7 @@ var defaults = require( './defaults.json' );
 * @param {Callback} clbk - callback to invoke after finding packages
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/standalones/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/standalones/lib/sync.js
@@ -37,7 +37,7 @@ var defaults = require( './defaults.json' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @returns {StringArray} list of names
 *

--- a/lib/node_modules/@stdlib/_tools/pkgs/toposort/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/toposort/lib/async.js
@@ -41,7 +41,7 @@ var defaults = require( './defaults.json' );
 * @param {Callback} clbk - callback to invoke after finding packages
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/toposort/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/toposort/lib/sync.js
@@ -37,7 +37,7 @@ var defaults = require( './defaults.json' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @returns {(StringArray|EmptyArray|Error)} list of names or an error
 *

--- a/lib/node_modules/@stdlib/_tools/pkgs/tree/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/tree/lib/async.js
@@ -41,7 +41,7 @@ var defaults = require( './config.json' );
 * @param {Callback} clbk - callback to invoke after generating a tree
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/tree/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/tree/lib/sync.js
@@ -37,7 +37,7 @@ var defaults = require( './config.json' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @returns {Object} tree
 *

--- a/lib/node_modules/@stdlib/_tools/pkgs/types/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/types/lib/main.js
@@ -43,7 +43,7 @@ var inspect = require( './inspect.js' );
 * @param {Callback} clbk - callback to invoke after finding packages
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/types/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/types/lib/sync.js
@@ -40,7 +40,7 @@ var validate = require( './validate.js' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {Error} unable to parse `package.json` as JSON
 * @returns {(EmptyArray|StringArray)} list of packages

--- a/lib/node_modules/@stdlib/_tools/pkgs/wasm/lib/async.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/wasm/lib/async.js
@@ -43,7 +43,7 @@ var inspect = require( './inspect.js' );
 * @param {Callback} clbk - callback to invoke after finding packages
 * @throws {TypeError} callback argument must be a function
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/_tools/pkgs/wasm/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/wasm/lib/sync.js
@@ -40,7 +40,7 @@ var validate = require( './validate.js' );
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
 * @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {Error} unable to parse `package.json` as JSON
 * @returns {(EmptyArray|StringArray)} list of packages

--- a/lib/node_modules/@stdlib/_tools/scaffold/package-json/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/scaffold/package-json/lib/main.js
@@ -41,7 +41,7 @@ var validate = require( './validate.js' );
 * @param {string} [options.cmd] - package command for use as a CLI tool
 * @param {string} [options.browser] - browser entry point
 * @throws {TypeError} must provide an object
-* @throws {TypeError} must provide valid options
+* @throws {Error} must provide valid options
 * @returns {Object} `package.json`
 *
 * @example

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dasum/README.md
@@ -33,7 +33,7 @@ The [_L1_ norm][l1norm] is defined as
 ```
 
 <!-- <div class="equation" align="center" data-raw-text="\|\mathbf{x}\|_1 = \sum_{i=0}^{n-1} \vert x_i \vert" data-equation="eq:l1norm">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@c403cb0cbb15d9b7b453e3cea34ca2379500ddd4/lib/node_modules/@stdlib/blas/base/dasum/docs/img/equation_l1norm.svg" alt="L1 norm definition.">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@c403cb0cbb15d9b7b453e3cea34ca2379500ddd4/lib/node_modules/@stdlib/blas/base/ndarray/dasum/docs/img/equation_l1norm.svg" alt="L1 norm definition.">
     <br>
 </div> -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dnrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dnrm2/README.md
@@ -33,7 +33,7 @@ The [L2-norm][l2-norm] is defined as
 ```
 
 <!-- <div class="equation" align="center" data-raw-text="\|\mathbf{x}\|_2 = \sqrt{x_0^2 + x_1^2 + \ldots + x_{N-1}^2}" data-equation="eq:l2_norm">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/dnrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/ndarray/dnrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
     <br>
 </div> -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/gasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/gasum/README.md
@@ -33,7 +33,7 @@ The [_L1_ norm][l1norm] is defined as
 ```
 
 <!-- <div class="equation" align="center" data-raw-text="\|\mathbf{x}\|_1 = \sum_{i=0}^{n-1} \vert x_i \vert" data-equation="eq:l1norm">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@30de397fadee10fa175a8332ae1447737f201818/lib/node_modules/@stdlib/blas/base/gasum/docs/img/equation_l1norm.svg" alt="L1 norm definition.">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@30de397fadee10fa175a8332ae1447737f201818/lib/node_modules/@stdlib/blas/base/ndarray/gasum/docs/img/equation_l1norm.svg" alt="L1 norm definition.">
     <br>
 </div> -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/gnrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/gnrm2/README.md
@@ -33,7 +33,7 @@ The [L2-norm][l2-norm] is defined as
 ```
 
 <!-- <div class="equation" align="center" data-raw-text="\|\mathbf{x}\|_2 = \sqrt{x_0^2 + x_1^2 + \ldots + x_{N-1}^2}" data-equation="eq:l2_norm">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/gnrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/ndarray/gnrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
     <br>
 </div> -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/sasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/sasum/README.md
@@ -33,7 +33,7 @@ The [_L1_ norm][l1norm] is defined as
 ```
 
 <!-- <div class="equation" align="center" data-raw-text="\|\mathbf{x}\|_1 = \sum_{i=0}^{n-1} \vert x_i \vert" data-equation="eq:l1norm">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@c403cb0cbb15d9b7b453e3cea34ca2379500ddd4/lib/node_modules/@stdlib/blas/base/sasum/docs/img/equation_l1norm.svg" alt="L1 norm definition.">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@c403cb0cbb15d9b7b453e3cea34ca2379500ddd4/lib/node_modules/@stdlib/blas/base/ndarray/sasum/docs/img/equation_l1norm.svg" alt="L1 norm definition.">
     <br>
 </div> -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/snrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/snrm2/README.md
@@ -33,7 +33,7 @@ The [L2-norm][l2-norm] is defined as
 ```
 
 <!-- <div class="equation" align="center" data-raw-text="\|\mathbf{x}\|_2 = \sqrt{x_0^2 + x_1^2 + \ldots + x_{N-1}^2}" data-equation="eq:l2_norm">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/snrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@f766d7eeb56ff14cbceeeeef03d7f7b88c467515/lib/node_modules/@stdlib/blas/base/ndarray/snrm2/docs/img/equation_l2_norm.svg" alt="L2-norm definition.">
     <br>
 </div> -->
 


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-05-24 19:39 UTC and 2026-05-25 10:04 UTC to sibling packages with the same underlying defect.

### `@throws {TypeError}` → `@throws {Error}` for catch-all option validation

Propagates the `@throws {Error}` fix from 09c01f1 to 37 sites across 21 `_tools/` packages where the same annotation was incorrectly typed as `@throws {TypeError}`. Each affected `lib/validate.js` returns a plain `Error` for at least one constraint — `pattern` suffix, `protocol` enum, or `name` prefix — making `TypeError` wrong in all cases.

Source: 09c01f1 ("docs: fix `@throws` annotation in `blas/ext/one-to` and `blas/ext/zero-to`")

Targets:

-   `_tools/pkgs/types` (`lib/main.js`, `lib/sync.js`)
-   `_tools/pkgs/readmes` (`lib/main.js`, `lib/sync.js`)
-   `_tools/pkgs/repl-help` (`lib/main.js`, `lib/sync.js`)
-   `_tools/pkgs/includes` (`lib/main.js`, `lib/sync.js`)
-   `_tools/pkgs/namespace-readmes` (`lib/main.js`, `lib/sync.js`)
-   `_tools/pkgs/namespaces` (`lib/async.js`, `lib/sync.js`)
-   `_tools/pkgs/toposort` (`lib/async.js`, `lib/sync.js`)
-   `_tools/pkgs/tree` (`lib/async.js`, `lib/sync.js`)
-   `_tools/pkgs/cmds` (`lib/async.js`, `lib/sync.js`)
-   `_tools/pkgs/wasm` (`lib/async.js`, `lib/sync.js`)
-   `_tools/pkgs/addons` (`lib/async.js`, `lib/sync.js`)
-   `_tools/pkgs/names` (`lib/async.js`, `lib/sync.js`)
-   `_tools/pkgs/browser-compatible` (`lib/async.js`, `lib/sync.js`)
-   `_tools/pkgs/standalones` (`lib/async.js`, `lib/sync.js`)
-   `_tools/pkgs/clis` (`lib/async.js`, `lib/sync.js`)
-   `_tools/scaffold/package-json` (`lib/main.js`)
-   `_tools/github/create-issue` (`lib/main.js`)
-   `_tools/github/dispatch-workflow` (`lib/main.js`)
-   `_tools/lint/pkg-json` (`lib/async.js`, `lib/sync.js`)
-   `_tools/docs/www/readme-fragment-file-tree` (`lib/main.js`)
-   `_tools/docs/www/readme-database` (`lib/main.js`)

### Missing `ndarray/` segment in HTML-comment `<img>` URLs

Propagates the `ndarray/` path correction from 6742bc8 to the six remaining sibling packages that carry the same stale `<img>` URL prefix, where the `ndarray/` segment was dropped from the `docs/img/` path, causing 404s. All affected lines follow the identical pattern corrected in `dznrm2` and `scnrm2`.

Source: 6742bc8 ("docs: follow-up fixes for commits merged to `develop` on 2026-05-24")

Targets:

-   `blas/base/ndarray/dasum/README.md`
-   `blas/base/ndarray/gasum/README.md`
-   `blas/base/ndarray/sasum/README.md`
-   `blas/base/ndarray/dnrm2/README.md`
-   `blas/base/ndarray/gnrm2/README.md`
-   `blas/base/ndarray/snrm2/README.md`

## Related Issues

No.

## Questions

No.

## Other

### Validation

-   Searched all of `lib/node_modules/@stdlib/` for the `@throws {TypeError} must provide valid options` JSDoc string (126 raw hits) and confirmed each of the 37 confirmed sites by reading the corresponding `lib/validate.js` to verify it returns `new Error(...)` for at least one option constraint; the remaining 89 hits live in packages whose validators only throw `TypeError`/`RangeError` and were left untouched.
-   Searched `lib/node_modules/@stdlib/blas/base/ndarray/` for HTML-comment ``&lt;img src="..."&gt;`` URLs whose path omits the `ndarray/` segment and confirmed each of the 6 sites; `ddot`, `gdot`, and `sdot` already carried the correct path and were excluded.
-   Two independent validation passes confirmed defect presence at each site; an adaptation pass produced the per-site patch; a style-consistency pass verified column alignment and surrounding-context conformance.

### Deliberately excluded

-   Source 8fdaa49 ("refactor: use `format` for error construction in `stats/incr/pcorrmat`") — exhaustive search of `stats/{incr,base,strided}/*` found zero remaining sites with raw string concatenation inside `throw new Error(...)`. The originating commit was the last instance.
-   Source 88e02d5 ("docs: update `assert` TypeScript declaration examples") — the target file `lib/node_modules/@stdlib/assert/docs/types/index.d.ts` is regenerated daily by the `namespace_declarations.yml` workflow via `_tools/scripts/create_namespace_types.js` from per-package `docs/types/index.d.ts` examples; propagating into the namespace file would be overwritten on the next run, and the upstream per-package modernization (`is-complex128matrix-like`, commit 00c05b8 from 2026-05-23) is outside the 24-hour window.
-   Source 6742bc8 Pattern A (`float16Array` → `Float16Array` typo) — no additional instances exist anywhere in the tree.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of the automated fix-propagation routine. The candidate-site enumeration, per-site validation, and patch application were performed by AI agents under a fixed routine; each site was independently confirmed against the source package's `validate.js` (Pattern 1) or the README path layout (Pattern 2) before the patch was applied. A maintainer should review classification and contents before promoting this draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01S1q6UeBtUtpozwzXUSVUcX)_