### PR TITLE
docs: align parameter descriptions in `blas/base/dzasum` with sibling `scasum`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dzasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/dzasum/README.md
@@ -47,7 +47,7 @@ The function has the following parameters:
 
 -   **N**: number of indexed elements.
 -   **x**: input [`Complex128Array`][@stdlib/array/complex128].
--   **strideX**: stride length.
+-   **strideX**: index increment for `x`.
 
 The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to traverse every other value,
 
@@ -91,7 +91,7 @@ var out = dzasum.ndarray( 4, x, 1, 0 );
 
 The function has the following additional parameters:
 
--   **offsetX**: starting index.
+-   **offsetX**: starting index for `x`.
 
 While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameter supports indexing semantics based on a starting index. For example, to start from the second element
 

--- a/lib/node_modules/@stdlib/blas/base/dzasum/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/dzasum/docs/repl.txt
@@ -20,7 +20,7 @@
         Input array.
 
     strideX: integer
-        Stride length.
+        Index increment for `x`.
 
     Returns
     -------
@@ -64,10 +64,10 @@
         Input array.
 
     strideX: integer
-        Stride length.
+        Index increment for `x`.
 
     offsetX: integer
-        Starting index.
+        Starting index of `x`.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/blas/base/dzasum/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/dzasum/docs/types/index.d.ts
@@ -31,8 +31,8 @@ interface Routine {
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
-	* @param strideX - stride length
-	* @returns sum
+	* @param strideX - `x` stride length
+	* @returns out
 	*
 	* @example
 	* var Complex128Array = require( '@stdlib/array/complex128' );
@@ -49,9 +49,9 @@ interface Routine {
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
-	* @param strideX - stride length
-	* @param offsetX - starting index
-	* @returns sum
+	* @param strideX - `x` stride length
+	* @param offsetX - starting index for `x`
+	* @returns out
 	*
 	* @example
 	* var Complex128Array = require( '@stdlib/array/complex128' );
@@ -69,7 +69,7 @@ interface Routine {
 *
 * @param N - number of indexed elements
 * @param x - input array
-* @param strideX - stride length
+* @param strideX - `x` stride length
 * @returns out
 *
 * @example

--- a/lib/node_modules/@stdlib/blas/base/dzasum/lib/dzasum.js
+++ b/lib/node_modules/@stdlib/blas/base/dzasum/lib/dzasum.js
@@ -31,7 +31,7 @@ var ndarray = require( './ndarray.js' );
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Complex128Array} x - input array
-* @param {integer} strideX - stride length
+* @param {integer} strideX - `x` stride length
 * @returns {number} result
 *
 * @example

--- a/lib/node_modules/@stdlib/blas/base/dzasum/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dzasum/lib/ndarray.js
@@ -31,8 +31,8 @@ var reinterpret = require( '@stdlib/strided/base/reinterpret-complex128' );
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Complex128Array} x - input array
-* @param {integer} strideX - stride length
-* @param {NonNegativeInteger} offsetX - starting index
+* @param {integer} strideX - `x` stride length
+* @param {NonNegativeInteger} offsetX - starting index for `x`
 * @returns {number} result
 *
 * @example


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-05-26 21:38 UTC and 2026-05-27 09:44 UTC (commits `e508f182`..`7d900094`, 15 commits).

This pull request aligns parameter descriptions in the newly added `blas/base/dzasum` package with the sibling `blas/base/scasum` package and resolves an internal inconsistency in its TypeScript declaration:

-   **`blas/base/dzasum`** (`1ff31b20`): `strideX` was described as `stride length` and `offsetX` as `starting index` across `README.md`, `docs/repl.txt`, `docs/types/index.d.ts`, `lib/dzasum.js`, and `lib/ndarray.js` — the established convention across `blas/base` (216 JSDoc occurrences) is `` `x` stride length `` / `` starting index for `x` ``, with `` index increment for `x` `` / `` Starting index of `x` `` in REPL docs. Additionally, `docs/types/index.d.ts` used `@returns sum` in the `Routine` interface but `@returns out` in the top-level `declare var`; sibling `scasum` uses `@returns out` throughout. All five files now match `scasum`.

## Related Issues

None.

## Questions

No.

## Other

### Validation

Checked against the per-file diffs of the 15 commits merged in the window. Each finding was independently flagged by two reviewers and cross-referenced against the sibling `blas/base/scasum` package as well as the dominant `blas/base` JSDoc/REPL conventions (`grep` counts: 216 vs 2 for `` `x` stride length `` vs `stride length`; 51 vs 17 for `@returns out` vs `@returns sum`).

Deliberately excluded:

-   `lib/ndarray.js` declared-variable ordering (`viewX` vs `stemp`) — both identifiers are equal length, so the style guide's "descending character length" rule does not mandate one ordering over the other.
-   Anything in the other 14 commits in the window — the two bug reviewers and both style reviewers returned no other high-signal findings.

No bug fixes (runtime correctness) were needed: both bug auditors returned empty result sets after tracing `dzasum`'s complex-stride arithmetic and the `bernoulli/mgf` `isProbability` refactor against the previous semantics.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated 24-hour commit review pass. Findings were produced by four independent reviewer subagents (two style, two bug), filtered to require either multi-agent corroboration or independent re-verification against the diff, and applied without scope expansion beyond the originating commit.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2ZWu61WEUj6QYFyRGCR7x)_