### PR TITLE
docs: fix mismatched README sub-header in `regexp/dirname`

### DIFF
--- a/lib/node_modules/@stdlib/regexp/dirname/README.md
+++ b/lib/node_modules/@stdlib/regexp/dirname/README.md
@@ -51,7 +51,7 @@ dir = RE.exec( 'C:\\foo\\bar\\index.js' )[ 1 ];
 // returns 'C:\foo\bar'
 ```
 
-#### reBasename.REGEXP
+#### reDirname.REGEXP
 
 [Regular expression][regexp] to capture a path dirname.
 


### PR DESCRIPTION
## Description

This pull request corrects a copy-paste typo in `@stdlib/regexp/dirname/README.md`. The sub-header at line 54 reads `#### reBasename.REGEXP` instead of `#### reDirname.REGEXP`. The code example immediately under it already uses `reDirname.REGEXP`, and the subsequent sub-headers (`reDirname.REGEXP_POSIX`, `reDirname.REGEXP_WIN32`) use the correct identifier, so this is the only line out of step.

### `regexp/dirname`

Renamed the README sub-header from `reBasename.REGEXP` to `reDirname.REGEXP`. Conformance with the namespace-wide convention of using a package's own main identifier in its README sub-headers: 26 of 27 sibling packages (96%); `dirname` was the lone outlier. Documentation-only — no JSDoc, source, or tests touched.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

The change was produced by an automated cross-package drift audit over the 27 non-autogenerated members of `@stdlib/regexp/*`. The drift candidate was confirmed by three independent reviewer agents (semantic, cross-reference, structural). No other corrections survived filtering: remaining outliers in the namespace either reflect intentional architectural differences (e.g., `reviver` and `to-json` lack `test/test.main.js` because they have no platform dispatch) or were ruled out by the auto-populated-section gate (the empty `## See Also` sections in five packages are package-generator output).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift detection routine over `@stdlib/regexp/*`. Three independent reviewer agents (semantic, cross-reference, structural) confirmed the candidate before the fix was applied. A maintainer should promote out of draft after review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dumu58kuf3rDzsh4ZbrWHf)_