### PR TITLE
chore: fix JavaScript lint errors (issue #12305)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dspr/test/test.dspr.js
+++ b/lib/node_modules/@stdlib/blas/base/dspr/test/test.dspr.js
@@ -26,7 +26,6 @@ var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var dspr = require( './../lib/dspr.js' );
 
-
 // FIXTURES //
 
 var rl = require( './fixtures/row_major_l.json' );

--- a/lib/node_modules/@stdlib/blas/base/dtrsv/test/test.dtrsv.js
+++ b/lib/node_modules/@stdlib/blas/base/dtrsv/test/test.dtrsv.js
@@ -26,7 +26,6 @@ var tape = require( 'tape' );
 var Float64Array = require( '@stdlib/array/float64' );
 var dtrsv = require( './../lib/dtrsv.js' );
 
-
 // FIXTURES //
 
 var rlntnu = require( './fixtures/row_major_l_nt_nu.json' );


### PR DESCRIPTION
## Summary

- removed the extra blank line between module-level `require` statements in the two files reported by the JavaScript lint workflow

## Related Issues

- resolves #12305

## Verification

- `git diff --check`
- checked the touched files for empty lines between adjacent module-level `require` statements

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)