### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-github/lib/transformer.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-github/lib/transformer.js
@@ -55,26 +55,26 @@ function factory( opts ) {
 	function transformer( tree ) {
 		debug( 'Processing virtual file...' );
 		visit( tree, 'definition', visitor );
+	}
 
-		/**
-		* Callback invoked upon finding a matching node.
-		*
-		* @private
-		* @param {Node} node - reference node
-		*/
-		function visitor( node ) {
-			var id;
+	/**
+	* Callback invoked upon finding a matching node.
+	*
+	* @private
+	* @param {Node} node - reference node
+	*/
+	function visitor( node ) {
+		var id;
 
-			debug( 'Found a definition: %s', node.identifier );
-			if ( RE_STDLIB.test( node.identifier ) ) {
-				debug( 'Found a package identifier.' );
-				id = replace( node.identifier, '@', '%40' );
+		debug( 'Found a definition: %s', node.identifier );
+		if ( RE_STDLIB.test( node.identifier ) ) {
+			debug( 'Found a package identifier.' );
+			id = replace( node.identifier, '@', '%40' );
 
-				debug( 'Current URL: %s', node.url );
-				node.url = BASE_URL + opts.branch + '/lib/node_modules/' + id;
+			debug( 'Current URL: %s', node.url );
+			node.url = BASE_URL + opts.branch + '/lib/node_modules/' + id;
 
-				debug( 'Resolved URL: %s', node.url );
-			}
+			debug( 'Resolved URL: %s', node.url );
 		}
 	}
 }


### PR DESCRIPTION
Resolves #12335.

## Description

> What is the purpose of this pull request?

This pull request:

-   Moves the `visitor` callback out of `transformer` so it sits at the same scope as `transformer` inside `factory` in `lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-github/lib/transformer.js`. `visitor` only references `opts.branch` from the outer `factory` scope, plus the module-level `debug`, `RE_STDLIB`, `BASE_URL`, and `replace`, so the nested form was unnecessary. The hoisted function declarations preserve the existing closure semantics, so behavior is unchanged.

Resolves the `stdlib/no-unnecessary-nested-functions` lint failure reported by the automated workflow ([run 26610340328](https://github.com/stdlib-js/stdlib/actions/runs/26610340328)):

```
lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-github/lib/transformer.js
  65:3  error  Function 'visitor' should be moved to outer function scope  stdlib/no-unnecessary-nested-functions
```

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   resolves #12335

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code; I reviewed the diff against the existing file structure and the `stdlib/no-unnecessary-nested-functions` rule before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
