### PR TITLE
fix: correctly type callback indices as an array

### DIFF
--- a/lib/node_modules/@stdlib/utils/map2d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/map2d/docs/types/index.d.ts
@@ -49,7 +49,7 @@ type Unary<T, U, V> = ( this: V, value: T ) => U;
 * @param indices - current array element indices
 * @returns result
 */
-type Binary<T, U, V> = ( this: V, value: T, index: number ) => U;
+type Binary<T, U, V> = ( this: V, value: T, indices: Array<number> ) => U;
 
 /**
 * Callback invoked for each array element.
@@ -59,7 +59,7 @@ type Binary<T, U, V> = ( this: V, value: T, index: number ) => U;
 * @param arr - array
 * @returns result
 */
-type Ternary<T, U, V> = ( this: V, value: T, index: number, arr: Array2D<T> ) => U;
+type Ternary<T, U, V> = ( this: V, value: T, indices: Array<number>, arr: Array2D<T> ) => U;
 
 /**
 * Callback invoked for each array element.

--- a/lib/node_modules/@stdlib/utils/map2d/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/map2d/docs/types/test.ts
@@ -28,6 +28,17 @@ function clbk( v: number ): number {
 	return v;
 }
 
+/**
+* Callback function.
+*
+* @param v - argument
+* @param indices - element indices
+* @returns result
+*/
+function clbki( v: number, indices: Array<number> ): number {
+	return v + indices[ 0 ];
+}
+
 
 // TESTS //
 
@@ -40,6 +51,7 @@ function clbk( v: number ): number {
 
 	map2d( arr, clbk ); // $ExpectType number[][]
 	map2d( arr, clbk, {} ); // $ExpectType number[][]
+	map2d( arr, clbki ); // $ExpectType number[][]
 }
 
 // The compiler throws an error if the function is provided a first argument other than an array of arrays...

--- a/lib/node_modules/@stdlib/utils/map3d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/map3d/docs/types/index.d.ts
@@ -49,7 +49,7 @@ type Unary<T, U, V> = ( this: V, value: T ) => U;
 * @param indices - current array element indices
 * @returns result
 */
-type Binary<T, U, V> = ( this: V, value: T, index: number ) => U;
+type Binary<T, U, V> = ( this: V, value: T, indices: Array<number> ) => U;
 
 /**
 * Callback invoked for each array element.
@@ -59,7 +59,7 @@ type Binary<T, U, V> = ( this: V, value: T, index: number ) => U;
 * @param arr - array
 * @returns result
 */
-type Ternary<T, U, V> = ( this: V, value: T, index: number, arr: Array3D<T> ) => U;
+type Ternary<T, U, V> = ( this: V, value: T, indices: Array<number>, arr: Array3D<T> ) => U;
 
 /**
 * Callback invoked for each array element.

--- a/lib/node_modules/@stdlib/utils/map3d/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/map3d/docs/types/test.ts
@@ -28,6 +28,17 @@ function clbk( v: number ): number {
 	return v;
 }
 
+/**
+* Callback function.
+*
+* @param v - argument
+* @param indices - element indices
+* @returns result
+*/
+function clbki( v: number, indices: Array<number> ): number {
+	return v + indices[ 0 ];
+}
+
 
 // TESTS //
 
@@ -40,6 +51,7 @@ function clbk( v: number ): number {
 
 	map3d( arr, clbk ); // $ExpectType number[][][]
 	map3d( arr, clbk, {} ); // $ExpectType number[][][]
+	map3d( arr, clbki ); // $ExpectType number[][][]
 }
 
 // The compiler throws an error if the function is provided a first argument other than a three-dimensional nested array...

--- a/lib/node_modules/@stdlib/utils/map4d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/map4d/docs/types/index.d.ts
@@ -49,7 +49,7 @@ type Unary<T, U, V> = ( this: V, value: T ) => U;
 * @param indices - current array element indices
 * @returns result
 */
-type Binary<T, U, V> = ( this: V, value: T, index: number ) => U;
+type Binary<T, U, V> = ( this: V, value: T, indices: Array<number> ) => U;
 
 /**
 * Callback invoked for each array element.
@@ -59,7 +59,7 @@ type Binary<T, U, V> = ( this: V, value: T, index: number ) => U;
 * @param arr - array
 * @returns result
 */
