### PR TITLE
refactor: align and simplify `array` TypeScript declarations

### DIFF
--- a/lib/node_modules/@stdlib/array/base/assert/contains/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/assert/contains/docs/types/index.d.ts
@@ -28,7 +28,7 @@ import { Collection } from '@stdlib/types/array';
 * @param value - search value
 * @returns boolean indicating whether an array contains a search value
 */
-type Unary = ( x: any ) => boolean;
+type Unary = ( value: any ) => boolean;
 
 /**
 * Interface for testing whether an array contains a provided search value.

--- a/lib/node_modules/@stdlib/array/base/bifurcate-indices-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/bifurcate-indices-by/docs/types/index.d.ts
@@ -69,7 +69,7 @@ type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
 /**
 * Group results.
 */
-type IndicesResults<T> = [ Array<T>, Array<T> ];
+type IndicesResults = [ Array<number>, Array<number> ];
 
 /**
 * Splits element indices into two groups according to a predicate function.
@@ -93,7 +93,7 @@ type IndicesResults<T> = [ Array<T>, Array<T> ];
 * var out = bifurcateIndicesBy( x, predicate );
 * // returns [ [ 0, 1, 3 ], [ 2 ] ]
 */
-declare function bifurcateIndicesBy<T = unknown, U = unknown>( x: Collection<T> | AccessorArrayLike<T>, predicate: Predicate<T, U>, thisArg?: ThisParameterType<Predicate<T, U>> ): IndicesResults<number>;
+declare function bifurcateIndicesBy<T = unknown, U = unknown>( x: Collection<T> | AccessorArrayLike<T>, predicate: Predicate<T, U>, thisArg?: ThisParameterType<Predicate<T, U>> ): IndicesResults;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/base/bifurcate-indices-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/bifurcate-indices-by/docs/types/test.ts
@@ -35,7 +35,7 @@ function predicate( v: string ): boolean {
 {
 	const x = [ 'foo', 'bar' ];
 
-	bifurcateIndicesBy( x, predicate ); // $ExpectType IndicesResults<number>
+	bifurcateIndicesBy( x, predicate ); // $ExpectType IndicesResults
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array...

--- a/lib/node_modules/@stdlib/array/base/cunone/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/cunone/docs/types/index.d.ts
@@ -25,7 +25,7 @@ import { Collection, AccessorArrayLike } from '@stdlib/types/array';
 /**
 * Interface describing `cunone`.
 */
-interface cunone {
+interface CuNone {
 	/**
 	* Cumulatively tests whether every element in a provided array is falsy.
 	*
@@ -78,7 +78,7 @@ interface cunone {
 * var arr = cunone.assign( x, y, 2, 0 );
 * // returns [ true, null, true, null, true, null, false, null, false, null ];
 */
-declare var cunone: cunone;
+declare var cunone: CuNone;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/base/to-deduped/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/to-deduped/docs/types/index.d.ts
@@ -29,7 +29,7 @@
 * @example
 * var x = [ 1, 1, 2, 3, 3 ];
 *
-* var y = dedupe( x, 1, false );
+* var y = toDeduped( x, 1, false );
 * // returns [ 1, 2, 3 ]
 *
 * var bool = ( x === y );
@@ -38,15 +38,15 @@
 * @example
 * var x = [ 1, 1, 1, 2, 1, 1, 3, 3 ];
 *
-* var y = dedupe( x, 2, false );
+* var y = toDeduped( x, 2, false );
 * // returns [ 1, 1, 2, 1, 1, 3, 3 ]
 *
 * var bool = ( x === y );
 * // returns false
 */
-declare function dedupe<T = unknown>( x: Array<T>, limit: number, equalNaNs: boolean ): Array<T>;
+declare function toDeduped<T = unknown>( x: Array<T>, limit: number, equalNaNs: boolean ): Array<T>;
 
 
 // EXPORTS //
 
-export = dedupe;
+export = toDeduped;

--- a/lib/node_modules/@stdlib/array/base/without/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/without/docs/types/index.d.ts
@@ -25,7 +25,7 @@ import { Collection, RealTypedArray, ComplexTypedArray, AccessorArrayLike } from
 /**
 * Interface describing `without`.
 */
-interface ArrayWith {
+interface Without {
 	/**
 	* Returns a new array containing every element from an input array, except for the element at a specified index.
 	*
@@ -210,7 +210,7 @@ interface ArrayWith {
 * var bool = ( arr === out );
 * // returns true
 */
-declare var without: ArrayWith;
+declare var without: Without;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/filled/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/filled/docs/types/index.d.ts
@@ -39,7 +39,7 @@ import { IterableIterator } from '@stdlib/types/iter';
 * var arr = filledarray( 'float32' );
 * // returns <Float32Array>
 */
-declare function filledarray<T = any, U extends keyof DataTypeMap<T> = 'float64'>( dtype?: U ): DataTypeMap<any>[U];
+declare function filledarray<T = any, U extends keyof DataTypeMap<T> = 'float64'>( dtype?: U ): DataTypeMap<T>[U];
 
 /**
 * Creates a filled array having a specified `length`.

--- a/lib/node_modules/@stdlib/array/typed-complex/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/typed-complex/docs/types/index.d.ts
@@ -46,7 +46,7 @@ declare function complexarray<T extends keyof DataTypeMap = 'complex128'>( dtype
 *
 * @param length - typed array length
 * @param dtype - data type (default: 'complex128')
-* @returns typed array
+* @returns complex number typed array
 *
 * @example
 * var arr = complexarray( 2 );
@@ -95,7 +95,7 @@ declare function complexarray<T extends keyof DataTypeMap = 'complex128'>( compl
 * var arr = complexarray( [ 5, -3 ], 'complex64' );
 * // returns <Complex64Array>
 */
-declare function complexarray<T extends keyof DataTypeMap = 'complex128'>( obj: ArrayLike<number> | Iterable<any>, dtype?: T ): DataTypeMap[T];
+declare function complexarray<T extends keyof DataTypeMap = 'complex128'>( obj: ArrayLike<number> | Iterable<unknown>, dtype?: T ): DataTypeMap[T];
 
 /**
 * Creates a complex number typed array.


### PR DESCRIPTION
## Description

This pull request applies **behavior-neutral** cleanups to several `@stdlib/array` TypeScript declarations, surfaced by an audit of the namespace's declaration files:

-   **`base/to-deduped`**: the declared function and its `@example` blocks used the internal name `dedupe`; renamed to the public `toDeduped` (and `export = toDeduped`).
-   **`base/without`**: the interface was named `ArrayWith` (copy-pasted from `with`); renamed to `Without`.
-   **`base/cunone`**: the interface used a lowercase `cunone` identifier; renamed to `CuNone` to match the `CuAny`/`CuEvery` siblings.
-   **`base/bifurcate-indices-by`**: dropped the dead `IndicesResults<T>` type parameter (always instantiated as `number`); updated the type test accordingly.
-   **`base/assert/contains`**: renamed the `Unary` function type's parameter from `x` to `value` to match its documented `@param value`.
-   **`filled`**: the first overload used `DataTypeMap<any>[U]`, leaving the type parameter `T` unused; switched to `DataTypeMap<T>[U]` (behaviorally identical).
-   **`typed-complex`**: the object overload used `Iterable<any>`; switched to `Iterable<unknown>` to match the `typed` sibling, and corrected a `@returns` description.

None of these changes affect runtime behavior or downstream-observable types.

## Related Issues

None.

## Questions

No.

## Other

This is one of a series of PRs addressing findings from a TypeScript-declaration audit of the `@stdlib/array` namespace.

Two audit findings in this category were intentionally **deferred** from this PR: `base/take-map` (its `assign` overloads appear disconnected from the exported function and its declaration examples fail the doctest linter) and `base/where` (its `assign` examples reference an undefined `assign` and fail the doctest linter). Both require deeper, documentation-focused fixes and are better handled separately.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

The issues addressed here were identified by a multi-agent audit run with Claude Code, and the changes were drafted by Claude Code under my direction and review. Each change was verified locally against the repository's TypeScript declaration doctest and `$ExpectType` linters.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
