### PR TITLE
fix: reflect the `returns` option in `@stdlib/utils` find/bifurcate/group return types

### DIFF
--- a/lib/node_modules/@stdlib/utils/bifurcate-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/bifurcate-by/docs/types/index.d.ts
@@ -187,12 +187,12 @@ declare function bifurcateBy<T = unknown, U = unknown>( collection: Collection<T
 * var arr = [ 'beep', 'boop', 'foo', 'bar' ];
 *
 * var opts = {
-*     'returns': 'values'
+*     'returns': '*'
 * };
 * var out = bifurcateBy( arr, opts, predicate );
-* // returns [ [ 'beep', 'boop', 'bar' ], [ 'foo' ] ]
+* // returns [ [ [ 0, 'beep' ], [ 1, 'boop' ], [ 3, 'bar' ] ], [ [ 2, 'foo' ] ] ]
 */
-declare function bifurcateBy<T = unknown, U = unknown>( collection: Collection<T>, options: ValuesOptions<T, U> | BaseOptions<T, U>, predicate: Predicate<T, U> ): [ Array<T>, Array<T> ];
+declare function bifurcateBy<T = unknown, U = unknown>( collection: Collection<T>, options: IndicesAndValuesOptions<T, U>, predicate: Predicate<T, U> ): [ Array<[ number, T ]>, Array<[ number, T ]> ];
 
 /**
 * Splits values into two groups according to a predicate function.
@@ -222,12 +222,12 @@ declare function bifurcateBy<T = unknown, U = unknown>( collection: Collection<T
 * var arr = [ 'beep', 'boop', 'foo', 'bar' ];
 *
 * var opts = {
-*     'returns': '*'
+*     'returns': 'values'
 * };
 * var out = bifurcateBy( arr, opts, predicate );
-* // returns [ [ [ 0, 'beep' ], [ 1, 'boop' ], [ 3, 'bar' ] ], [ [ 2, 'foo' ] ] ]
+* // returns [ [ 'beep', 'boop', 'bar' ], [ 'foo' ] ]
 */
-declare function bifurcateBy<T = unknown, U = unknown>( collection: Collection<T>, options: IndicesAndValuesOptions<T, U>, predicate: Predicate<T, U> ): [ Array<[ number, T ]>, Array<[ number, T ]> ];
+declare function bifurcateBy<T = unknown, U = unknown>( collection: Collection<T>, options: ValuesOptions<T, U> | BaseOptions<T, U>, predicate: Predicate<T, U> ): [ Array<T>, Array<T> ];
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/utils/bifurcate/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/bifurcate/docs/types/index.d.ts
@@ -23,13 +23,43 @@
 import { Collection } from '@stdlib/types/array';
 
 /**
-* Interface defining function options.
+* Interface defining base function options.
 */
-interface Options {
+interface BaseOptions {
 	/**
 	* If `'values'`, values are returned; if `'indices'`, indices are returned; if `'*'`, both indices and values are returned.
 	*/
 	returns?: 'values' | 'indices' | '*';
+}
+
+/**
+* Interface defining function options when returning indices.
+*/
+interface IndicesOptions extends BaseOptions {
+	/**
+	* Specifies that indices should be returned.
+	*/
+	returns: 'indices';
+}
+
+/**
+* Interface defining function options when returning values.
+*/
+interface ValuesOptions extends BaseOptions {
+	/**
+	* Specifies that values should be returned.
+	*/
+	returns: 'values';
+}
+
+/**
+* Interface defining function options when returning indices and values.
+*/
+interface IndicesAndValuesOptions extends BaseOptions {
+	/**
+	* Specifies that indices and values should be returned.
+	*/
+	returns: '*';
 }
 
 /**
@@ -43,7 +73,7 @@ interface Options {
 * @param collection - input collection
 * @param filter - collection indicating which group an element in the input collection belongs to
 * @throws first and last arguments must be the same length
-* @returns results
+* @returns group results
 *
 * @example
 * var arr = [ 'beep', 'boop', 'foo', 'bar' ];
@@ -67,7 +97,7 @@ declare function bifurcate<T = unknown>( collection: Collection<T>, filter: Coll
 * @param options.returns - if `values`, values are returned; if `indices`, indices are returned; if `*`, both indices and values are returned (default: 'values')
 * @param filter - collection indicating which group an element in the input collection belongs to
 * @throws first and last arguments must be the same length
-* @returns results
+* @returns group results
 *
 * @example
 * var arr = [ 'beep', 'boop', 'foo', 'bar' ];
@@ -79,6 +109,23 @@ declare function bifurcate<T = unknown>( collection: Collection<T>, filter: Coll
 *
 * var out = bifurcate( arr, opts, filter );
 * // returns [ [ 0, 1, 3 ], [ 2 ] ]
+*/
+declare function bifurcate<T = unknown>( collection: Collection<T>, options: IndicesOptions, filter: Collection ): Array<Array<number>>;
+
+/**
+* Splits values into two groups.
+*
+* ## Notes
+*
+* -   If an element in `filter` is truthy, then the corresponding element in the input collection belongs to the first group; otherwise, the collection element belongs to the second group.
+* -   If provided an empty collection, the function returns an empty array.
+*
+* @param collection - input collection
+* @param options - function options
+* @param options.returns - if `values`, values are returned; if `indices`, indices are returned; if `*`, both indices and values are returned (default: 'values')
+* @param filter - collection indicating which group an element in the input collection belongs to
+* @throws first and last arguments must be the same length
+* @returns group results
 *
 * @example
 * var arr = [ 'beep', 'boop', 'foo', 'bar' ];
@@ -91,7 +138,31 @@ declare function bifurcate<T = unknown>( collection: Collection<T>, filter: Coll
 * var out = bifurcate( arr, opts, filter );
 * // returns [ [ [ 0, 'beep' ], [ 1, 'boop' ], [ 3, 'bar' ] ], [ [ 2, 'foo' ] ] ]
 */
-declare function bifurcate<T = unknown>( collection: Collection<T>, options: Options, filter: Collection ): Array<Array<T>>;
+declare function bifurcate<T = unknown>( collection: Collection<T>, options: IndicesAndValuesOptions, filter: Collection ): Array<Array<[ number, T ]>>;
+
+/**
+* Splits values into two groups.
+*
+* ## Notes
+*
+* -   If an element in `filter` is truthy, then the corresponding element in the input collection belongs to the first group; otherwise, the collection element belongs to the second group.
+* -   If provided an empty collection, the function returns an empty array.
+*
+* @param collection - input collection
+* @param options - function options
+* @param options.returns - if `values`, values are returned; if `indices`, indices are returned; if `*`, both indices and values are returned (default: 'values')
+* @param filter - collection indicating which group an element in the input collection belongs to
+* @throws first and last arguments must be the same length
+* @returns group results
+*
+* @example
+* var arr = [ 'beep', 'boop', 'foo', 'bar' ];
+* var filter = [ true, true, false, true ];
+*
+* var out = bifurcate( arr, filter );
+* // returns [ [ 'beep', 'boop', 'bar' ], [ 'foo' ] ]
+*/
+declare function bifurcate<T = unknown>( collection: Collection<T>, options: ValuesOptions | BaseOptions, filter: Collection ): Array<Array<T>>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/utils/bifurcate/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/bifurcate/docs/types/test.ts
@@ -25,10 +25,20 @@ import bifurcate = require( './index' );
 {
 	bifurcate( [ 'beep', 'boop', 'foo', 'bar' ], [ true, true, false, true ] ); // $ExpectType string[][]
 
-	const opts = {
+	const indices = {
 		'returns': 'indices' as 'indices'
 	};
-	bifurcate( [ 'beep', 'boop', 'foo', 'bar' ], opts, [ true, true, false, true ] ); // $ExpectType string[][]
+	bifurcate( [ 'beep', 'boop', 'foo', 'bar' ], indices, [ true, true, false, true ] ); // $ExpectType number[][]
+
+	const values = {
+		'returns': 'values' as 'values'
+	};
+	bifurcate( [ 'beep', 'boop', 'foo', 'bar' ], values, [ true, true, false, true ] ); // $ExpectType string[][]
+
+	const both = {
+		'returns': '*' as '*'
+	};
+	bifurcate( [ 'beep', 'boop', 'foo', 'bar' ], both, [ true, true, false, true ] ); // $ExpectType [number, string][][]
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a collection...

--- a/lib/node_modules/@stdlib/utils/find/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/find/docs/types/index.d.ts
@@ -141,44 +141,6 @@ declare function find<T = unknown>( arr: Collection<T> | string, clbk: Callback<
 * @param options.k - limits the number of returned elements (default: arr.length)
 * @param options.returns - if `values`, values are returned; if `indices`, indices are returned; if `*`, both indices and values are returned (default: 'indices')
 * @param clbk - function invoked for each array element. If the return value is truthy, the value is considered to have satisfied the test condition.
-* @returns array of indices
-*
-* @example
-* function condition( val ) {
-*     return val > 20;
-* }
-*
-* var data = [ 30, 20, 50, 60, 10 ];
-* var opts = {
-*     'k': 2,
-*     'returns': 'indices'
-* };
-* var vals = find( data, opts, condition );
-* // returns [ 0, 2 ]
-*
-* @example
-* function condition( val ) {
-*     return val > 20;
-* }
-*
-* var data = [ 30, 20, 50, 60, 10 ];
-* var opts = {
-*     'k': -2,
-*     'returns': 'indices'
-* };
-* var vals = find( data, opts, condition );
-* // returns [ 3, 2 ]
-*/
-declare function find<T = unknown>( arr: Collection<T> | string, options: IndicesOptions | BaseOptions, clbk: Callback<T> ): Array<number>;
-
-/**
-* Finds elements in an array-like object that satisfy a test condition.
-*
-* @param arr - object from which elements will be tested
-* @param options - function options
-* @param options.k - limits the number of returned elements (default: arr.length)
-* @param options.returns - if `values`, values are returned; if `indices`, indices are returned; if `*`, both indices and values are returned (default: 'indices')
-* @param clbk - function invoked for each array element. If the return value is truthy, the value is considered to have satisfied the test condition.
 * @returns array of values
 *
 * @example
@@ -233,6 +195,44 @@ declare function find<T = unknown>( arr: Collection<T> | string, options: Values
 * // returns [ [3, 60], [2, 50] ]
 */
 declare function find<T = unknown>( arr: Collection<T> | string, options: IndicesAndValuesOptions, clbk: Callback<T> ): Array<[ number, T ]>;
+
+/**
+* Finds elements in an array-like object that satisfy a test condition.
+*
+* @param arr - object from which elements will be tested
+* @param options - function options
+* @param options.k - limits the number of returned elements (default: arr.length)
+* @param options.returns - if `values`, values are returned; if `indices`, indices are returned; if `*`, both indices and values are returned (default: 'indices')
+* @param clbk - function invoked for each array element. If the return value is truthy, the value is considered to have satisfied the test condition.
+* @returns array of indices
+*
+* @example
+* function condition( val ) {
+*     return val > 20;
+* }
+*
+* var data = [ 30, 20, 50, 60, 10 ];
+* var opts = {
+*     'k': 2,
+*     'returns': 'indices'
+* };
+* var vals = find( data, opts, condition );
+* // returns [ 0, 2 ]
+*
+* @example
+* function condition( val ) {
+*     return val > 20;
+* }
+*
+* var data = [ 30, 20, 50, 60, 10 ];
+* var opts = {
+*     'k': -2,
+*     'returns': 'indices'
+* };
+* var vals = find( data, opts, condition );
+* // returns [ 3, 2 ]
+*/
+declare function find<T = unknown>( arr: Collection<T> | string, options: IndicesOptions | BaseOptions, clbk: Callback<T> ): Array<number>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/utils/find/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/find/docs/types/test.ts
@@ -53,6 +53,26 @@ function condition( v: number ): boolean {
 	find( arr, opts3, condition ); // $ExpectType [number, number][]
 }
 
+// The function resolves the element type according to the `returns` option...
+{
+	const arr = [ 'a', 'b', 'c' ];
+
+	/**
+	* Condition function.
+	*
+	* @param v - value
+	* @returns boolean result
+	*/
+	function isB( v: string ): boolean {
+		return ( v === 'b' );
+	}
+
+	find( arr, { 'returns': 'indices' as 'indices' }, isB ); // $ExpectType number[]
+	find( arr, { 'returns': 'values' as 'values' }, isB ); // $ExpectType string[]
+	find( arr, { 'returns': '*' as '*' }, isB ); // $ExpectType [number, string][]
+	find( arr, { 'k': 2 }, isB ); // $ExpectType number[]
+}
+
 // The compiler throws an error if the function is provided a first argument which is not a collection...
 {
 	find( true, condition ); // $ExpectError

--- a/lib/node_modules/@stdlib/utils/group/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/group/docs/types/index.d.ts
@@ -23,13 +23,43 @@
 import { Collection } from '@stdlib/types/array';
 
 /**
-* Interface defining function options.
+* Interface defining base function options.
 */
-interface Options {
+interface BaseOptions {
 	/**
 	* If `'values'`, values are returned; if `'indices'`, indices are returned; if `'*'`, both indices and values are returned.
 	*/
 	returns?: 'values' | 'indices' | '*';
+}
+
+/**
+* Interface defining function options when returning indices.
+*/
+interface IndicesOptions extends BaseOptions {
+	/**
+	* Specifies that indices should be returned.
+	*/
+	returns: 'indices';
+}
+
+/**
+* Interface defining function options when returning values.
+*/
+interface ValuesOptions extends BaseOptions {
+	/**
+	* Specifies that values should be returned.
+	*/
+	returns: 'values';
+}
+
+/**
+* Interface defining function options when returning indices and values.
+*/
+interface IndicesAndValuesOptions extends BaseOptions {
+	/**
+	* Specifies that indices and values should be returned.
+	*/
+	returns: '*';
 }
 
 /**
@@ -80,6 +110,26 @@ declare function group<T, K extends PropertyKey>(
 *
 * var out = group( arr, opts, groups );
 * // returns { 'b': [ 0, 1, 3 ], 'f': [ 2 ] }
+*/
+declare function group<T, K extends PropertyKey>(
+	collection: Collection<T>,
+	options: IndicesOptions,
+	groups: Collection<K>
+): { [key in K]: Collection<number> };
+
+/**
+* Groups values as arrays associated with distinct keys.
+*
+* ## Notes
+*
+* -   If provided an empty collection, the function returns an empty object.
+*
+* @param collection - collection to group
+* @param options - function options
+* @param options.returns - if `values`, values are returned; if `indices`, indices are returned; if `*`, both indices and values are returned (default: 'values')
+* @param groups - collection defining which group an element in the input collection belongs to
+* @throws first and last arguments must be the same length
+* @returns group results
 *
 * @example
 * var arr = [ 'beep', 'boop', 'foo', 'bar' ];
@@ -94,7 +144,34 @@ declare function group<T, K extends PropertyKey>(
 */
 declare function group<T, K extends PropertyKey>(
 	collection: Collection<T>,
-	options: Options,
+	options: IndicesAndValuesOptions,
+	groups: Collection<K>
+): { [key in K]: Collection<[ number, T ]> };
+
+/**
+* Groups values as arrays associated with distinct keys.
+*
+* ## Notes
+*
+* -   If provided an empty collection, the function returns an empty object.
+*
+* @param collection - collection to group
+* @param options - function options
+* @param options.returns - if `values`, values are returned; if `indices`, indices are returned; if `*`, both indices and values are returned (default: 'values')
+* @param groups - collection defining which group an element in the input collection belongs to
+* @throws first and last arguments must be the same length
+* @returns group results
+*
+* @example
+* var arr = [ 'beep', 'boop', 'foo', 'bar' ];
+* var groups = [ 'b', 'b', 'f', 'b' ];
+*
+* var out = group( arr, groups );
+* // returns { 'b': [ 'beep', 'boop', 'bar' ], 'f': [ 'foo' ] }
+*/
+declare function group<T, K extends PropertyKey>(
+	collection: Collection<T>,
+	options: ValuesOptions | BaseOptions,
 	groups: Collection<K>
 ): { [key in K]: Collection<T> };
 

--- a/lib/node_modules/@stdlib/utils/group/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/group/docs/types/test.ts
@@ -24,10 +24,21 @@ import group = require( './index' );
 // The function returns an object...
 {
 	group( [ 'beep', 'boop', 'foo', 'bar' ], [ 'b', 'b', 'f', 'b' ] ); // $ExpectType { b: Collection<string>; f: Collection<string>; }
-	const opts = {
+
+	const indices = {
 		'returns': 'indices' as 'indices'
 	};
-	group( [ 'beep', 'boop', 'foo', 'bar' ], opts, [ 'b', 'b', 'f', 'b' ] ); // $ExpectType { b: Collection<string>; f: Collection<string>; }
+	group( [ 'beep', 'boop', 'foo', 'bar' ], indices, [ 'b', 'b', 'f', 'b' ] ); // $ExpectType { b: Collection<number>; f: Collection<number>; }
+
+	const values = {
+		'returns': 'values' as 'values'
+	};
+	group( [ 'beep', 'boop', 'foo', 'bar' ], values, [ 'b', 'b', 'f', 'b' ] ); // $ExpectType { b: Collection<string>; f: Collection<string>; }
+
+	const both = {
+		'returns': '*' as '*'
+	};
+	group( [ 'beep', 'boop', 'foo', 'bar' ], both, [ 'b', 'b', 'f', 'b' ] ); // $ExpectType { b: Collection<[number, string]>; f: Collection<[number, string]>; }
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a collection...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request fixes the TypeScript declaration return types of `find`, `bifurcate`, `group`, and `bifurcate-by` so that the options-accepting overloads reflect the `returns` option. Because `BaseOptions` is structurally a supertype of the discriminated `*Options` interfaces, the broad overload shadowed the more specific ones, so calls supplying `returns: 'values'` or `returns: '*'` were mistyped. Specifically, it:

-   `find`: reorders the `IndicesOptions | BaseOptions` catch-all overload to last so the `ValuesOptions` (`Array<T>`) and `IndicesAndValuesOptions` (`Array<[ number, T ]>`) overloads become reachable. (Reordering rather than removing `| BaseOptions` preserves support for no-`returns` options such as `find( arr, { 'k': 2 }, clbk )`.)
-   `bifurcate-by`: reorders the `ValuesOptions | BaseOptions` catch-all after the `IndicesAndValuesOptions` overload so the `'*'` tuple result is reachable.
-   `bifurcate`: adds discriminated `IndicesOptions`/`ValuesOptions`/`IndicesAndValuesOptions` interfaces and per-`returns` overloads returning `Array<Array<number>>` / `Array<Array<T>>` / `Array<Array<[ number, T ]>>`.
-   `group`: adds the same discriminated overloads, returning `{ [key in K]: Collection<number> }` / `Collection<T>` / `Collection<[ number, T ]>` per the `returns` option.
-   updates the affected `$ExpectType` declaration tests, and adds cases (using non-`number` collections) that exercise the previously-shadowed `values`/`*` results, which the existing `number[]`-based tests could not distinguish.

All four declaration files and their type tests pass the `lint-typescript-declarations-files` (`expect-type`) checks.

This is one of several follow-up PRs from a `@stdlib/utils` declaration audit. Opened as a **draft** because these are public-API type-surface changes that warrant careful review.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

-   `group-by`'s `ValuesResults | BaseOptions` values overload has the same latent ordering as the pre-fix `bifurcate-by`; it was not in scope here but may warrant the same reorder.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The corrected overload ordering follows the canonical stdlib pattern: the structurally-broad `BaseOptions` catch-all must appear last so it does not shadow the discriminated overloads. Findings were surfaced by a multi-agent audit of the `@stdlib/utils` declarations and verified against the implementations.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored primarily by Claude Code: it analyzed the overload-shadowing bug, designed the corrected discriminated overloads (mirroring the canonical stdlib pattern), updated the `$ExpectType` tests, and verified every change against the `expect-type` declaration tests before committing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md