### PR TITLE
fix: use `ArrayCallback` for the `assign` thisArg type in `@stdlib/utils` map/map-right

### DIFF
--- a/lib/node_modules/@stdlib/utils/map-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/map-right/docs/types/index.d.ts
@@ -219,7 +219,7 @@ interface Routine {
 	* console.log( out );
 	* // => [ 1, 2, 3, 4, 5, 6 ]
 	*/
-	assign<T = unknown, U = unknown, V = unknown>( arr: Collection<T>, out: Collection<U>, fcn: ArrayCallback<T, U, V>, thisArg?: ThisParameterType<Callback<T, U, V>> ): Collection<U>;
+	assign<T = unknown, U = unknown, V = unknown>( arr: Collection<T>, out: Collection<U>, fcn: ArrayCallback<T, U, V>, thisArg?: ThisParameterType<ArrayCallback<T, U, V>> ): Collection<U>;
 }
 
 /**

--- a/lib/node_modules/@stdlib/utils/map/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/map/docs/types/index.d.ts
@@ -219,7 +219,7 @@ interface Routine {
 	* console.log( out );
 	* // => [ 1, 2, 3, 4, 5, 6 ]
 	*/
-	assign<T = unknown, U = unknown, V = unknown>( arr: Collection<T>, out: Collection<U>, fcn: ArrayCallback<T, U, V>, thisArg?: ThisParameterType<Callback<T, U, V>> ): Collection<U>;
+	assign<T = unknown, U = unknown, V = unknown>( arr: Collection<T>, out: Collection<U>, fcn: ArrayCallback<T, U, V>, thisArg?: ThisParameterType<ArrayCallback<T, U, V>> ): Collection<U>;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request fixes the `assign` overload type in `map` and `map-right`. In the array `assign` overload, the callback (`fcn`) is typed as `ArrayCallback<T, U, V>`, but the optional execution context (`thisArg`) was typed `ThisParameterType<Callback<T, U, V>>`. This pull request aligns `thisArg` with the callback by using `ThisParameterType<ArrayCallback<T, U, V>>`, matching the corresponding non-`assign` `Collection` overload in the same interface.

Both declaration files and their type tests pass the `lint-typescript-declarations-files` (`expect-type`) checks.

One of several follow-up PRs from a `@stdlib/utils` declaration audit. Opened as a **draft** for review.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by a multi-agent audit of the `@stdlib/utils` declarations.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored primarily by Claude Code, which identified the `thisArg`/`fcn` type mismatch against the sibling overload and verified the fix with the `expect-type` declaration tests.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md