### PR TITLE
docs: document short-circuit early-return

### DIFF
--- a/lib/node_modules/@stdlib/iter/any/README.md
+++ b/lib/node_modules/@stdlib/iter/any/README.md
@@ -70,6 +70,10 @@ var bool = iterAny( array2iterator( [] ) );
 
 <section class="notes">
 
+## Notes
+
+-   The function immediately returns upon encountering a truthy value.
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/iter/every/README.md
+++ b/lib/node_modules/@stdlib/iter/every/README.md
@@ -70,6 +70,10 @@ var bool = iterEvery( array2iterator( [] ) );
 
 <section class="notes">
 
+## Notes
+
+-   The function immediately returns upon encountering a falsy value.
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/iter/none/README.md
+++ b/lib/node_modules/@stdlib/iter/none/README.md
@@ -70,6 +70,10 @@ var bool = iterNone( array2iterator( [] ) );
 
 <section class="notes">
 
+## Notes
+
+-   The function immediately returns upon encountering a truthy value.
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/iter/some/README.md
+++ b/lib/node_modules/@stdlib/iter/some/README.md
@@ -70,6 +70,10 @@ var bool = iterSome( array2iterator( [] ), 1 );
 
 <section class="notes">
 
+## Notes
+
+-   The function immediately returns upon finding `n` truthy values.
+
 </section>
 
 <!-- /.notes -->


### PR DESCRIPTION
## Description

This pull request populates an empty `<section class="notes">` wrapper in four `@stdlib/iter` package READMEs: `iter/any`, `iter/every`, `iter/none`, and `iter/some`. Each wrapper was present but contained no `## Notes` heading or body; the bullet added to each describes the short-circuit early-return behavior implemented in `lib/main.js`. Wording is taken verbatim from each package's existing `docs/repl.txt`, so the REPL docs and README now agree.

## Namespace summary

- **Namespace analyzed:** `@stdlib/iter`
- **Members:** 65 (no autogenerated packages excluded)
- **Features extracted:** file tree, `package.json` shape, README section structure, `lib/index.js` shape, JSDoc presence, error construction style
- **Features with a clear majority (≥75%):** file tree (100%), `package.json` top-level keys (100%), `package.json.directories/engines/os/license/main/types` values (100%), `## Usage` (100%), `## Examples` (100%), `## See Also` (85%), `## Notes` (83%), `lib/index.js` shape (100%), error construction (100% conformant once static vs. interpolated messages are distinguished)
- **Features without a clear majority (excluded):** `### subsection` headings (package-specific), JSDoc `@throws` message phrasing (largest cluster is 22/65 — no convention reaches threshold)

## Per outlier package

### `@stdlib/iter/any`

The `<section class="notes">` block was empty. `iterAny` short-circuits at `lib/main.js:54-56`, returning `true` on the first truthy iterated value. `docs/repl.txt` already documents this with the same wording added here. 54/65 (83%) of `iter/*` siblings populate this section, and `iter/any-by` documents the analogous predicate-driven behavior.

### `@stdlib/iter/every`

`iterEvery` short-circuits at `lib/main.js:54-56`, returning `false` on the first falsy iterated value. README Notes section was empty; bullet text matches `docs/repl.txt` verbatim. 54/65 (83%) sibling conformance; `iter/every-by` documents the analogous predicate behavior.

### `@stdlib/iter/none`

`iterNone` short-circuits at `lib/main.js:54-56`, returning `false` on the first truthy iterated value. README Notes section was empty; bullet text matches `docs/repl.txt` verbatim. 54/65 (83%) sibling conformance; `iter/none-by` documents the analogous predicate behavior.

### `@stdlib/iter/some`

`iterSome` short-circuits at `lib/main.js:62-66`, returning `true` once `n` truthy values have been counted. README Notes section was empty; bullet text matches `docs/repl.txt` verbatim ("finding `n` truthy values"). 54/65 (83%) sibling conformance; `iter/some-by` documents the analogous predicate behavior.

## Validation

Each correction was validated by three independent agents per the drift-detection routine:

1. **Semantic review** — read each package's `lib/main.js` to confirm the documented short-circuit behavior is present in code and that the proposed wording faithfully describes it.
2. **Cross-reference** — verified that no test, example, or other doc relies on the absence of the Notes text. Independently observed that `docs/repl.txt` for all four packages already contains the exact target wording.
3. **Structural review** — confirmed each empty `<section class="notes">` wrapper, the populated `-by` siblings as reference, and the stdlib bullet convention (`-   `, backticked variable names).

All four corrections received `confirmed-drift` from all three agents.

Deliberately excluded from this PR:

- README `## See Also` outliers (10 packages) — auto-populated by the package generator and outside hand-editing scope.
- README `## Notes` for cumulative variants (`cuany`, `cuevery`, `cunone`, `cusome`) — these do not short-circuit, so the `-by` sibling wording does not apply.
- README `## Notes` for `last`, `length`, `nth` — no sibling pattern provides correct, mechanically-derivable content.
- JSDoc `@throws` message normalization — no single phrasing crosses the 75% majority threshold.

## Related Issues

No.

## Questions

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The four bullets added are identical in form to those already present in the `-by` siblings (`any-by`, `every-by`, `none-by`, `some-by`), adjusted from "return value" to direct value-test wording to match how the non-predicate variants operate. The exact wording was taken from each package's own `docs/repl.txt`, so the change brings the README and REPL docs into agreement rather than introducing new copy.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift-detection routine over the `@stdlib/iter` namespace. The routine extracted structural and semantic features from each member package, identified majority patterns, gated out generator-owned sections and content-bearing deltas, and applied a three-agent review (two opus, one sonnet) before any patch was applied. The four edits in this PR are README-only and align with text already present in each package's `docs/repl.txt`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_014VHB7qK3HAw7izB3FQqxSb)_