### PR TITLE
docs(@stdlib/math/base/tools/evalpoly-compile): use relative require path in example

### DIFF
--- a/lib/node_modules/@stdlib/math/base/tools/evalpoly-compile/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/tools/evalpoly-compile/examples/index.js
@@ -18,22 +18,12 @@
 
 'use strict';
 
-var resolve = require( 'path' ).resolve;
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
-var tryRequire = require( '@stdlib/utils/try-require' );
+var compile = require( './../lib' );
 
-var compile = tryRequire( resolve( __dirname, '..', 'lib' ) );
-if ( compile instanceof Error ) {
-	console.log( 'Unable to run example. Unsupported environment.' );
-} else {
-	main();
-}
+// Create an array of random coefficients:
+var coef = discreteUniform( 10, -100, 100 );
 
-function main() {
-	// Create an array of random coefficients:
-	var coef = discreteUniform( 10, -100, 100 );
-
-	// Compile a module for evaluating a polynomial:
-	var str = compile( coef );
-	console.log( str );
-}
+// Compile a module for evaluating a polynomial:
+var str = compile( coef );
+console.log( str );


### PR DESCRIPTION
Resolves #12359.

## Description

This pull request:

-   Replaces the unnecessary `tryRequire`-based loading pattern in
    `@stdlib/math/base/tools/evalpoly-compile/examples/index.js` with
    a direct `require( './../lib' )`, resolving the
    `stdlib/require-last-path-relative` ESLint violation that causes
    the `lint_random_files` workflow to fail on `develop`.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/26668990373
(2026-05-30T00:34 UTC)

**Symptom:** `stdlib/require-last-path-relative` error at
`examples/index.js:23` — the last `require()` call in AST order was
`require('@stdlib/utils/try-require')`, a non-relative path.

**Root cause:** The example used the `tryRequire` guard pattern, which
is intended for packages with optional native addons that may fail to
compile. `evalpoly-compile` is pure JavaScript: its `lib/` directory
contains only `index.js`, `main.js`, and `templates/`; it has no
`binding.gyp`, no native source, and empty `dependencies` and
`devDependencies`. The guard is therefore both unnecessary and
counter-productive — the `tryRequire( resolve( __dirname, '..', 'lib' ) )`
call is not a `require()` call per the rule's AST traversal, so it
does not reset the "last require" pointer, leaving
`require('@stdlib/utils/try-require')` as the final flagged path.

**Fix:** Remove `path`, `@stdlib/utils/try-require`, the error guard,
and the `main()` wrapper. Load the package with `require( './../lib' )`,
which is both the correct relative-path form and the convention used
by sibling packages such as `@stdlib/math/base/tools/evalpoly`.

## Related Issues

This pull request has the following related issues:

-   resolves #12359

## Questions

No.

## Other

**Validation:** Fix reviewed by three independent agents prior to commit.

- Reviewer A (correctness, Opus): **approve** — confirmed `require('./../lib')` resolves correctly, `tryRequire` is genuinely unnecessary for a pure-JS package, and observable example output is preserved.
- Reviewer B (regression scope, Opus): **approve** — only `examples/index.js` changed; tests do not import examples; no platform-specific behavior change; diff is minimal.
- Reviewer C (style + conventions, Sonnet): **approve** — `'./../lib'` satisfies the lint rule (starts with `./`); copyright header preserved; spacing, `var` declarations, and comment style match stdlib conventions and sibling example.

**Note:** `@stdlib/math/base/tools/evalrational-compile` has an
identical `tryRequire` pattern in its example file and will trigger
the same lint rule in a future automated run. That file is out of
scope for this PR (no open failure event) but warrants a follow-up.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated CI-failure
triage routine. Root-cause analysis, fix, three-agent validation, and
commit were produced by the agent; the diff was reviewed against the
ESLint rule implementation and sibling package examples before being
staged.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_012C16VHyGJG9T8aUAP6k7Aj)_