### PR TITLE
docs: remove orphan `@param` tags in `_tools/makie/plugins`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/makie/plugins/makie-list-pkgs-names/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/makie/plugins/makie-list-pkgs-names/lib/main.js
@@ -79,7 +79,6 @@ function stderr( data ) {
 *
 * @param {string} dir - Makefile directory
 * @param {string} cwd - current working directory
-* @param {string} subpath - subdirectory path
 */
 function plugin( dir, cwd ) {
 	var opts;

--- a/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-complexity/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-complexity/lib/main.js
@@ -78,8 +78,6 @@ function stderr( data ) {
 * Plugin to view a complexity report.
 *
 * @param {string} dir - Makefile directory
-* @param {string} cwd - current working directory
-* @param {string} subpath - subdirectory path
 */
 function plugin( dir ) {
 	var opts;

--- a/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-cov/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/makie/plugins/makie-view-cov/lib/main.js
@@ -78,8 +78,6 @@ function stderr( data ) {
 * Plugin to view a test coverage report.
 *
 * @param {string} dir - Makefile directory
-* @param {string} cwd - current working directory
-* @param {string} subpath - subdirectory path
 */
 function plugin( dir ) {
 	var opts;


### PR DESCRIPTION
## Description

This pull request:

-   Trims JSDoc `@param` tags in three `_tools/makie/plugins/*` packages so that the documented parameters match what each plugin's `function plugin( ... )` actually accepts. No behavior change; documentation-only edits to `lib/main.js`.

### Namespace summary

-   Namespace: `@stdlib/_tools/makie/plugins`
-   Member count: 23 (all non-autogenerated)
-   Structural features analyzed: file tree, `package.json` top-level/`scripts`/`stdlib` keys, `engines`/`directories`/`license`/`main` values, READMEs, `manifest.json`, `test/`/`benchmark/`/`examples/` contents. **No structural drift** — every member shares an identical scaffold.
-   Semantic features analyzed: `lib/main.js` module imports, function signature, helper function set, listener wiring on the spawned child, `stdio` setting, JSDoc shape on the exported plugin, `lib/index.js` module-level tags.
-   Features with clear majority (≥75%): function signature `(dir, cwd, subpath)` (83%), JSDoc `@param` count matching signature arity (87%), helper-set presence (91-96%), `proc.on('error'/'close', ...)` wiring (91%), explicit `stdout`/`stderr` data handlers (87%), absence of `stdio: 'inherit'` (91%).
-   Features without clear majority (excluded from drift analysis): `keywords` array length (mode reaches only 22%); legitimately varies per plugin.

### Per outlier package

#### `@stdlib/_tools/makie/plugins/makie-list-pkgs-names`

Signature is `plugin( dir, cwd )`. JSDoc carried a third `@param {string} subpath` that the function never accepts and never references in its body. Removed the orphan tag. The body uses `cwd` as the make-target's `SRC_DIR` env var; no `subpath` codepath exists. Matches the project convention of trimming JSDoc to the actual signature (see `makie-repl`, which correctly documents only its two real parameters).

#### `@stdlib/_tools/makie/plugins/makie-view-complexity`

Signature is `plugin( dir )`. JSDoc carried two orphan tags — `@param {string} cwd` and `@param {string} subpath` — for parameters the function neither declares nor uses. The body only references `dir` (for `opts.cwd`) and hardcodes `args[ 0 ] = 'view-complexity'`. Removed both orphan tags.

#### `@stdlib/_tools/makie/plugins/makie-view-cov`

Signature is `plugin( dir )`. JSDoc carried the same two orphan tags as `makie-view-complexity`. The body only uses `dir` and `args = [ 'view-cov' ]`. Removed both orphan tags.

### Validation

What was checked:

-   Deterministic structural extraction over the 23 members (file tree, `package.json` shape, READMEs, `manifest.json`, test/benchmark/example layout).
-   Deterministic semantic extraction over `lib/main.js` and `lib/index.js` (signature, helper set, listener wiring, `stdio` flag, JSDoc `@param`/`@returns` counts).
-   Two-agent drift validation in parallel: semantic review confirmed the orphan tags are copy-pasted residue from a 3-arg sibling and never used by the function bodies; cross-reference review confirmed no `test/`, `examples/`, `.d.ts`, `repl.txt`, or external JSDoc consumer is affected, and the only callsite (`etc/.makie.js` via the `makie` dispatcher) passes args positionally without consulting JSDoc.

What was deliberately excluded:

-   `makie-repl` — uses `stdio: 'inherit'` and a 2-arg signature with matching JSDoc; intentional deviation for an interactive REPL.
-   `makie-stats-list-contributors` — uses `stdio: 'inherit'` and omits the `stdout`/`stderr` data helpers; internally consistent.
-   `makie-install-node-addons` — names the spawned-child variable `child` rather than `proc`; this avoids shadowing the `proc = require('process')` import and is arguably better than the majority pattern, not drift.
-   `keywords` array length variation — no clear majority; legitimate per-plugin variation.

## Related Issues

None.

## Questions

None.

## Other

Diff is 5 deletions across 3 files (-1 in `makie-list-pkgs-names`, -2 each in `makie-view-complexity` and `makie-view-cov`). Each package is committed separately to keep the per-package audit trail readable.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by Claude Code as part of a cross-package drift-detection routine over the `@stdlib/_tools/makie/plugins` namespace. Structural and semantic features were extracted programmatically across all 23 packages; majority patterns were computed at a 75% threshold; outliers were classified by parallel opus review agents to filter out intentional deviations. The three accepted corrections are mechanical JSDoc-tag deletions with no behavior change.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZqtzP79dnNqnreSHHWx4G)_