### PR TITLE
chore: fix keyword

### DIFF
--- a/lib/node_modules/@stdlib/random/streams/poisson/package.json
+++ b/lib/node_modules/@stdlib/random/streams/poisson/package.json
@@ -64,7 +64,7 @@
     "random",
     "rand",
     "poisson",
-    "continuous",
+    "discrete",
     "readable",
     "stream",
     "seed",


### PR DESCRIPTION
## Description

This pull request:

-   Corrects a keyword mismatch in `@stdlib/random/streams/poisson`: replaces `"continuous"` with `"discrete"` in `package.json`. The Poisson distribution has discrete (non-negative integer) support, and all other discrete-distribution stream packages (`bernoulli`, `binomial`, `discrete-uniform`, `geometric`, `hypergeometric`, `negative-binomial`, `randi`) already use the `"discrete"` keyword. This change brings `@stdlib/random/streams/poisson` into conformance with 31/41 sibling packages in `random/streams/` and with the corresponding `random/iter`, `random/array`, and `random/strided` Poisson packages.

## Related Issues

None.

## Questions

No.

## Other

Single-line metadata correction in `package.json`; no source, tests, examples, or documentation are touched. No tests or downstream consumers read the `keywords` array of this package.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code, running a cross-package API drift detection routine across the `@stdlib/random/streams` namespace. The routine identified `random/streams/poisson` as a single-feature outlier (keyword classification), confirmed via cross-reference against sibling `random/{iter,array,strided}/poisson` packages, and applied the mechanical one-line fix. Two validation passes (cross-reference and structural review) confirmed `confirmed-drift` before the change was committed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01BTTDiC5C9zLzcmWNQQd1tf)_