### PR TITLE
test(@stdlib/blas/base): remove blank lines between fixture requires

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dspr/test/test.dspr.js
+++ b/lib/node_modules/@stdlib/blas/base/dspr/test/test.dspr.js
@@ -33,7 +33,6 @@ var rl = require( './fixtures/row_major_l.json' );
 var ru = require( './fixtures/row_major_u.json' );
 var rxp = require( './fixtures/row_major_xp.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var cl = require( './fixtures/column_major_l.json' );
 var cu = require( './fixtures/column_major_u.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dtrsv/test/test.dtrsv.js
+++ b/lib/node_modules/@stdlib/blas/base/dtrsv/test/test.dtrsv.js
@@ -39,7 +39,6 @@ var rutnu = require( './fixtures/row_major_u_t_nu.json' );
 var rutu = require( './fixtures/row_major_u_t_u.json' );
 var rxt = require( './fixtures/row_major_xt.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
 var cltnu = require( './fixtures/column_major_l_t_nu.json' );
 var clntu = require( './fixtures/column_major_l_nt_u.json' );


### PR DESCRIPTION
Resolves #12305.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes `stdlib/no-empty-lines-between-requires` ESLint errors in `blas/base/dtrsv/test/test.dtrsv.js` (line 42) and `blas/base/dspr/test/test.dspr.js` (line 36) that caused the CI run at https://github.com/stdlib-js/stdlib/actions/runs/26482961208 to fail
-   removes blank lines separating row-major and column-major fixture `require` groups, which the rule treats as a single require block and does not permit internal blank lines
-   deletes one blank line per file (two total)

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #12305

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

PR #12311 targeted the same issue but removed blank lines before the `// FIXTURES //` comment rather than between the require groups, leaving the lint errors in place.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was generated by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUUvLs3JqQ3CT7LLyMBbaV)_