### PR TITLE
test: add baseline test for `_tools/licenses/infer`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/licenses/infer/package.json
+++ b/lib/node_modules/@stdlib/_tools/licenses/infer/package.json
@@ -20,7 +20,8 @@
   "directories": {
     "doc": "./docs",
     "example": "./examples",
-    "lib": "./lib"
+    "lib": "./lib",
+    "test": "./test"
   },
   "scripts": {},
   "homepage": "https://github.com/stdlib-js/stdlib",

--- a/lib/node_modules/@stdlib/_tools/licenses/infer/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/licenses/infer/test/test.js
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var infer = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof infer, 'function', 'main export is a function' );
+	t.end();
+});


### PR DESCRIPTION
## Description

This pull request adds a baseline smoke test to `@stdlib/_tools/licenses/infer`, the sole package in the `@stdlib/_tools/licenses/*` namespace that previously lacked a `test/` directory.

The fix was produced by a cross-package drift audit over the 11 non-autogenerated members of the namespace. Two drift items were applied to `infer`:

- A `test/test.js` exercising `typeof infer === 'function'`, mirroring the boilerplate used by 10 of 11 (91%) siblings.
- A `"test": "./test"` entry under `directories` in `package.json`, mirroring 10 of 11 (91%) siblings.

No other corrections survived filtering: the remaining semantic features either had no clear majority across the namespace or were satisfied by every package.

### Namespace summary

- Members analyzed: 11 (all non-autogenerated).
- Features with clear majority (≥75%): `test/test.js` presence, `directories.test` presence, `lib/index.js` presence, `lib/main.js` presence, `examples/index.js` presence, `errorConstruction = format` (9/11; outliers `header-regexp` and `infer` do not construct errors at all, so this was treated as a false positive and dropped).
- Features without clear majority (excluded from drift analysis): `returnKind` (6 value / 5 void), `os` in `package.json` (6/11), `__stdlib__` in `package.json` (6/11), `directories.doc` (8/11), README `Notes` section (8/11), README `CLI` section (7/11), per-package signatures and validation prologues (each shape unique to the package).

### Per outlier package

### `_tools/licenses/infer`

Added `test/test.js` with a baseline smoke test verifying the main export is a function (91% of `@stdlib/_tools/licenses/*` siblings carry this test). Added `"test": "./test"` to `directories` in `package.json` for the same reason — 91% conformance across siblings.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

### Validation

Three-agent validation was run over the candidate corrections:

- Semantic review: confirmed-drift — the `@private` JSDoc tag on `infer`'s main function is a documentation tic shared across siblings (`licenses`, `insert-header-file-list`, etc.) and does not indicate the package is untestable; the module is exported and documented in `README.md` as a usage-facing API.
- Cross-reference review: confirmed-drift — no test-runner config, ignore pattern, or external reference depends on the file's absence; `infer/package.json` shows several signs of being incomplete relative to siblings (missing `directories.test`), consistent with unintentional drift.
- Structural review: confirmed-drift — `infer` is structurally identical to its tested siblings (`lib/index.js` re-exporting `lib/main.js`, a `README.md` documenting the API, a `bin/cli`), and the boilerplate smoke test is universally applicable since `module.exports` is a function.

Deliberately excluded from this PR:

- The `errorConstruction` "drift" in `header-regexp` and `infer` — both packages either delegate validation to a callee or are internal helpers with no thrown errors. There are no error messages to normalize.
- Features without a clear ≥75% majority (`returnKind`, `os`, `__stdlib__`, `directories.doc`, README `Notes`/`CLI`).
- Per-package signature and validation-prologue differences, which reflect genuine semantic differences in what each package does.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift detection routine over `@stdlib/_tools/licenses/*`. The audit identified structural drift via majority vote across 11 sibling packages; the proposed correction was validated by three independent reviewer agents (semantic, cross-reference, structural) before being applied. A human maintainer should promote out of draft after review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01RUr3tNMrvD6B7Sp512rmGy)_