### PR TITLE
fix: correct return and parameter types in `array/base` declarations

### DIFF
--- a/lib/node_modules/@stdlib/array/base/count-ifs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/count-ifs/docs/types/index.d.ts
@@ -69,7 +69,7 @@ type Ternary<T, U> = ( value: T, index: number, arr: U ) => boolean;
 * @param arr - input array
 * @returns boolean indicating whether an element passes a test
 */
-type Predicate<T, U> = Nullary | Unary<U> | Binary<U> | Ternary<T, U>;
+type Predicate<T, U> = Nullary | Unary<T> | Binary<T> | Ternary<T, U>;
 
 /**
 * Performs element-wise evaluation of one or more input arrays according to provided predicate functions and counts the number of elements for which all predicates respectively return `true`.
@@ -184,7 +184,7 @@ declare function countIfs<T = unknown, U extends InputArray<T> = InputArray<T>>(
 * var x2 = [ 0, 4, 3, 2, 12 ];
 * var x3 = [ 2, 9, 3, 6, 5 ];
 *
-* var n = countIfs( x0, predicate0, x1, predicate1, x3, predicate3 );
+* var n = countIfs( x0, predicate0, x1, predicate1, x2, predicate2, x3, predicate3 );
 * // returns 2
 */
 declare function countIfs<T = unknown, U extends InputArray<T> = InputArray<T>>( x0: U, predicate0: Predicate<T, U>, x1: U, predicate1: Predicate<T, U>, x2: U, predicate2: Predicate<T, U>, x3: U, predicate3: Predicate<T, U> ): number;
