### PR TITLE
docs: updae descriptions in `stats/strided/*abs` package descriptions

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dmidrangeabs/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/dmidrangeabs/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # dmidrangeabs
 
-> Compute the [mid-range][mid-range] of absolute values of a double-precision floating-point strided array.
+> Calculate the [mid-range][mid-range] of absolute values of a double-precision floating-point strided array.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/strided/dmidrangeabs/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/dmidrangeabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/strided/dmidrangeabs",
   "version": "0.0.0",
-  "description": "Compute the mid-range of absolute values of a double-precision floating-point strided array.",
+  "description": "Calculate the mid-range of absolute values of a double-precision floating-point strided array.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/strided/dnanrangeabs/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/dnanrangeabs/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # dnanrangeabs
 
-> Compute the [range][range] of absolute values of a double-precision floating-point strided array, ignoring `NaN` values.
+> Calculate the [range][range] of absolute values of a double-precision floating-point strided array, ignoring `NaN` values.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/strided/dnanrangeabs/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/dnanrangeabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/strided/dnanrangeabs",
   "version": "0.0.0",
-  "description": "Compute the range of absolute values of a double-precision floating-point strided array, ignoring NaN values.",
+  "description": "Calculate the range of absolute values of a double-precision floating-point strided array, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/strided/drangeabs/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/drangeabs/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # drangeabs
 
-> Compute the [range][range] of absolute values of a double-precision floating-point strided array.
+> Calculate the [range][range] of absolute values of a double-precision floating-point strided array.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/strided/drangeabs/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/drangeabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/strided/drangeabs",
   "version": "0.0.0",
-  "description": "Compute the range of absolute values of a double-precision floating-point strided array.",
+  "description": "Calculate the range of absolute values of a double-precision floating-point strided array.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/strided/nanrangeabs/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/nanrangeabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/strided/nanrangeabs",
   "version": "0.0.0",
-  "description": "Compute the range of absolute values of a strided array, ignoring NaN values.",
+  "description": "Calculate the range of absolute values of a strided array, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/strided/srangeabs/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/srangeabs/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # srangeabs
 
-> Compute the [range][range] of absolute values of a single-precision floating-point strided array.
+> Calculate the [range][range] of absolute values of a single-precision floating-point strided array.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/strided/srangeabs/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/srangeabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/strided/srangeabs",
   "version": "0.0.0",
-  "description": "Compute the range of absolute values of a single-precision floating-point strided array.",
+  "description": "Calculate the range of absolute values of a single-precision floating-point strided array.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Replaces the imperative verb `"Compute"` with `"Calculate"` in the `package.json` `"description"` field and `README.md` intro blockquote of five `*abs` packages in `@stdlib/stats/strided`, aligning them with the convention used by 227/239 (95.0%) non-aggregator sibling packages in the namespace.

### Namespace summary

