### PR TITLE
docs: document exported constants

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-big-endian/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-big-endian/lib/main.js
@@ -23,11 +23,6 @@
 var ctors = require( './ctors.js' );
 
 
-// VARIABLES //
-
-var bool;
-
-
 // FUNCTIONS //
 
 /**
@@ -63,7 +58,13 @@ function isBigEndian() {
 
 // MAIN //
 
-bool = isBigEndian();
+/**
+* Boolean indicating if an environment is big endian.
+*
+* @constant
+* @type {boolean}
+*/
+var bool = isBigEndian(); // eslint-disable-line vars-on-top
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/assert/is-little-endian/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-little-endian/lib/main.js
@@ -23,11 +23,6 @@
 var ctors = require( './ctors.js' );
 
 
-// VARIABLES //
-
-var bool;
-
-
 // FUNCTIONS //
 
 /**
@@ -63,7 +58,13 @@ function isLittleEndian() {
 
 // MAIN //
 
-bool = isLittleEndian();
+/**
+* Boolean indicating if an environment is little endian.
+*
+* @constant
+* @type {boolean}
+*/
+var bool = isLittleEndian(); // eslint-disable-line vars-on-top
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request propagates fixes merged to `develop` between 2026-05-29 21:55:51 UTC and 2026-05-30 10:20:09 UTC to sibling packages.

Document the exported `bool` singleton in `assert/is-big-endian` and `assert/is-little-endian` by adding a JSDoc constant block (`@constant`, `@type {boolean}`) to the assignment in the `// MAIN //` section. Remove the now-vacuous `// VARIABLES //` sections and suppress the `vars-on-top` ESLint rule at the assignment site. Propagates the fix introduced for `os/num-cpus`.

Source commit: `5e64030` ("docs: document exported constant in `os/num-cpus`")

Target packages:

-   `@stdlib/assert/is-big-endian`
-   `@stdlib/assert/is-little-endian`

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Candidate sites were enumerated by structurally matching the source pattern — an empty `var X;` declaration in `// VARIABLES //` paired with a later top-level assignment in `// MAIN //` of a value exported via `module.exports = X;` — across `lib/node_modules/@stdlib/**/lib/{main,index}.js`, excluding internal tooling under `_tools/`. Each candidate was independently confirmed by two validation passes that read the target file in full, followed by an adaptation pass producing the per-site patch and a style-consistency pass verifying JSDoc layout, `@type`, and description alignment with the file's existing module-level documentation.

**Deliberately excluded.** `constants/float32/ninf/lib/index.js` and `constants/float32/pinf/lib/index.js` match the structural signature but were flagged `needs-human`: each file already carries a `@constant`/`@type {number}` JSDoc block attached to an intermediate uint32 bit-pattern (`FLOAT32_NINF` / `FLOAT32_PINF`) rather than to the exported float `v`. A mechanical propagation would create overlapping documentation; the correct fix is a deliberate restructure of the JSDoc placement, not part of this run.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of the automated fix-propagation routine: it identified candidate sibling sites for a recent `develop` fix, independently validated the defect at each site, produced and style-checked the patches, and applied them mechanically. A human should verify the changes before merging.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXYhGdiGmT2Ybr8ENdD736)_