### PR TITLE
docs: fix stale plural-function wording in `stats/array/stdev`

### DIFF
--- a/lib/node_modules/@stdlib/stats/array/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/array/stdev/README.md
@@ -132,7 +132,7 @@ var v = stdev( x, 0.0 );
 ## Notes
 
 -   If provided an empty array, the function returns `NaN`.
--   If `N - c` is less than or equal to `0` (where `c` corresponds to the provided degrees of freedom adjustment), both functions return `NaN`.
+-   If `N - c` is less than or equal to `0` (where `c` corresponds to the provided degrees of freedom adjustment), the function returns `NaN`.
 -   The function supports array-like objects having getter and setter accessors for array element access (e.g., [`@stdlib/array/base/accessor`][@stdlib/array/base/accessor]).
 
 </section>


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   docs: correct a residual two-function phrasing in `stats/array/stdev`'s Notes section. The package exports a single function, but one bullet read "...both functions return `NaN`" — leftover wording copied from the strided counterpart (`stats/strided/stdev`), where both a positional form and an `.ndarray` method are exported. Replaced with the singular "...the function returns `NaN`", matching all 11 sibling stdev/nanstdev variants (`stdevch`, `stdevpn`, `stdevtk`, `stdevwd`, `stdevyc`, `nanstdev`, `nanstdevch`, `nanstdevpn`, `nanstdevtk`, `nanstdevwd`, `nanstdevyc` — 100% sibling conformance).

### `stats/array/stdev`

`stats/array/stdev/README.md` was the lone outlier in the `stats/array` namespace carrying the plural "both functions return `NaN`" phrasing in its Notes section. The package exports a single function (no `.ndarray` method attached); the wording is residual from the strided counterpart and is contradicted by the surrounding bullets, which already use the singular ("...the function returns `NaN`" on the preceding line; "...the function supports array-like objects..." on the following line). Aligns the line with the 11 stdev/nanstdev siblings in the same namespace. README-only change; no observable behavior, signature, or test expectation changes.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Sibling conformance: 11/11 stdev/nanstdev variants use the singular phrasing; this is the only namespace member that diverged.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running a cross-package drift-detection routine against `@stdlib/stats/array`: structural and semantic features were extracted from all 69 namespace members, the majority pattern per feature was computed (with a 75% threshold), and outliers were flagged. A three-agent validation pass (semantic-review, cross-reference, structural-review) confirmed this specific change as `confirmed-drift` on all three axes before it was applied. The change is a one-line README wording fix; the supporting analysis is in a local report and was not committed to the tree.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiYjqf9h9KscWphnSfE1bS)_