### PR TITLE
docs: fix JSDoc text

### DIFF
--- a/lib/node_modules/@stdlib/os/num-cpus/lib/index.js
+++ b/lib/node_modules/@stdlib/os/num-cpus/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Return the number of CPUs.
+* Number of CPUs.
 *
 * @module @stdlib/os/num-cpus
 *

--- a/lib/node_modules/@stdlib/os/tmpdir/lib/index.js
+++ b/lib/node_modules/@stdlib/os/tmpdir/lib/index.js
@@ -27,7 +27,7 @@
 * var tmpdir = require( '@stdlib/os/tmpdir' );
 *
 * var dir = tmpdir();
-* // e.g., returns '/path/to/tempory/files/directory'
+* // e.g., returns '/path/to/temporary/files/directory'
 */
 
 // MODULES //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Brings the `@module` JSDoc in two `@stdlib/os` packages back into line with sibling conventions in the same namespace. One change is a typo correction (`tempory` → `temporary`); the other replaces a verb-form description on a constant export with the noun-phrase form already used by every other constant in the namespace. Both edits are one-line, documentation-only, no runtime behavior changes.

### Namespace summary

-   **Namespace:** `@stdlib/os`
-   **Members analyzed:** 8 (all hand-written; no autogenerated members)
-   **Features with a clear majority (≥75%):** universal file set (`README.md`, `bin/cli`, `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, `docs/usage.txt`, `etc/cli_opts.json`, `examples/index.js`, `lib/index.js`, `lib/main.js`, `package.json`, `test/test.cli.js`, `test/test.js`), `package.json` top-level key set, `directories` core (`doc`, `example`, `lib`, `test`), README `## Usage` / `## Examples` / `## CLI` sections, `@example` presence in `lib/main.js` and `lib/index.js` `@module` JSDoc, return-kind, function-export "Return ..." imperative phrasing, constant-export noun-phrase description style.
-   **Features excluded for no clear majority or for semantic differences:** `benchmark/benchmark.js` (3/8; constants resolved at load time have nothing to benchmark), `lib/browser.js` and `package.json` `browser` field (2-3/8; tracks which packages have browser-specific implementations), `manifest.json` / `include/` / `examples/c/` (2/8; intentional — only the native-binding packages `byte-order` and `float-word-order` carry these), `## Notes` README section (6/8 = exactly 75%; content is package-specific and not mechanically derivable), `publicSignature` and `validationPrologue` (split between constant and function exports; no namespace-wide majority).

### `@stdlib/os/num-cpus`

In `lib/index.js`, the `@module` JSDoc described the exported value as `Return the number of CPUs.` — a verb-form description applied to a constant export. The four other constants in the namespace (`arch`, `byte-order`, `float-word-order`, `platform`) all use noun-phrase descriptions in their `@module` JSDoc; verb-form `Return ...` is reserved for the three function exports (`configdir`, `homedir`, `tmpdir`). The package's own `docs/types/index.d.ts` already uses `Number of CPUs.`. Replaces the verb form with `Number of CPUs.` to bring `lib/index.js` into agreement with both the sibling-constant convention (4/5 = 80%) and the package's own TypeScript declaration. Pure JSDoc edit; no tests, examples, or runtime behavior affected.

### `@stdlib/os/tmpdir`

The `@example` block in `lib/index.js` carried a `tempory` typo in the example output path (`'/path/to/tempory/files/directory'`). The same example in `lib/main.js`, the README, and `docs/types/index.d.ts` all use the correct `temporary` spelling — `lib/index.js` was the only site in the package that disagreed with itself. `grep` for `tempory` across the entire stdlib worktree returns this site and no other. Corrects the spelling in place.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   Structural feature extraction across all 8 members of `@stdlib/os` (file trees, `package.json` shapes, `directories` keys, `manifest.json` shapes where present, README section orderings, test / benchmark / example filenames).
-   Semantic feature extraction per package (public signatures, return kinds, validation prologues, error-construction style, JSDoc shapes including `@module` description form, dependency sets read from `require()` calls).
-   Three-agent drift validation: semantic review (verb-vs-noun description form for constants vs functions), test/example cross-reference (confirmed no test or example asserts on the affected JSDoc strings or example paths), and structural review (confirmed both fixes are mechanical and surface no cascading edits in tests or examples).
-   Cross-run dedup: no open PR and no PR merged in the last 14 days touches `@stdlib/os/*`.

### Deliberately excluded

-   `## See Also` missing in `num-cpus` README — the section is auto-populated and out of scope for this routine.
-   `## Notes` missing in `platform` and `tmpdir` READMEs (and in `tmpdir/docs/types/index.d.ts`) — borderline 75% conformance; the content that exists in sibling Notes sections is package-specific (platform-specific behavior, env-var fallback chains, OS conventions) and not derivable mechanically.
-   `benchmark/benchmark.js` absent in `arch`, `byte-order`, `float-word-order`, `num-cpus`, `platform` — these export values resolved once at load time; no behavior to benchmark.
-   `lib/browser.js` and `package.json` `browser` field — present only on packages that need a browser-specific implementation (`num-cpus`, `platform`); legitimate architectural difference, not drift.
-   Native artifacts (`manifest.json`, `include/stdlib/os/*.h`, `examples/c/*`) — present only on the two native-binding packages (`byte-order`, `float-word-order`); intentional.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code as part of a cross-package API drift detection routine over `@stdlib/os`. Structural and semantic features were extracted from every member package, the majority pattern per feature was computed (≥75% threshold), outliers were checked by three independent validation agents, and only mechanical, behavior-preserving single-line fixes survived to this PR. A human will audit and promote out of draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01HL3nn5Bgvuo5nZedaXTefm)_