### PR TITLE
docs: fix examples and descriptions in `array/base` package declarations

### DIFF
--- a/lib/node_modules/@stdlib/array/base/accessor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/accessor/docs/types/index.d.ts
@@ -49,7 +49,7 @@ declare class AccessorArray<T> implements AccessorArrayLike<T> {
 	* // returns <AccessorArray>
 	*
 	* var len = arr.length;
-	* // returns 2
+	* // returns 3
 	*/
 	length: number;
 
@@ -72,7 +72,7 @@ declare class AccessorArray<T> implements AccessorArrayLike<T> {
 	* Sets an array element.
 	*
 	* @param value - value
-	* @param i - element index at which to start writing values (default: 0)
+	* @param i - element index (default: 0)
 	*
 	* @example
 	* var arr = new AccessorArray( [ 1, 2, 3 ] );

--- a/lib/node_modules/@stdlib/array/base/any-by-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/any-by-right/docs/types/index.d.ts
@@ -77,7 +77,7 @@ type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
 * @param x - input array
 * @param predicate - predicate function
 * @param thisArg - predicate function execution context
-* @returns boolean indicating whether all elements pass a test
+* @returns boolean indicating whether at least one element passes a test
 *
 * @example
 * function isPositive( v ) {

--- a/lib/node_modules/@stdlib/array/base/any-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/any-by/docs/types/index.d.ts
@@ -77,7 +77,7 @@ type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
 * @param x - input array
 * @param predicate - predicate function
 * @param thisArg - predicate function execution context
-* @returns boolean indicating whether all elements pass a test
+* @returns boolean indicating whether at least one element passes a test
 *
 * @example
 * function isPositive( v ) {

--- a/lib/node_modules/@stdlib/array/base/arraylike2object/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/arraylike2object/docs/types/index.d.ts
@@ -1014,7 +1014,7 @@ declare function arraylike2object<T = unknown>( x: Array<T> ): GenericAccessorOb
 *     '0': 1,
 *     '1': 2,
 *     '2': 3,
-*     '4': 4,
+*     '3': 4,
 *     'length': 4
 * };
 * var obj = arraylike2object( x );

--- a/lib/node_modules/@stdlib/array/base/assert/is-accessor-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/assert/is-accessor-array/docs/types/index.d.ts
@@ -42,7 +42,7 @@ interface AccessorArray {
 	/**
 	* Sets an array element.
 	*
-	* @param value - value(s)
+	* @param value - value
 	* @param i - element index at which to start writing values (default: 0)
 	*/
 	set( value: any, i?: number ): void;

--- a/lib/node_modules/@stdlib/array/base/assert/is-complex-typed-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/assert/is-complex-typed-array/docs/types/index.d.ts
@@ -26,7 +26,7 @@ import { Collection, ComplexTypedArray } from '@stdlib/types/array';
 * Tests if a value is a complex typed array.
 *
 * @param value - value to test
-* @returns boolean indicating whether a value is complex typed array
+* @returns boolean indicating whether a value is a complex typed array
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );

--- a/lib/node_modules/@stdlib/array/base/bifurcate-indices/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/bifurcate-indices/docs/types/index.d.ts
@@ -33,7 +33,7 @@ import { Collection, AccessorArrayLike } from '@stdlib/types/array';
 * var x = [ 'beep', 'boop', 'foo', 'bar' ];
 * var filter = [ true, true, false, true ];
 *
-* var out = bifurcateIndices( arr, filter );
+* var out = bifurcateIndices( x, filter );
 * // returns [ [ 0, 1, 3 ], [ 2 ] ]
 */
 declare function bifurcateIndices( x: Collection | AccessorArrayLike<any>, filter: Collection | AccessorArrayLike<any> ): [ Array<number>, Array<number> ]; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/lib/node_modules/@stdlib/array/base/broadcasted-ternary4d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-ternary4d/docs/types/index.d.ts
@@ -104,7 +104,7 @@ type InOutShapes = [
 * bternary4d( [ x, y, z, out ], shapes, add );
 *
 * console.log( out );
-* // => [ [ [ 3.0, 3.0 ], [ 3.0, 3.0 ] ], [ [ 3.0, 3.0 ], [ 3.0, 3.0 ] ], [ [ 3.0, 3.0 ], [ 3.0, 3.0 ] ], [ [ 3.0, 3.0 ], [ 3.0, 3.0 ] ] ]
+* // => [ [ [ [ 3.0, 3.0 ], [ 3.0, 3.0 ] ], [ [ 3.0, 3.0 ], [ 3.0, 3.0 ] ] ], [ [ [ 3.0, 3.0 ], [ 3.0, 3.0 ] ], [ [ 3.0, 3.0 ], [ 3.0, 3.0 ] ] ] ]
 */
 declare function bternary4d<T = unknown, U = unknown, V = unknown, W = unknown>( arrays: InOutArrays<T, U, V, W>, shapes: InOutShapes, fcn: Ternary<T, U, V, W> ): void;
 

--- a/lib/node_modules/@stdlib/array/base/broadcasted-ternary5d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-ternary5d/docs/types/index.d.ts
@@ -88,6 +88,7 @@ type InOutShapes = [
 * var ones5d = require( '@stdlib/array/base/ones5d' );
 * var zeros5d = require( '@stdlib/array/base/zeros5d' );
 * var add = require( '@stdlib/number/float64/base/add3' );
+*
 * var shapes = [
 *     [ 1, 2, 1, 1, 1 ],
 *     [ 2, 1, 1, 1, 1 ],
@@ -103,7 +104,7 @@ type InOutShapes = [
 * bternary5d( [ x, y, z, out ], shapes, add );
 *
 * console.log( out );
-* // => [ [ [ [ [ 3 ] ] ], [ [ [ 3 ] ] ] ], [ [ [ 3 ] ] ], [ [ [ 3 ] ] ] ] ]
+* // => [ [ [ [ [ 3.0 ] ] ], [ [ [ 3.0 ] ] ] ], [ [ [ [ 3.0 ] ] ], [ [ [ 3.0 ] ] ] ] ]
 */
 declare function bternary5d<T = unknown, U = unknown, V = unknown, W = unknown>( arrays: InOutArrays<T, U, V, W>, shapes: InOutShapes, fcn: Ternary<T, U, V, W> ): void;
 

--- a/lib/node_modules/@stdlib/array/base/cuany-by-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/cuany-by-right/docs/types/index.d.ts
@@ -16,6 +16,8 @@
 * limitations under the License.
 */
 
+// TypeScript Version: 4.1
+
 /// <reference types="@stdlib/types"/>
 
 import { Collection, AccessorArrayLike, TypedArray, BooleanArray } from '@stdlib/types/array';

--- a/lib/node_modules/@stdlib/array/base/cuany-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/cuany-by/docs/types/index.d.ts
@@ -94,7 +94,7 @@ interface CuAnyBy {
 	* Cumulatively tests whether at least one element in a provided array passes a test implemented by a predicate function and assigns the results to a provided output array.
 	*
 	* @param x - input array
-	* @param y - output array
+	* @param out - output array
 	* @param stride - output array stride
 	* @param offset - output array offset
 	* @param predicate - predicate function
@@ -121,8 +121,8 @@ interface CuAnyBy {
 	* @param out - output array
 	* @param stride - output array stride
 	* @param offset - output array offset
-	* @param predicate - test function
-	* @param thisArg - execution context
+	* @param predicate - predicate function
+	* @param thisArg - predicate function execution context
 	* @returns output array
 	*
 	* @example
@@ -171,6 +171,8 @@ interface CuAnyBy {
 * Cumulatively tests whether at least one element in a provided array passes a test implemented by a predicate function.
 *
 * @param x - input array
+* @param predicate - test function
+* @param thisArg - execution context
 * @returns output array
 *
 * @example

--- a/lib/node_modules/@stdlib/array/base/cunone-by-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/cunone-by-right/docs/types/index.d.ts
@@ -93,7 +93,7 @@ interface CunoneByRight {
 	* Cumulatively tests whether every array element in a provided array fails a test implemented by a predicate function, while iterating from right-to-left, and assigns the results to the provided output array.
 	*
 	* @param x - input array
-	* @param y - output array
+	* @param out - output array
 	* @param stride - output array stride
 	* @param offset - output array offset
 	* @param predicate - test function
@@ -165,7 +165,7 @@ interface CunoneByRight {
 }
 
 /**
-* Cumulatively tests whether no array element in a provided array passes a test implemented by a predicate function, while iterating from right-to-left.
+* Cumulatively tests whether every array element in a provided array fails a test implemented by a predicate function, while iterating from right-to-left.
 *
 * @param x - input array
 * @param predicate - test function
@@ -188,7 +188,7 @@ interface CunoneByRight {
 * var x = [ 0, 1, 1, 0, 0 ];
 * var y = [ false, null, false, null, false, null, false, null, false, null ];
 *
-* var arr = cunoneByRight.assign( x, 2, y, 2, 0, fcn );
+* var arr = cunoneByRight.assign( x, y, 2, 0, fcn );
 * // returns [ true, null, true, null, false, null, false, null, false, null ]
 */
 declare var cunoneByRight: CunoneByRight;

--- a/lib/node_modules/@stdlib/array/base/cusome-by-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/cusome-by-right/docs/types/index.d.ts
@@ -183,7 +183,7 @@ interface CusomeByRight {
 * }
 * var x = [ 1, 1, 0, 0, 0 ];
 *
-* var result = cusomeByright( x, 2, fcn );
+* var result = cusomeByRight( x, 2, fcn );
 * // returns [ false, false, false, false, true ]
 *
 * @example

--- a/lib/node_modules/@stdlib/array/base/cusome/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/cusome/docs/types/index.d.ts
@@ -78,7 +78,7 @@ interface cusome {
 * var x = [ false, false, false, true, true ];
 * var y = [ false, null, false, null, false, null, false, null, false, null ];
 *
-* var arr = cusome.assign( x, y, 2, 0 );
+* var arr = cusome.assign( x, 2, y, 2, 0 );
 * // returns [ false, null, false, null, false, null, false, null, true, null ];
 */
 declare var cusome: cusome;

--- a/lib/node_modules/@stdlib/array/base/filled/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/filled/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /**
 * Returns a filled "generic" array.
 *
-* @param value - fill value,
+* @param value - fill value
 * @param len - array length
 * @returns output array
 *

--- a/lib/node_modules/@stdlib/array/base/fillednd-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/fillednd-by/docs/types/index.d.ts
@@ -315,7 +315,7 @@ declare function filledndBy<T = unknown, V = unknown>( shape: Shape10D, clbk: Ca
 * var constantFunction = require( '@stdlib/utils/constant-function' );
 *
 * var out = filledndBy( [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3 ], constantFunction( 1.0 ) );
-* // returns [ [ [ [ [ [ [ [ [ [ [ 1.0, 1.0, 1.0 ] ] ] ] ] ] ] ] ] ]
+* // returns [ [ [ [ [ [ [ [ [ [ [ 1.0, 1.0, 1.0 ] ] ] ] ] ] ] ] ] ] ]
 */
 declare function filledndBy<T = unknown, V = unknown>( shape: Shape, clbk: Callback<T, V>, thisArg?: ThisParameterType<Callback<T, V>> ): Array<T>;
 

--- a/lib/node_modules/@stdlib/array/base/flatten4d-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/flatten4d-by/docs/types/index.d.ts
@@ -161,6 +161,8 @@ interface Flatten4dBy {
 * @param x - input array
 * @param shape - array shape
 * @param colexicographic - specifies whether to flatten array values in colexicographic order
+* @param clbk - callback function
+* @param thisArg - callback execution context
 * @returns flattened array
 *
 * @example

--- a/lib/node_modules/@stdlib/array/base/flatten4d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/flatten4d/docs/types/index.d.ts
@@ -73,7 +73,7 @@ interface Flatten4d {
 	*
 	* var x = [ [ [ [ 1, 2 ] ] ], [ [ [ 3, 4 ] ] ] ];
 	*
-	* var out = flatten4d.assign( x, [ 2, 2 ], false, new Float64Array( 4 ), 1, 0 );
+	* var out = flatten4d.assign( x, [ 2, 1, 1, 2 ], false, new Float64Array( 4 ), 1, 0 );
 	* // returns <Float64Array>[ 1, 2, 3, 4 ]
 	*
 	* @example
@@ -81,7 +81,7 @@ interface Flatten4d {
 	*
 	* var x = [ [ [ [ 1, 2 ] ] ], [ [ [ 3, 4 ] ] ] ];
 	*
-	* var out = flatten4d.assign( x, [ 2, 2 ], true, new Float64Array( 4 ), 1, 0 );
+	* var out = flatten4d.assign( x, [ 2, 1, 1, 2 ], true, new Float64Array( 4 ), 1, 0 );
 	* // returns <Float64Array>[ 1, 3, 2, 4 ]
 	*/
 	assign<T = unknown, U = unknown>( x: Array4D<T>, shape: Shape4D, colexicographic: boolean, out: Collection<U>, stride: number, offset: number ): Collection<T | U>;

--- a/lib/node_modules/@stdlib/array/base/flatten5d-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/flatten5d-by/docs/types/index.d.ts
@@ -93,7 +93,7 @@ interface Flatten5dBy {
 	* var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 	*
 	* var out = flatten5dBy( x, [ 2, 1, 1, 1, 2 ], false, scale );
-	* // returns [ 1, 2, 3, 4 ]
+	* // returns [ 2, 4, 6, 8 ]
 	*
 	* @example
 	* function scale( v ) {
@@ -103,7 +103,7 @@ interface Flatten5dBy {
 	* var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 	*
 	* var out = flatten5dBy( x, [ 2, 1, 1, 1, 2 ], true, scale );
-	* // returns [ 1, 3, 2, 4 ]
+	* // returns [ 2, 6, 4, 8 ]
 	*/
 	<T = unknown, U = unknown, V = unknown>( x: Array5D<T>, shape: Shape5D, colexicographic: boolean, clbk: Callback<T, U, V>, thisArg?: ThisParameterType<Callback<T, U, V>> ): Array<U>;
 
@@ -134,7 +134,7 @@ interface Flatten5dBy {
 	* var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 	*
 	* var out = flatten5dBy.assign( x, [ 2, 2 ], false, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 2, 3, 4 ]
+	* // returns <Float64Array>[ 2, 4, 6, 8 ]
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
@@ -146,7 +146,7 @@ interface Flatten5dBy {
 	* var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 	*
 	* var out = flatten5dBy.assign( x, [ 2, 2 ], true, new Float64Array( 4 ), 1, 0, scale );
-	* // returns <Float64Array>[ 1, 3, 2, 4 ]
+	* // returns <Float64Array>[ 2, 6, 4, 8 ]
 	*/
 	assign<T = unknown, U = unknown, V = unknown, W = unknown>( x: Array5D<T>, shape: Shape5D, colexicographic: boolean, out: Collection<V>, stride: number, offset: number, clbk: Callback<T, U, W>, thisArg?: ThisParameterType<Callback<T, U, W>> ): Collection<U | V>;
 }
@@ -173,7 +173,7 @@ interface Flatten5dBy {
 * var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 *
 * var out = flatten5dBy( x, [ 2, 1, 1, 1, 2 ], false, scale );
-* // returns [ 1, 2, 3, 4 ]
+* // returns [ 2, 4, 6, 8 ]
 *
 * @example
 * function scale( v ) {
@@ -183,7 +183,7 @@ interface Flatten5dBy {
 * var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 *
 * var out = flatten5dBy( x, [ 2, 1, 1, 1, 2 ], true, scale );
-* // returns [ 1, 3, 2, 4 ]
+* // returns [ 2, 6, 4, 8 ]
 */
 declare var flatten5dBy: Flatten5dBy;
 

--- a/lib/node_modules/@stdlib/array/base/flatten5d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/flatten5d/docs/types/index.d.ts
@@ -73,7 +73,7 @@ interface Flatten5d {
 	*
 	* var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 	*
-	* var out = flatten5d.assign( x, [ 2, 2 ], false, new Float64Array( 4 ), 1, 0 );
+	* var out = flatten5d.assign( x, [ 2, 1, 1, 1, 2 ], false, new Float64Array( 4 ), 1, 0 );
 	* // returns <Float64Array>[ 1, 2, 3, 4 ]
 	*
 	* @example
@@ -81,7 +81,7 @@ interface Flatten5d {
 	*
 	* var x = [ [ [ [ [ 1, 2 ] ] ] ], [ [ [ [ 3, 4 ] ] ] ] ];
 	*
-	* var out = flatten5d.assign( x, [ 2, 2 ], true, new Float64Array( 4 ), 1, 0 );
+	* var out = flatten5d.assign( x, [ 2, 1, 1, 1, 2 ], true, new Float64Array( 4 ), 1, 0 );
 	* // returns <Float64Array>[ 1, 3, 2, 4 ]
 	*/
 	assign<T = unknown, U = unknown>( x: Array5D<T>, shape: Shape5D, colexicographic: boolean, out: Collection<U>, stride: number, offset: number ): Collection<T | U>;

--- a/lib/node_modules/@stdlib/array/base/from-strided/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/from-strided/docs/types/index.d.ts
@@ -33,7 +33,7 @@ import { Collection } from '@stdlib/types/array';
 * @param x - input array
 * @param stride - index stride
 * @param offset - index of the first indexed value in the input array
-* @returns two-dimensional nested array
+* @returns output array
 *
 * @example
 * var x = [ 1, 2, 3, 4, 5, 6 ];

--- a/lib/node_modules/@stdlib/array/base/map/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/map/docs/types/index.d.ts
@@ -115,7 +115,7 @@ interface Routine {
 	* }
 	*
 	* var x = ones( 4 );
-	* // returns [ 0, 0, 0, 0 ]
+	* // returns [ 1, 1, 1, 1 ]
 	*
 	* var y = map( x, scale );
 	* // returns [ 10, 10, 10, 10 ]
@@ -138,7 +138,7 @@ interface Routine {
 	* }
 	*
 	* var x = ones( 4, 'int32' );
-	* // returns <Int32Array>[ 0, 0, 0, 0 ]
+	* // returns <Int32Array>[ 1, 1, 1, 1 ]
 	*
 	* var y = map( x, scale );
 	* // returns <Int32Array>[ 10, 10, 10, 10 ]
@@ -165,7 +165,7 @@ interface Routine {
 	* }
 	*
 	* var x = ones( 4 );
-	* // returns [ 0, 0, 0, 0 ]
+	* // returns [ 1, 1, 1, 1 ]
 	*
 	* var y = map( x, scale );
 	* // returns [ 10, 10, 10, 10 ]
@@ -193,7 +193,7 @@ interface Routine {
 	* }
 	*
 	* var x = ones( 4 );
-	* // returns [ 0, 0, 0, 0 ]
+	* // returns [ 1, 1, 1, 1 ]
 	*
 	* var y = map( toAccessorArray( x ), scale );
 	* // returns [ 10, 10, 10, 10 ]
@@ -238,7 +238,7 @@ interface Routine {
 	* var x = ones( 4 );
 	* var y = zeros( x.length );
 	*
-	* var out = map.assign( toAccessorArray( x ), toAccessorArray( y ), 1, 0 scale );
+	* var out = map.assign( toAccessorArray( x ), toAccessorArray( y ), 1, 0, scale );
 	* // y => [ 10, 10, 10, 10 ]
 	*/
 	assign<T = unknown, U extends InputArray<T> = InputArray<T>, V = unknown, W extends OutputArray<V> = OutputArray<V>, ThisArg = unknown>( x: U, y: W, stride: number, offset: number, fcn: Callback<T, U, V, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, V, ThisArg>> ): W;

--- a/lib/node_modules/@stdlib/array/base/map2d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/map2d/docs/types/index.d.ts
@@ -139,7 +139,7 @@ interface Routine {
 *
 *     -   **value**: array element.
 *     -   **indices**: current array element indices.
-*     --  **array**: input nested array.
+*     -   **array**: input nested array.
 *
 * @param x - input nested array
 * @param shape - array shape

--- a/lib/node_modules/@stdlib/array/base/map3d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/map3d/docs/types/index.d.ts
@@ -139,7 +139,7 @@ interface Routine {
 *
 *     -   **value**: array element.
 *     -   **indices**: current array element indices.
-*     --  **array**: input nested array.
+*     -   **array**: input nested array.
 *
 * @param x - input nested array
 * @param shape - array shape

--- a/lib/node_modules/@stdlib/array/base/map4d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/map4d/docs/types/index.d.ts
@@ -139,7 +139,7 @@ interface Routine {
 *
 *     -   **value**: array element.
 *     -   **indices**: current array element indices.
-*     --  **array**: input nested array.
+*     -   **array**: input nested array.
 *
 * @param x - input nested array
 * @param shape - array shape

--- a/lib/node_modules/@stdlib/array/base/n-cartesian-product/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/n-cartesian-product/docs/types/index.d.ts
@@ -79,9 +79,11 @@ declare function nCartesianProduct<T = unknown, U = unknown, V = unknown>( x1: C
 * @example
 * var x1 = [ 1, 2, 3 ];
 * var x2 = [ 4, 5 ];
+* var x3 = [ 6 ];
+* var x4 = [ 7 ];
 *
-* var out = nCartesianProduct( x1, x2 );
-* // returns [ [ 1, 4 ], [ 1, 5 ], [ 2, 4 ], [ 2, 5 ], [ 3, 4 ], [ 3, 5 ] ]
+* var out = nCartesianProduct( x1, x2, x3, x4 );
+* // returns [ [ 1, 4, 6, 7 ], [ 1, 5, 6, 7 ], [ 2, 4, 6, 7 ], [ 2, 5, 6, 7 ], [ 3, 4, 6, 7 ], [ 3, 5, 6, 7 ] ]
 */
 declare function nCartesianProduct<T = unknown, U = unknown, V = unknown>( x1: Collection<T>, x2: Collection<U>, ...xN: Array<Collection<V>> ): Array<Array<T | U | V>>;
 

--- a/lib/node_modules/@stdlib/array/base/none-by-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/none-by-right/docs/types/index.d.ts
@@ -57,12 +57,7 @@ type Binary<T, U> = ( this: U, value: T, index: number ) => boolean;
 type Ternary<T, U> = ( this: U, value: T, index: number, arr: Collection<T> | AccessorArrayLike<T> ) => boolean;
 
 /**
-* Returns a boolean indicating whether an element passes a test.
-*
-* @param value - current array element
-* @param index - current array element index
-* @param arr - input array
-* @returns boolean indicating whether an element passes a test
+* Predicate function invoked for each array element.
 */
 type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
 

--- a/lib/node_modules/@stdlib/array/base/onesnd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/onesnd/docs/types/index.d.ts
@@ -248,7 +248,7 @@ declare function onesnd( shape: Shape10D ): Array10D<number>;
 *
 * @example
 * var out = onesnd( [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3 ] );
-* // returns [ [ [ [ [ [ [ [ [ [ [ 1.0, 1.0, 1.0 ] ] ] ] ] ] ] ] ] ]
+* // returns [ [ [ [ [ [ [ [ [ [ [ 1.0, 1.0, 1.0 ] ] ] ] ] ] ] ] ] ] ]
 */
 declare function onesnd<T = unknown>( shape: Collection<number> ): Array<T>;
 

--- a/lib/node_modules/@stdlib/array/base/reshape/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/reshape/docs/types/index.d.ts
@@ -33,7 +33,7 @@ type ArrayND<T> = Array1D<T> | Array2D<T> | Array3D<T> | Array4D<T> | Array5D<T>
 *
 * ## Notes
 *
-* -   The function assumes that `fromShape` and `toShape` describe arrays have same the number of elements.
+* -   The function assumes that `fromShape` and `toShape` describe arrays having the same number of elements.
 *
 * @param x - input nested array
 * @param fromShape - shape of the input array

--- a/lib/node_modules/@stdlib/array/base/setter/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/setter/docs/types/index.d.ts
@@ -132,7 +132,7 @@ type SetArrayLike<T> = ( arr: Collection<T>, idx: number, value: T ) => void;
 *
 * var arr = new Float64Array( 4 );
 *
-* var get = setter( 'float64' );
+* var set = setter( 'float64' );
 * set( arr, 2, 3 );
 *
 * var v = arr[ 2 ];

--- a/lib/node_modules/@stdlib/array/base/unary2d-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/unary2d-by/docs/types/index.d.ts
@@ -52,6 +52,7 @@ type BinaryCallback<T, U, W> = ( this: W, value: T, indices: Array<number> ) => 
 *
 * @param value - array element value
 * @param indices - current array element indices
+* @param arrays - input and output arrays
 * @returns accessed value
 */
 type TernaryCallback<T, U, V, W> = ( this: W, value: T, indices: Array<number>, arrays: [ Array2D<T>, Array2D<V> ] ) => U;
@@ -104,7 +105,7 @@ type Unary<U, V> = ( value: U ) => V;
 * var x = ones2d( shape );
 * var y = zeros2d( shape );
 *
-* unary2dBy( [ x, y ], shape, scale );
+* unary2dBy( [ x, y ], shape, scale, accessor );
 *
 * console.log( y );
 * // => [ [ -10.0, -10.0 ], [ -10.0, -10.0 ] ]

--- a/lib/node_modules/@stdlib/array/base/unary5d-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/unary5d-by/docs/types/index.d.ts
@@ -104,7 +104,7 @@ type Unary<U, V> = ( value: U ) => V;
 * var x = ones5d( shape );
 * var y = zeros5d( shape );
 *
-* unary5dBy( [ x, y ], shape, scale );
+* unary5dBy( [ x, y ], shape, scale, accessor );
 *
 * console.log( y );
 * // => [ [ [ [ [ -10.0, -10.0 ], [ -10.0, -10.0 ] ] ] ] ]

--- a/lib/node_modules/@stdlib/array/base/zerosnd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/zerosnd/docs/types/index.d.ts
@@ -248,7 +248,7 @@ declare function zerosnd( shape: Shape10D ): Array10D<number>;
 *
 * @example
 * var out = zerosnd( [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3 ] );
-* // returns [ [ [ [ [ [ [ [ [ [ [ 0.0, 0.0, 0.0 ] ] ] ] ] ] ] ] ] ]
+* // returns [ [ [ [ [ [ [ [ [ [ [ 0.0, 0.0, 0.0 ] ] ] ] ] ] ] ] ] ] ]
 */
 declare function zerosnd<T = unknown>( shape: Shape ): Array<T>;
 


### PR DESCRIPTION
## Description

This pull request fixes documentation defects across individual `@stdlib/array/base` package TypeScript declaration files, surfaced by an audit of the namespace's declarations. All changes are confined to JSDoc comments (examples and prose); no declared types are affected.

-   **`@example` code**: undefined/misspelled identifiers (`bifurcate-indices` referenced an undeclared `arr`; `cusome-by-right` called `cusomeByright`; `setter` called an undefined `set`), incorrect arguments (`cunone-by-right`/`cusome` `assign` argument lists; `unary2d-by`/`unary5d-by` omitted the `accessor` argument), wrong shapes (`flatten4d`/`flatten5d` `assign` passed 2-element shapes), and `// returns`/`// =>` annotations that ignored a doubling callback (`flatten5d-by`) or had unbalanced nesting (`broadcasted-ternary4d`, `broadcasted-ternary5d`, `fillednd-by`, `onesnd`, `zerosnd`).
-   **`// returns` annotations**: corrected stale values (`accessor` length, `arraylike2object` key, `map` `ones` outputs).
-   **prose**: corrected `@param`/`@returns`/summary text (`any-by`/`any-by-right` "all elements" → "at least one element"; `assert/is-complex-typed-array` missing article; `assert/is-accessor-array` `value(s)` → `value`; `cuany-by`/`cuany-by-right` missing/inconsistent `@param`; `cunone-by-right` summary; `from-strided` `@returns`; `reshape` word order; `none-by-right` predicate alias tags; `filled` trailing comma; `n-cartesian-product` example coverage).
-   **Markdown**: repaired malformed `--` list bullets in `map2d`/`map3d`/`map4d` Notes.

## Related Issues

None.

## Questions

No.

## Other

This is one of a series of PRs addressing findings from a TypeScript-declaration audit of the `@stdlib/array` namespace. The corresponding fixes in the `array/base` *namespace aggregate* declaration file are submitted separately.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

The issues fixed here were identified by a multi-agent audit run with Claude Code, and the changes were drafted by Claude Code under my direction and review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
