### PR TITLE
chore: fix JavaScript lint errors (issue #12195)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/slice-to/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/slice-to/test/test.js
@@ -634,11 +634,11 @@ tape( 'in non-strict mode, the function returns an empty array when an ending in
 	var i;
 
 	values = [
-		zeros( [ 1 ], { 'dtype': 'float64' } ),
-		zeros( [ 1, 1 ], { 'dtype': 'float32' } ),
-		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' } ),
-		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' } ),
-		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' } )
+		zeros( [1], { 'dtype': 'float64' } ),
+		zeros( [1, 1], { 'dtype': 'float32' } ),
+		zeros( [1, 1, 1], { 'dtype': 'int32' } ),
+		zeros( [1, 1, 1, 1], { 'dtype': 'uint32' } ),
+		zeros( [1, 1, 1, 1, 1], { 'dtype': 'complex128' } )
 	];
 
 	stop = [
@@ -666,11 +666,11 @@ tape( 'the function returns an empty array when an ending index is the first ele
 	var i;
 
 	values = [
-		zeros( [ 1 ], { 'dtype': 'float64' } ),
-		zeros( [ 1, 1 ], { 'dtype': 'float32' } ),
-		zeros( [ 1, 1, 1 ], { 'dtype': 'int32' } ),
-		zeros( [ 1, 1, 1, 1 ], { 'dtype': 'uint32' } ),
-		zeros( [ 1, 1, 1, 1, 1 ], { 'dtype': 'complex128' } )
+		zeros( [1], { 'dtype': 'float64' } ),
+		zeros( [1, 1], { 'dtype': 'float32' } ),
+		zeros( [1, 1, 1], { 'dtype': 'int32' } ),
+		zeros( [1, 1, 1, 1], { 'dtype': 'uint32' } ),
+		zeros( [1, 1, 1, 1, 1], { 'dtype': 'complex128' } )
 	];
 
 	stop = [


### PR DESCRIPTION
Resolves #12195 

## Description

> What is the purpose of this pull request?
Removes spaces inside array literals passed to zeros() calls in @stdlib/ndarray/slice-to/test/test.js to comply with the stdlib/line-closing-bracket-spacing lint rule .

This pull request:

-   It removes the extra spacing to comply with the lint rules

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   N/A

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
