### PR TITLE
bench: add missing `benchmark.js` in `array/complex128` and `array/slice`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.js
@@ -1,0 +1,360 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var ArrayBuffer = require( '@stdlib/array/buffer' );
+var Float64Array = require( '@stdlib/array/float64' );
+var isArrayBuffer = require( '@stdlib/assert/is-arraybuffer' );
+var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
+var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': ( ITERATOR_SYMBOL === null )
+};
+
+
+// MAIN //
+
+bench( format( '%s::instantiation,new', pkg ), function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Complex128Array();
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::instantiation,no_new', pkg ), function benchmark( b ) {
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = Complex128Array;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = ctor();
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::instantiation,length', pkg ), function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Complex128Array( 0 );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::instantiation,typed_array', pkg ), function benchmark( b ) {
+	var buf;
+	var arr;
+	var i;
+
+	buf = new Float64Array( 0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Complex128Array( buf );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::instantiation,complex_typed_array', pkg ), function benchmark( b ) {
+	var buf;
+	var arr;
+	var i;
+
+	buf = new Complex128Array( 0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Complex128Array( buf );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::instantiation,array', pkg ), function benchmark( b ) {
+	var buf;
+	var arr;
+	var i;
+
+	buf = [];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Complex128Array( buf );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::instantiation,iterable', pkg ), opts, function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Complex128Array( createIterable() );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function createIterable() {
+		var out = {};
+		out[ ITERATOR_SYMBOL ] = iterator;
+		return out;
+
+		function iterator() {
+			return {
+				'next': next
+			};
+		}
+
+		function next() {
+			return {
+				'done': true
+			};
+		}
+	}
+});
+
+bench( format( '%s::instantiation,arraybuffer', pkg ), function benchmark( b ) {
+	var buf;
+	var arr;
+	var i;
+
+	buf = new ArrayBuffer( 0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Complex128Array( buf );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::instantiation,arraybuffer,byte_offset', pkg ), function benchmark( b ) {
+	var buf;
+	var arr;
+	var i;
+
+	buf = new ArrayBuffer( 16 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Complex128Array( buf, 16 );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::instantiation,arraybuffer,byte_offset,length', pkg ), function benchmark( b ) {
+	var buf;
+	var arr;
+	var i;
+
+	buf = new ArrayBuffer( 16 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Complex128Array( buf, 16, 0 );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Complex128Array) ) {
+		b.fail( 'should return an instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::get:buffer', pkg ), function benchmark( b ) {
+	var arr;
+	var v;
+	var i;
+
+	arr = new Complex128Array();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		// Note: the following may be optimized away due to loop invariant code motion and/or other compiler optimizations, rendering this benchmark meaningless...
+		v = arr.buffer;
+		if ( typeof v !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isArrayBuffer( v ) ) {
+		b.fail( 'should return an ArrayBuffer' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::get:byteLength', pkg ), function benchmark( b ) {
+	var arr;
+	var v;
+	var i;
+
+	arr = new Complex128Array();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		// Note: the following may be optimized away due to loop invariant code motion and/or other compiler optimizations, rendering this benchmark meaningless...
+		v = arr.byteLength;
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( !isNonNegativeInteger( v ) ) {
+		b.fail( 'should return a nonnegative integer' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::get:byteOffset', pkg ), function benchmark( b ) {
+	var arr;
+	var v;
+	var i;
+
+	arr = new Complex128Array();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		// Note: the following may be optimized away due to loop invariant code motion and/or other compiler optimizations, rendering this benchmark meaningless...
+		v = arr.byteOffset;
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( !isNonNegativeInteger( v ) ) {
+		b.fail( 'should return a nonnegative integer' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::get:length', pkg ), function benchmark( b ) {
+	var arr;
+	var v;
+	var i;
+
+	arr = new Complex128Array();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		// Note: the following may be optimized away due to loop invariant code motion and/or other compiler optimizations, rendering this benchmark meaningless...
+		v = arr.length;
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( !isNonNegativeInteger( v ) ) {
+		b.fail( 'should return a nonnegative integer' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/slice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/slice/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/slice/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/slice/benchmark/benchmark.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isArray = require( '@stdlib/assert/is-array' );
+var ones = require( '@stdlib/array/ones' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var slice = require( './../lib' );
+
+
+// MAIN //
+
+bench( format( '%s:dtype=generic,len=100', pkg ), function benchmark( b ) {
+	var out;
+	var x;
+	var i;
+
+	x = ones( 100, 'generic' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = slice( x );
+		if ( out.length !== 100 ) {
+			b.fail( 'unexpected length' );
+		}
+	}
+	b.toc();
+	if ( !isArray( out ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a missing top-level `benchmark/benchmark.js` to `array/complex128` and `array/slice`. Both packages were the only two outliers in the `@stdlib/array` namespace lacking the canonical end-to-end benchmark file: 100 of 102 sibling packages (98%) carry one.

### Namespace summary

-   **Target:** `@stdlib/array` — 103 direct child packages; `array/base` excluded as it is itself an eligible sub-namespace (242 children), leaving **102 members** for the vote.
-   **Features analyzed:** file presence, `package.json` top-level keys, `scripts` keys, `stdlib` keys, README heading set, `manifest.json` keys, `test/`/`benchmark/`/`examples/` filename inventories.
-   **Features with a clear majority (≥75% conformance):** standard `package.json` field set (100%), `lib/index.js` / `lib/main.js` / `test/test.js` / `examples/index.js` / `README.md` / `benchmark/benchmark.js` presence (≥98%), README sections `## Usage` and `## Examples` (100%).
-   **Features excluded as out of scope per generator gates:** `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, README `## See Also` — all auto-populated by the package-generator pipeline and not appropriate to backfill in a drift PR.
-   **Features without a clear majority:** semantic features (`publicSignature`, `validationPrologue`, `returnKind`, JSDoc shape) — the namespace mixes typed-array constructors, utility functions, and iterators with structurally different APIs, so a 75% majority cannot exist by construction. Semantic extraction was therefore skipped for this namespace; the structural findings are self-contained.

### `array/complex128`

Carries 55 per-method benchmark files (`benchmark.at.js`, `benchmark.fill.js`, …, `benchmark.with.length.js`) but no top-level `benchmark.js`. Its sibling `array/complex64`, identical in API shape and created in 2018, ships a `benchmark.js` covering every constructor overload (`new`, `no_new`, `length`, `typed_array`, `complex_typed_array`, `array`, `iterable`, `arraybuffer`, `arraybuffer,byte_offset`, `arraybuffer,byte_offset,length`) and the `buffer` / `byteLength` / `byteOffset` / `length` accessors. The added file mirrors that template with `Complex128Array` substituted for `Complex64Array` and `Float64Array` for `Float32Array`; `ArrayBuffer` sizes were scaled from 8 to 16 bytes to match the 128-bit element width.

### `array/slice`

Has only `benchmark.length.js` (sweeping `len = 10^1`…`10^6`); siblings such as `array/take` and `array/put` carry both `benchmark.js` and a length-parametrized companion, where `benchmark.js` times a single fixed-size invocation as the baseline. The added file follows the `array/take` template: one `len=100, dtype=generic` invocation of `slice( x )` with `isArray` validation. No existing benchmark or test is touched.

### Validation

-   **Structural extraction.** File trees, `package.json` shape, README heading sets, and benchmark/test/example filename inventories were captured for all 102 in-scope members; per-feature majority was computed at the 75% conformance threshold.
-   **Drift validation.** Each outlier was reviewed by two independent agents — a sonnet structural-review pass to confirm the majority pattern is the correct convention to apply, and an opus cross-reference pass to verify no test, example, or consumer depends on the absence of the file. Both outliers cleared both passes as `confirmed-drift` (purely additive, no observable behavior change).
-   **Deliberately excluded.** Auto-generated artifacts (`docs/repl.txt`, `docs/types/*`, README `## See Also`) are out of scope for drift PRs; semantic features were excluded for the reason noted in the namespace summary; one further structural finding (`lib/main.js` missing in `array/base`) was dropped because `array/base` is itself an eligible namespace and was excluded from the vote.
-   **Open-PR collision check.** No open PR targets `array/complex128/benchmark/benchmark.js` or `array/slice/benchmark/benchmark.js`. The pattern of backfilling missing `array/*` benchmark files is active and accepted upstream (see #11367, #11371).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The `Complex128Array` instantiation benchmark uses `ArrayBuffer` sizes of 16 bytes (vs. 8 for `Complex64Array`) to match the 128-bit element width; the resulting array length is still 0 in both cases, preserving the post-loop `length !== 0` invariant from the template.
-   `array/slice` already exports an `array/base/slice` underneath; the added benchmark exercises the wrapped path through input validation, matching what `array/take`'s `benchmark.js` does.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a cross-package drift-detection routine that extracts structural features from every package in a namespace, computes the per-feature majority pattern (≥75% conformance), and flags deviating packages. The benchmark files were generated mechanically from sibling templates (`array/complex64/benchmark/benchmark.js` and `array/take/benchmark/benchmark.js`), and both outliers were reviewed by independent validation agents before any file was written.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqENP8s3Jyim4rEQB5vdCr)_