### PR TITLE
docs: tidy JSDoc and README drift in `@stdlib/constants`

### DIFF
--- a/lib/node_modules/@stdlib/constants/complex64/README.md
+++ b/lib/node_modules/@stdlib/constants/complex64/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Constants
 
-> Half-precision floating-point mathematical constants.
+> 64-bit complex number mathematical constants.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var constants = require( '@stdlib/constants/complex64' );
 
 #### constants
 
-Half-precision floating-point mathematical constants.
+64-bit complex number mathematical constants.
 
 ```javascript
 var c = constants;

--- a/lib/node_modules/@stdlib/constants/path/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/path/lib/index.js
@@ -40,6 +40,7 @@ var ns = {};
 * @name DELIMITER
 * @memberof ns
 * @readonly
+* @constant
 * @type {string}
 * @see {@link module:@stdlib/constants/path/delimiter}
 */
@@ -49,6 +50,7 @@ setReadOnly( ns, 'DELIMITER', require( '@stdlib/constants/path/delimiter' ) );
 * @name DELIMITER_POSIX
 * @memberof ns
 * @readonly
+* @constant
 * @type {string}
 * @see {@link module:@stdlib/constants/path/delimiter-posix}
 */
@@ -58,6 +60,7 @@ setReadOnly( ns, 'DELIMITER_POSIX', require( '@stdlib/constants/path/delimiter-p
 * @name DELIMITER_WIN32
 * @memberof ns
 * @readonly
+* @constant
 * @type {string}
 * @see {@link module:@stdlib/constants/path/delimiter-win32}
 */
@@ -67,6 +70,7 @@ setReadOnly( ns, 'DELIMITER_WIN32', require( '@stdlib/constants/path/delimiter-w
 * @name SEP
 * @memberof ns
 * @readonly
+* @constant
 * @type {string}
 * @see {@link module:@stdlib/constants/path/sep}
 */
@@ -76,6 +80,7 @@ setReadOnly( ns, 'SEP', require( '@stdlib/constants/path/sep' ) );
 * @name SEP_POSIX
 * @memberof ns
 * @readonly
+* @constant
 * @type {string}
 * @see {@link module:@stdlib/constants/path/sep-posix}
 */
@@ -85,6 +90,7 @@ setReadOnly( ns, 'SEP_POSIX', require( '@stdlib/constants/path/sep-posix' ) );
 * @name SEP_WIN32
 * @memberof ns
 * @readonly
+* @constant
 * @type {string}
 * @see {@link module:@stdlib/constants/path/sep-win32}
 */

--- a/lib/node_modules/@stdlib/constants/unicode/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/unicode/lib/index.js
@@ -40,6 +40,7 @@ var ns = {};
 * @name MAX
 * @memberof ns
 * @readonly
+* @constant
 * @type {number}
 * @see {@link module:@stdlib/constants/unicode/max}
 */
@@ -49,6 +50,7 @@ setReadOnly( ns, 'MAX', require( '@stdlib/constants/unicode/max' ) );
 * @name MAX_BMP
 * @memberof ns
 * @readonly
+* @constant
 * @type {number}
 * @see {@link module:@stdlib/constants/unicode/max-bmp}
 */


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Aligns three outlier members of the `@stdlib/constants` namespace with the documentation conventions used by their siblings (random namespace pick, seed `20260531`).

### Namespace summary

-   **Target namespace:** `@stdlib/constants` (top-level umbrella namespace).
-   **Member count:** 15 non-autogenerated members (`array`, `complex128`, `complex64`, `float16`, `float32`, `float64`, `int16`, `int32`, `int8`, `path`, `time`, `uint16`, `uint32`, `uint8`, `unicode`). Each is a namespace-aggregator that re-exports its sub-constants via `setReadOnly`.
-   **Features analyzed:** file tree; `package.json` shape, scripts, `stdlib` keys, `directories`, `engines`, top-level field values; `manifest.json` shape; README headings and inline structure; `docs/types/index.d.ts` and `docs/types/test.ts`; test/example file names; `lib/index.js` body structure and JSDoc tag set.
-   **Features with clear majority (≥75%):** file tree (100%), `package.json` top-level keys (100%, modulo `name`/`description`/`keywords`), `directories`/`engines`/`scripts`/`types` (100%), README `##` section list `[Usage, Examples]` (100%), `test/test.js` / `examples/index.js` / `lib/index.js` / `docs/types/index.d.ts` / `docs/types/test.ts` file presence (100%), `@stdlib/utils/define-read-only-property` dependency (100%), TypeScript declaration `export = ns` (100%), `@constant` JSDoc tag on every entry in `lib/index.js` (**13/15 = 86.7%**), README tagline equals own `package.json` `description` (**14/15 = 93.3%**).
-   **Features without clear majority (excluded):** `lib/index.js` namespace variable name (`constants` 9/15 vs `ns` 6/15 — 60% plurality); README h1 title (`# Constants` 13/15 vs disambiguating `# Path Constants` / `# Unicode Constants` — treated as intentional disambiguation per the precedent set in PR [#11909](https://github.com/stdlib-js/stdlib/pull/11909)); local alias variable name in README inline snippets and `examples/index.js` (`c`/`constants` 12/15 vs `ns` 3/15 — would create internal mismatch with `lib/index.js` export name, dropped on intentional-deviation grounds).

### Per-outlier corrections

#### `@stdlib/constants/path`

Adds the missing `@constant` JSDoc tag to each of the six namespace entries in `lib/index.js` (`DELIMITER`, `DELIMITER_POSIX`, `DELIMITER_WIN32`, `SEP`, `SEP_POSIX`, `SEP_WIN32`). The tag sits between `@readonly` and `@type {string}` in every other umbrella member that exposes constants via `setReadOnly`; `path` was the only member with `@type {string}` constants, but the string vs number distinction is irrelevant — `time` (also `var ns =`) carries `@constant` on every entry, so this is structural drift rather than a deliberate convention. Pure documentation; no behavior, tests, or examples touched.

#### `@stdlib/constants/unicode`

Adds the missing `@constant` JSDoc tag to the two namespace entries in `lib/index.js` (`MAX`, `MAX_BMP`). Same shape as the `path` fix: tag inserted between `@readonly` and `@type {number}` to match the convention carried by 13 of 15 sibling packages (86.7%). The Unicode code-point limits are immutable values wrapped in `setReadOnly`, so `@constant` is the accurate JSDoc descriptor. Pure documentation; no behavior, tests, or examples touched.

#### `@stdlib/constants/complex64`

Fixes a stale README description. Both the tagline at line 23 and the `#### constants` section description at line 35 read `"Half-precision floating-point mathematical constants."` — a copy-paste from `float16` that was never updated. The package's own `package.json` already declares the correct text (`"64-bit complex number mathematical constants."`); the README is replaced with that value, matching the convention carried by 14 of 15 sibling packages (93.3%, README tagline == `package.json` description). Pure documentation; no API or tests touched.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Checked:

-   **Structural feature extraction** across all 15 members: file tree, `package.json` shape and field values, `manifest.json` shape, README heading/structure, `lib/index.js` JSDoc tag set, `test/`/`examples/`/`docs/types/` file names, dependency sets.
-   **Semantic feature extraction** was waived: each member is a namespace-aggregator (no `lib/main.js`, no function signature, no validation prologue, no error construction), so the semantic schema fields are largely N/A. Dependency sets were verified identical: every member imports only `@stdlib/utils/define-read-only-property` and its own `@stdlib/constants/<self>/*` children.
-   **Three-agent drift validation** on the two candidate findings:
    -   Agent 1 (Opus semantic-review): all three corrections (`@constant` in `path`, `@constant` in `unicode`, `complex64` README description) returned `confirmed-drift`. Confirmed the `@constant` tag is orthogonal to the `var ns =` / `var constants =` namespace name (`time` and `array` use `ns` and still carry `@constant`), so the omission is not a stylistic differentiator; confirmed the `complex64` text contradicts the package's own `package.json`, keywords, and TOC entries.
    -   Agent 2 (Opus cross-reference): repo-wide grep for the stale tagline confirmed `Half-precision floating-point mathematical constants.` legitimately belongs only to `float16`; no test in `path/test/`, `unicode/test/`, or `complex64/test/` references either the JSDoc tag or the README text; `docs/types/*.d.ts` files import sub-package modules directly and don't read JSDoc from `lib/index.js`.
    -   Agent 3 (Sonnet structural-review): confirmed the `@constant` tag is the correct annotation for `setReadOnly`-wrapped string and number values; flagged the `complex64` line 35 description (in addition to the tagline at line 23) as carrying the same stale text — both are fixed in this PR.

Deliberately excluded:

-   `lib/index.js` namespace variable naming (`constants` 9/15 vs `ns` 6/15) — neither value reaches the 75% threshold.
-   README h1 title disambiguation (`# Path Constants` / `# Unicode Constants`) — treated as intentional per PR [#11909](https://github.com/stdlib-js/stdlib/pull/11909).
-   Local alias variable name drift in `examples/index.js` and inline README snippets — applying the majority would create an internal name mismatch with each outlier's own `lib/index.js` export name.
-   `package.json` `description` text variations for `path` / `unicode` (e.g., `"Standard string path constants."` vs `"Path constants."` in the README) — both are accurate; treated as editorial choice, not drift.
-   Any change to public API, test expectations, or example behavior.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code as part of the cross-package drift-detection routine: the namespace (`@stdlib/constants`) was selected at random (seed `20260531`), structural features were extracted across all 15 members, majority patterns were computed at the 75% threshold, and three independent validation agents (two Opus semantic/cross-reference, one Sonnet structural-review) confirmed each correction before it was applied. Only the `@constant` JSDoc tag in two `lib/index.js` files and a stale README description in one package were touched — mechanical documentation alignment to the namespace majority.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBLMyZ7wxsGCMjsgGEjmsc)_