### PR TITLE
docs: use relative `require` path in `evalpoly-compile` example

### DIFF
--- a/lib/node_modules/@stdlib/math/base/tools/evalpoly-compile/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/tools/evalpoly-compile/examples/index.js
@@ -18,22 +18,12 @@
 
 'use strict';
 
-var resolve = require( 'path' ).resolve;
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
-var tryRequire = require( '@stdlib/utils/try-require' );
+var compile = require( './../lib' );
 
-var compile = tryRequire( resolve( __dirname, '..', 'lib' ) );
-if ( compile instanceof Error ) {
-	console.log( 'Unable to run example. Unsupported environment.' );
-} else {
-	main();
-}
+// Create an array of random coefficients:
+var coef = discreteUniform( 10, -100, 100 );
 
-function main() {
-	// Create an array of random coefficients:
-	var coef = discreteUniform( 10, -100, 100 );
-
-	// Compile a module for evaluating a polynomial:
-	var str = compile( coef );
-	console.log( str );
-}
+// Compile a module for evaluating a polynomial:
+var str = compile( coef );
+console.log( str );


### PR DESCRIPTION
Resolves #12359.

## Description

> What is the purpose of this pull request?

This pull request:

-   Replaces the unnecessary `tryRequire`-based package loading in
    `@stdlib/math/base/tools/evalpoly-compile/examples/index.js` with
    a direct `require( './../lib' )` call, fixing the
    `stdlib/require-last-path-relative` lint violation that caused the
    automated JavaScript lint workflow to fail on `develop`.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/26668990373
(2026-05-30 00:34:49 UTC)

**Symptom:** `stdlib/require-last-path-relative` error at line 23 of
`evalpoly-compile/examples/index.js` — the last `require()` call was
`require('@stdlib/utils/try-require')`, a non-relative path.

**Root cause:** The example used the `tryRequire` pattern (intended for
packages with optional native addons that may fail to compile). The
`evalpoly-compile` package is pure JavaScript: its `lib/` directory
contains only `index.js`, `main.js`, and `templates/`; it has no
native source, no native dependencies, and no build artifacts. The
`tryRequire` guard was therefore both unnecessary and counter-productive
— it made the last visible `require()` a non-relative path, triggering
the lint rule. The `tryRequire( resolve( __dirname, '..', 'lib' ) )`
call is not a `require()` call per the rule's AST check, so it does not
reset the "last require" pointer.

**Fix:** Remove `path`, `@stdlib/utils/try-require`, the error guard,
and the `main()` wrapper. Load the package directly with
`require( './../lib' )`, which is both the correct relative-path form
and the uniform convention used by sibling packages such as
`@stdlib/math/base/tools/evalpoly`.

This matches example in README.md.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   resolves #12359

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation:** The fix was reviewed by three independent agents prior to
commit. Reviewer C (style/conventions) caught that the initial draft used
`require( '..' )`, which does not satisfy `isRelativePath` (the rule
checks for `'./'` or `'../'` prefix). The fix was corrected to
`require( './../lib' )` — consistent with sibling packages and
unambiguously a relative path — before the commit was staged.

The `evalrational-compile` package has an identical `tryRequire` pattern
in its example file and will trigger the same lint rule in a future
automated run. That file is out of scope for this PR (separate failure
event) but warrants a follow-up.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated CI-failure
triage routine. The root-cause analysis, fix, and commit were produced
by the agent; the diff was reviewed against the ESLint rule
implementation and sibling package examples before being committed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVVqEVeJjgv5undurMUTbX)_