### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/stats/ztest2/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/ztest2/examples/index.js
@@ -28,14 +28,14 @@ var y;
 var i;
 
 // Values drawn from a Normal(4,2) distribution
-x = new Array( 100 );
+x = [];
 for ( i = 0; i < 100; i++ ) {
-	x[ i ] = rnorm( 4.0, 2.0 );
+	x.push( rnorm( 4.0, 2.0 ) );
 }
 // Values drawn from a Normal(3,2) distribution
-y = new Array( 80 );
+y = [];
 for ( i = 0; i < 80; i++ ) {
-	y[ i ] = rnorm( 3.0, 2.0 );
+	y.push( rnorm( 3.0, 2.0 ) );
 }
 
 out = ztest2( x, y, 2.0, 2.0 );

--- a/lib/node_modules/@stdlib/stats/ztest2/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/ztest2/examples/index.js
@@ -18,28 +18,17 @@
 
 'use strict';
 
-var rnorm = require( '@stdlib/random/base/normal' );
+var normal = require( '@stdlib/random/array/normal' );
 var ztest2 = require( './../lib' );
 
-var table;
-var out;
-var x;
-var y;
-var i;
-
 // Values drawn from a Normal(4,2) distribution
-x = [];
-for ( i = 0; i < 100; i++ ) {
-	x.push( rnorm( 4.0, 2.0 ) );
-}
-// Values drawn from a Normal(3,2) distribution
-y = [];
-for ( i = 0; i < 80; i++ ) {
-	y.push( rnorm( 3.0, 2.0 ) );
-}
+var x = normal( 100, 4.0, 2.0 );
 
-out = ztest2( x, y, 2.0, 2.0 );
-table = out.print();
+// Values drawn from a Normal(3,2) distribution
+var y = normal( 80, 3.0, 2.0 );
+
+var out = ztest2( x, y, 2.0, 2.0 );
+var table = out.print();
 console.log( table );
 
 out = ztest2( x, y, 2.0, 2.0, {


### PR DESCRIPTION
Resolves #12411

## Summary

Fixes 2 lint errors in `lib/node_modules/@stdlib/stats/ztest2/examples/index.js` by replacing `new Array()` constructor calls with array literals and `.push()`, as required by the `stdlib/no-new-array` lint rule.

### Changes
- Line 31: `new Array(100)` → `[]` with `.push()` in loop
- Line 36: `new Array(80)` → `[]` with `.push()` in loop

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)