### PR TITLE
refactor: rename parameter to ensure consistency with other packages

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dmeankbn/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmeankbn/lib/ndarray.js
@@ -38,7 +38,7 @@ var dsumkbn = require( '@stdlib/blas/ext/base/dsumkbn' ).ndarray;
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Float64Array} x - input array
-* @param {integer} stride - stride length
+* @param {integer} strideX - stride length
 * @param {NonNegativeInteger} offsetX - starting index
 * @returns {number} arithmetic mean
 *
@@ -50,14 +50,14 @@ var dsumkbn = require( '@stdlib/blas/ext/base/dsumkbn' ).ndarray;
 * var v = dmeankbn( 4, x, 2, 1 );
 * // returns 1.25
 */
-function dmeankbn( N, x, stride, offsetX ) {
+function dmeankbn( N, x, strideX, offsetX ) {
 	if ( N <= 0 ) {
 		return NaN;
 	}
-	if ( N === 1 || stride === 0 ) {
+	if ( N === 1 || strideX === 0 ) {
 		return x[ offsetX ];
 	}
-	return dsumkbn( N, x, stride, offsetX ) / N;
+	return dsumkbn( N, x, strideX, offsetX ) / N;
 }
 
 


### PR DESCRIPTION
## Description

This pull request:

-   Renames the bare `stride` parameter (and its three in-body references) in `lib/node_modules/@stdlib/stats/strided/dmeankbn/lib/ndarray.js` to `strideX`. The convention `strideX` (suffix matching the corresponding array parameter `x`) is used by 237 of 239 sibling packages in `@stdlib/stats/strided` with an `ndarray.js` (99.2% conformance), and the same package's own `README.md`, `docs/types/index.d.ts`, and `docs/repl.txt` already document the parameter as `strideX` — so the source was the only piece out of sync. Positional rename; no behavior change.

## Related Issues

No.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was generated by an automated cross-package API drift detection routine driven by Claude Code. The routine performs a majority-vote scan over a randomly selected stdlib namespace (here, `stats/strided`), runs a three-agent validation pass (semantic, cross-reference, structural), and applies only mechanical, single-package, behavior-preserving fixes. A maintainer should review and promote out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01VS4UTP5s6iWv1EKXKA4G3p)_