### PR TITLE
docs: normalize `@returns {void}` and remove stray `@private` in `_tools/licenses` main JSDoc

### DIFF
--- a/lib/node_modules/@stdlib/_tools/licenses/infer/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/licenses/infer/lib/main.js
@@ -37,10 +37,10 @@ var debug = logger( 'licenses:infer' );
 /**
 * Infers license information from file content.
 *
-* @private
 * @param {ObjectArray} pkgs - package data
 * @param {string} pattern - glob pattern
 * @param {Callback} clbk - callback to invoke upon completion
+* @returns {void}
 */
 function infer( pkgs, pattern, clbk ) {
 	var count;

--- a/lib/node_modules/@stdlib/_tools/licenses/licenses/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/licenses/licenses/lib/main.js
@@ -52,6 +52,7 @@ var debug = createDebug( 'licenses:main' );
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
 * @throws {TypeError} must provide a function
+* @returns {void}
 *
 * @example
 * licenses( onResults );


### PR DESCRIPTION
## Description

Two JSDoc-only corrections in `@stdlib/_tools/licenses`, restoring the namespace convention for callback-based public functions in `lib/main.js`. No behavior change.

### `_tools/licenses/licenses`

Added `* @returns {void}` to the JSDoc for the public `licenses( options, clbk )` function, immediately after the last `@throws` line. The three other callback-based void-returning public functions in the namespace (`insert-header-file-list`, `remove-header-file-list`, `update-header-file-list`) all carry this exact tag in the same position; `licenses` was the only one without it. Conformance: 9 of 11 namespace mains (82%) have a `@returns` tag.

### `_tools/licenses/infer`

Removed `* @private` from the `infer( pkgs, pattern, clbk )` JSDoc and added `* @returns {void}` after the last `@param`. The annotation was stale: `lib/index.js` declares `@module @stdlib/_tools/licenses/infer` and re-exports `main` as the package's public API, and `README.md` documents the function as the package's public require target. 10 of 11 namespace mains (91%) do not mark the public main `@private`.

## Related Issues

No.

## Questions

No.

## Other

> Any other information relevant to this pull request?

This PR was authored by Claude Code running an automated cross-package API-drift detection routine over the eleven packages in `@stdlib/_tools/licenses`. Both candidate fixes survived three independent validation passes (semantic-review, cross-reference, structural-review) before being applied. Full audit trail is in the local run report.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code running an automated namespace-drift routine: structural and semantic feature extraction across all eleven members, majority-vote pattern detection at a 75% threshold, three-agent validation of each candidate correction, and mechanical application of only those corrections that survived all validators. The applied changes are documentation-only (single-line JSDoc tag insertions plus one stray-annotation removal); no source logic, test, or example was modified.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017w1LrwHtdxrJfBjfwgR71A)_