-type Ternary<T, U, V> = ( this: V, value: T, index: number, arr: Array4D<T> ) => U;
+type Ternary<T, U, V> = ( this: V, value: T, indices: Array<number>, arr: Array4D<T> ) => U;
 
 /**
 * Callback invoked for each array element.

--- a/lib/node_modules/@stdlib/utils/map4d/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/map4d/docs/types/test.ts
@@ -28,6 +28,17 @@ function clbk( v: number ): number {
 	return v;
 }
 
+/**
+* Callback function.
+*
+* @param v - argument
+* @param indices - element indices
+* @returns result
+*/
+function clbki( v: number, indices: Array<number> ): number {
+	return v + indices[ 0 ];
+}
+
 
 // TESTS //
 
@@ -40,6 +51,7 @@ function clbk( v: number ): number {
 
 	map4d( arr, clbk ); // $ExpectType number[][][][]
 	map4d( arr, clbk, {} ); // $ExpectType number[][][][]
+	map4d( arr, clbki ); // $ExpectType number[][][][]
 }
 
 // The compiler throws an error if the function is provided a first argument other than a four-dimensional nested array...

--- a/lib/node_modules/@stdlib/utils/map5d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/map5d/docs/types/index.d.ts
@@ -49,7 +49,7 @@ type Unary<T, U, V> = ( this: V, value: T ) => U;
 * @param indices - current array element indices
 * @returns result
 */
-type Binary<T, U, V> = ( this: V, value: T, index: number ) => U;
+type Binary<T, U, V> = ( this: V, value: T, indices: Array<number> ) => U;
 
 /**
 * Callback invoked for each array element.
@@ -59,7 +59,7 @@ type Binary<T, U, V> = ( this: V, value: T, index: number ) => U;
 * @param arr - array
 * @returns result
 */
-type Ternary<T, U, V> = ( this: V, value: T, index: number, arr: Array5D<T> ) => U;
+type Ternary<T, U, V> = ( this: V, value: T, indices: Array<number>, arr: Array5D<T> ) => U;
 
 /**
 * Callback invoked for each array element.

--- a/lib/node_modules/@stdlib/utils/map5d/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/map5d/docs/types/test.ts
@@ -28,6 +28,17 @@ function clbk( v: number ): number {
 	return v;
 }
 
+/**
+* Callback function.
+*
+* @param v - argument
+* @param indices - element indices
+* @returns result
+*/
+function clbki( v: number, indices: Array<number> ): number {
+	return v + indices[ 0 ];
+}
+
 
 // TESTS //
 
@@ -40,6 +51,7 @@ function clbk( v: number ): number {
 
 	map5d( arr, clbk ); // $ExpectType number[][][][][]
 	map5d( arr, clbk, {} ); // $ExpectType number[][][][][]
+	map5d( arr, clbki ); // $ExpectType number[][][][][]
 }
 
 // The compiler throws an error if the function is provided a first argument other than a five-dimensional nested array...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request fixes the callback type signatures of `map2d`, `map3d`, `map4d`, and `map5d`. The `Binary` and `Ternary` callback types declared the third argument as `index: number`, but the implementations invoke the callback with an **array** of dimension indices (e.g. `fcn.call( thisArg, a[ j ], [ i, j ], arr )` in `map2d`), and the accompanying TSDoc already documents the argument as `indices`. Specifically, it:

-   retypes the third callback argument from `index: number` to `indices: Array<number>` in the `Binary` and `Ternary` callback signatures of all four packages, matching both the runtime and the existing `@param indices` documentation.
-   adds a declaration test in each package exercising a callback that consumes the `indices` array (the previous tests only used a unary callback, so they did not cover this argument).

All four declaration files and their type tests pass the `lint-typescript-declarations-files` (`expect-type`) checks.

One of several follow-up PRs from a `@stdlib/utils` declaration audit. Opened as a **draft** for review of the public callback-type change.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verified against the implementations: each `map<n>d` passes an `n`-element index array to the callback. Surfaced by a multi-agent audit of the `@stdlib/utils` declarations.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored primarily by Claude Code, which confirmed the callback argument against each implementation, retyped the signatures, added exercising tests, and verified them with the `expect-type` declaration tests.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md