### PR TITLE
build: restrict slash commands to users with write access

### DIFF
--- a/.github/workflows/slash_commands.yml
+++ b/.github/workflows/slash_commands.yml
@@ -97,7 +97,10 @@ jobs:
     needs: [ add_initial_reaction ]
 
     # Define the conditions under which the job should run:
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/stdlib check-files')
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/stdlib check-files') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
 
     # Run reusable workflow:
     uses: ./.github/workflows/check_required_files.yml
@@ -132,7 +135,10 @@ jobs:
     name: 'Update copyright header years'
 
     # Define the conditions under which the job should run:
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/stdlib update-copyright-years')
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/stdlib update-copyright-years') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
 
     # Run reusable workflow:
     uses: ./.github/workflows/update_pr_copyright_years.yml
@@ -153,7 +159,10 @@ jobs:
     needs: [ add_initial_reaction ]
 
     # Define the conditions under which the job should run:
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/stdlib lint-autofix')
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/stdlib lint-autofix') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
 
     # Run reusable workflow:
     uses: ./.github/workflows/lint_autofix.yml
@@ -174,7 +183,10 @@ jobs:
     needs: [ add_initial_reaction ]
 
     # Define the conditions under which the job should run:
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/stdlib merge')
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/stdlib merge') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
 
     # Run reusable workflow:
     uses: ./.github/workflows/pr_merge_develop.yml
@@ -195,7 +207,10 @@ jobs:
     needs: [ add_initial_reaction ]
 
     # Define the conditions under which the job should run:
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/stdlib rebase')
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/stdlib rebase') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
 
     # Run reusable workflow:
     uses: ./.github/workflows/pr_rebase_develop.yml

--- a/.github/workflows/slash_commands.yml
+++ b/.github/workflows/slash_commands.yml
@@ -234,7 +234,10 @@ jobs:
     needs: [ add_initial_reaction ]
 
     # Define the conditions under which the job should run:
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/stdlib help')
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/stdlib help') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
 
     # Define the job's steps:
     steps:

--- a/.github/workflows/slash_commands.yml
+++ b/.github/workflows/slash_commands.yml
@@ -119,7 +119,10 @@ jobs:
     needs: [ add_initial_reaction ]
 
     # Define the conditions under which the job should run:
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/stdlib make-commands')
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/stdlib make-commands')  &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
 
     # Run reusable workflow:
     uses: ./.github/workflows/pr_commands_comment.yml


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   restricts the `check-files`, `update-copyright-years`, `lint-autofix`, `merge`, and `rebase` slash commands so they only run when the triggering comment's author association is `OWNER`, `MEMBER`, or `COLLABORATOR`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored with Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
