### PR TITLE
refactor: rename output array parameter from `y` to `w` in `blas/ext/base/gwxsa`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/README.md
@@ -20,16 +20,16 @@ limitations under the License.
 
 # gwxsa
 
-> Subtract a scalar constant from each element in a strided array `x` and assign the results to elements in a strided array `y`.
+> Subtract a scalar constant from each element in a strided array `x` and assign the results to elements in a strided array `w`.
 
 <section class="intro">
 
 This BLAS extension implements the operation
 
-<!-- <equation class="equation" label="eq:wxsa" align="center" raw="\mathbf{y} = \mathbf{x} - \alpha" alt="Equation for wxsa operation."> -->
+<!-- <equation class="equation" label="eq:wxsa" align="center" raw="\mathbf{w} = \mathbf{x} - \alpha" alt="Equation for wxsa operation."> -->
 
 ```math
-\mathbf{y} = \mathbf{x} - \alpha
+\mathbf{w} = \mathbf{x} - \alpha
 ```
 
 <!-- </equation> -->
@@ -48,16 +48,16 @@ This API is complementary to the package [`@stdlib/blas/ext/base/gwapx`][@stdlib
 var gwxsa = require( '@stdlib/blas/ext/base/gwxsa' );
 ```
 
-#### gwxsa( N, alpha, x, strideX, y, strideY )
+#### gwxsa( N, alpha, x, strideX, w, strideW )
 
-Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `y`.
+Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `w`.
 
 ```javascript
 var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-var y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+var w = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
-gwxsa( x.length, 5.0, x, 1, y, 1 );
-// y => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
+gwxsa( x.length, 5.0, x, 1, w, 1 );
+// w => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
 ```
 
 The function has the following parameters:
@@ -66,17 +66,17 @@ The function has the following parameters:
 -   **alpha**: scalar constant.
 -   **x**: input [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
 -   **strideX**: stride length for `x`.
--   **y**: output [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
--   **strideY**: stride length for `y`.
+-   **w**: output [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
+-   **strideW**: stride length for `w`.
 
-The `N` and stride parameters determine which elements in the strided arrays are accessed at runtime. For example, to subtract `alpha` from every other element in `x` and assign the results to every other element in `y`:
+The `N` and stride parameters determine which elements in the strided arrays are accessed at runtime. For example, to subtract `alpha` from every other element in `x` and assign the results to every other element in `w`:
 
 ```javascript
 var x = [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ];
-var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+var w = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
-gwxsa( 3, 5.0, x, 2, y, 2 );
-// y => [ -4.0, 0.0, -2.0, 0.0, 0.0, 0.0 ]
+gwxsa( 3, 5.0, x, 2, w, 2 );
+// w => [ -4.0, 0.0, -2.0, 0.0, 0.0, 0.0 ]
 ```
 
 Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
@@ -86,41 +86,41 @@ var Float64Array = require( '@stdlib/array/float64' );
 
 // Initial arrays...
 var x0 = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-var y0 = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+var w0 = new Float64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 // Create offset views...
 var x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
-var y1 = new Float64Array( y0.buffer, y0.BYTES_PER_ELEMENT*2 ); // start at 3rd element
+var w1 = new Float64Array( w0.buffer, w0.BYTES_PER_ELEMENT*2 ); // start at 3rd element
 
-gwxsa( 3, 5.0, x1, 1, y1, 1 );
-// y0 => <Float64Array>[ 0.0, 0.0, -3.0, -2.0, -1.0, 0.0 ]
+gwxsa( 3, 5.0, x1, 1, w1, 1 );
+// w0 => <Float64Array>[ 0.0, 0.0, -3.0, -2.0, -1.0, 0.0 ]
 ```
 
-#### gwxsa.ndarray( N, alpha, x, strideX, offsetX, y, strideY, offsetY )
+#### gwxsa.ndarray( N, alpha, x, strideX, offsetX, w, strideW, offsetW )
 
-Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `y` using alternative indexing semantics.
+Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `w` using alternative indexing semantics.
 
 ```javascript
 var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-var y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+var w = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
-gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, 0 );
-// y => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
+gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, 0 );
+// w => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
 ```
 
 The function has the following additional parameters:
 
 -   **offsetX**: starting index for `x`.
--   **offsetY**: starting index for `y`.
+-   **offsetW**: starting index for `w`.
 
-While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example, to subtract `alpha` from the last three elements of `x` and assign the results to the last three elements of `y`:
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example, to subtract `alpha` from the last three elements of `x` and assign the results to the last three elements of `w`:
 
 ```javascript
 var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-var y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+var w = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
-gwxsa.ndarray( 3, 5.0, x, 1, x.length-3, y, 1, y.length-3 );
-// y => [ 0.0, 0.0, -2.0, -1.0, 0.0 ]
+gwxsa.ndarray( 3, 5.0, x, 1, x.length-3, w, 1, w.length-3 );
+// w => [ 0.0, 0.0, -2.0, -1.0, 0.0 ]
 ```
 
 </section>
@@ -131,7 +131,7 @@ gwxsa.ndarray( 3, 5.0, x, 1, x.length-3, y, 1, y.length-3 );
 
 ## Notes
 
--   If `N <= 0`, both functions return `y` unchanged.
+-   If `N <= 0`, both functions return `w` unchanged.
 -   Both functions support array-like objects having getter and setter accessors for array element access (e.g., [`@stdlib/array/base/accessor`][@stdlib/array/base/accessor]).
 
 </section>
@@ -153,13 +153,13 @@ var x = discreteUniform( 10, -100, 100, {
 });
 console.log( x );
 
-var y = discreteUniform( 10, -100, 100, {
+var w = discreteUniform( 10, -100, 100, {
     'dtype': 'float64'
 });
-console.log( y );
+console.log( w );
 
-gwxsa( x.length, 5.0, x, 1, y, 1 );
-console.log( y );
+gwxsa( x.length, 5.0, x, 1, w, 1 );
+console.log( w );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/benchmark/benchmark.js
@@ -47,7 +47,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var w = uniform( len, -100, 100, options );
 	return benchmark;
 
 	/**
@@ -62,7 +62,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			z = gwxsa( x.length, 5.0, x, 1, y, 1 );
+			z = gwxsa( x.length, 5.0, x, 1, w, 1 );
 			if ( isnan( z[ i%x.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/benchmark/benchmark.ndarray.js
@@ -47,7 +47,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var w = uniform( len, -100, 100, options );
 	return benchmark;
 
 	/**
@@ -62,7 +62,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			z = gwxsa( x.length, 5.0, x, 1, 0, y, 1, 0 );
+			z = gwxsa( x.length, 5.0, x, 1, 0, w, 1, 0 );
 			if ( isnan( z[ i%x.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/docs/repl.txt
@@ -1,7 +1,7 @@
 
-{{alias}}( N, alpha, x, strideX, y, strideY )
+{{alias}}( N, alpha, x, strideX, w, strideW )
     Subtracts a scalar constant from each element in a strided array `x` and
-    assigns the results to elements in a strided array `y`.
+    assigns the results to elements in a strided array `w`.
 
     The `N` and stride parameters determine which elements in the strided
     arrays are accessed at runtime.
@@ -9,7 +9,7 @@
     Indexing is relative to the first index. To introduce an offset, use typed
     array views.
 
-    If `N <= 0`, the function returns `y` unchanged.
+    If `N <= 0`, the function returns `w` unchanged.
 
     Parameters
     ----------
@@ -25,49 +25,49 @@
     strideX: integer
         Stride length for `x`.
 
-    y: Array<number>|TypedArray
+    w: Array<number>|TypedArray
         Output array.
 
-    strideY: integer
-        Stride length for `y`.
+    strideW: integer
+        Stride length for `w`.
 
     Returns
     -------
-    y: Array<number>|TypedArray
+    w: Array<number>|TypedArray
         Output array.
 
     Examples
     --------
     // Standard Usage:
     > var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ];
-    > var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
-    > {{alias}}( x.length, 5.0, x, 1, y, 1 )
+    > var w = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+    > {{alias}}( x.length, 5.0, x, 1, w, 1 )
     [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
 
     // Using `N` and stride parameters:
     > x = [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ];
-    > y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
-    > {{alias}}( 4, 5.0, x, 2, y, 2 )
+    > w = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+    > {{alias}}( 4, 5.0, x, 2, w, 2 )
     [ -7.0, 0.0, -2.0, 0.0, -1.0, 0.0, -6.0, 0.0 ]
 
     // Using view offsets:
     > var bufX = [ 1.0, -2.0, 3.0, -4.0, 5.0, -6.0 ];
-    > var bufY = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+    > var bufW = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
     > var x0 = new {{alias:@stdlib/array/float64}}( bufX );
-    > var y0 = new {{alias:@stdlib/array/float64}}( bufY );
+    > var w0 = new {{alias:@stdlib/array/float64}}( bufW );
     > var offsetX = x0.BYTES_PER_ELEMENT * 1;
-    > var offsetY = y0.BYTES_PER_ELEMENT * 1;
+    > var offsetW = w0.BYTES_PER_ELEMENT * 1;
     > var x1 = new {{alias:@stdlib/array/float64}}( x0.buffer, offsetX );
-    > var y1 = new {{alias:@stdlib/array/float64}}( y0.buffer, offsetY );
-    > {{alias}}( 3, 5.0, x1, 2, y1, 2 )
+    > var w1 = new {{alias:@stdlib/array/float64}}( w0.buffer, offsetW );
+    > {{alias}}( 3, 5.0, x1, 2, w1, 2 )
     <Float64Array>[ -7.0, 0.0, -9.0, 0.0, -11.0 ]
-    > y0
+    > w0
     <Float64Array>[ 0.0, -7.0, 0.0, -9.0, 0.0, -11.0 ]
 
 
-{{alias}}.ndarray( N, alpha, x, strideX, offsetX, y, strideY, offsetY )
+{{alias}}.ndarray( N, alpha, x, strideX, offsetX, w, strideW, offsetW )
     Subtracts a scalar constant from each element in a strided array `x` and
-    assigns the results to elements in a strided array `y` using alternative
+    assigns the results to elements in a strided array `w` using alternative
     indexing semantics.
 
     While typed array views mandate a view offset based on the underlying
@@ -91,32 +91,32 @@
     offsetX: integer
         Starting index for `x`.
 
-    y: Array<number>|TypedArray
+    w: Array<number>|TypedArray
         Output array.
 
-    strideY: integer
-        Stride length for `y`.
+    strideW: integer
+        Stride length for `w`.
 
-    offsetY: integer
-        Starting index for `y`.
+    offsetW: integer
+        Starting index for `w`.
 
     Returns
     -------
-    y: Array<number>|TypedArray
+    w: Array<number>|TypedArray
         Output array.
 
     Examples
     --------
     // Standard Usage:
     > var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ];
-    > var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
-    > {{alias}}.ndarray( x.length, 5.0, x, 1, 0, y, 1, 0 )
+    > var w = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+    > {{alias}}.ndarray( x.length, 5.0, x, 1, 0, w, 1, 0 )
     [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
 
     // Using index offsets:
     > x = [ 1.0, -2.0, 3.0, -4.0, 5.0, -6.0 ];
-    > y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
-    > {{alias}}.ndarray( 3, 5.0, x, 1, x.length-3, y, 1, y.length-3 )
+    > w = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+    > {{alias}}.ndarray( 3, 5.0, x, 1, x.length-3, w, 1, w.length-3 )
     [ 0.0, 0.0, 0.0, -9.0, 0.0, -11.0 ]
 
     See Also

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/docs/types/index.d.ts
@@ -32,72 +32,72 @@ type InputArray = NumericArray | Collection<number> | AccessorArrayLike<number>;
 */
 interface Routine {
 	/**
-	* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to a strided array `y`.
+	* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to a strided array `w`.
 	*
 	* @param N - number of indexed elements
 	* @param alpha - scalar constant
 	* @param x - input array
 	* @param strideX - `x` stride length
-	* @param y - output array
-	* @param strideY - `y` stride length
-	* @returns `y`
+	* @param w - output array
+	* @param strideW - `w` stride length
+	* @returns `w`
 	*
 	* @example
 	* var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ];
-	* var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	* var w = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
 	*
-	* gwxsa( x.length, 5.0, x, 1, y, 1 );
-	* // y => [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
+	* gwxsa( x.length, 5.0, x, 1, w, 1 );
+	* // w => [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
 	*/
-	<T extends InputArray, U extends InputArray>( N: number, alpha: number, x: T, strideX: number, y: U, strideY: number ): U;
+	<T extends InputArray, U extends InputArray>( N: number, alpha: number, x: T, strideX: number, w: U, strideW: number ): U;
 
 	/**
-	* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to a strided array `y` using alternative indexing semantics.
+	* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to a strided array `w` using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param alpha - scalar constant
 	* @param x - input array
 	* @param strideX - `x` stride length
 	* @param offsetX - starting index for `x`
-	* @param y - output array
-	* @param strideY - `y` stride length
-	* @param offsetY - starting index for `y`
-	* @returns `y`
+	* @param w - output array
+	* @param strideW - `w` stride length
+	* @param offsetW - starting index for `w`
+	* @returns `w`
 	*
 	* @example
 	* var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ];
-	* var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	* var w = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
 	*
-	* gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, 0 );
-	* // y => [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
+	* gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, 0 );
+	* // w => [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
 	*/
-	ndarray<T extends InputArray, U extends InputArray>( N: number, alpha: number, x: T, strideX: number, offsetX: number, y: U, strideY: number, offsetY: number ): U;
+	ndarray<T extends InputArray, U extends InputArray>( N: number, alpha: number, x: T, strideX: number, offsetX: number, w: U, strideW: number, offsetW: number ): U;
 }
 
 /**
-* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to a strided array `y`.
+* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to a strided array `w`.
 *
 * @param N - number of indexed elements
 * @param alpha - scalar constant
 * @param x - input array
 * @param strideX - `x` stride length
-* @param y - output array
-* @param strideY - `y` stride length
-* @returns `y`
+* @param w - output array
+* @param strideW - `w` stride length
+* @returns `w`
 *
 * @example
 * var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ];
-* var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+* var w = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *
-* gwxsa( x.length, 5.0, x, 1, y, 1 );
-* // y => [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
+* gwxsa( x.length, 5.0, x, 1, w, 1 );
+* // w => [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
 *
 * @example
 * var x = [ -2.0, 1.0, 3.0, -5.0, 4.0, 0.0, -1.0, -3.0 ];
-* var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+* var w = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *
-* gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, 0 );
-* // y => [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
+* gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, 0 );
+* // w => [ -7.0, -4.0, -2.0, -10.0, -1.0, -5.0, -6.0, -8.0 ]
 */
 declare var gwxsa: Routine;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/docs/types/test.ts
@@ -25,70 +25,70 @@ import gwxsa = require( './index' );
 // The function returns a numeric array...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa( x.length, 5.0, x, 1, y, 1 ); // $ExpectType Float64Array
-	gwxsa( x.length, 5.0, new AccessorArray( x ), 1, new AccessorArray( y ), 1 ); // $ExpectType AccessorArray<number>
+	gwxsa( x.length, 5.0, x, 1, w, 1 ); // $ExpectType Float64Array
+	gwxsa( x.length, 5.0, new AccessorArray( x ), 1, new AccessorArray( w ), 1 ); // $ExpectType AccessorArray<number>
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa( '10', 5.0, x, 1, y, 1 ); // $ExpectError
-	gwxsa( true, 5.0, x, 1, y, 1 ); // $ExpectError
-	gwxsa( false, 5.0, x, 1, y, 1 ); // $ExpectError
-	gwxsa( null, 5.0, x, 1, y, 1 ); // $ExpectError
-	gwxsa( undefined, 5.0, x, 1, y, 1 ); // $ExpectError
-	gwxsa( [], 5.0, x, 1, y, 1 ); // $ExpectError
-	gwxsa( {}, 5.0, x, 1, y, 1 ); // $ExpectError
-	gwxsa( ( x: number ): number => x, 5.0, x, 1, y, 1 ); // $ExpectError
+	gwxsa( '10', 5.0, x, 1, w, 1 ); // $ExpectError
+	gwxsa( true, 5.0, x, 1, w, 1 ); // $ExpectError
+	gwxsa( false, 5.0, x, 1, w, 1 ); // $ExpectError
+	gwxsa( null, 5.0, x, 1, w, 1 ); // $ExpectError
+	gwxsa( undefined, 5.0, x, 1, w, 1 ); // $ExpectError
+	gwxsa( [], 5.0, x, 1, w, 1 ); // $ExpectError
+	gwxsa( {}, 5.0, x, 1, w, 1 ); // $ExpectError
+	gwxsa( ( x: number ): number => x, 5.0, x, 1, w, 1 ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a second argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa( x.length, '10', x, 1, y, 1 ); // $ExpectError
-	gwxsa( x.length, true, x, 1, y, 1 ); // $ExpectError
-	gwxsa( x.length, false, x, 1, y, 1 ); // $ExpectError
-	gwxsa( x.length, null, x, 1, y, 1 ); // $ExpectError
-	gwxsa( x.length, undefined, x, 1, y, 1 ); // $ExpectError
-	gwxsa( x.length, [], x, 1, y, 1 ); // $ExpectError
-	gwxsa( x.length, {}, x, 1, y, 1 ); // $ExpectError
-	gwxsa( x.length, ( x: number ): number => x, x, 1, y, 1 ); // $ExpectError
+	gwxsa( x.length, '10', x, 1, w, 1 ); // $ExpectError
+	gwxsa( x.length, true, x, 1, w, 1 ); // $ExpectError
+	gwxsa( x.length, false, x, 1, w, 1 ); // $ExpectError
+	gwxsa( x.length, null, x, 1, w, 1 ); // $ExpectError
+	gwxsa( x.length, undefined, x, 1, w, 1 ); // $ExpectError
+	gwxsa( x.length, [], x, 1, w, 1 ); // $ExpectError
+	gwxsa( x.length, {}, x, 1, w, 1 ); // $ExpectError
+	gwxsa( x.length, ( x: number ): number => x, x, 1, w, 1 ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a third argument which is not a numeric array...
 {
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa( 10, 5.0, 10, 1, y, 1 ); // $ExpectError
-	gwxsa( 10, 5.0, '10', 1, y, 1 ); // $ExpectError
-	gwxsa( 10, 5.0, true, 1, y, 1 ); // $ExpectError
-	gwxsa( 10, 5.0, false, 1, y, 1 ); // $ExpectError
-	gwxsa( 10, 5.0, null, 1, y, 1 ); // $ExpectError
-	gwxsa( 10, 5.0, undefined, 1, y, 1 ); // $ExpectError
-	gwxsa( 10, 5.0, [ '1' ], 1, y, 1 ); // $ExpectError
-	gwxsa( 10, 5.0, {}, 1, y, 1 ); // $ExpectError
-	gwxsa( 10, 5.0, ( x: number ): number => x, 1, y, 1 ); // $ExpectError
+	gwxsa( 10, 5.0, 10, 1, w, 1 ); // $ExpectError
+	gwxsa( 10, 5.0, '10', 1, w, 1 ); // $ExpectError
+	gwxsa( 10, 5.0, true, 1, w, 1 ); // $ExpectError
+	gwxsa( 10, 5.0, false, 1, w, 1 ); // $ExpectError
+	gwxsa( 10, 5.0, null, 1, w, 1 ); // $ExpectError
+	gwxsa( 10, 5.0, undefined, 1, w, 1 ); // $ExpectError
+	gwxsa( 10, 5.0, [ '1' ], 1, w, 1 ); // $ExpectError
+	gwxsa( 10, 5.0, {}, 1, w, 1 ); // $ExpectError
+	gwxsa( 10, 5.0, ( x: number ): number => x, 1, w, 1 ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a fourth argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa( x.length, 5.0, x, '10', y, 1 ); // $ExpectError
-	gwxsa( x.length, 5.0, x, true, y, 1 ); // $ExpectError
-	gwxsa( x.length, 5.0, x, false, y, 1 ); // $ExpectError
-	gwxsa( x.length, 5.0, x, null, y, 1 ); // $ExpectError
-	gwxsa( x.length, 5.0, x, undefined, y, 1 ); // $ExpectError
-	gwxsa( x.length, 5.0, x, [], y, 1 ); // $ExpectError
-	gwxsa( x.length, 5.0, x, {}, y, 1 ); // $ExpectError
-	gwxsa( x.length, 5.0, x, ( x: number ): number => x, y, 1 ); // $ExpectError
+	gwxsa( x.length, 5.0, x, '10', w, 1 ); // $ExpectError
+	gwxsa( x.length, 5.0, x, true, w, 1 ); // $ExpectError
+	gwxsa( x.length, 5.0, x, false, w, 1 ); // $ExpectError
+	gwxsa( x.length, 5.0, x, null, w, 1 ); // $ExpectError
+	gwxsa( x.length, 5.0, x, undefined, w, 1 ); // $ExpectError
+	gwxsa( x.length, 5.0, x, [], w, 1 ); // $ExpectError
+	gwxsa( x.length, 5.0, x, {}, w, 1 ); // $ExpectError
+	gwxsa( x.length, 5.0, x, ( x: number ): number => x, w, 1 ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a fifth argument which is not a numeric array...
@@ -109,114 +109,114 @@ import gwxsa = require( './index' );
 // The compiler throws an error if the function is provided a sixth argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa( x.length, 5.0, x, 1, y, '10' ); // $ExpectError
-	gwxsa( x.length, 5.0, x, 1, y, true ); // $ExpectError
-	gwxsa( x.length, 5.0, x, 1, y, false ); // $ExpectError
-	gwxsa( x.length, 5.0, x, 1, y, null ); // $ExpectError
-	gwxsa( x.length, 5.0, x, 1, y, undefined ); // $ExpectError
-	gwxsa( x.length, 5.0, x, 1, y, [] ); // $ExpectError
-	gwxsa( x.length, 5.0, x, 1, y, {} ); // $ExpectError
-	gwxsa( x.length, 5.0, x, 1, y, ( x: number ): number => x ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w, '10' ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w, true ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w, false ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w, null ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w, undefined ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w, [] ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w, {} ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w, ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
 	gwxsa(); // $ExpectError
 	gwxsa( x.length ); // $ExpectError
 	gwxsa( x.length, 5.0 ); // $ExpectError
 	gwxsa( x.length, 5.0, x ); // $ExpectError
 	gwxsa( x.length, 5.0, x, 1 ); // $ExpectError
-	gwxsa( x.length, 5.0, x, 1, y ); // $ExpectError
-	gwxsa( x.length, 5.0, x, 1, y, 1, 10 ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w ); // $ExpectError
+	gwxsa( x.length, 5.0, x, 1, w, 1, 10 ); // $ExpectError
 }
 
 // Attached to the main export is an `ndarray` method which returns a numeric array...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, 0 ); // $ExpectType Float64Array
-	gwxsa.ndarray( x.length, 5.0, new AccessorArray( x ), 1, 0, new AccessorArray( y ), 1, 0 ); // $ExpectType AccessorArray<number>
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, 0 ); // $ExpectType Float64Array
+	gwxsa.ndarray( x.length, 5.0, new AccessorArray( x ), 1, 0, new AccessorArray( w ), 1, 0 ); // $ExpectType AccessorArray<number>
 }
 
 // The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa.ndarray( '10', 5.0, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( true, 5.0, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( false, 5.0, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( null, 5.0, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( undefined, 5.0, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( [], 5.0, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( {}, 5.0, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( ( x: number ): number => x, 5.0, x, 1, 0, y, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( '10', 5.0, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( true, 5.0, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( false, 5.0, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( null, 5.0, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( undefined, 5.0, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( [], 5.0, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( {}, 5.0, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( ( x: number ): number => x, 5.0, x, 1, 0, w, 1, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `ndarray` method is provided a second argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa.ndarray( x.length, '10', x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, true, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, false, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, null, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, undefined, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, [], x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, {}, x, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, ( x: number ): number => x, x, 1, 0, y, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, '10', x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, true, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, false, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, null, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, undefined, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, [], x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, {}, x, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, ( x: number ): number => x, x, 1, 0, w, 1, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `ndarray` method is provided a third argument which is not a numeric array...
 {
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa.ndarray( 10, 5.0, 10, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( 10, 5.0, '10', 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( 10, 5.0, true, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( 10, 5.0, false, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( 10, 5.0, null, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( 10, 5.0, undefined, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( 10, 5.0, [ '1' ], 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( 10, 5.0, {}, 1, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( 10, 5.0, ( x: number ): number => x, 1, 0, y, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( 10, 5.0, 10, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( 10, 5.0, '10', 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( 10, 5.0, true, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( 10, 5.0, false, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( 10, 5.0, null, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( 10, 5.0, undefined, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( 10, 5.0, [ '1' ], 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( 10, 5.0, {}, 1, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( 10, 5.0, ( x: number ): number => x, 1, 0, w, 1, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa.ndarray( x.length, 5.0, x, '10', 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, true, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, false, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, null, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, undefined, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, [], 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, {}, 0, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, ( x: number ): number => x, 0, y, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, '10', 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, true, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, false, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, null, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, undefined, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, [], 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, {}, 0, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, ( x: number ): number => x, 0, w, 1, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `ndarray` method is provided a fifth argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa.ndarray( x.length, 5.0, x, 1, '10', y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, true, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, false, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, null, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, undefined, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, [], y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, {}, y, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, ( x: number ): number => x, y, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, '10', w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, true, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, false, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, null, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, undefined, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, [], w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, {}, w, 1, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, ( x: number ): number => x, w, 1, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `ndarray` method is provided a sixth argument which is not a numeric array...
@@ -237,37 +237,37 @@ import gwxsa = require( './index' );
 // The compiler throws an error if the `ndarray` method is provided a seventh argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, '10', 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, true, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, false, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, null, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, undefined, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, [], 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, {}, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, ( x: number ): number => x, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, '10', 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, true, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, false, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, null, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, undefined, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, [], 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, {}, 0 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, ( x: number ): number => x, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `ndarray` method is provided an eighth argument which is not a number...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, '10' ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, true ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, false ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, null ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, undefined ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, [] ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, {} ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, ( x: number ): number => x ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, '10' ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, true ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, false ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, null ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, undefined ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, [] ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, {} ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
 {
 	const x = new Float64Array( 10 );
-	const y = new Float64Array( 10 );
+	const w = new Float64Array( 10 );
 
 	gwxsa.ndarray(); // $ExpectError
 	gwxsa.ndarray( x.length ); // $ExpectError
@@ -275,7 +275,7 @@ import gwxsa = require( './index' );
 	gwxsa.ndarray( x.length, 5.0, x ); // $ExpectError
 	gwxsa.ndarray( x.length, 5.0, x, 1 ); // $ExpectError
 	gwxsa.ndarray( x.length, 5.0, x, 1, 0 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1 ); // $ExpectError
-	gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, 0, 10 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1 ); // $ExpectError
+	gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, 0, 10 ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/examples/index.js
@@ -26,10 +26,10 @@ var x = discreteUniform( 10, -100, 100, {
 });
 console.log( x );
 
-var y = discreteUniform( 10, -100, 100, {
+var w = discreteUniform( 10, -100, 100, {
 	'dtype': 'float64'
 });
-console.log( y );
+console.log( w );
 
-gwxsa( x.length, 5.0, x, 1, y, 1 );
-console.log( y );
+gwxsa( x.length, 5.0, x, 1, w, 1 );
+console.log( w );

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/lib/accessors.js
@@ -21,7 +21,7 @@
 // MAIN //
 
 /**
-* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `y`.
+* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `w`.
 *
 * @private
 * @param {PositiveInteger} N - number of indexed elements
@@ -31,11 +31,11 @@
 * @param {Array<Function>} x.accessors - array element accessors
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index
-* @param {Object} y - output array object
-* @param {Collection} y.data - output array data
-* @param {Array<Function>} y.accessors - array element accessors
-* @param {integer} strideY - `y` stride length
-* @param {NonNegativeInteger} offsetY - starting `y` index
+* @param {Object} w - output array object
+* @param {Collection} w.data - output array data
+* @param {Array<Function>} w.accessors - array element accessors
+* @param {integer} strideW - `w` stride length
+* @param {NonNegativeInteger} offsetW - starting `w` index
 * @returns {Object} output array object
 *
 * @example
@@ -43,36 +43,36 @@
 * var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 *
 * var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-* var y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+* var w = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *
-* gwxsa( x.length, 5.0, arraylike2object( toAccessorArray( x ) ), 1, 0, arraylike2object( toAccessorArray( y ) ), 1, 0 );
-* // y => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
+* gwxsa( x.length, 5.0, arraylike2object( toAccessorArray( x ) ), 1, 0, arraylike2object( toAccessorArray( w ) ), 1, 0 );
+* // w => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
 */
-function gwxsa( N, alpha, x, strideX, offsetX, y, strideY, offsetY ) {
+function gwxsa( N, alpha, x, strideX, offsetX, w, strideW, offsetW ) {
 	var xbuf;
-	var ybuf;
+	var wbuf;
 	var xget;
-	var yset;
+	var wset;
 	var ix;
-	var iy;
+	var iw;
 	var i;
 
 	// Cache references to array data:
 	xbuf = x.data;
-	ybuf = y.data;
+	wbuf = w.data;
 
 	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
-	yset = y.accessors[ 1 ];
+	wset = w.accessors[ 1 ];
 
 	ix = offsetX;
-	iy = offsetY;
+	iw = offsetW;
 	for ( i = 0; i < N; i++ ) {
-		yset( ybuf, iy, xget( xbuf, ix ) - alpha );
+		wset( wbuf, iw, xget( xbuf, ix ) - alpha );
 		ix += strideX;
-		iy += strideY;
+		iw += strideW;
 	}
-	return y;
+	return w;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Subtract a scalar constant from each element in a strided array `x` and assign the results to elements in a strided array `y`.
+* Subtract a scalar constant from each element in a strided array `x` and assign the results to elements in a strided array `w`.
 *
 * @module @stdlib/blas/ext/base/gwxsa
 *
@@ -27,19 +27,19 @@
 * var gwxsa = require( '@stdlib/blas/ext/base/gwxsa' );
 *
 * var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-* var y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+* var w = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *
-* gwxsa( x.length, 5.0, x, 1, y, 1 );
-* // y => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
+* gwxsa( x.length, 5.0, x, 1, w, 1 );
+* // w => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
 *
 * @example
 * var gwxsa = require( '@stdlib/blas/ext/base/gwxsa' );
 *
 * var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-* var y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+* var w = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *
-* gwxsa.ndarray( x.length, 5.0, x, 1, 0, y, 1, 0 );
-* // y => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
+* gwxsa.ndarray( x.length, 5.0, x, 1, 0, w, 1, 0 );
+* // w => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/lib/main.js
@@ -27,25 +27,25 @@ var ndarray = require( './ndarray.js' );
 // MAIN //
 
 /**
-* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `y`.
+* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `w`.
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} alpha - scalar constant
 * @param {NumericArray} x - input array
 * @param {integer} strideX - `x` stride length
-* @param {NumericArray} y - output array
-* @param {integer} strideY - `y` stride length
+* @param {NumericArray} w - output array
+* @param {integer} strideW - `w` stride length
 * @returns {NumericArray} output array
 *
 * @example
 * var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-* var y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+* var w = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *
-* gwxsa( x.length, 5.0, x, 1, y, 1 );
-* // y => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
+* gwxsa( x.length, 5.0, x, 1, w, 1 );
+* // w => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
 */
-function gwxsa( N, alpha, x, strideX, y, strideY ) {
-	return ndarray( N, alpha, x, strideX, stride2offset( N, strideX ), y, strideY, stride2offset( N, strideY ) );
+function gwxsa( N, alpha, x, strideX, w, strideW ) {
+	return ndarray( N, alpha, x, strideX, stride2offset( N, strideX ), w, strideW, stride2offset( N, strideW ) );
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/lib/ndarray.js
@@ -33,81 +33,81 @@ var M = 5;
 // MAIN //
 
 /**
-* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `y` using alternative indexing semantics.
+* Subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `w` using alternative indexing semantics.
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} alpha - scalar constant
 * @param {NumericArray} x - input array
 * @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index
-* @param {NumericArray} y - output array
-* @param {integer} strideY - `y` stride length
-* @param {NonNegativeInteger} offsetY - starting `y` index
+* @param {NumericArray} w - output array
+* @param {integer} strideW - `w` stride length
+* @param {NonNegativeInteger} offsetW - starting `w` index
 * @returns {NumericArray} output array
 *
 * @example
 * var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-* var y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+* var w = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *
-* gwxsa( x.length, 5.0, x, 1, 0, y, 1, 0 );
-* // y => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
+* gwxsa( x.length, 5.0, x, 1, 0, w, 1, 0 );
+* // w => [ -4.0, -3.0, -2.0, -1.0, 0.0 ]
 */
-function gwxsa( N, alpha, x, strideX, offsetX, y, strideY, offsetY ) {
+function gwxsa( N, alpha, x, strideX, offsetX, w, strideW, offsetW ) {
 	var ix;
-	var iy;
+	var iw;
 	var ox;
-	var oy;
+	var ow;
 	var m;
 	var i;
 
 	if ( N <= 0 ) {
-		return y;
+		return w;
 	}
-	// Fast path: when alpha = 0.0, delegate to gcopy (y = x)
+	// Fast path: when alpha = 0.0, delegate to gcopy (w = x)
 	if ( alpha === 0.0 ) {
-		return gcopy( N, x, strideX, offsetX, y, strideY, offsetY );
+		return gcopy( N, x, strideX, offsetX, w, strideW, offsetW );
 	}
 	ox = arraylike2object( x );
-	oy = arraylike2object( y );
-	if ( ox.accessorProtocol || oy.accessorProtocol ) {
-		accessors( N, alpha, ox, strideX, offsetX, oy, strideY, offsetY );
-		return y;
+	ow = arraylike2object( w );
+	if ( ox.accessorProtocol || ow.accessorProtocol ) {
+		accessors( N, alpha, ox, strideX, offsetX, ow, strideW, offsetW );
+		return w;
 	}
 	ix = offsetX;
-	iy = offsetY;
+	iw = offsetW;
 
 	// Use loop unrolling if both strides are equal to `1`...
-	if ( strideX === 1 && strideY === 1 ) {
+	if ( strideX === 1 && strideW === 1 ) {
 		m = N % M;
 
 		// If we have a remainder, run a clean-up loop...
 		if ( m > 0 ) {
 			for ( i = 0; i < m; i++ ) {
-				y[ iy ] = x[ ix ] - alpha;
+				w[ iw ] = x[ ix ] - alpha;
 				ix += strideX;
-				iy += strideY;
+				iw += strideW;
 			}
 		}
 		if ( N < M ) {
-			return y;
+			return w;
 		}
 		for ( i = m; i < N; i += M ) {
-			y[ iy ] = x[ ix ] - alpha;
-			y[ iy+1 ] = x[ ix+1 ] - alpha;
-			y[ iy+2 ] = x[ ix+2 ] - alpha;
-			y[ iy+3 ] = x[ ix+3 ] - alpha;
-			y[ iy+4 ] = x[ ix+4 ] - alpha;
+			w[ iw ] = x[ ix ] - alpha;
+			w[ iw+1 ] = x[ ix+1 ] - alpha;
+			w[ iw+2 ] = x[ ix+2 ] - alpha;
+			w[ iw+3 ] = x[ ix+3 ] - alpha;
+			w[ iw+4 ] = x[ ix+4 ] - alpha;
 			ix += M;
-			iy += M;
+			iw += M;
 		}
-		return y;
+		return w;
 	}
 	for ( i = 0; i < N; i++ ) {
-		y[ iy ] = x[ ix ] - alpha;
+		w[ iw ] = x[ ix ] - alpha;
 		ix += strideX;
-		iy += strideY;
+		iw += strideW;
 	}
-	return y;
+	return w;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/gwxsa",
   "version": "0.0.0",
-  "description": "Subtract a scalar constant from each element in a strided array `x` and assign the results to elements in a strided array `y`",
+  "description": "Subtract a scalar constant from each element in a strided array `x` and assign the results to elements in a strided array `w`",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/test/test.main.js
@@ -40,10 +40,10 @@ tape( 'the function has an arity of 6', function test( t ) {
 	t.end();
 });
 
-tape( 'the function subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `y`', function test( t ) {
+tape( 'the function subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `w`', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		4.0,
@@ -55,7 +55,7 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 		-5.0,
 		6.0
 	];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [
 		-1.0,
 		-3.0,
@@ -67,23 +67,23 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 		1.0
 	];
 
-	gwxsa( x.length, 5.0, x, 1, y, 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 5.0, x, 1, w, 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	x = [ 1.0, 2.0 ];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [ -4.0, -3.0 ];
 
-	gwxsa( x.length, 5.0, x, 1, y, 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 5.0, x, 1, w, 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'the function subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `y` (accessors)', function test( t ) {
+tape( 'the function subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `w` (accessors)', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		4.0,
@@ -95,7 +95,7 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 		-5.0,
 		6.0
 	];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [
 		-1.0,
 		-3.0,
@@ -107,15 +107,15 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 		1.0
 	];
 
-	gwxsa( x.length, 5.0, toAccessorArray( x ), 1, toAccessorArray( y ), 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 5.0, toAccessorArray( x ), 1, toAccessorArray( w ), 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	x = [ 1.0, 2.0 ];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [ -4.0, -3.0 ];
 
-	gwxsa( x.length, 5.0, toAccessorArray( x ), 1, toAccessorArray( y ), 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 5.0, toAccessorArray( x ), 1, toAccessorArray( w ), 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -123,52 +123,52 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 tape( 'the function returns a reference to the output array', function test( t ) {
 	var out;
 	var x;
-	var y;
+	var w;
 
 	x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-	y = zeros( x.length );
-	out = gwxsa( x.length, 3.0, x, 1, y, 1 );
+	w = zeros( x.length );
+	out = gwxsa( x.length, 3.0, x, 1, w, 1 );
 
-	t.strictEqual( out, y, 'same reference' );
+	t.strictEqual( out, w, 'same reference' );
 	t.end();
 });
 
-tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `y` unchanged', function test( t ) {
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `w` unchanged', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [ 3.0, -4.0, 1.0 ];
-	y = [ 4.0, 5.0, 6.0 ];
+	w = [ 4.0, 5.0, 6.0 ];
 	expected = [ 4.0, 5.0, 6.0 ];
 
-	gwxsa( 0, 5.0, x, 1, y, 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 0, 5.0, x, 1, w, 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
-	gwxsa( -4, 5.0, x, 1, y, 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( -4, 5.0, x, 1, w, 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'if `alpha` equals `0`, the function assigns `x` to `y`', function test( t ) {
+tape( 'if `alpha` equals `0`, the function assigns `x` to `w`', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ];
 
-	gwxsa( x.length, 0.0, x, 1, y, 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 0.0, x, 1, w, 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		1.0, // 0
@@ -177,22 +177,22 @@ tape( 'the function supports an `x` stride', function test( t ) {
 		4.0,
 		5.0  // 2
 	];
-	y = zeros( 3 );
+	w = zeros( 3 );
 	expected = [
 		-4.0, // 0
 		-2.0, // 1
 		0.0   // 2
 	];
 
-	gwxsa( 3, 5.0, x, 2, y, 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, x, 2, w, 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports an `x` stride (accessors)', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		1.0, // 0
@@ -201,25 +201,25 @@ tape( 'the function supports an `x` stride (accessors)', function test( t ) {
 		4.0,
 		5.0  // 2
 	];
-	y = zeros( 3 );
+	w = zeros( 3 );
 	expected = [
 		-4.0, // 0
 		-2.0, // 1
 		0.0   // 2
 	];
 
-	gwxsa( 3, 5.0, toAccessorArray( x ), 2, toAccessorArray( y ), 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, toAccessorArray( x ), 2, toAccessorArray( w ), 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the function supports a `y` stride', function test( t ) {
+tape( 'the function supports a `w` stride', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [ 1.0, 2.0, 3.0 ];
-	y = [
+	w = [
 		0.0, // 0
 		30.0,
 		0.0, // 1
@@ -234,18 +234,18 @@ tape( 'the function supports a `y` stride', function test( t ) {
 		-2.0  // 2
 	];
 
-	gwxsa( 3, 5.0, x, 1, y, 2 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, x, 1, w, 2 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the function supports a `y` stride (accessors)', function test( t ) {
+tape( 'the function supports a `w` stride (accessors)', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [ 1.0, 2.0, 3.0 ];
-	y = [
+	w = [
 		0.0, // 0
 		30.0,
 		0.0, // 1
@@ -260,15 +260,15 @@ tape( 'the function supports a `y` stride (accessors)', function test( t ) {
 		-2.0  // 2
 	];
 
-	gwxsa( 3, 5.0, toAccessorArray( x ), 1, toAccessorArray( y ), 2 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, toAccessorArray( x ), 1, toAccessorArray( w ), 2 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports negative strides', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		2.0,  // 2
@@ -277,7 +277,7 @@ tape( 'the function supports negative strides', function test( t ) {
 		7.0,
 		6.0   // 0
 	];
-	y = zeros( 5 );
+	w = zeros( 5 );
 	expected = [
 		-3.0,  // 2
 		0.0,
@@ -286,15 +286,15 @@ tape( 'the function supports negative strides', function test( t ) {
 		1.0    // 0
 	];
 
-	gwxsa( 3, 5.0, x, -2, y, -2 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, x, -2, w, -2 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports negative strides (accessors)', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		2.0,  // 2
@@ -303,7 +303,7 @@ tape( 'the function supports negative strides (accessors)', function test( t ) {
 		7.0,
 		6.0   // 0
 	];
-	y = zeros( 5 );
+	w = zeros( 5 );
 	expected = [
 		-3.0,  // 2
 		0.0,
@@ -312,17 +312,17 @@ tape( 'the function supports negative strides (accessors)', function test( t ) {
 		1.0    // 0
 	];
 
-	gwxsa( 3, 5.0, toAccessorArray( x ), -2, toAccessorArray( y ), -2 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, toAccessorArray( x ), -2, toAccessorArray( w ), -2 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports view offsets', function test( t ) {
 	var expected;
 	var x0;
-	var y0;
+	var w0;
 	var x1;
-	var y1;
+	var w1;
 
 	x0 = new Float64Array([
 		1.0,
@@ -331,7 +331,7 @@ tape( 'the function supports view offsets', function test( t ) {
 		4.0, // 2
 		5.0
 	]);
-	y0 = new Float64Array([
+	w0 = new Float64Array([
 		10.0,
 		10.0,
 		0.0, // 0
@@ -340,7 +340,7 @@ tape( 'the function supports view offsets', function test( t ) {
 	]);
 
 	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
-	y1 = new Float64Array( y0.buffer, y0.BYTES_PER_ELEMENT*2 );
+	w1 = new Float64Array( w0.buffer, w0.BYTES_PER_ELEMENT*2 );
 
 	expected = new Float64Array([
 		10.0,
@@ -350,8 +350,8 @@ tape( 'the function supports view offsets', function test( t ) {
 		-1.0  // 2
 	]);
 
-	gwxsa( 3, 5.0, x1, 1, y1, 1 );
-	t.deepEqual( y0, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, x1, 1, w1, 1 );
+	t.deepEqual( w0, expected, 'returns expected value' );
 	t.end();
 });
 
@@ -359,29 +359,29 @@ tape( 'if both strides are equal to `1`, the function efficiently subtracts a co
 	var expected;
 	var alpha;
 	var x;
-	var y;
+	var w;
 	var i;
 
 	alpha = 3.0;
 	x = new Float64Array( 100 );
-	y = new Float64Array( 100 );
+	w = new Float64Array( 100 );
 	expected = new Float64Array( x.length );
 	for ( i = 0; i < x.length; i++ ) {
 		x[ i ] = i;
 		expected[ i ] = x[ i ] - alpha;
 	}
-	gwxsa( x.length, alpha, x, 1, y, 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, alpha, x, 1, w, 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	x = new Float64Array( 240 );
-	y = new Float64Array( 240 );
+	w = new Float64Array( 240 );
 	expected = new Float64Array( x.length );
 	for ( i = 0; i < x.length; i++ ) {
 		x[ i ] = i;
 		expected[ i ] = x[ i ] - alpha;
 	}
-	gwxsa( x.length, alpha, x, 1, y, 1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, alpha, x, 1, w, 1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/test/test.ndarray.js
@@ -40,10 +40,10 @@ tape( 'the function has an arity of 8', function test( t ) {
 	t.end();
 });
 
-tape( 'the function subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `y`', function test( t ) {
+tape( 'the function subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `w`', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		4.0,
@@ -55,7 +55,7 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 		-5.0,
 		6.0
 	];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [
 		-1.0,
 		-3.0,
@@ -67,23 +67,23 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 		1.0
 	];
 
-	gwxsa( x.length, 5.0, x, 1, 0, y, 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 5.0, x, 1, 0, w, 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	x = [ 1.0, 2.0 ];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [ -4.0, -3.0 ];
 
-	gwxsa( x.length, 5.0, x, 1, 0, y, 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 5.0, x, 1, 0, w, 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'the function subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `y` (accessors)', function test( t ) {
+tape( 'the function subtracts a scalar constant from each element in a strided array `x` and assigns the results to elements in a strided array `w` (accessors)', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		4.0,
@@ -95,7 +95,7 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 		-5.0,
 		6.0
 	];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [
 		-1.0,  // 4.0 - 5.0
 		-3.0,  // 2.0 - 5.0
@@ -107,15 +107,15 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 		1.0    // 6.0 - 5.0
 	];
 
-	gwxsa( x.length, 5.0, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 5.0, toAccessorArray( x ), 1, 0, toAccessorArray( w ), 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	x = [ 1.0, 2.0 ];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [ -4.0, -3.0 ];
 
-	gwxsa( x.length, 5.0, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 5.0, toAccessorArray( x ), 1, 0, toAccessorArray( w ), 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -123,52 +123,52 @@ tape( 'the function subtracts a scalar constant from each element in a strided a
 tape( 'the function returns a reference to the output array', function test( t ) {
 	var out;
 	var x;
-	var y;
+	var w;
 
 	x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
-	y = zeros( x.length );
-	out = gwxsa( x.length, 3.0, x, 1, 0, y, 1, 0 );
+	w = zeros( x.length );
+	out = gwxsa( x.length, 3.0, x, 1, 0, w, 1, 0 );
 
-	t.strictEqual( out, y, 'same reference' );
+	t.strictEqual( out, w, 'same reference' );
 	t.end();
 });
 
-tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `y` unchanged', function test( t ) {
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `w` unchanged', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [ 3.0, -4.0, 1.0 ];
-	y = [ 4.0, 5.0, 6.0 ];
+	w = [ 4.0, 5.0, 6.0 ];
 	expected = [ 4.0, 5.0, 6.0 ];
 
-	gwxsa( 0, 5.0, x, 1, 0, y, 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 0, 5.0, x, 1, 0, w, 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
-	gwxsa( -4, 5.0, x, 1, 0, y, 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( -4, 5.0, x, 1, 0, w, 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	t.end();
 });
 
-tape( 'if `alpha` equals `0`, the function assigns `x` to `y`', function test( t ) {
+tape( 'if `alpha` equals `0`, the function assigns `x` to `w`', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ];
-	y = zeros( x.length );
+	w = zeros( x.length );
 	expected = [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ];
 
-	gwxsa( x.length, 0.0, x, 1, 0, y, 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, 0.0, x, 1, 0, w, 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports an `x` stride', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		2.0,  // 0
@@ -177,22 +177,22 @@ tape( 'the function supports an `x` stride', function test( t ) {
 		7.0,
 		6.0   // 2
 	];
-	y = zeros( 3 );
+	w = zeros( 3 );
 	expected = [
 		-3.0,  // 0
 		-10.0, // 1
 		1.0    // 2
 	];
 
-	gwxsa( 3, 5.0, x, 2, 0, y, 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, x, 2, 0, w, 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports an `x` stride (accessors)', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		2.0,  // 0
@@ -201,25 +201,25 @@ tape( 'the function supports an `x` stride (accessors)', function test( t ) {
 		7.0,
 		6.0   // 2
 	];
-	y = zeros( 3 );
+	w = zeros( 3 );
 	expected = [
 		-3.0,  // 0
 		-10.0, // 1
 		1.0    // 2
 	];
 
-	gwxsa( 3, 5.0, toAccessorArray( x ), 2, 0, toAccessorArray( y ), 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, toAccessorArray( x ), 2, 0, toAccessorArray( w ), 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the function supports a `y` stride', function test( t ) {
+tape( 'the function supports a `w` stride', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [ 1.0, 2.0, 3.0 ];
-	y = [
+	w = [
 		0.0, // 0
 		30.0,
 		0.0, // 1
@@ -234,18 +234,18 @@ tape( 'the function supports a `y` stride', function test( t ) {
 		-2.0  // 2
 	];
 
-	gwxsa( 3, 5.0, x, 1, 0, y, 2, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, x, 1, 0, w, 2, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the function supports a `y` stride (accessors)', function test( t ) {
+tape( 'the function supports a `w` stride (accessors)', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [ 1.0, 2.0, 3.0 ];
-	y = [
+	w = [
 		0.0, // 0
 		30.0,
 		0.0, // 1
@@ -260,15 +260,15 @@ tape( 'the function supports a `y` stride (accessors)', function test( t ) {
 		-2.0  // 2
 	];
 
-	gwxsa( 3, 5.0, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 2, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, toAccessorArray( x ), 1, 0, toAccessorArray( w ), 2, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports negative strides', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		2.0,  // 2
@@ -277,7 +277,7 @@ tape( 'the function supports negative strides', function test( t ) {
 		7.0,
 		6.0   // 0
 	];
-	y = [
+	w = [
 		0.0, // 2
 		0.0, // 1
 		0.0  // 0
@@ -288,15 +288,15 @@ tape( 'the function supports negative strides', function test( t ) {
 		1.0    // 0
 	];
 
-	gwxsa( 3, 5.0, x, -2, x.length-1, y, -1, y.length-1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, x, -2, x.length-1, w, -1, w.length-1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports negative strides (accessors)', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		2.0,  // 2
@@ -305,7 +305,7 @@ tape( 'the function supports negative strides (accessors)', function test( t ) {
 		7.0,
 		6.0   // 0
 	];
-	y = [
+	w = [
 		0.0, // 2
 		0.0, // 1
 		0.0  // 0
@@ -316,15 +316,15 @@ tape( 'the function supports negative strides (accessors)', function test( t ) {
 		1.0    // 0
 	];
 
-	gwxsa( 3, 5.0, toAccessorArray( x ), -2, x.length-1, toAccessorArray( y ), -1, y.length-1 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, toAccessorArray( x ), -2, x.length-1, toAccessorArray( w ), -1, w.length-1 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports an `x` offset', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [
 		1.0,
@@ -333,7 +333,7 @@ tape( 'the function supports an `x` offset', function test( t ) {
 		4.0, // 2
 		5.0
 	];
-	y = zeros( 5 );
+	w = zeros( 5 );
 	expected = [
 		-3.0, // 0
 		-2.0, // 1
@@ -342,18 +342,18 @@ tape( 'the function supports an `x` offset', function test( t ) {
 		0.0
 	];
 
-	gwxsa( 3, 5.0, x, 1, 1, y, 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, x, 1, 1, w, 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the function supports a `y` offset', function test( t ) {
+tape( 'the function supports a `w` offset', function test( t ) {
 	var expected;
 	var x;
-	var y;
+	var w;
 
 	x = [ 1.0, 2.0, 3.0 ];
-	y = [
+	w = [
 		0.0,
 		0.0,
 		0.0, // 0
@@ -368,8 +368,8 @@ tape( 'the function supports a `y` offset', function test( t ) {
 		-2.0  // 2
 	];
 
-	gwxsa( 3, 5.0, x, 1, 0, y, 1, 2 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( 3, 5.0, x, 1, 0, w, 1, 2 );
+	t.deepEqual( w, expected, 'returns expected value' );
 	t.end();
 });
 
@@ -377,29 +377,29 @@ tape( 'if both strides are equal to `1`, the function efficiently subtracts a co
 	var expected;
 	var alpha;
 	var x;
-	var y;
+	var w;
 	var i;
 
 	alpha = 3.0;
 	x = new Float64Array( 100 );
-	y = new Float64Array( 100 );
+	w = new Float64Array( 100 );
 	expected = new Float64Array( x.length );
 	for ( i = 0; i < x.length; i++ ) {
 		x[ i ] = i;
 		expected[ i ] = x[ i ] - alpha;
 	}
-	gwxsa( x.length, alpha, x, 1, 0, y, 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, alpha, x, 1, 0, w, 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	x = new Float64Array( 240 );
-	y = new Float64Array( 240 );
+	w = new Float64Array( 240 );
 	expected = new Float64Array( x.length );
 	for ( i = 0; i < x.length; i++ ) {
 		x[ i ] = i;
 		expected[ i ] = x[ i ] - alpha;
 	}
-	gwxsa( x.length, alpha, x, 1, 0, y, 1, 0 );
-	t.deepEqual( y, expected, 'returns expected value' );
+	gwxsa( x.length, alpha, x, 1, 0, w, 1, 0 );
+	t.deepEqual( w, expected, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-   renames output array parameter from `y` to `w` in `blas/ext/base/gwxsa`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- https://github.com/stdlib-js/metr-issue-tracker/issues/618

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used Cursor+VS Code code-generation tools to help assist with the feature.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md