### PR TITLE
docs: fix text wrapping in repl text file

### DIFF
--- a/lib/node_modules/@stdlib/ml/base/kmeans/metric-resolve-enum/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ml/base/kmeans/metric-resolve-enum/docs/repl.txt
@@ -4,8 +4,8 @@
     distance metric value.
 
     Downstream consumers of this function should *not* rely on specific integer
-    values (e.g., `SQEUCLIDEAN == 0`). Instead, the function should be used in an
-    opaque manner.
+    values (e.g., `SQEUCLIDEAN == 0`). Instead, the function should be used in
+    an opaque manner.
 
     Parameters
     ----------


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-05-27 14:42:47 -0500 (`8ff59d6`) and 2026-05-28 15:26:38 +0530 (`af6a5d7a`).

## Description

> What is the purpose of this pull request?

This pull request:

-   `58d7eb2d` `lib/node_modules/@stdlib/ml/base/kmeans/metric-resolve-enum/docs/repl.txt` line 7 exceeds the 80-character line-width limit (`docs/contributing/repl_text.md`); rewrap "in an" to the next line (78 + 21 chars).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Reviewed all 13 first-parent commits merged to `develop` in the 24-hour window for style-guide compliance and bugs:

-   Checked: REPL text width rule, JSDoc consistency, BLAS sibling-package conventions, new package structure (`ml/base/kmeans/metric-*`), new C native sources (`blas/base/csscal`), TypeScript declarations vs. implementation, namespace/ToC updates, and the lint-workflow change.
-   Excluded as out-of-scope (require interpretation or sibling lookup outside the window's diff): the new `metric-*` packages import `isNumber`/`isString` rather than using inline `typeof` as every sibling `*-str2enum`/`*-enum2str` package does — internally consistent across the four new packages, so deferred for the original author to address if desired. JSDoc summary lines in `blas/base/{dscal,sscal}/lib/*.js` still read "by a scalar `alpha`" while the @param now reads "scalar constant"; the sweep author deliberately scoped to `@param` lines, so not expanding scope here. The 8777ff69 REPL-namespace regen commit (20MB of generated output) was skipped.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a 24-hour commit-window audit: parallel agents reviewed the recently-merged commits for style-guide compliance and bugs; only findings that were objectively verifiable from the diff and a concrete style-guide rule survived filtering. A human will audit before promoting to ready-for-review.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSFAdSzY8KbBk4Y9k74V5X)_