### PR TITLE
docs: add note concerning generalization

### DIFF
--- a/lib/node_modules/@stdlib/time/day-of-quarter/README.md
+++ b/lib/node_modules/@stdlib/time/day-of-quarter/README.md
@@ -70,6 +70,16 @@ var num = dayOfQuarter( new Date() );
 
 <!-- /.usage -->
 
+<section class="notes">
+
+## Notes
+
+-   The function's return value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
+
+</section>
+
+<!-- /.notes -->
+
 <section class="examples">
 
 ## Examples

--- a/lib/node_modules/@stdlib/time/day-of-year/README.md
+++ b/lib/node_modules/@stdlib/time/day-of-year/README.md
@@ -73,6 +73,16 @@ var num = dayOfYear( new Date() );
 
 <!-- /.usage -->
 
+<section class="notes">
+
+## Notes
+
+-   The function's return value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
+
+</section>
+
+<!-- /.notes -->
+
 <section class="examples">
 
 ## Examples


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a `## Notes` section to two `@stdlib/time` package READMEs (`day-of-year` and `day-of-quarter`) so they carry the same DST/timezone caveat already documented in their sibling packages. No source, type, or test changes.

### Namespace summary

-   **Namespace:** `@stdlib/time`
-   **Member count:** 19 packages
-   **Features analyzed:** file tree, `package.json` keys/`scripts`/`stdlib` keys/`directories`/`keywords`/`bin`/`os`/`engines`, `manifest.json` keys, README section list and ordering, `test/`/`benchmark/`/`examples/` filenames, public signature, return kind, validation prologue, error construction, JSDoc `@param`/`@returns`/`@throws`/`@example`, and source-level dependencies.
-   **Features with clear majority (≥75%):** `package.json` top-level keys (19/19), `os` and `engines` shape (19/19), universal keywords (19/19), `directories` keys (19/19), `lib/index.js` and `docs/types/*` (19/19), `lib/main.js` and `docs/repl.txt` (18/19), `bin`/CLI files (16/19), `## Usage` and `## Examples` (19/19), `## CLI` and its sub-sections (16/19), **`## Notes`** (15/19, 78.9%), JSDoc `@example` and `@returns` (18/19), error construction via `format` (15/15 among packages that perform validation), return kind `value` (19/19).
-   **Features excluded for no clear majority:** `## See Also` (14/19, also gated as auto-populated content), `### Notes` CLI sub-section (2/19), `benchmark/benchmark.js` (2/19), `browser` field (1/19), package-specific implementation files (`lib/days.json`, `lib/detect.js`, `lib/polyfill.js`, `lib/browser.js`).

### `time/day-of-year`

Adds a `## Notes` section to the `@stdlib/time/day-of-year` README documenting that the return value is a generalization and does not account for DST, timezone crossings, or related time complications. The note matches verbatim the disclaimer already present in nine sibling packages (`days-in-month`, `days-in-year`, `hours-in-month`, `hours-in-year`, `minutes-in-month`, `minutes-in-year`, `seconds-in-month`, `seconds-in-year`, `iso-weeks-in-year`) and brings `day-of-year` into conformance with the 78.9% majority of `time/*` packages that carry this section. The addition is warranted because `day-of-year` reads month, day, and year via local-time accessors and is subject to the same DST and timezone exposure as those siblings.

### `time/day-of-quarter`

Adds a `## Notes` section to the `@stdlib/time/day-of-quarter` README to align with the 15 of 19 sibling `time/*` packages that already carry this section. The DST/timezone caveat is verbatim from nine siblings (`days-in-month`, `days-in-year`, `hours-in-month`, `hours-in-year`, `minutes-in-month`, `minutes-in-year`, `seconds-in-month`, `seconds-in-year`, `iso-weeks-in-year`) and applies here because `day-of-quarter` delegates to `day-of-year` and `quarter-of-year`, reading month, day, and year through local-time accessors. No logic changes; documentation only.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   Structural feature extraction: file tree, `package.json` shape, README section list/order, `manifest.json` shape, and `test/`/`benchmark/`/`examples/` filenames captured for every member of the namespace.
-   Semantic feature extraction: per-package agents read `lib/main.js`, `lib/index.js`, and `lib/validate.js` (where present) and reported public signature, return kind, validation prologue, error construction, JSDoc shape, and source-level dependencies.
-   Three-agent drift validation: an opus semantic-review agent confirmed the DST/timezone disclaimer applies to both candidates; an opus cross-reference agent confirmed no tests/examples/sibling READMEs depend on the absence of the Notes section and no API contract is affected; a sonnet structural-review agent confirmed the templated text and insertion position match the nine-sibling convention.
-   Deliberately excluded:
    -   `quarter-of-year` — `## Notes` is also absent, but the templated DST/timezone bullet does not apply (function maps month index → quarter index without consulting any DST- or timezone-sensitive date value).
    -   `base` — sub-namespace re-export package; absence of `## Notes`, `## CLI`, `bin`, and the CLI fixtures is intentional.
    -   `tic`, `toc` — high-resolution timing primitives; CLI is conceptually inapplicable, so the missing CLI section/files are intentional.
    -   `## See Also` — auto-populated section; excluded from drift correction by routine policy.
    -   Cosmetic JSDoc differences (e.g., `@param` type-union ordering): excluded as below the 75% threshold and non-mechanical.

The inserted Notes block in both files is byte-identical to the `time/days-in-year` template (`diff` of the bracketed `<section class="notes">…<!-- /.notes -->` ranges returned empty).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was prepared by Claude Code running a cross-package API drift detection routine over the `@stdlib/time` namespace: feature extraction, majority-vote computation, three-agent validation (two opus, one sonnet) of the candidate corrections, and patch authoring. Both corrections are mechanical README insertions whose templated text and insertion position are byte-identical to the nine-sibling convention; no source or test files were modified.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019LFrz3iN3P4JMSSEaUGNcS)_