### PR TITLE
chore: remove misspelled keyword

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/iladlc/package.json
+++ b/lib/node_modules/@stdlib/lapack/base/iladlc/package.json
@@ -59,7 +59,6 @@
     "column",
     "index",
     "matrix",
-    "auxilary",
     "linear",
     "algebra",
     "subroutines",

--- a/lib/node_modules/@stdlib/lapack/base/iladlr/package.json
+++ b/lib/node_modules/@stdlib/lapack/base/iladlr/package.json
@@ -59,7 +59,6 @@
     "row",
     "index",
     "matrix",
-    "auxilary",
     "linear",
     "algebra",
     "subroutines",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Drops the misspelled `"auxilary"` keyword from the `package.json` `keywords` array in `@stdlib/lapack/base/iladlc` and `@stdlib/lapack/base/iladlr`. The misspelled form appears nowhere else in stdlib, and 26 of 28 sibling routine packages in `lapack/base` carry no `auxiliary`-family keyword at all (93% namespace conformance for "absent"). Removal brings the two manifests in line with the rest of the namespace.

**Namespace summary**

- Namespace scanned: `@stdlib/lapack/base`
- Members: 30 raw → 28 routines after excluding `shared` and `xerbla` (both path-export utilities, not function-routines)
- Structural features analyzed: file-tree presence, `package.json` top-level keys, `scripts`/`engines` blobs, keyword sets, manifest shape, README `##`/`###` section sequence and presence
- Semantic features analyzed (per package, via `sonnet` agents): public signature, `returnKind`, validation prologue, error construction, JSDoc shape, runtime dependencies
- Features with a clear majority (≥75%): file-tree skeleton (8 files at 100%), `## C APIs` section (86%), JSDoc `LDA`/`LDB`/`LDO`/`LDC` type (≥87%), JSDoc `M` type for matrix routines (83%), keyword core set (10 terms at 96–100%), error construction (100% `format` among packages that throw)
- Features without a clear majority (excluded): `returnKind` (64% mode), JSDoc `N` type (58%), per-package validation-prologue sequence

### `lapack/base/iladlc`

Removes the misspelled keyword `"auxilary"` from `package.json`. The correct spelling `"auxiliary"` is absent from 26 of 28 sibling packages in `lapack/base`, making the keyword itself non-conformant with namespace conventions. One-line deletion brings the manifest in line with the rest of the namespace.

### `lapack/base/iladlr`

Removes the misspelled keyword `"auxilary"` from `package.json` to match the convention used by 26 of 28 other routines in `lapack/base`, which carry no `auxiliary`-family keyword. The correct spelling appears in neither this package nor `iladlc`, so deletion is the conformant fix rather than correction.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation**

- Structural extraction over all 28 routine packages (file tree, `package.json` shape, README headings, manifest shape).
- Semantic extraction via per-package `sonnet` subagents in two batches of 14 (no JSON retries needed).
- Three-agent adversarial review on every surviving candidate (opus semantic, opus cross-reference, sonnet structural).

**Deliberately excluded from this PR**

- `## C APIs` README stub absent in `clacgv`, `crot`, `zlacgv`, `zrot`: stdlib-wide presence is only ~63% in `blas/base` and 0% in `stats/base`, failing the ≥90% ecosystem-wide gate for "add a missing section" fixes.
- `lib/ndarray.js` / `benchmark/benchmark.ndarray.js` absent in `dlamch`, `dlapy2`, `dlapy3`: scalar-input routines have no strided variant; intentional.
- `lib/base.js` absent in 7 packages: requires extracting and rewiring the kernel — not a mechanical fix.
- JSDoc `@param {integer} LDA` → `{PositiveInteger}` in `iladlc`/`iladlr` (87% namespace conformance, runtime guard enforces `LDA ≥ 1`): correct on substance but Agent 2 flagged `needs-human` because `docs/repl.txt` documents the old type and is generator-owned per stdlib convention, so cannot be hand-edited in lockstep. Dropped to avoid leaving a half-state. Should be revisited once a REPL regen routine is in place.
- JSDoc `@param {PositiveInteger} M` → `{NonNegativeInteger}` in `iladlc`/`iladlr` (83% namespace conformance for matrix routines): the per-namespace majority for `N` is only 58%, so changing `M` alone would leave the two annotations internally inconsistent against an identical kernel guard (`if ( M <= 0 || N <= 0 ) return -1;`). Dropped pending broader rework.
- `xerbla` and `shared` excluded entirely: both are JS-side path-export utilities, not routines.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by Claude Code running a cross-package drift detection routine over `@stdlib/lapack/base`. The routine extracted structural features (file tree, `package.json` shape, README sections) and semantic features (per-package via sonnet subagents) from all 28 routine packages, ran a three-agent adversarial validation pass (semantic, cross-reference, structural) on every candidate that exceeded the 75% majority threshold, and applied only the corrections that survived. Two larger drift findings (LDA type, M type) were dropped on validator review — see the `Other` section above. The remaining keyword removal is mechanical and was applied verbatim.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01UxvWT628JCfycWkcoPJKgf)_