### PR TITLE
fix: correct TypeScript types in top-level `array` declarations

### DIFF
--- a/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
@@ -60,7 +60,7 @@ declare function scalar2array( value: number, dtype: 'float32' ): Float32Array;
 * var x = scalar2array( true, 'bool' );
 * // returns <BooleanArray>
 */
-declare function scalar2array( value: any, dtype: 'bool' ): BooleanArray;
+declare function scalar2array( value: boolean, dtype: 'bool' ): BooleanArray; // eslint-disable-line @typescript-eslint/unified-signatures
 
 /**
 * Returns a single-element array containing a provided scalar value.

--- a/lib/node_modules/@stdlib/array/next-dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/next-dtype/docs/types/index.d.ts
@@ -251,8 +251,8 @@ declare function nextDataType( dtype: 'complex64' ): 'complex128';
 * @returns next larger data type
 *
 * @example
-* var dt = nextDataType( 'complex64' );
-* // returns 'complex128'
+* var dt = nextDataType( 'float64' );
+* // returns -1
 */
 declare function nextDataType( dtype: DataType ): DataType | number;
 
@@ -260,6 +260,7 @@ declare function nextDataType( dtype: DataType ): DataType | number;
 * Returns the next larger array data type of the same kind.
 *
 * ## Notes
+*
 * -   If provided an unrecognized data type, the function returns `null`.
 *
 * @param dtype - array data type
@@ -280,18 +281,13 @@ declare function nextDataType( dtype: string ): null;
 * -   If a data type does not have a next larger data type or the next larger type is not supported, the function returns `-1`.
 * -   If provided an unrecognized data type, the function returns `null`.
 *
-* @param dtype - array data type
 * @returns next larger data type(s) or null
 *
 * @example
 * var table = nextDataType();
 * // returns {...}
-*
-* @example
-* var dt = nextDataType( 'float32' );
-* // returns 'float64'
 */
-declare function nextDataType( dtype?: DataType ): Table;
+declare function nextDataType(): Table;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/to-json/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/to-json/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { RealOrComplexTypedArray } from '@stdlib/types/array';
+import { BooleanArray, RealOrComplexTypedArray } from '@stdlib/types/array';
 
 /**
 * Typed array data type.
@@ -61,7 +61,7 @@ interface JSONRepresentation {
 * var json = typedarray2json( arr );
 * // returns { 'type': 'Float64Array', 'data': [ 5.0, 3.0 ] }
 */
-declare function typedarray2json( arr: RealOrComplexTypedArray ): JSONRepresentation;
+declare function typedarray2json( arr: RealOrComplexTypedArray | BooleanArray ): JSONRepresentation;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/to-json/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/to-json/docs/types/test.ts
@@ -35,7 +35,6 @@ import typedarray2json = require( './index' );
 	typedarray2json( true ); // $ExpectError
 	typedarray2json( false ); // $ExpectError
 	typedarray2json( {} ); // $ExpectError
-	typedarray2json( [] ); // $ExpectError
 	typedarray2json( null ); // $ExpectError
 	typedarray2json( undefined ); // $ExpectError
 }


### PR DESCRIPTION
## Description

This pull request corrects TypeScript **type-signature** defects in three top-level `@stdlib/array` package declarations, surfaced by an audit of the `array` namespace declaration files:

-   **`from-scalar`**: the explicit `'bool'` dtype overload typed its `value` parameter as `any`. Narrowed it to `boolean`, matching the inferred-dtype boolean overload and the `full-like` sibling. Because this makes the overload unifiable with the inferred-dtype boolean overload, a `// eslint-disable-line @typescript-eslint/unified-signatures` directive is added (the same approach already used in `array/filled-by`), since the two overloads are intentionally kept in their respective explicit/inferred groups.
-   **`to-json`**: `typedarray2json` accepted only `RealOrComplexTypedArray`, excluding `BooleanArray`, even though the implementation, README, and the declaration's own `dtype` union all support boolean arrays. Broadened the parameter to `RealOrComplexTypedArray | BooleanArray` (matching the `filled-by` and `pool` siblings).
-   **`next-dtype`**: the table-returning catch-all overload was declared as `( dtype?: DataType ): Table`, accepting a `dtype` argument even though the implementation returns a table only when invoked with **no** arguments. Made the overload parameterless and corrected its duplicated/contradictory examples.

## Related Issues

None.

## Questions

No.

## Other

This is one of a series of PRs addressing findings from a TypeScript-declaration audit of the `@stdlib/array` namespace; it contains only type-signature corrections.

One note for reviewers: broadening `to-json` to accept `BooleanArray` causes the empty-array literal `[]` to type-check (the `BooleanArray` interface extends `AccessorArrayLike`, which an empty array literal structurally satisfies), so the now-invalid `typedarray2json( [] ); // $ExpectError` assertion was removed from the type test. The remaining negative assertions (string, number, boolean, `{}`, `null`, `undefined`) are retained.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

The issues fixed here were identified by a multi-agent audit run with Claude Code, and the changes were drafted by Claude Code under my direction and review. Each fix was verified locally against the repository's TypeScript declaration doctest and `$ExpectType` linters.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
