### PR TITLE
chore: propagate `blas/*` JSDoc and `cscal` header fixes to siblings

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/caxpy/include/stdlib/blas/base/caxpy_cblas.h
+++ b/lib/node_modules/@stdlib/blas/base/caxpy/include/stdlib/blas/base/caxpy_cblas.h
@@ -17,7 +17,7 @@
 */
 
 /**
-* Header file containing function declarations for the C interface to the CBLAS Level 1 routine `cblas_ccopy`.
+* Header file containing function declarations for the C interface to the CBLAS Level 1 routine `cblas_caxpy`.
 */
 #ifndef STDLIB_BLAS_BASE_CAXPY_CBLAS_H
 #define STDLIB_BLAS_BASE_CAXPY_CBLAS_H

--- a/lib/node_modules/@stdlib/blas/base/caxpy/src/caxpy_cblas.c
+++ b/lib/node_modules/@stdlib/blas/base/caxpy/src/caxpy_cblas.c
@@ -20,6 +20,7 @@
 #include "stdlib/blas/base/caxpy_cblas.h"
 #include "stdlib/blas/base/shared.h"
 #include "stdlib/complex/float32/ctor.h"
+#include "stdlib/strided/base/min_view_buffer_index.h"
 
 /**
 * Scales a single-precision complex floating-point vector by a single-precision complex floating-point constant and adds the result to a single-precision complex floating-point vector.

--- a/lib/node_modules/@stdlib/blas/base/daxpy/lib/daxpy.js
+++ b/lib/node_modules/@stdlib/blas/base/daxpy/lib/daxpy.js
@@ -30,7 +30,7 @@ var ndarray = require( './ndarray.js' );
 * Multiplies a vector `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {Float64Array} y - output array

--- a/lib/node_modules/@stdlib/blas/base/daxpy/lib/daxpy.native.js
+++ b/lib/node_modules/@stdlib/blas/base/daxpy/lib/daxpy.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Multiplies a vector `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {Float64Array} y - output array

--- a/lib/node_modules/@stdlib/blas/base/daxpy/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/daxpy/lib/ndarray.js
@@ -29,7 +29,7 @@ var M = 4;
 * Multiplies a vector `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index

--- a/lib/node_modules/@stdlib/blas/base/daxpy/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/daxpy/lib/ndarray.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Multiplies a vector `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index

--- a/lib/node_modules/@stdlib/blas/base/dscal/lib/dscal.js
+++ b/lib/node_modules/@stdlib/blas/base/dscal/lib/dscal.js
@@ -30,7 +30,7 @@ var ndarray = require( './ndarray.js' );
 * Multiplies a vector `x` by a scalar `alpha`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} stride - index increment
 * @returns {Float64Array} input array

--- a/lib/node_modules/@stdlib/blas/base/dscal/lib/dscal.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dscal/lib/dscal.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Multiplies a vector `x` by a scalar `alpha`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} stride - index increment
 * @returns {Float64Array} input array

--- a/lib/node_modules/@stdlib/blas/base/dscal/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dscal/lib/ndarray.js
@@ -29,7 +29,7 @@ var M = 5;
 * Multiplies a vector `x` by a scalar `alpha`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} stride - index increment
 * @param {NonNegativeInteger} offset - starting index

--- a/lib/node_modules/@stdlib/blas/base/dscal/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dscal/lib/ndarray.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Multiplies a vector `x` by a scalar `alpha`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} stride - index increment
 * @param {NonNegativeInteger} offset - starting index

--- a/lib/node_modules/@stdlib/blas/base/gaxpy/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/base/gaxpy/lib/accessors.js
@@ -25,7 +25,7 @@
 *
 * @private
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Object} x - input array object
 * @param {Collection} x.data - input array data
 * @param {Array<Function>} x.accessors - array element accessors

--- a/lib/node_modules/@stdlib/blas/base/gaxpy/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/gaxpy/lib/main.js
@@ -30,7 +30,7 @@ var ndarray = require( './ndarray.js' );
 * Multiplies `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NumericArray} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NumericArray} y - output array

--- a/lib/node_modules/@stdlib/blas/base/gaxpy/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/gaxpy/lib/ndarray.js
@@ -35,7 +35,7 @@ var M = 4;
 * Multiplies `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NumericArray} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index

--- a/lib/node_modules/@stdlib/blas/base/saxpy/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/saxpy/lib/ndarray.js
@@ -34,7 +34,7 @@ var M = 4;
 * Multiplies a vector `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/saxpy/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/saxpy/lib/ndarray.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Multiplies a vector `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/saxpy/lib/saxpy.js
+++ b/lib/node_modules/@stdlib/blas/base/saxpy/lib/saxpy.js
@@ -30,7 +30,7 @@ var ndarray = require( './ndarray.js' );
 * Multiplies a vector `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {Float32Array} y - output array

--- a/lib/node_modules/@stdlib/blas/base/saxpy/lib/saxpy.native.js
+++ b/lib/node_modules/@stdlib/blas/base/saxpy/lib/saxpy.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Multiplies a vector `x` by a constant and adds the result to `y`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {Float32Array} y - output array

--- a/lib/node_modules/@stdlib/blas/base/sscal/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sscal/lib/ndarray.js
@@ -29,7 +29,7 @@ var M = 5;
 * Multiplies a vector `x` by a scalar `alpha`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} stride - index increment
 * @param {NonNegativeInteger} offset - starting index

--- a/lib/node_modules/@stdlib/blas/base/sscal/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sscal/lib/ndarray.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Multiplies a vector `x` by a scalar `alpha`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} stride - index increment
 * @param {NonNegativeInteger} offset - starting index

--- a/lib/node_modules/@stdlib/blas/base/sscal/lib/sscal.js
+++ b/lib/node_modules/@stdlib/blas/base/sscal/lib/sscal.js
@@ -30,7 +30,7 @@ var ndarray = require( './ndarray.js' );
 * Multiplies a vector `x` by a scalar `alpha`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} stride - index increment
 * @returns {Float32Array} input array

--- a/lib/node_modules/@stdlib/blas/base/sscal/lib/sscal.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sscal/lib/sscal.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Multiplies a vector `x` by a scalar `alpha`.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} stride - index increment
 * @returns {Float32Array} input array

--- a/lib/node_modules/@stdlib/blas/base/wasm/cscal/lib/routine.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/cscal/lib/routine.js
@@ -103,7 +103,7 @@ inherits( Routine, Module );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {Complex64} alpha - scalar
+* @param {Complex64} alpha - scalar constant
 * @param {Complex64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @returns {Complex64Array} input array
@@ -140,7 +140,7 @@ setReadOnly( Routine.prototype, 'main', function cscal( N, alpha, x, strideX ) {
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {Complex64} alpha - scalar
+* @param {Complex64} alpha - scalar constant
 * @param {Complex64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/wasm/daxpy/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/daxpy/lib/module.js
@@ -114,7 +114,7 @@ inherits( Module, WasmModule );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} yptr - output array pointer (i.e., byte offset)
@@ -180,7 +180,7 @@ setReadOnly( Module.prototype, 'main', function daxpy( N, alpha, xptr, strideX, 
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index

--- a/lib/node_modules/@stdlib/blas/base/wasm/daxpy/lib/routine.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/daxpy/lib/routine.js
@@ -96,7 +96,7 @@ inherits( Routine, Module );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {Float64Array} y - output array
@@ -132,7 +132,7 @@ setReadOnly( Routine.prototype, 'main', function daxpy( N, alpha, x, strideX, y,
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index

--- a/lib/node_modules/@stdlib/blas/base/wasm/dscal/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dscal/lib/module.js
@@ -111,7 +111,7 @@ inherits( Module, WasmModule );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
 * @param {integer} strideX - `x` stride length
 * @returns {NonNegativeInteger} input array pointer (i.e., byte offset)
@@ -172,7 +172,7 @@ setReadOnly( Module.prototype, 'main', function dscal( N, alpha, xptr, strideX )
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index

--- a/lib/node_modules/@stdlib/blas/base/wasm/dscal/lib/routine.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dscal/lib/routine.js
@@ -94,7 +94,7 @@ inherits( Routine, Module );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @returns {Float64Array} input array
@@ -127,7 +127,7 @@ setReadOnly( Routine.prototype, 'main', function dscal( N, alpha, x, strideX ) {
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/wasm/saxpy/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/saxpy/lib/module.js
@@ -114,7 +114,7 @@ inherits( Module, WasmModule );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} yptr - output array pointer (i.e., byte offset)
@@ -180,7 +180,7 @@ setReadOnly( Module.prototype, 'main', function saxpy( N, alpha, xptr, strideX, 
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index

--- a/lib/node_modules/@stdlib/blas/base/wasm/saxpy/lib/routine.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/saxpy/lib/routine.js
@@ -96,7 +96,7 @@ inherits( Routine, Module );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {Float32Array} y - output array
@@ -132,7 +132,7 @@ setReadOnly( Routine.prototype, 'main', function saxpy( N, alpha, x, strideX, y,
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index

--- a/lib/node_modules/@stdlib/blas/base/wasm/sscal/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sscal/lib/module.js
@@ -112,7 +112,7 @@ inherits( Module, WasmModule );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
 * @param {integer} strideX - `x` stride length
 * @returns {NonNegativeInteger} input array pointer (i.e., byte offset)
@@ -174,7 +174,7 @@ setReadOnly( Module.prototype, 'main', function sscal( N, alpha, xptr, strideX )
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index

--- a/lib/node_modules/@stdlib/blas/base/wasm/sscal/lib/routine.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sscal/lib/routine.js
@@ -94,7 +94,7 @@ inherits( Routine, Module );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @returns {Float32Array} input array
@@ -127,7 +127,7 @@ setReadOnly( Routine.prototype, 'main', function sscal( N, alpha, x, strideX ) {
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/wasm/zscal/lib/routine.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zscal/lib/routine.js
@@ -103,7 +103,7 @@ inherits( Routine, Module );
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {Complex128} alpha - scalar
+* @param {Complex128} alpha - scalar constant
 * @param {Complex128Array} x - input array
 * @param {integer} strideX - stride length for `x`
 * @returns {Complex128Array} input array
@@ -140,7 +140,7 @@ setReadOnly( Routine.prototype, 'main', function zscal( N, alpha, x, strideX ) {
 * @readonly
 * @type {Function}
 * @param {PositiveInteger} N - number of indexed elements
-* @param {Complex128} alpha - scalar
+* @param {Complex128} alpha - scalar constant
 * @param {Complex128Array} x - input array
 * @param {integer} strideX - stride length for `x`
 * @param {NonNegativeInteger} offsetX - starting index for `x`

--- a/lib/node_modules/@stdlib/blas/base/zscal/src/zscal_cblas.c
+++ b/lib/node_modules/@stdlib/blas/base/zscal/src/zscal_cblas.c
@@ -20,6 +20,7 @@
 #include "stdlib/blas/base/zscal_cblas.h"
 #include "stdlib/blas/base/shared.h"
 #include "stdlib/complex/float64/ctor.h"
+#include "stdlib/strided/base/min_view_buffer_index.h"
 
 /**
 * Scales a double-precision complex floating-point vector by a double-precision complex floating-point constant.

--- a/lib/node_modules/@stdlib/blas/ext/base/dapx/lib/dapx.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapx/lib/dapx.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-// VARIABLES //
+// MODULES //
 
 var stride2offset = require( '@stdlib/strided/base/stride2offset' );
 var ndarray = require( './ndarray.js' );

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill/lib/ndarray.js
@@ -29,7 +29,7 @@ var M = 8;
 * Fills a single-precision floating-point strided array with a specified scalar constant.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - index increment
 * @param {NonNegativeInteger} offsetX - starting index

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill/lib/ndarray.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Fills a single-precision floating-point strided array with a specified scalar constant.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - index increment
 * @param {NonNegativeInteger} offsetX - starting index

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill/lib/sfill.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill/lib/sfill.js
@@ -30,7 +30,7 @@ var ndarray = require( './ndarray.js' );
 * Fills a single-precision floating-point strided array with a specified scalar constant.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - index increment
 * @returns {Float32Array} input array

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill/lib/sfill.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill/lib/sfill.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Fills a single-precision floating-point strided array with a specified scalar constant.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - scalar
+* @param {number} alpha - scalar constant
 * @param {Float32Array} x - input array
 * @param {integer} strideX - index increment
 * @returns {Float32Array} input array

--- a/lib/node_modules/@stdlib/ndarray/find-last/lib/callback_wrapper.js
+++ b/lib/node_modules/@stdlib/ndarray/find-last/lib/callback_wrapper.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-// VARIABLES //
+// MODULES //
 
 var getShape = require( '@stdlib/ndarray/shape' );
 


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-05-26 13:11 UTC and 2026-05-27 13:11 UTC to sibling packages.

### `blas/*` scalar JSDoc descriptors

Propagates JSDoc fixes from `95a8c41a` ("fix: use correct argument value in error message and propagate JSDoc fixes to sibling packages") to remaining `blas/*` packages where `@param` descriptors for `alpha`, `beta`, and related scalar arguments still read `scalar` rather than `scalar constant`. The fix is mechanical: every matching JSDoc line in the affected packages under `blas/base`, `blas/base/wasm`, and `blas/ext/base` has the trailing `scalar` replaced with `scalar constant` to align with the established convention.

Source: `95a8c41a`

Target packages:

-   `blas/base/daxpy`
-   `blas/base/dscal`
-   `blas/base/gaxpy`
-   `blas/base/saxpy`
-   `blas/base/sscal`
-   `blas/base/wasm/cscal`
-   `blas/base/wasm/daxpy`
-   `blas/base/wasm/dscal`
-   `blas/base/wasm/saxpy`
-   `blas/base/wasm/sscal`
-   `blas/base/wasm/zscal`
-   `blas/ext/base/sfill`

### Missing `min_view_buffer_index.h` include and stale header description

Propagates fixes from `7d900094` ("fix: import `src` utility and fix description in `blas/base/cscal`"), which corrected a missing `stdlib/strided/base/min_view_buffer_index.h` include in the cblas C source and a stale `cblas_ccopy` reference in the cblas header. `blas/base/caxpy` receives both corrections — the missing include in `caxpy_cblas.c` and the wrong `cblas_ccopy` description in `caxpy_cblas.h`; `blas/base/zscal` receives only the missing include fix in `zscal_cblas.c`, as its header description is already correct.

Source: `7d900094`

Target packages:

-   `blas/base/caxpy`
-   `blas/base/zscal`

### Misclassified `VARIABLES` section header

Propagates the fix from `4ed822d3` ("docs: follow-up fixes for commits merged to develop on 2026-05-26"), which corrected `// VARIABLES //` section headers that contained only `require()` calls to `// MODULES //`. The same misclassification was present in `blas/ext/base/dapx` (`lib/dapx.js`) and `ndarray/find-last` (`lib/callback_wrapper.js`), neither of which had a preceding `// MODULES //` section. Both headers are renamed accordingly.

Source: `4ed822d3`

Target packages:

-   `blas/ext/base/dapx`
-   `ndarray/find-last`

## Related Issues

None.

## Questions

No.

## Other

### Validation

-   Each source commit was specified into a pattern with a concrete search signature, then candidate sites were enumerated under the in-scope namespaces (`blas/*`, `ndarray/*`) via `rg` and verified individually before patching.
-   Per-site verification: each target file was read in full to confirm the defect is present (e.g., that a `// VARIABLES //` block contains only `require()` calls and lacks a preceding `// MODULES //` section; that a cblas C source actually calls `stdlib_strided_min_view_buffer_index()` without the corresponding header include; that the BLAS JSDoc line uses the bare `scalar` descriptor in a `@param alpha`/`@param beta` slot).
-   Style consistency: replacements preserve indentation, leading `*` JSDoc markers, and surrounding lines verbatim. No unrelated lines were touched.
-   Deliberately excluded:
    -   `assert/*` candidates for the "Return a boolean indicating" → "Boolean indicating" pattern from `95a8c41a` — the source fix applied to a module exporting a constant boolean, whereas the matching `signbit`/`is-buffer-length-compatible*` modules export functions, so the original wording is grammatically correct at those sites.
    -   `@returns input array` → `@returns \`x\`` from `4ed822d3` — too broad a scope and a stylistic convention rather than a defect; defer to a dedicated cleanup PR.
    -   The chisquare doc example variable rename from `fdcf93d0` — site-specific and not present at sibling distribution packages.
    -   The `time/iso-weeks-in-year` Notes section from `3b5ee6b3` — single-package documentation, no clear sibling target.
    -   The `bernoulli/mgf` `isProbability` inline refactor from `3c1e93d7` — adaptive and would require cross-package judgment; deferred.
    -   The `stats/strided/*abs` "Compute" → "Calculate" descriptor refresh from `ba77943b` — descriptor choice is per-package and not uniformly converged across `stats/strided/*`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a routine fix-propagation pass over commits merged to `develop` in the prior 24 hours. Source commits were identified mechanically; candidate sites were enumerated by `rg` over a per-pattern search signature, then individually validated by reading each target file in full before patching. All patches are direct, self-contained analogs of the cited source commits.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01NAvdVH4qtLDsgJKiDEacJP)_