@@ -232,7 +232,7 @@ declare function countIfs<T = unknown, U extends InputArray<T> = InputArray<T>>(
 * var x3 = [ 2, 9, 3, 6, 5 ];
 * var x4 = [ false, true, false, true, true ];
 *
-* var n = countIfs( x0, predicate0, x1, predicate1, x3, predicate3, x4, predicate4 );
+* var n = countIfs( x0, predicate0, x1, predicate1, x2, predicate2, x3, predicate3, x4, predicate4 );
 * // returns 2
 */
 declare function countIfs<T = unknown, U extends InputArray<T> = InputArray<T>>( x0: U, predicate0: Predicate<T, U>, x1: U, predicate1: Predicate<T, U>, x2: U, predicate2: Predicate<T, U>, x3: U, predicate3: Predicate<T, U>, x4: U, predicate4: Predicate<T, U>, ...args: Array<U | Predicate<T, U>> ): number;

--- a/lib/node_modules/@stdlib/array/base/fillednd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/fillednd/docs/types/index.d.ts
@@ -299,13 +299,13 @@ declare function fillednd<T = unknown>( value: T, shape: Shape10D ): Array10D<T>
 *
 * @example
 * var out = fillednd( 0.0, [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3 ] );
-* // returns [ [ [ [ [ [ [ [ [ [ [ 0.0, 0.0, 0.0 ] ] ] ] ] ] ] ] ] ]
+* // returns [ [ [ [ [ [ [ [ [ [ [ 0.0, 0.0, 0.0 ] ] ] ] ] ] ] ] ] ] ]
 *
 * @example
 * var out = fillednd( 'beep', [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3 ] );
-* // returns [ [ [ [ [ [ [ [ [ [ [ 'beep', 'beep', 'beep' ] ] ] ] ] ] ] ] ] ]
+* // returns [ [ [ [ [ [ [ [ [ [ [ 'beep', 'beep', 'beep' ] ] ] ] ] ] ] ] ] ] ]
 */
-declare function fillednd<T = unknown, U = unknown>( value: T, shape: Shape ): Array<U>;
+declare function fillednd<T = unknown>( value: T, shape: Shape ): Array<T>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/base/flatten-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/flatten-by/docs/types/index.d.ts
@@ -356,7 +356,7 @@ interface FlattenBy {
 	* var x = [ [ 1, 2 ], [ 3, 4 ] ];
 	*
 	* var out = flattenBy( x, [ 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -366,9 +366,9 @@ interface FlattenBy {
 	* var x = [ [ 1, 2 ], [ 3, 4 ] ];
 	*
 	* var out = flattenBy( x, [ 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array2D<T>, shape: Shape2D, colexicographic: boolean, clbk: Callback2D<T, U, V>, thisArg?: ThisParameterType<Callback2D<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array2D<T>, shape: Shape2D, colexicographic: boolean, clbk: Callback2D<T, U, V>, thisArg?: ThisParameterType<Callback2D<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens a three-dimensional nested array according to a callback function.
@@ -392,7 +392,7 @@ interface FlattenBy {
 	* var x = [ [ [ 1, 2 ], [ 3, 4 ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -402,9 +402,9 @@ interface FlattenBy {
 	* var x = [ [ [ 1, 2 ], [ 3, 4 ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array3D<T>, shape: Shape3D, colexicographic: boolean, clbk: Callback3D<T, U, V>, thisArg?: ThisParameterType<Callback3D<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array3D<T>, shape: Shape3D, colexicographic: boolean, clbk: Callback3D<T, U, V>, thisArg?: ThisParameterType<Callback3D<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens a four-dimensional nested array according to a callback function.
@@ -428,7 +428,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -438,9 +438,9 @@ interface FlattenBy {
 	* var x = [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array4D<T>, shape: Shape4D, colexicographic: boolean, clbk: Callback4D<T, U, V>, thisArg?: ThisParameterType<Callback4D<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array4D<T>, shape: Shape4D, colexicographic: boolean, clbk: Callback4D<T, U, V>, thisArg?: ThisParameterType<Callback4D<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens a five-dimensional nested array according to a callback function.
@@ -464,7 +464,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -474,9 +474,9 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array5D<T>, shape: Shape5D, colexicographic: boolean, clbk: Callback5D<T, U, V>, thisArg?: ThisParameterType<Callback5D<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array5D<T>, shape: Shape5D, colexicographic: boolean, clbk: Callback5D<T, U, V>, thisArg?: ThisParameterType<Callback5D<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens a six-dimensional nested array according to a callback function.
@@ -500,7 +500,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -510,9 +510,9 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array6D<T>, shape: Shape6D, colexicographic: boolean, clbk: Callback6D<T, U, V>, thisArg?: ThisParameterType<Callback6D<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array6D<T>, shape: Shape6D, colexicographic: boolean, clbk: Callback6D<T, U, V>, thisArg?: ThisParameterType<Callback6D<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens a seven-dimensional nested array according to a callback function.
@@ -536,7 +536,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 1, 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -546,9 +546,9 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 1, 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array7D<T>, shape: Shape7D, colexicographic: boolean, clbk: Callback7D<T, U, V>, thisArg?: ThisParameterType<Callback7D<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array7D<T>, shape: Shape7D, colexicographic: boolean, clbk: Callback7D<T, U, V>, thisArg?: ThisParameterType<Callback7D<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens an eight-dimensional nested array according to a callback function.
@@ -572,7 +572,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 1, 1, 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -582,9 +582,9 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 1, 1, 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array8D<T>, shape: Shape8D, colexicographic: boolean, clbk: Callback8D<T, U, V>, thisArg?: ThisParameterType<Callback8D<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array8D<T>, shape: Shape8D, colexicographic: boolean, clbk: Callback8D<T, U, V>, thisArg?: ThisParameterType<Callback8D<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens a nine-dimensional nested array according to a callback function.
@@ -608,7 +608,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 1, 1, 1, 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -618,9 +618,9 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 1, 1, 1, 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array9D<T>, shape: Shape9D, colexicographic: boolean, clbk: Callback9D<T, U, V>, thisArg?: ThisParameterType<Callback9D<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array9D<T>, shape: Shape9D, colexicographic: boolean, clbk: Callback9D<T, U, V>, thisArg?: ThisParameterType<Callback9D<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens a ten-dimensional nested array according to a callback function.
@@ -644,7 +644,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 1, 1, 1, 1, 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -654,9 +654,9 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy( x, [ 1, 1, 1, 1, 1, 1, 1, 1, 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array10D<T>, shape: Shape10D, colexicographic: boolean, clbk: Callback10D<T, U, V>, thisArg?: ThisParameterType<Callback10D<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array10D<T>, shape: Shape10D, colexicographic: boolean, clbk: Callback10D<T, U, V>, thisArg?: ThisParameterType<Callback10D<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens a one-dimensional nested array according to a callback function and assigns elements to a provided output array.
@@ -724,7 +724,7 @@ interface FlattenBy {
 	* var x = [ [ 1, 2 ], [ 3, 4 ] ];
 	*
 	* var out = flattenBy.assign( x, [ 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -736,7 +736,7 @@ interface FlattenBy {
 	* var x = [ [ 1, 2 ], [ 3, 4 ] ];
 	*
 	* var out = flattenBy.assign( x, [ 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array2D<T>, shape: Shape2D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback2D<T, U, W>, thisArg?: ThisParameterType<Callback2D<T, U, W>> ): Collection<U | V>;
 
@@ -767,7 +767,7 @@ interface FlattenBy {
 	* var x = [ [ [ 1, 2 ], [ 3, 4 ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -779,7 +779,7 @@ interface FlattenBy {
 	* var x = [ [ [ 1, 2 ], [ 3, 4 ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array3D<T>, shape: Shape3D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback3D<T, U, W>, thisArg?: ThisParameterType<Callback3D<T, U, W>> ): Collection<U | V>;
 
@@ -810,7 +810,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -822,7 +822,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array4D<T>, shape: Shape4D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback4D<T, U, W>, thisArg?: ThisParameterType<Callback4D<T, U, W>> ): Collection<U | V>;
 
@@ -853,7 +853,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -865,7 +865,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array5D<T>, shape: Shape5D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback5D<T, U, W>, thisArg?: ThisParameterType<Callback5D<T, U, W>> ): Collection<U | V>;
 
@@ -896,7 +896,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -908,7 +908,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array6D<T>, shape: Shape6D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback6D<T, U, W>, thisArg?: ThisParameterType<Callback6D<T, U, W>> ): Collection<U | V>;
 
@@ -939,7 +939,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 1, 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -951,7 +951,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 1, 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array7D<T>, shape: Shape7D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback7D<T, U, W>, thisArg?: ThisParameterType<Callback7D<T, U, W>> ): Collection<U | V>;
 
@@ -982,7 +982,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 1, 1, 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -994,7 +994,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 1, 1, 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array8D<T>, shape: Shape8D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback8D<T, U, W>, thisArg?: ThisParameterType<Callback8D<T, U, W>> ): Collection<U | V>;
 
@@ -1025,7 +1025,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 1, 1, 1, 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -1037,7 +1037,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 1, 1, 1, 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array9D<T>, shape: Shape9D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback9D<T, U, W>, thisArg?: ThisParameterType<Callback9D<T, U, W>> ): Collection<U | V>;
 
@@ -1068,7 +1068,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 1, 1, 1, 1, 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -1080,7 +1080,7 @@ interface FlattenBy {
 	* var x = [ [ [ [ [ [ [ [ [ [ 1, 2 ], [ 3, 4 ] ] ] ] ] ] ] ] ] ];
 	*
 	* var out = flattenBy.assign( x, [ 1, 1, 1, 1, 1, 1, 1, 1, 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array10D<T>, shape: Shape10D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback10D<T, U, W>, thisArg?: ThisParameterType<Callback10D<T, U, W>> ): Collection<U | V>;
 }
@@ -1107,7 +1107,7 @@ interface FlattenBy {
 * var x = [ [ 1, 2 ], [ 3, 4 ] ];
 *
 * var out = flattenBy( x, [ 2, 2 ], false, scale );
-* // returns [ 1, 2, 3, 4 ]
+* // returns [ 2, 4, 6, 8 ]
 *
 * @example
 * function scale( v ) {
@@ -1117,7 +1117,7 @@ interface FlattenBy {
 * var x = [ [ 1, 2 ], [ 3, 4 ] ];
 *
 * var out = flattenBy( x, [ 2, 2 ], true, scale );
-* // returns [ 1, 3, 2, 4 ]
+* // returns [ 2, 6, 4, 8 ]
 */
 declare var flattenBy: FlattenBy;
 

--- a/lib/node_modules/@stdlib/array/base/flatten3d-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/flatten3d-by/docs/types/index.d.ts
@@ -72,7 +72,7 @@ type Callback<T, U, V> = Nullary<U, V> | Unary<T, U, V> | Binary<T, U, V> | Tern
 */
 interface Flatten3dBy {
 	/**
-	* Flattens a three-dimensional nested array according to a callback function..
+	* Flattens a three-dimensional nested array according to a callback function.
 	*
 	* ## Notes
 	*
@@ -105,7 +105,7 @@ interface Flatten3dBy {
 	* var out = flatten3dBy( x, [ 2, 1, 2 ], true, scale );
 	* // returns [ 2, 6, 4, 8 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Array3D<T>, shape: Shape3D, colexicographic: boolean, clbk: Callback<T, U, V>, thisArg?: ThisParameterType<Callback<T, U, V>> ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Array3D<T>, shape: Shape3D, colexicographic: boolean, clbk: Callback<T, U, V>, thisArg?: ThisParameterType<Callback<T, U, V>> ): Array<U>;
 
 	/**
 	* Flattens a three-dimensional nested array according to a callback function and assigns elements to a provided output array.

--- a/lib/node_modules/@stdlib/array/base/mskfiltern/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/mskfiltern/docs/types/index.d.ts
@@ -133,12 +133,16 @@ declare function mskfiltern<T = unknown, U = unknown, V = unknown, W = unknown, 
 * @example
 * var x = [ 1, 2, 3, 4 ];
 * var y = [ 5, 6, 7, 8 ];
+* var z = [ 1, 1, 1, 1 ];
+* var u = [ 0, 0, 0, 0 ];
+* var v = [ 1, 2, 3, 4 ];
+* var w = [ 5, 6, 7, 8 ];
 * var mask = [ 0, 1, 0, 1 ];
 *
-* var out = mskfiltern( x, y, mask );
-* // returns [ [ 2, 4 ], [ 6, 8 ] ]
+* var out = mskfiltern( x, y, z, u, v, w, mask );
+* // returns [ [ 2, 4 ], [ 6, 8 ], [ 1, 1 ], [ 0, 0 ], [ 2, 4 ], [ 6, 8 ] ]
 */
-declare function mskfiltern<T = unknown, U = unknown>( x: Collection<T>, y: Collection, ...arrays: Array<U> ): Array<Array<T|U>>;
+declare function mskfiltern<T = unknown, U = unknown>( x: Collection<T>, y: Collection<U>, ...arrays: Array<Collection> ): Array<Array<T|U>>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/base/mskreject-map/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/mskreject-map/docs/types/index.d.ts
@@ -80,7 +80,7 @@ interface MskrejectMap {
 	* } );
 	* // returns [ 2, 6 ]
 	*/
-	<T = unknown, U = unknown, V = unknown>( x: Collection<T> | AccessorArrayLike<T>, mask: Collection, clbk: Callback<T, U, V>, thisArg?: U ): Array<T>;
+	<T = unknown, U = unknown, V = unknown>( x: Collection<T> | AccessorArrayLike<T>, mask: Collection, clbk: Callback<T, U, V>, thisArg?: U ): Array<V>;
 
 	/**
 	* Applies a mask to a provided input array, maps the unmasked values according to a callback function, and assigns to elements in a provided output array.
@@ -109,7 +109,7 @@ interface MskrejectMap {
 	* var bool = ( arr === out );
 	* // returns true
 	*/
-	assign<T = unknown, U = unknown, V = unknown>( x: Collection | AccessorArrayLike<T>, mask: Collection, out: Collection<T>, stride: number, offset: number, clbk: Callback<T, U, V>, thisArg?: U ): Collection<T>;
+	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Collection<T> | AccessorArrayLike<T>, mask: Collection, out: Collection<W>, stride: number, offset: number, clbk: Callback<T, U, V>, thisArg?: U ): Collection<V | W>;
 }
 
 /**

--- a/lib/node_modules/@stdlib/array/base/mskreject-map/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/mskreject-map/docs/types/test.ts
@@ -47,9 +47,9 @@ function identity( val: string ): string {
 // The function returns an array...
 {
 	mskrejectMap( [ 1, 2, 3, 4 ], [ 0, 0, 0, 0 ], timesTwo ); // $ExpectType number[]
-	mskrejectMap<any>( [ 1, 2, 3, 4 ], [ 0, 0, 0, 0 ], timesTwo ); // $ExpectType any[]
-	mskrejectMap<number>( [ 1, 2, 3, 4 ], [ 0, 0, 0, 0 ], timesTwo ); // $ExpectType number[]
-	mskrejectMap<string>( [ '1', '2', '3', '4' ], [ 0, 0, 0, 0 ], identity ); // $ExpectType string[]
+	mskrejectMap<number, unknown, any>( [ 1, 2, 3, 4 ], [ 0, 0, 0, 0 ], timesTwo ); // $ExpectType any[]
+	mskrejectMap<number, unknown, number>( [ 1, 2, 3, 4 ], [ 0, 0, 0, 0 ], timesTwo ); // $ExpectType number[]
+	mskrejectMap<string, unknown, string>( [ '1', '2', '3', '4' ], [ 0, 0, 0, 0 ], identity ); // $ExpectType string[]
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array-like object...

--- a/lib/node_modules/@stdlib/array/base/zip2views/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/zip2views/docs/types/index.d.ts
@@ -28,6 +28,11 @@ import { Collection, AccessorArrayLike, ArrayLike } from '@stdlib/types/array';
 type PropertyKey = string | number | symbol;
 
 /**
+* Composite view.
+*/
+type Zip2View<U extends PropertyKey, T> = Record<U, T> & { toJSON(): Record<U, T> };
+
+/**
 * Zips one or more arrays to an array of composite views.
 *
 * ## Notes
@@ -73,7 +78,7 @@ type PropertyKey = string | number | symbol;
 * var y1 = y.slice();
 * // returns [ 'a', 'beep', 'c' ]
 */
-declare function zip2views<T = unknown, U extends PropertyKey = PropertyKey>( arrays: ArrayLike<Collection<T> | AccessorArrayLike<T>>, labels: Collection<U> | AccessorArrayLike<U> ): Array<Record<U, T>>;
+declare function zip2views<T = unknown, U extends PropertyKey = PropertyKey>( arrays: ArrayLike<Collection<T> | AccessorArrayLike<T>>, labels: Collection<U> | AccessorArrayLike<U> ): Array<Zip2View<U, T>>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/base/zip2views/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/zip2views/docs/types/test.ts
@@ -23,7 +23,7 @@ import zip2views = require( './index' );
 
 // The function returns an array of objects...
 {
-	zip2views( [ [ 1, 2 ], [ 1, 3 ] ], [ 'x', 'y' ] ); // $ExpectType Record<"x" | "y", number>[]
+	zip2views( [ [ 1, 2 ], [ 1, 3 ] ], [ 'x', 'y' ] ); // $ExpectType Zip2View<"x" | "y", number>[]
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array-like object...


### PR DESCRIPTION
## Description

This pull request corrects TypeScript **type-signature** defects in several `@stdlib/array/base` package declarations that were surfaced by an audit of the `array` namespace declaration files:

-   **`flatten-by`**: the 2D–10D non-assign overloads returned `Array<T>` (the input element type) instead of `Array<U>` (the callback's mapped result type). The 1D overload already returned `Array<U>`, so type-changing callbacks were mis-typed for all higher dimensions.
-   **`flatten3d-by`**: the call signature returned `Array<T>` instead of the mapped `Array<U>`.
-   **`mskreject-map`**: the main overload returned `Array<T>` instead of the callback's mapped type `Array<V>`, and `assign` returned `Collection<T>` rather than incorporating the mapped output element type (now `Collection<V | W>`, mirroring `mskfilter-map`).
-   **`count-ifs`**: the `Predicate<T, U>` union instantiated `Unary`/`Binary` with the array type `U` instead of the element type `T`, so a predicate's `value` was typed as the whole array (now matches the `count-if` sibling).
-   **`mskfiltern`**: the variadic fallback overload typed its rest parameter as `Array<U>` (a scalar) instead of `Array<Collection>`, and `y` as `Collection` instead of `Collection<U>`.
-   **`fillednd`**: the fallback overload declared a never-inferable type parameter `U` (now returns `Array<T>`).
-   **`zip2views`**: the return type did not reflect the composite view's `toJSON` method (introduces a `Zip2View` type).

Affected declaration `@example` annotations and the corresponding type tests are updated accordingly.

## Related Issues

None.

## Questions

No.

## Other

This is one of a series of PRs addressing findings from a TypeScript-declaration audit of the `@stdlib/array` namespace. This PR contains only type-signature corrections; documentation-only fixes (examples, descriptions) are submitted separately so that each PR is a single logical unit.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

The issues fixed here were identified by a multi-agent audit run with Claude Code, and the changes were drafted by Claude Code under my direction and review. Each fix was independently verified, and the corrected declarations/tests pass the repository's TypeScript declaration doctest and `$ExpectType` linters locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
