### PR TITLE
fix: use correct argument value in error message and propagate JSDoc fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-little-endian/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-little-endian/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Return a boolean indicating if an environment is little endian.
+* Boolean indicating if an environment is little endian.
 *
 * @module @stdlib/assert/is-little-endian
 *

--- a/lib/node_modules/@stdlib/blas/base/dgemm/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemm/lib/base.js
@@ -124,7 +124,7 @@ function zeros( M, N, X, strideX1, strideX2, offsetX ) { // TODO: consider movin
 * @private
 * @param {NonNegativeInteger} M - number of rows
 * @param {NonNegativeInteger} N - number of columns
-* @param {number} beta - scalar
+* @param {number} beta - scalar constant
 * @param {Float64Array} X - matrix to fill
 * @param {integer} strideX1 - stride of the first dimension of `X`
 * @param {integer} strideX2 - stride of the second dimension of `X`

--- a/lib/node_modules/@stdlib/blas/base/dspr/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/dspr/lib/base.js
@@ -33,7 +33,7 @@ var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string
 * @param {string} order - storage layout
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` is supplied
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input vector
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/dspr/lib/dspr.js
+++ b/lib/node_modules/@stdlib/blas/base/dspr/lib/dspr.js
@@ -35,7 +35,7 @@ var base = require( './base.js' );
 * @param {string} order - storage layout
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` is supplied
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input vector
 * @param {integer} strideX - `x` stride length
 * @param {Float64Array} AP - packed form of a symmetric matrix `A`

--- a/lib/node_modules/@stdlib/blas/base/dspr/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dspr/lib/ndarray.js
@@ -34,7 +34,7 @@ var base = require( './base.js' );
 * @param {string} order - storage layout
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` is supplied
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input vector
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/dsyr2/lib/dsyr2.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr2/lib/dsyr2.js
@@ -81,7 +81,7 @@ function dsyr2( order, uplo, N, alpha, x, strideX, y, strideY, A, LDA ) {
 		throw new RangeError( format( 'invalid argument. Sixth argument must be non-zero. Value: `%d`.', strideX ) );
 	}
 	if ( strideY === 0 ) {
-		throw new RangeError( format( 'invalid argument. Eighth argument must be non-zero. Value: `%d`.', strideX ) );
+		throw new RangeError( format( 'invalid argument. Eighth argument must be non-zero. Value: `%d`.', strideY ) );
 	}
 	if ( LDA < max( 1, N ) ) {
 		throw new RangeError( format( 'invalid argument. Tenth argument must be greater than or equal to max(1,%d). Value: `%d`.', N, LDA ) );

--- a/lib/node_modules/@stdlib/blas/base/dsyr2/lib/dsyr2.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr2/lib/dsyr2.native.js
@@ -76,7 +76,7 @@ function dsyr2( order, uplo, N, alpha, x, strideX, y, strideY, A, LDA ) {
 		throw new RangeError( format( 'invalid argument. Sixth argument must be non-zero. Value: `%d`.', strideX ) );
 	}
 	if ( strideY === 0 ) {
-		throw new RangeError( format( 'invalid argument. Eighth argument must be non-zero. Value: `%d`.', strideX ) );
+		throw new RangeError( format( 'invalid argument. Eighth argument must be non-zero. Value: `%d`.', strideY ) );
 	}
 	if ( LDA < max( 1, N ) ) {
 		throw new RangeError( format( 'invalid argument. Tenth argument must be greater than or equal to max(1,%d). Value: `%d`.', N, LDA ) );

--- a/lib/node_modules/@stdlib/blas/base/ggemm/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemm/lib/accessors.js
@@ -136,7 +136,7 @@ function zeros( M, N, X, strideX1, strideX2, offsetX ) { // TODO: consider movin
 * @private
 * @param {NonNegativeInteger} M - number of rows
 * @param {NonNegativeInteger} N - number of columns
-* @param {number} beta - scalar
+* @param {number} beta - scalar constant
 * @param {Object} X - matrix object
 * @param {Collection} X.data - matrix data
 * @param {Array<Function>} X.accessors - array element accessors

--- a/lib/node_modules/@stdlib/blas/base/ggemm/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemm/lib/base.js
@@ -122,7 +122,7 @@ function zeros( M, N, X, strideX1, strideX2, offsetX ) { // TODO: consider movin
 * @private
 * @param {NonNegativeInteger} M - number of rows
 * @param {NonNegativeInteger} N - number of columns
-* @param {number} beta - scalar
+* @param {number} beta - scalar constant
 * @param {NumericArray} X - matrix to fill
 * @param {integer} strideX1 - stride of the first dimension of `X`
 * @param {integer} strideX2 - stride of the second dimension of `X`

--- a/lib/node_modules/@stdlib/blas/base/gscal/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/base/gscal/lib/accessors.js
@@ -29,7 +29,7 @@ var M = 5;
 * Multiplies `x` by a scalar `alpha`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Object} x - input array object
 * @param {Collection} x.data - input array data
 * @param {Array<Function>} x.accessors - array element accessors

--- a/lib/node_modules/@stdlib/blas/base/gscal/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/gscal/lib/ndarray.js
@@ -35,7 +35,7 @@ var M = 5;
 * Multiplies a vector by a scalar constant using alternative indexing semantics.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NumericArray} x - input array
 * @param {integer} stride - stride length
 * @param {NonNegativeInteger} offset - starting index

--- a/lib/node_modules/@stdlib/blas/base/sgemm/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemm/lib/base.js
@@ -125,7 +125,7 @@ function zeros( M, N, X, strideX1, strideX2, offsetX ) { // TODO: consider movin
 * @private
 * @param {NonNegativeInteger} M - number of rows
 * @param {NonNegativeInteger} N - number of columns
-* @param {number} beta - scalar
+* @param {number} beta - scalar constant
 * @param {Float32Array} X - matrix to fill
 * @param {integer} strideX1 - stride of the first dimension of `X`
 * @param {integer} strideX2 - stride of the second dimension of `X`

--- a/lib/node_modules/@stdlib/blas/base/sspr/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/lib/base.js
@@ -34,7 +34,7 @@ var f32 = require( '@stdlib/number/float64/base/to-float32' );
 * @param {string} order - storage layout
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` is supplied
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input vector
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/sspr/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/lib/ndarray.js
@@ -34,7 +34,7 @@ var base = require( './base.js' );
 * @param {string} order - storage layout
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` is supplied
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input vector
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/sspr/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/lib/ndarray.native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 * @param {string} order - storage layout
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` is supplied
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input vector
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/sspr/lib/sspr.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/lib/sspr.js
@@ -35,7 +35,7 @@ var base = require( './base.js' );
 * @param {string} order - storage layout
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` is supplied
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input vector
 * @param {integer} strideX - `x` stride length
 * @param {Float32Array} AP - packed form of a symmetric matrix `A`

--- a/lib/node_modules/@stdlib/blas/base/sspr/lib/sspr.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/lib/sspr.native.js
@@ -33,7 +33,7 @@ var addon = require( './../src/addon.node' );
 * @param {string} order - storage layout
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` is supplied
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input vector
 * @param {integer} strideX - `x` stride length
 * @param {Float32Array} AP - packed form of a symmetric matrix `A`

--- a/lib/node_modules/@stdlib/blas/base/ssyr2/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr2/lib/base.js
@@ -32,7 +32,7 @@ var f32 = require( '@stdlib/number/float64/base/to-float32' );
 * @private
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` should be referenced
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - first input vector
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/ssyr2/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr2/lib/ndarray.js
@@ -32,7 +32,7 @@ var base = require( './base.js' );
 *
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` should be referenced
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - first input vector
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/ssyr2/lib/ssyr2.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr2/lib/ssyr2.js
@@ -37,7 +37,7 @@ var base = require( './base.js' );
 * @param {string} order - storage layout
 * @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` should be referenced
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - first input vector
 * @param {integer} strideX - `x` stride length
 * @param {Float32Array} y - second input vector

--- a/lib/node_modules/@stdlib/blas/base/ssyr2/lib/ssyr2.native.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr2/lib/ssyr2.native.js
@@ -76,7 +76,7 @@ function ssyr2( order, uplo, N, alpha, x, strideX, y, strideY, A, LDA ) {
 		throw new RangeError( format( 'invalid argument. Sixth argument must be non-zero. Value: `%d`.', strideX ) );
 	}
 	if ( strideY === 0 ) {
-		throw new RangeError( format( 'invalid argument. Eighth argument must be non-zero. Value: `%d`.', strideX ) );
+		throw new RangeError( format( 'invalid argument. Eighth argument must be non-zero. Value: `%d`.', strideY ) );
 	}
 	if ( LDA < max( 1, N ) ) {
 		throw new RangeError( format( 'invalid argument. Tenth argument must be greater than or equal to max(1,%d). Value: `%d`.', N, LDA ) );

--- a/lib/node_modules/@stdlib/blas/ext/base/gapx/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapx/lib/ndarray.js
@@ -35,7 +35,7 @@ var M = 5;
 * Adds a scalar constant to each element in a strided array.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NumericArray} x - input array
 * @param {integer} strideX - stride length
 * @param {NonNegativeInteger} offsetX - starting index


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-05-25 13:11 UTC and 2026-05-26 13:11 UTC to sibling packages.

### `fix:` use correct argument in `format()` error message

`blas/base/dgemm` had a `RangeError` for `N < 0` whose `format()` value interpolated `M` instead of `N`. Three `*syr2` siblings carry the analogous defect: the zero-stride check on `strideY` reports `strideX`. The non-native `ssyr2.js` (and both `ndarray.js` files) already report `strideY` correctly, confirming the helper-file copy-paste.

-   Source: 6c22721f0
-   Targets:
    -   `blas/base/ssyr2/lib/ssyr2.native.js`
    -   `blas/base/dsyr2/lib/dsyr2.js`
    -   `blas/base/dsyr2/lib/dsyr2.native.js`

### `docs:` align scalar parameter descriptions to package style

`blas/ext/base/gxsa` aligned `* @param {number} alpha - scalar` to `... - scalar constant` to match the package's declared types. The same wording mismatch lives in eighteen BLAS helper files where `alpha` or `beta` is documented as just `scalar` while the package's own `index.d.ts` (and, for the GEMM helpers, the sibling JSDoc later in the same file) uses `scalar constant`.

-   Source: 8f8c6566
-   Targets:
    -   `blas/base/sspr` (`ndarray.js`, `sspr.js`, `ndarray.native.js`, `base.js`, `sspr.native.js`)
    -   `blas/base/dspr` (`ndarray.js`, `dspr.js`, `base.js`)
    -   `blas/base/ssyr2` (`ndarray.js`, `ssyr2.js`, `base.js`)
    -   `blas/base/gscal` (`ndarray.js`, `accessors.js`)
    -   `blas/ext/base/gapx` (`ndarray.js`)
    -   `blas/base/dgemm/lib/base.js`, `blas/base/sgemm/lib/base.js`
    -   `blas/base/ggemm` (`base.js`, `accessors.js`)

### `docs:` convert imperative to noun phrase in constant-module JSDoc

`os/num-cpus` changed its `@module` description from `Return the number of CPUs.` to `Number of CPUs.` because the module exports a value, not a function. `assert/is-little-endian` is the lone outlier among the `is-*` endian/platform constants — `is-big-endian`, `is-darwin`, and `is-windows` all use the noun phrase.

-   Source: 4531b431
-   Target: `assert/is-little-endian/lib/index.js`

## Related Issues

None.

## Questions

No.

## Other

### Validation

Search scope was `lib/node_modules/@stdlib/blas/**` (Patterns A and B) and `lib/node_modules/@stdlib/**/lib/index.js` exporting constants (Pattern C). Each site was independently confirmed by two opus validation agents, verified for self-containment by an adaptation pass, and checked for style consistency against the package's own d.ts / siblings by a final pass.

Deliberately excluded:
-   ~33 BLAS sites whose `alpha - scalar` JSDoc lives in packages whose canonical wording is just "constant" (e.g., `*scal`, `*axpy`, `*fill`, `gaxpy`, `wasm/*scal`, `wasm/*axpy`) — these require human judgment about which canonical wording the package should adopt.
-   The `tempory → temporary` typo pattern from 4531b431 — zero additional occurrences in the repo.
-   Other `throw new ...( format(...) )` mismatches in BLAS that, on inspection, turned out to be intentional (e.g., `transA` reported when `ta = resolveStr(transA)` is null; `LDA` bound variables computed from `order`).

No `refactor:` commits propagated this run — `b3c6c81b` / `04fe53bd` (`isMatrixTranspose` → `resolveStr` in `sgemm`/`ggemm`) change signatures and warrant human review before being applied to `dgemm` and the complex GEMM variants.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was prepared by Claude Code as part of an automated fix-propagation routine. Each propagation site was independently confirmed by two opus validation agents and a style-consistency pass before patches were applied; the routine refuses to propagate any site that fails consensus.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01LQqvYu57VWsHdpQc4ybLE3)_