-   **Target:** `@stdlib/stats/strided`
-   **Members analyzed:** 239 (240 packages minus the `distances` namespace aggregator, which is structurally distinct — same exclusion as PR #11957)
-   **Features extracted:** complete file tree, `package.json` shape (top-level keys, `scripts`, `stdlib`, `keywords`, description verb), `manifest.json` shape, README H2/H3/H4 heading sequences, `test/`, `benchmark/`, `examples/` file-name patterns
-   **Features with clear majority (≥75%):** universal file set (13 files at 100%), `package.json` top-level key set (19 keys at 100%), nine `keywords` strings at 100% (`array`, `math`, `mathematics`, `statistics`, `stats`, `stdlib`, `stdmath`, `strided`, `strided array`), three universal H2 sections (`Usage`, `Notes`, `Examples` — 100%), `## See Also` (83.7%, auto-populated → excluded), `"Calculate"` description verb (95.0%)
-   **Features without clear majority (excluded):** native-binding cluster files (69.0% — presence correlates with C implementation), `## References` H2 (38.1% — math-references-dependent), `keywords: typed` (85.8% namespace-wide but a near-50/50 split *within* the no-prefix generic sub-group, indicating undecided sub-group convention rather than drift), various H3/H4 sub-heading sequences (no single sequence ≥75%)

### Outlier corrections

#### `@stdlib/stats/strided/drangeabs`

Aligns the `package.json` `description` field and `README.md` intro blockquote of `@stdlib/stats/strided/drangeabs` with the `"Calculate"` verb used by 227 of 239 (95%) sibling packages under `stats/strided`, matching direct analogues `drange` and `rangeabs`. The package was one of five outliers — all `*abs` variants — retaining the non-standard `"Compute"` prefix. JSDoc, `docs/repl.txt`, and `docs/types/index.d.ts` are unchanged, as `"Computes"` remains the correct gerund form for machine-readable documentation across the entire sibling set.

#### `@stdlib/stats/strided/dnanrangeabs`

Aligns the `package.json` description and `README.md` introductory blockquote with the established `"Calculate"` verb used by 227 of 239 (95%) packages in `stats/strided`, replacing the non-conforming `"Compute"`. Sibling packages `dnanrange` and `nanrangeabs` both use `"Calculate"`; `dnanrangeabs` was one of five remaining outliers. Internal JSDoc, `docs/repl.txt`, and `docs/types/index.d.ts` retain their existing gerund form and were not modified.

#### `@stdlib/stats/strided/srangeabs`

Replaces `"Compute"` with `"Calculate"` in the `package.json` description field and the `README.md` introductory blockquote for `@stdlib/stats/strided/srangeabs`. This aligns the package with the 227/239 (95%) majority convention among `stats/strided` non-aggregator packages and matches the wording used by direct siblings `srange`, `drangeabs`, and `rangeabs`. JSDoc, `docs/repl.txt`, and `docs/types/index.d.ts` retain their existing `"Computes"` gerund form, which is consistent across all 239 packages and is unchanged.

#### `@stdlib/stats/strided/nanrangeabs`

Updates the `package.json` description verb from `"Compute"` to `"Calculate"` to match the README intro, which already read `"Calculate the range of …"` — making this the only package in the corrected set where the fix is `package.json`-only. The change brings the description into conformance with the `nanrange` and `rangeabs` siblings and with 227 of 239 (95%) `stats/strided` non-aggregator packages that use `"Calculate"` as the leading verb. JSDoc, `docs/repl.txt`, and `docs/types/index.d.ts` were not touched, as those sources use the gerund `"Computes"` consistently across all 239 packages.

#### `@stdlib/stats/strided/dmidrangeabs`

Replaces `"Compute"` with `"Calculate"` in `package.json` and the `README.md` intro blockquote, the only two surface areas that varied from the prevailing verb across `stats/strided`. Of 239 non-aggregator packages in that namespace, 227 (95%) open their `package.json` description with `"Calculate"`; `dmidrangeabs` was one of five outliers. JSDoc, `docs/repl.txt`, and `docs/types/index.d.ts` use the gerund `"Computes"` throughout and are unchanged, consistent with the convention shared by all 239 packages.

### Validation

Three independent validation agents reviewed each outlier before any patch was applied:

1.  **Semantic-review (Opus):** for each outlier, read `lib/main.js`, `lib/ndarray.js`, and `README.md` in full and compared against non-abs siblings (`drange`, `dnanrange`, `srange`, `nanrange`, `dmidrange`) and generic-abs siblings (`rangeabs`, `midrangeabs`). Result for all 5: `confirmed-drift`. Each outlier is a structurally simple per-element absolute-value variant of its non-abs sibling; no multi-array, no statistical-procedure semantics that would warrant the `"Compute"` verb. The 7 *other* `"Compute"` packages in the namespace — `ztest`, `ztest2`, `dztest`, `dztest2`, `sztest`, `sztest2`, `dcovmatmtk` — were identified as intentional deviations (statistical-test and matrix-multi-array conventions) and were not corrected.
2.  **Cross-reference (Opus):** for each outlier, greppped `test/`, `examples/`, `benchmark/`, `docs/repl.txt`, `docs/types/`, and the wider `lib/node_modules/@stdlib/` tree for any test, snapshot, REPL fixture, or sibling-package documentation that references the literal `"Compute"` description text. Result for all 5: `safe-to-fix`. `examples/c/example.c` files contain unrelated `// Compute the range:` C inline comments outside the touched lines; `docs/repl.txt` and `docs/types/index.d.ts` use the gerund `"Computes"` (separate string, separate convention, untouched). The parent `stats/strided/README.md` TOC is regenerated from `package.json` and re-syncs automatically.
3.  **Structural-review (Sonnet):** confirmed `"Compute"` appears exactly once in each `package.json` (the description line) and exactly once in each `README.md` prose (the line-23 intro blockquote), except `nanrangeabs` where the README already said `"Calculate"`. All 7 sibling reference packages (`drange`, `srange`, `nanrange`, `rangeabs`, `midrangeabs`, `dmidrange`, `dnanrange`) confirmed to use `"Calculate the …"`. Result for all 5: `confirmed-drift`.

### Deliberately excluded

-   `## See Also` H2 section missing in 39 packages (83.7% conformance) — auto-populated by the package-generator (`<!-- Section for related stdlib packages. Do not manually edit this section, as it is automatically populated. -->`); gate 7a forbids manual edits.
-   `keywords: typed` missing in 34 generic-prefix packages (85.8% namespace-wide conformance) — within the no-prefix generic sub-group, the rate is 31/65 with `typed` and 34/65 without (47.7% / 52.3%), with no semantic axis distinguishing the two halves (`max` omits but `mskmax` carries; `mean` omits but `variance` carries). The namespace-wide majority is dominated by the typed-array-specific packages; the convention within the generic sub-group is undecided. Logged as a candidate for a future targeted standardization run.
-   The 7 other `"Compute"` packages — `ztest`/`ztest2`/`dztest`/`dztest2`/`sztest`/`sztest2`/`dcovmatmtk` — are intentional deviations using domain-conventional terminology (hypothesis testing, covariance matrix) and were not corrected.
-   The 74-package native-binding cluster (extra files `binding.gyp`, `manifest.json`, `lib/native.js`, `src/`, etc.) — presence at 69.0%, below threshold; tracks whether a C implementation exists.
-   Various H3/H4 sub-heading sequences — no single sequence reaches 75% majority. Partially addressed in prior PR #11957 for `dnanrangeabs` heading levels.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Per-package commits keep the audit trail readable per-outlier rather than per-feature; 5 commits in total.
-   Total diff is 9 lines across 9 files: `package.json` description + `README.md` intro blockquote for 4 packages, `package.json` description only for `nanrangeabs` (its README already used `"Calculate"`).
-   No tests, examples, benchmarks, REPL fixtures, TypeScript declarations, or JSDoc were modified; `package.json.description` and the `README.md` intro blockquote are the only surface areas touched.
-   Branch: `philipp/drift-stats-strided-2026-05-27`.
-   Full local report (member list, feature distributions, agent verdicts, dropped findings, future-run notes) saved at `~/drift-reports/drift-stats-strided-2026-05-27.md` outside the repo working tree.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package API drift detection routine: structural feature extraction across all 239 non-aggregator `@stdlib/stats/strided` packages, three independent validation agents (semantic-review, cross-reference, structural-review) per outlier, and a final per-package PR-body refinement pass. Each patch is a one-line verb change to a human-facing documentation field; no code, signatures, types, tests, examples, benchmarks, or REPL fixtures were changed. A human will audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0154huhESY63LWjQoi8R1SLb)_