### PR TITLE
docs: fix examples and descriptions in the `array/base` namespace declaration

### DIFF
--- a/lib/node_modules/@stdlib/array/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/docs/types/index.d.ts
@@ -398,7 +398,7 @@ interface Namespace {
 	* @param x - input array
 	* @param predicate - predicate function
 	* @param thisArg - predicate function execution context
-	* @returns boolean indicating whether all elements pass a test
+	* @returns boolean indicating whether an element passes a test
 	*
 	* @example
 	* function isPositive( v ) {
@@ -423,7 +423,7 @@ interface Namespace {
 	* @param x - input array
 	* @param predicate - predicate function
 	* @param thisArg - predicate function execution context
-	* @returns boolean indicating whether all elements pass a test
+	* @returns boolean indicating whether at least one element passes a test
 	*
 	* @example
 	* function isPositive( v ) {
@@ -785,7 +785,7 @@ interface Namespace {
 	* var x = [ 'beep', 'boop', 'foo', 'bar' ];
 	* var filter = [ true, true, false, true ];
 	*
-	* var out = ns.bifurcateIndices( arr, filter );
+	* var out = ns.bifurcateIndices( x, filter );
 	* // returns [ [ 0, 1, 3 ], [ 2 ] ]
 	*/
 	bifurcateIndices: typeof bifurcateIndices;
@@ -1560,7 +1560,7 @@ interface Namespace {
 	* ns.bternary5d( [ x, y, z, out ], shapes, add );
 	*
 	* console.log( out );
-	* // => [ [ [ [ [ 3 ] ] ], [ [ [ 3 ] ] ] ], [ [ [ 3 ] ] ], [ [ [ 3 ] ] ] ] ]
+	* // => [ [ [ [ [ 3 ] ] ], [ [ [ 3 ] ] ] ], [ [ [ [ 3 ] ] ], [ [ [ 3 ] ] ] ] ]
 	*/
 	bternary5d: typeof bternary5d;
 
@@ -1948,6 +1948,8 @@ interface Namespace {
 	* Cumulatively tests whether at least one element in a provided array passes a test implemented by a predicate function.
 	*
 	* @param x - input array
+	* @param predicate - test function
+	* @param thisArg - execution context
 	* @returns output array
 	*
 	* @example
@@ -2155,7 +2157,7 @@ interface Namespace {
 	* var x = [ 0, 1, 1, 0, 0 ];
 	* var y = [ false, null, false, null, false, null, false, null, false, null ];
 	*
-	* var arr = ns.cunoneByRight.assign( x, 2, y, 2, 0, fcn );
+	* var arr = ns.cunoneByRight.assign( x, y, 2, 0, fcn );
 	* // returns [ true, null, true, null, false, null, false, null, false, null ]
 	*/
 	cunoneByRight: typeof cunoneByRight;
@@ -2213,7 +2215,7 @@ interface Namespace {
 	cusomeBy: typeof cusomeBy;
 
 	/**
-	* Cumulatively test whether at least `n` elements in a provided array pass a test implemented by a predicate function, while iterating from right-to-left.
+	* Cumulatively tests whether at least `n` elements in a provided array pass a test implemented by a predicate function, while iterating from right-to-left.
 	*
 	* @param x - input array
 	* @param n - number of elements
@@ -2227,7 +2229,7 @@ interface Namespace {
 	* }
 	* var x = [ 1, 1, 0, 0, 0 ];
 	*
-	* var result = cusomeByright( x, 2, fcn );
+	* var result = ns.cusomeByRight( x, 2, fcn );
 	* // returns [ false, false, false, false, true ]
 	*
 	* @example
@@ -2527,7 +2529,7 @@ interface Namespace {
 	/**
 	* Returns a filled "generic" array.
 	*
-	* @param value - fill value,
+	* @param value - fill value
 	* @param len - array length
 	* @returns output array
 	*
@@ -2802,7 +2804,7 @@ interface Namespace {
 	* var x = [ [ 1, 2 ], [ 3, 4 ] ];
 	*
 	* var out = ns.flattenBy( x, [ 2, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -2812,7 +2814,7 @@ interface Namespace {
 	* var x = [ [ 1, 2 ], [ 3, 4 ] ];
 	*
 	* var out = ns.flattenBy( x, [ 2, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
 	flattenBy: typeof flattenBy;
 
@@ -3048,7 +3050,7 @@ interface Namespace {
 	* var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 	*
 	* var out = ns.flatten5dBy( x, [ 2, 1, 1, 1, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -3058,7 +3060,7 @@ interface Namespace {
 	* var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 	*
 	* var out = ns.flatten5dBy( x, [ 2, 1, 1, 1, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
 	flatten5dBy: typeof flatten5dBy;
 
@@ -3235,7 +3237,7 @@ interface Namespace {
 	* @param x - input array
 	* @param stride - index stride
 	* @param offset - index of the first indexed value in the input array
-	* @returns two-dimensional nested array
+	* @returns output array
 	*
 	* @example
 	* var x = [ 1, 2, 3, 4, 5, 6 ];
@@ -3714,7 +3716,7 @@ interface Namespace {
 	*
 	*     -   **value**: array element.
 	*     -   **indices**: current array element indices.
-	*     --  **array**: input nested array.
+	*     -   **array**: input nested array.
 	*
 	* @param x - input nested array
 	* @param shape - array shape
@@ -3764,7 +3766,7 @@ interface Namespace {
 	*
 	*     -   **value**: array element.
 	*     -   **indices**: current array element indices.
-	*     --  **array**: input nested array.
+	*     -   **array**: input nested array.
 	*
 	* @param x - input nested array
 	* @param shape - array shape
@@ -3814,7 +3816,7 @@ interface Namespace {
 	*
 	*     -   **value**: array element.
 	*     -   **indices**: current array element indices.
-	*     --  **array**: input nested array.
+	*     -   **array**: input nested array.
 	*
 	* @param x - input nested array
 	* @param shape - array shape
@@ -5086,7 +5088,7 @@ interface Namespace {
 	*
 	* ## Notes
 	*
-	* -   The function assumes that `fromShape` and `toShape` describe arrays have same the number of elements.
+	* -   The function assumes that `fromShape` and `toShape` describe arrays having the same number of elements.
 	*
 	* @param x - input nested array
 	* @param fromShape - shape of the input array
@@ -5830,7 +5832,7 @@ interface Namespace {
 	* var x = ones2d( shape );
 	* var y = zeros2d( shape );
 	*
-	* ns.unary2dBy( [ x, y ], shape, scale );
+	* ns.unary2dBy( [ x, y ], shape, scale, accessor );
 	*
 	* console.log( y );
 	* // => [ [ -10.0, -10.0 ], [ -10.0, -10.0 ] ]
@@ -6034,7 +6036,7 @@ interface Namespace {
 	* var x = ones5d( shape );
 	* var y = zeros5d( shape );
 	*
-	* ns.unary5dBy( [ x, y ], shape, scale );
+	* ns.unary5dBy( [ x, y ], shape, scale, accessor );
 	*
 	* console.log( y );
 	* // => [ [ [ [ [ -10.0, -10.0 ], [ -10.0, -10.0 ] ] ] ] ]


### PR DESCRIPTION
## Description

This pull request fixes documentation defects in the `@stdlib/array/base` **namespace declaration file** (`base/docs/types/index.d.ts`), surfaced by an audit of the namespace's TypeScript declarations. All changes are confined to JSDoc comments (examples and prose); no declared types are affected.

-   **`@example` code**: fixed references to undefined/misspelled identifiers (`cusomeByright` → `ns.cusomeByRight`; `bifurcateIndices( arr, ... )` → `( x, ... )`) and incorrect arguments (`cunoneByRight.assign` had a spurious extra `2`; `unary2dBy`/`unary5dBy` omitted the required `accessor` argument).
-   **`// returns` / `// =>` annotations**: corrected annotations that ignored a doubling callback (`flattenBy`, `flatten5dBy`) or had unbalanced/incorrect nesting (`bternary5d`).
-   **prose**: corrected `@returns`/`@param`/summary text for `anyBy`/`anyByRight` (described an all-elements test instead of at-least-one), `strided2array` (claimed a two-dimensional return), `reshape` (garbled word order), `cusomeByRight` (verb agreement), `cuanyBy` (missing `@param predicate`/`@param thisArg`), and `filled` (stray trailing comma).
-   **Markdown**: repaired malformed `--` list bullets in the `map2d`/`map3d`/`map4d` Notes.

## Related Issues

None.

## Questions

No.

## Other

This is one of a series of PRs addressing findings from a TypeScript-declaration audit of the `@stdlib/array` namespace. The corresponding fixes in the individual `array/base` package declaration files are submitted in a separate PR.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

The issues fixed here were identified by a multi-agent audit run with Claude Code, and the changes were drafted by Claude Code under my direction and review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
