### PR TITLE
chore: fix EditorConfig lint errors

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/coth/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/coth/manifest.json
@@ -65,7 +65,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/special/tanh"
+        "@stdlib/math/base/special/tanh"
       ]
     }
   ]


### PR DESCRIPTION
Resolves #12334.

## Description

> What is the purpose of this pull request?

This pull request:

-   Pads `lib/node_modules/@stdlib/math/base/special/coth/manifest.json` line 68 from 7 spaces to 8 spaces, so the `dependencies` array entry matches the 8-space indent every other array element at the same depth already uses (see sibling `tanh/manifest.json` for precedent). This satisfies the EditorConfig indent rule that wants the left-padding to be a multiple of 2.

Resolves the EditorConfig lint failure reported by the automated workflow ([run 26610340328](https://github.com/stdlib-js/stdlib/actions/runs/26610340328)):

```
lib/node_modules/@stdlib/math/base/special/coth/manifest.json:
	68: Wrong amount of left-padding spaces(want multiple of 2)

1 errors found
```

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   resolves #12334

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code; I reviewed the diff and confirmed the 8-space indent matches sibling manifest files at the same depth before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
