### PR TITLE
docs: fix option description

### DIFF
--- a/lib/node_modules/@stdlib/regexp/eol/lib/validate.js
+++ b/lib/node_modules/@stdlib/regexp/eol/lib/validate.js
@@ -36,7 +36,7 @@ var format = require( '@stdlib/string/format' );
 * @param {Object} opts - destination object
 * @param {Options} options - function options
 * @param {string} [options.flags] - regular expression flags
-* @param {boolean} [options.capture] - boolean indicating whether to wrap a regular expression matching a decimal number with a capture group
+* @param {boolean} [options.capture] - boolean indicating whether to wrap a regular expression matching a newline character sequence with a capture group
 * @returns {(Error|null)} null or an error object
 *
 * @example


### PR DESCRIPTION
## Description

The `@param options.capture` description in `@stdlib/regexp/eol/lib/validate.js` was copy-pasted from `@stdlib/regexp/decimal-number/lib/validate.js` and still referenced "a decimal number" — the wrong domain for a package whose `lib/main.js` matches a newline character sequence. Replaced the wording with "a newline character sequence" to match `eol/lib/main.js` and the local pattern set by `@stdlib/regexp/whitespace/lib/validate.js`.

### `regexp/eol`

`lib/validate.js:39` — the `@param options.capture` text said `"matching a decimal number with a capture group"`. The sibling `@stdlib/regexp/whitespace/lib/validate.js` documents the same option as `"matching white space characters with a capture group"`, swapping in its own domain term; `eol`'s text was never updated after the file was forked from `decimal-number`. Among the three options-validating packages in this namespace (`decimal-number`, `eol`, `whitespace`), 2/3 use the domain-appropriate phrase; `eol` was the lone holdout still referencing decimal numbers.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

Surfaced by an automated cross-package drift audit over the 27 non-autogenerated members of `@stdlib/regexp/*`. A second candidate correction was identified in the same run (a stray double space in `@stdlib/regexp/dirname/lib/main.js:53`'s error message) but **deliberately not included here**: that string is registered in `@stdlib/error/tools/database/data/data.csv` as error code `7r` (the single-space variant is code `7p`), so collapsing the space in source would silently switch `dirname`'s production-minified error code and orphan the `7r` row. That cleanup needs a human decision on whether to also remove the orphaned database entry and is logged for follow-up.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift detection routine over `@stdlib/regexp/*`. The audit extracted structural and semantic features from all 27 packages, identified majority patterns at the 75% threshold, and validated outliers with three independent reviewer agents (semantic, cross-reference, structural). A human maintainer should promote out of draft after review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHCmoBkPiFSsg5c2Hzmus3)_