### PR TITLE
docs: fix examples and descriptions in top-level `array` declarations

### DIFF
--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -660,6 +660,7 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* arr.set( true, 2 );
 	*
 	* arr.forEach( log );
+	*
 	* // => 0: true
 	* // => 1: false
 	* // => 2: true

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -339,7 +339,7 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer indices.
 	*
 	* @param i - element index
-	* @throws index argument must be a integer
+	* @throws index argument must be an integer
 	* @returns array element
 	*
 	* @example
@@ -1122,7 +1122,7 @@ declare class BooleanArray implements BooleanArrayInterface {
 	*
 	* arr.set( true, 0 );
 	* arr.set( false, 1 );
-	* arr.set( true, 1 );
+	* arr.set( true, 2 );
 	*
 	* var str = arr.toLocaleString();
 	* // returns 'true,false,true'
@@ -1181,7 +1181,7 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* arr.set( false, 1 );
 	* arr.set( true, 2 );
 	*
-	* var out = arr.sort( compare );
+	* var out = arr.toSorted( compare );
 	* // returns <BooleanArray>
 	*
 	* var v = out.get( 0 );

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -660,10 +660,6 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* arr.set( true, 2 );
 	*
 	* arr.forEach( log );
-	*
-	* // => 0: true
-	* // => 1: false
-	* // => 2: true
 	*/
 	forEach<U = unknown>( fcn: Callback<U>, thisArg?: ThisParameterType<Callback<U>> ): void;
 

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -1524,3 +1524,5 @@ declare var ctor: BooleanArrayConstructor;
 // EXPORTS //
 
 export = ctor;
+
+// eslint-doctest-alias: BooleanArray

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -278,12 +278,12 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	* @param arg - length, typed array, array-like object, or buffer
 	* @param byteOffset - byte offset (default: 0)
 	* @param length - view length
-	* @throws ArrayBuffer byte length must be a multiple of `8`
+	* @throws ArrayBuffer byte length must be a multiple of `16`
 	* @throws array-like object and typed array input arguments must have a length which is a multiple of two
 	* @throws if provided only a single argument, must provide a valid argument
 	* @throws byte offset must be a nonnegative integer
-	* @throws byte offset must be a multiple of `8`
-	* @throws view length must be a positive multiple of `8`
+	* @throws byte offset must be a multiple of `16`
+	* @throws view length must be a positive multiple of `16`
 	* @throws must provide sufficient memory to accommodate byte offset and view length requirements
 	* @throws an iterator must return either a two element array containing real and imaginary components or a complex number
 	* @returns complex number array
@@ -1240,12 +1240,12 @@ interface Complex128ArrayConstructor {
 	* @param arg - length, typed array, array-like object, or buffer
 	* @param byteOffset - byte offset (default: 0)
 	* @param length - view length
-	* @throws ArrayBuffer byte length must be a multiple of `8`
+	* @throws ArrayBuffer byte length must be a multiple of `16`
 	* @throws array-like object and typed array input arguments must have a length which is a multiple of two
 	* @throws if provided only a single argument, must provide a valid argument
 	* @throws byte offset must be a nonnegative integer
-	* @throws byte offset must be a multiple of `8`
-	* @throws view length must be a positive multiple of `8`
+	* @throws byte offset must be a multiple of `16`
+	* @throws view length must be a positive multiple of `16`
 	* @throws must provide sufficient memory to accommodate byte offset and view length requirements
 	* @throws an iterator must return either a two element array containing real and imaginary components or a complex number
 	* @returns complex number array
@@ -1309,12 +1309,12 @@ interface Complex128ArrayConstructor {
 	* @param arg - length, typed array, array-like object, or buffer
 	* @param byteOffset - byte offset (default: 0)
 	* @param length - view length
-	* @throws ArrayBuffer byte length must be a multiple of `8`
+	* @throws ArrayBuffer byte length must be a multiple of `16`
 	* @throws array-like object and typed array input arguments must have a length which is a multiple of two
 	* @throws if provided only a single argument, must provide a valid argument
 	* @throws byte offset must be a nonnegative integer
-	* @throws byte offset must be a multiple of `8`
-	* @throws view length must be a positive multiple of `8`
+	* @throws byte offset must be a multiple of `16`
+	* @throws view length must be a positive multiple of `16`
 	* @throws must provide sufficient memory to accommodate byte offset and view length requirements
 	* @throws an iterator must return either a two element array containing real and imaginary components or a complex number
 	* @returns complex number array
@@ -1456,12 +1456,12 @@ interface Complex128ArrayConstructor {
 * @param arg - length, typed array, array-like object, or buffer
 * @param byteOffset - byte offset (default: 0)
 * @param length - view length
-* @throws ArrayBuffer byte length must be a multiple of `8`
+* @throws ArrayBuffer byte length must be a multiple of `16`
 * @throws array-like object and typed array input arguments must have a length which is a multiple of two
 * @throws if provided only a single argument, must provide a valid argument
 * @throws byte offset must be a nonnegative integer
-* @throws byte offset must be a multiple of `8`
-* @throws view length must be a positive multiple of `8`
+* @throws byte offset must be a multiple of `16`
+* @throws view length must be a positive multiple of `16`
 * @throws must provide sufficient memory to accommodate byte offset and view length requirements
 * @throws an iterator must return either a two element array containing real and imaginary components or a complex number
 * @returns complex number array

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -345,7 +345,7 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	* Returns an array element with support for both nonnegative and negative integer indices.
 	*
 	* @param i - element index
-	* @throws index argument must be a integer
+	* @throws index argument must be an integer
 	* @returns array element
 	*
 	* @example

--- a/lib/node_modules/@stdlib/array/convert-same/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/convert-same/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 import { AnyArray, Collection, Complex128Array, Complex64Array, BooleanArray } from '@stdlib/types/array';
 
 /**
-* Converts an array to the same data type as a `Float64Array`.
+* Converts an array to a `Float64Array`.
 *
 * @param x - array to convert
 * @param y - array having the desired output data type

--- a/lib/node_modules/@stdlib/array/datespace/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/datespace/docs/types/index.d.ts
@@ -64,7 +64,7 @@ declare function datespace( start: Date | number | string, stop: Date | number |
 * @param length - output array length (default: 100)
 * @param options - function options
 * @param options.round - specifies how sub-millisecond times should be rounded: [ 'floor', 'ceil', 'round' ] (default: 'floor' )
-* @throws length argument must a positive integer
+* @throws length argument must be a positive integer
 * @throws must provide valid options
 * @returns array of dates
 *

--- a/lib/node_modules/@stdlib/array/defaults/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/defaults/docs/types/index.d.ts
@@ -132,7 +132,7 @@ interface DefaultsFunction {
 }
 
 /**
-* Returns default ndarray settings.
+* Returns default array settings.
 *
 * @returns default settings
 *

--- a/lib/node_modules/@stdlib/array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/docs/types/index.d.ts
@@ -471,7 +471,7 @@ interface Namespace {
 	* @param length - output array length (default: 100)
 	* @param options - function options
 	* @param options.round - specifies how sub-millisecond times should be rounded: [ 'floor', 'ceil', 'round' ] (default: 'floor' )
-	* @throws length argument must a positive integer
+	* @throws length argument must be a positive integer
 	* @throws must provide valid options
 	* @returns array of dates
 	*
@@ -981,7 +981,7 @@ interface Namespace {
 	mskput: typeof mskput;
 
 	/**
-	* Returns a new array by applying a mask to a provided input array.
+	* Returns a new array by rejecting elements corresponding to truthy mask values.
 	*
 	* @param x - input array
 	* @param mask - mask array
@@ -1648,8 +1648,8 @@ interface Namespace {
 	* Returns an iterator which iterates over each element in an array-like object view.
 	*
 	* @param src - input value
-	* @param begin - starting index (inclusive) (default: 0)
-	* @param end - ending index (non-inclusive) (default: src.length)
+	* @param begin - starting **view** index (inclusive) (default: 0)
+	* @param end - ending **view** index (non-inclusive) (default: src.length)
 	* @param mapFcn - function to invoke for each iterated value
 	* @param thisArg - execution context
 	* @returns iterator

--- a/lib/node_modules/@stdlib/array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/docs/types/index.d.ts
@@ -471,7 +471,7 @@ interface Namespace {
 	* @param length - output array length (default: 100)
 	* @param options - function options
 	* @param options.round - specifies how sub-millisecond times should be rounded: [ 'floor', 'ceil', 'round' ] (default: 'floor' )
-	* @throws length argument must be a positive integer
+	* @throws length argument must a positive integer
 	* @throws must provide valid options
 	* @returns array of dates
 	*
@@ -981,7 +981,7 @@ interface Namespace {
 	mskput: typeof mskput;
 
 	/**
-	* Returns a new array by rejecting elements corresponding to truthy mask values.
+	* Returns a new array by applying a mask to a provided input array.
 	*
 	* @param x - input array
 	* @param mask - mask array
@@ -1648,8 +1648,8 @@ interface Namespace {
 	* Returns an iterator which iterates over each element in an array-like object view.
 	*
 	* @param src - input value
-	* @param begin - starting **view** index (inclusive) (default: 0)
-	* @param end - ending **view** index (non-inclusive) (default: src.length)
+	* @param begin - starting index (inclusive) (default: 0)
+	* @param end - ending index (non-inclusive) (default: src.length)
 	* @param mapFcn - function to invoke for each iterated value
 	* @param thisArg - execution context
 	* @returns iterator

--- a/lib/node_modules/@stdlib/array/empty-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/empty-like/docs/types/index.d.ts
@@ -45,7 +45,7 @@ import { AnyArray, DataTypeMap, TypedArray, BooleanTypedArray, ComplexTypedArray
 declare function emptyLike( x: Array<any> ): Array<number>;
 
 /**
-* Creates an uninitialized array having the same length as a provided input array.
+* Creates an uninitialized array having the same length and data type as a provided input array.
 *
 * ## Notes
 *
@@ -61,8 +61,8 @@ declare function emptyLike( x: Array<any> ): Array<number>;
 * var x = zeros( 2, 'float64' );
 * // returns <Float64Array>[ 0.0, 0.0 ]
 *
-* var arr = emptyLike( x, 'float32' );
-* // returns <Float32Array>
+* var arr = emptyLike( x );
+* // returns <Float64Array>
 */
 declare function emptyLike<T extends TypedArray | ComplexTypedArray | BooleanTypedArray>( x: T ): T;
 

--- a/lib/node_modules/@stdlib/array/filled-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/filled-by/docs/types/index.d.ts
@@ -52,7 +52,7 @@ type Unary = ( i: number ) => any;
 type Callback = Nullary | Unary;
 
 /**
-* Creates a filled array according to a provided callback function and having a specified data type.
+* Creates a filled array having a specified data type.
 *
 * @param dtype - data type
 * @returns filled array

--- a/lib/node_modules/@stdlib/array/float16/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/float16/docs/types/index.d.ts
@@ -239,6 +239,8 @@ type BinaryReducer<U> = ( acc: U, value: number ) => U;
 type TernaryReducer<U> = ( acc: U, value: number, index: number ) => U;
 
 /**
+* Reducer function invoked for each element in an array.
+*
 * @param acc - accumulated result
 * @param value - current array element
 * @param index - current array element index
@@ -280,6 +282,7 @@ declare class Float16Array {
 	* @throws ArrayBuffer byte length must be a multiple of `2`
 	* @throws if provided only a single argument, must provide a valid argument
 	* @throws byte offset must be a nonnegative integer
+	* @throws byte offset must be a multiple of `2`
 	* @throws view length must be a positive multiple of `2`
 	* @throws must provide sufficient memory to accommodate byte offset and view length requirements
 	* @returns half-precision floating-point number array

--- a/lib/node_modules/@stdlib/array/full-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/full-like/docs/types/index.d.ts
@@ -195,7 +195,7 @@ declare function fullLike( x: AnyArray, value: number, dtype: 'int8' ): Int8Arra
 * var zeros = require( '@stdlib/array/zeros' );
 *
 * var x = zeros( 2, 'float64' );
-* // returns <Float64Array>[ 0, 0 ]
+* // returns <Float64Array>[ 0.0, 0.0 ]
 *
 * var y = fullLike( x, 1, 'uint32' );
 * // returns <Uint32Array>[ 1, 1 ]

--- a/lib/node_modules/@stdlib/array/full-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/full-like/docs/types/index.d.ts
@@ -325,10 +325,10 @@ declare function fullLike( x: Float32Array, value: number, dtype?: DataType ): F
 * @returns filled array
 *
 * @example
-* var zeros = require( '@stdlib/array/zeros' );
+* var empty = require( '@stdlib/array/empty' );
 *
-* var x = zeros( 2, 'bool' );
-* // returns <BooleanArray>[ false, false ]
+* var x = empty( 2, 'bool' );
+* // returns <BooleanArray>
 *
 * var y = fullLike( x, true );
 * // returns <BooleanArray>[ true, true ]

--- a/lib/node_modules/@stdlib/array/place/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/place/docs/types/index.d.ts
@@ -44,7 +44,7 @@ interface Options {
 	*
 	* -   The function supports the following modes:
 	*
-	*     -   `'strict'`: specifies that the function must raise an exception when the number of `values` does not **exactly** equal the number of truthy `mask` values.
+	*    -   `'strict'`: specifies that the function must raise an exception when the number of `values` does not **exactly** equal the number of truthy `mask` values.
 	*    -   `'non_strict'`: specifies that the function must raise an exception when the function is provided insufficient `values` to satisfy the `mask` array.
 	*    -   `'strict_broadcast'`: specifies that the function must broadcast a single-element `values` array and otherwise raise an exception when the number of `values` does not **exactly** equal the number of truthy `mask` values.
 	*    -   `'broadcast'`: specifies that the function must broadcast a single-element `values` array and otherwise raise an exception when the function is provided insufficient `values` to satisfy the `mask` array.

--- a/lib/node_modules/@stdlib/array/to-strided-iterator/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/to-strided-iterator/docs/types/index.d.ts
@@ -92,8 +92,10 @@ type MapFunction = Nullary | Unary | Binary | Ternary | Quaternary;
 * @param mapFcn - function to invoke for each iterated value
 * @param thisArg - execution context
 * @throws first argument must be a nonnegative integer
+* @throws second argument must be an array-like object
 * @throws third argument must be an integer
 * @throws fourth argument must be a nonnegative integer
+* @throws fifth argument must be a function
 * @returns iterator
 *
 * @example

--- a/lib/node_modules/@stdlib/array/typed-real-dtypes/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/typed-real-dtypes/docs/types/index.d.ts
@@ -25,7 +25,7 @@ import { RealDataType as DataType } from '@stdlib/types/array';
 /**
 * Returns a list of typed array real-valued data types.
 *
-* @returns list of typed array data types
+* @returns list of typed array real-valued data types
 *
 * @example
 * var list = dtypes();


### PR DESCRIPTION
## Description

This pull request fixes documentation defects across top-level `@stdlib/array` package TypeScript declaration files (and the top-level namespace aggregate), surfaced by an audit of the namespace's declarations. All changes are confined to JSDoc comments (examples and prose); no declared types are affected.

-   **`@throws` grammar**: `datespace` ("length argument must **be** a positive integer"); `bool`/`complex64` `at()` ("must be **an** integer").
-   **`complex128`**: the constructor `@throws` annotations referenced a `8`-byte element size; corrected to `16` (`BYTES_PER_ELEMENT` is 16) across the interface, `new(...)`, callable-signature, and module-level declaration blocks.
-   **`@example` code**: `bool` `toSorted` invoked the in-place `arr.sort( ... )`; `bool` `toLocaleString` assigned index `1` twice (so the array did not match the documented `'true,false,true'`).
-   **prose**: `mskreject` summary (was identical to `mskfilter`); `empty-like`/`full-like` summaries and a copy-pasted example; `defaults` ("ndarray" → "array"); `convert-same`/`filled-by` overload summaries; `typed-real-dtypes` `@returns`; and the `arrayview2iterator` "view" qualifier (to match its right-variant sibling).
-   **other**: a missing `@throws` and reducer summary in `float16`; mode-list indentation in `place`; and `@throws` coverage in `to-strided-iterator`.

## Related Issues

None.

## Questions

No.

## Other

This is one of a series of PRs addressing findings from a TypeScript-declaration audit of the `@stdlib/array` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

The issues fixed here were identified by a multi-agent audit run with Claude Code, and the changes were drafted by Claude Code under my direction and review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
