### PR TITLE
docs: document `Date` input and add Notes section in `time/iso-weeks-in-year`

### DIFF
--- a/lib/node_modules/@stdlib/time/iso-weeks-in-year/README.md
+++ b/lib/node_modules/@stdlib/time/iso-weeks-in-year/README.md
@@ -56,6 +56,16 @@ num = isoWeeksInYear( 2017 );
 
 <!-- /.usage -->
 
+<section class="notes">
+
+## Notes
+
+-   The function's return value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
+
+</section>
+
+<!-- /.notes -->
+
 <section class="examples">
 
 ## Examples

--- a/lib/node_modules/@stdlib/time/iso-weeks-in-year/docs/repl.txt
+++ b/lib/node_modules/@stdlib/time/iso-weeks-in-year/docs/repl.txt
@@ -1,5 +1,5 @@
 
-{{alias}}( [year] )
+{{alias}}( [value] )
     Returns the number of ISO weeks in a year according to the Gregorian
     calendar.
 
@@ -7,10 +7,14 @@
     (according to local time). To determine the number of ISO weeks for a
     particular year, provide either a year or a `Date` object.
 
+    The function's return value is a generalization and does **not** take into
+    account inaccuracies due to daylight savings conventions, crossing
+    timezones, or other complications with time and dates.
+
     Parameters
     ----------
-    year: integer (optional)
-        Year.
+    value: integer|Date (optional)
+        Year or `Date` object.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/time/iso-weeks-in-year/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/time/iso-weeks-in-year/docs/types/index.d.ts
@@ -24,6 +24,7 @@
 * ## Notes
 *
 * -   By default, the function returns the number of ISO weeks in the current year (according to local time). To determine the number of ISO weeks for a particular year, provide either a year or a `Date` object.
+* -   The function's return value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
 *
 * @param value - year or `Date` object
 * @returns number of ISO weeks in a year


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Aligns the user-facing documentation for `@stdlib/time/iso-weeks-in-year` with the package's actual function signature and with the four sibling year-input packages in the `@stdlib/time` namespace.

### Namespace summary

-   **Target namespace:** `@stdlib/time`
-   **Member count:** 18 non-autogenerated packages (the namespace aggregator `time/base` was excluded as it is a sub-namespace package, not a leaf utility)
-   **Features analyzed:** file tree, `package.json` top-level / `scripts` / `stdlib` keys, `manifest.json` shape, README heading set and order, README `## Notes` body, `docs/repl.txt` parameter declarations and Notes paragraph, `docs/types/index.d.ts` JSDoc shape, `test/`/`benchmark/`/`examples/` file names, `lib/main.js` public signature, validation prologue, error construction, JSDoc `@param`/`@throws`/`@returns`/`@example` tags, `require()` graph.
-   **Features with clear majority (≥75% = 14/18):** `package.json` top-level key set (100%), `package.json` `scripts` (empty in 18/18), `package.json` `stdlib` (absent in 18/18), README `## Usage` + `## Examples` (100%), README `## CLI` + `### Usage` + `### Examples` (16/18, missing only in `tic`/`toc`), `bin/cli` + `docs/usage.txt` + `etc/cli_opts.json` + `test/test.cli.js` (16/18, same exclusion), README `## Notes` (14/18), README `## See Also` (14/18), `examples/index.js` (18/18), `test/test.js` (18/18), error construction via `@stdlib/string/format` (100% of packages that throw).
-   **Features without clear majority (excluded):** `keywords` arrays (per-package vocab — `date` 13/18, `gregorian` 12/18 — both below threshold); `directories.benchmark` (2/18 — far below threshold); `lib/*.json` data files (per-package); `## Notes` body text (package-specific content); `repl.txt` month-parameter type ordering (3 different orderings, max 3/7 within applicable sub-cluster).

### Per outlier package

#### `@stdlib/time/iso-weeks-in-year`

The package's function signature (`isoWeeksInYear( value )`) already accepts `integer|Date` — confirmed in `lib/main.js`, the JSDoc `@param`, the `index.d.ts` `value?: number | Date` declaration, and the `test/test.js` `value` variable naming. The four sibling year-input packages in the namespace (`days-in-year`, `hours-in-year`, `minutes-in-year`, `seconds-in-year` — 4/4 conformance among the year-input sub-cluster) all carry an identical `repl.txt`/`README`/`index.d.ts` triplet that documents the `Date` input and adds the daylight-savings/timezone caveat. This pull request applies the same triplet to `iso-weeks-in-year`:

-   `docs/repl.txt` — rename the parameter and signature placeholder from `year` to `value`, widen the declared type from `integer` to `integer|Date`, change the description from `Year.` to `` Year or `Date` object. ``, and add the daylight-savings/timezone caveat paragraph. The pre-existing declaration mis-documented the type: the function has always accepted a `Date`, but `repl.txt` advertised only `integer`.
-   `docs/types/index.d.ts` — add the daylight-savings/timezone caveat bullet to the `## Notes` JSDoc block.
-   `README.md` — insert the `<section class="notes">` block carrying the same caveat between the `usage` and `examples` sections.

No code, tests, or examples change. Net diff: +18/−3 across three files.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Checked:

-   **Structural extraction** across all 18 members (file tree, `package.json` shape, README heading set/order, `manifest.json` shape, test/example/benchmark file names).
-   **Semantic extraction** of `lib/main.js` and `lib/index.js` for each member: public signature, dispatch arity, validation prologue, error-construction style, `@param`/`@throws`/`@returns`/`@example` tags, `require()` graph.
-   **Self-review** of the iso-weeks-in-year correction against the four sibling `-in-year` packages — confirmed the deviation is unintentional drift (the function already accepts `Date` per source and TS declaration) rather than a genuine semantic difference, and confirmed the majority pattern is the correct shape to apply.
-   **Cross-reference check** that tests, examples, and downstream `require()`-ers of `@stdlib/time/iso-weeks-in-year` do not depend on the previous (incorrect) `repl.txt` parameter name or the absent README Notes section.

Deliberately excluded:

-   **`tic`/`toc`** structural drift (missing `bin/cli`, `docs/usage.txt`, `etc/cli_opts.json`, `test/test.cli.js`, `## CLI` README section, `package.json` `bin` field) — these packages are not CLI tools by design; absence is intentional.
-   **Missing `## Notes` section** in `day-of-quarter`, `day-of-year`, `quarter-of-year` — writing package-specific notes content is not a mechanical fix, dropped.
-   **Missing `## See Also` section** in `duration2ms`, `ms2duration`, `now` — auto-populated generator content, not drift.
-   **`repl.txt` month-parameter type ordering** (three different orderings across siblings, no clear majority within applicable scope).
-   **`benchmark/benchmark.js`** absence in 16/18 packages — below threshold (2/18 = 11.1%); presence is the minority, not a majority pattern to propagate.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running a cross-package drift-detection routine. The namespace `@stdlib/time` was chosen at random from the set of `@stdlib` namespaces with ≥8 non-autogenerated members. Structural and semantic features were extracted for every member, majority patterns were computed at a 75% threshold, candidate corrections were filtered through pre-validation gates (open-PR collision check, generator-owned content exclusion, materiality), and the surviving correction (`iso-weeks-in-year` documentation triplet) was self-reviewed against the four sibling `-in-year` packages before being applied. Only text in `README.md`, `docs/repl.txt`, and `docs/types/index.d.ts` was modified — no code, tests, or examples were touched.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nmq2yBZRReLzKUtg7eW2GS)_