### PR TITLE
feat: add TypeScript declarations for `blas/base/igamax`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/igamax/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/igamax/docs/types/index.d.ts
@@ -1,0 +1,93 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { NumericArray, Collection, AccessorArrayLike } from '@stdlib/types/array';
+
+/**
+* Input array.
+*/
+type InputArray = NumericArray | Collection<number> | AccessorArrayLike<number>;
+
+/**
+* Interface describing `igamax`.
+*/
+interface Routine {
+	/**
+	* Finds the index of the first element having the maximum absolute value.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - stride length for `x`
+	* @returns index value
+	*
+	* @example
+	* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+	*
+	* var idx = igamax( x.length, x, 1 );
+	* // returns 4
+	*/
+	( N: number, x: InputArray, strideX: number ): number;
+
+	/**
+	* Finds the index of the first element having the maximum absolute value using alternative indexing semantics.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - stride length for `x`
+	* @param offsetX - starting index for `x`
+	* @returns index value
+	*
+	* @example
+	* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+	*
+	* var idx = igamax.ndarray( x.length, x, 1, 0 );
+	* // returns 4
+	*/
+	ndarray( N: number, x: InputArray, strideX: number, offsetX: number ): number;
+}
+
+/**
+* Finds the index of the first element having the maximum absolute value.
+*
+* @param N - number of indexed elements
+* @param x - input array
+* @param strideX - stride length for `x`
+* @returns index value
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+*
+* var idx = igamax( x.length, x, 1 );
+* // returns 4
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+*
+* var idx = igamax.ndarray( x.length, x, 1, 0 );
+* // returns 4
+*/
+declare var igamax: Routine;
+
+
+// EXPORTS //
+
+export = igamax;

--- a/lib/node_modules/@stdlib/blas/base/igamax/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/base/igamax/docs/types/test.ts
@@ -1,0 +1,160 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import AccessorArray = require( '@stdlib/array/base/accessor' );
+import igamax = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	const x = new Float64Array( 10 );
+
+	igamax( x.length, x, 1 ); // $ExpectType number
+	igamax( x.length, new AccessorArray( x ), 1 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	igamax( '10', x, 1 ); // $ExpectError
+	igamax( true, x, 1 ); // $ExpectError
+	igamax( false, x, 1 ); // $ExpectError
+	igamax( null, x, 1 ); // $ExpectError
+	igamax( undefined, x, 1 ); // $ExpectError
+	igamax( [], x, 1 ); // $ExpectError
+	igamax( {}, x, 1 ); // $ExpectError
+	igamax( ( x: number ): number => x, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a numeric array...
+{
+	const x = new Float64Array( 10 );
+
+	igamax( x.length, 10, 1 ); // $ExpectError
+	igamax( x.length, '10', 1 ); // $ExpectError
+	igamax( x.length, true, 1 ); // $ExpectError
+	igamax( x.length, false, 1 ); // $ExpectError
+	igamax( x.length, null, 1 ); // $ExpectError
+	igamax( x.length, undefined, 1 ); // $ExpectError
+	igamax( x.length, [ '1' ], 1 ); // $ExpectError
+	igamax( x.length, {}, 1 ); // $ExpectError
+	igamax( x.length, ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	igamax( x.length, x, '10' ); // $ExpectError
+	igamax( x.length, x, true ); // $ExpectError
+	igamax( x.length, x, false ); // $ExpectError
+	igamax( x.length, x, null ); // $ExpectError
+	igamax( x.length, x, undefined ); // $ExpectError
+	igamax( x.length, x, [] ); // $ExpectError
+	igamax( x.length, x, {} ); // $ExpectError
+	igamax( x.length, x, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+
+	igamax(); // $ExpectError
+	igamax( x.length ); // $ExpectError
+	igamax( x.length, x ); // $ExpectError
+	igamax( x.length, x, 1, 10 ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a number...
+{
+	const x = new Float64Array( 10 );
+
+	igamax.ndarray( x.length, x, 1, 0 ); // $ExpectType number
+	igamax.ndarray( x.length, new AccessorArray( x ), 1, 0 ); // $ExpectType number
+}
+
+// The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	igamax.ndarray( '10', x, 1, 0 ); // $ExpectError
+	igamax.ndarray( true, x, 1, 0 ); // $ExpectError
+	igamax.ndarray( false, x, 1, 0 ); // $ExpectError
+	igamax.ndarray( null, x, 1, 0 ); // $ExpectError
+	igamax.ndarray( undefined, x, 1, 0 ); // $ExpectError
+	igamax.ndarray( [], x, 1, 0 ); // $ExpectError
+	igamax.ndarray( {}, x, 1, 0 ); // $ExpectError
+	igamax.ndarray( ( x: number ): number => x, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a second argument which is not a numeric array...
+{
+	const x = new Float64Array( 10 );
+
+	igamax.ndarray( x.length, 10, 1, 0 ); // $ExpectError
+	igamax.ndarray( x.length, '10', 1, 0 ); // $ExpectError
+	igamax.ndarray( x.length, true, 1, 0 ); // $ExpectError
+	igamax.ndarray( x.length, false, 1, 0 ); // $ExpectError
+	igamax.ndarray( x.length, null, 1, 0 ); // $ExpectError
+	igamax.ndarray( x.length, undefined, 1, 0 ); // $ExpectError
+	igamax.ndarray( x.length, [ '1' ], 1, 0 ); // $ExpectError
+	igamax.ndarray( x.length, {}, 1, 0 ); // $ExpectError
+	igamax.ndarray( x.length, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	igamax.ndarray( x.length, x, '10', 0 ); // $ExpectError
+	igamax.ndarray( x.length, x, true, 0 ); // $ExpectError
+	igamax.ndarray( x.length, x, false, 0 ); // $ExpectError
+	igamax.ndarray( x.length, x, null, 0 ); // $ExpectError
+	igamax.ndarray( x.length, x, undefined, 0 ); // $ExpectError
+	igamax.ndarray( x.length, x, [], 0 ); // $ExpectError
+	igamax.ndarray( x.length, x, {}, 0 ); // $ExpectError
+	igamax.ndarray( x.length, x, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+
+	igamax.ndarray( x.length, x, 1, '10' ); // $ExpectError
+	igamax.ndarray( x.length, x, 1, true ); // $ExpectError
+	igamax.ndarray( x.length, x, 1, false ); // $ExpectError
+	igamax.ndarray( x.length, x, 1, null ); // $ExpectError
+	igamax.ndarray( x.length, x, 1, undefined ); // $ExpectError
+	igamax.ndarray( x.length, x, 1, [] ); // $ExpectError
+	igamax.ndarray( x.length, x, 1, {} ); // $ExpectError
+	igamax.ndarray( x.length, x, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+
+	igamax.ndarray(); // $ExpectError
+	igamax.ndarray( x.length ); // $ExpectError
+	igamax.ndarray( x.length, x ); // $ExpectError
+	igamax.ndarray( x.length, x, 1 ); // $ExpectError
+	igamax.ndarray( x.length, x, 1, 0, 10 ); // $ExpectError
+}


### PR DESCRIPTION
## Description

Adds the missing `docs/types/index.d.ts` and `docs/types/test.ts` files for `@stdlib/blas/base/igamax`. The package's `package.json` already declares `"types": "./docs/types"` — pointing at a directory that did not exist. This patch makes that pointer resolve.

### Namespace summary

- **Target:** `@stdlib/blas/base`
- **Members:** 110 total; 107 voted (3 namespace-aggregator packages — `assert`, `ndarray`, `wasm` — excluded).
- **Features extracted:** file tree, `package.json` shape (top-level keys, `scripts`, `keywords`), `manifest.json` shape, README H2/H3 sections, test/benchmark/example file naming, plus a fast cross-package scan for error-construction patterns in `lib/main.js`.
- **Features with a clear majority (≥75%):** top-level `package.json` keys (100%), `manifest.json` shape where present (100%), `lib/`, `test/`, `examples/`, `docs/` directories (100%), `benchmark/` directory (98%), `docs/types/` directory (99%), `docs/repl.txt` (98%), `test/test.js` (100%), `examples/index.js` (100%), `benchmark/benchmark.js` (97%), README `## Usage` / `## Examples` (100% / 98%), and error-construction (the 4 main files that throw all use `format`).
- **Features without a clear majority (excluded):** `## Notes` (79% — many small enum/resolver utilities legitimately do not need notes), `binding.gyp` / `include.gypi` / `src/` / native-bindings cluster (~47-53% — split intentionally between native and pure-JS implementations), `## C APIs` (64%), `## See Also` (23%), `## References` (7%).

### `blas/base/igamax`

`igamax` is the lone outlier on the `docs/types/` feature (106/107 = 99% conformance). The package's own `package.json` declares `"types": "./docs/types"`, but the directory does not exist; every other generic `g*` sibling (`gasum`, `gaxpy`, `gcopy`, `gdot`, `ggemm`, `ggemv`, `gger`, `gnrm2`, `gscal`, `gswap`, `gsyr`) ships one. The added `index.d.ts` adopts `gasum`'s generic input typing — `NumericArray | Collection<number> | AccessorArrayLike<number>` — because `igamax` accepts any numeric array. The signature surface mirrors the existing `idamax` / `isamax` declarations (the closest `i*amax` siblings): a `Routine` interface with the 3-arg main overload and the 4-arg `.ndarray` overload, both returning `number`. The `test.ts` exercises both overloads against `Float64Array` and `AccessorArray`, with `$ExpectError` coverage for argument-type and arity mismatches matching the sibling conventions.

### Validation

Checked:

- Structural feature extraction across all 110 members (3 aggregators excluded).
- Per-package agent extraction was scoped to error-construction patterns rather than full signature/JSDoc shape, since the 100% `format`-conformance signal made the wider semantic sweep unnecessary.
- Three-agent drift validation on the surviving candidate. Both reviewers (cross-reference, structural) returned `confirmed-drift`.
- Pre-validation open-PR collision check via GitHub MCP — no open PRs touch `blas/base/igamax`.
- No tests or examples in `blas/base/igamax/` reference the absence of `docs/types/`; the README's documented signatures (`igamax( N, x, strideX )` and `igamax.ndarray( N, x, strideX, offsetX )`, both returning an index) match the declarations exactly.

Deliberately excluded:

- `blas/base/drotg` and `blas/base/srotg` (missing `## Examples` H2 inside the `<section class="examples">` wrapper) — dropped on open-PR collision (PRs #9628, #9592, #2264, #9537, #987 all touch these packages).
- `blas/base/dgemm`, `sgemm`, `ggemm` (missing `benchmark/benchmark.js`) — intentional deviation: each ships ~40 parameter-variant benchmarks instead of a canonical entry; the structure reflects matrix-matrix multiply's parameter space, not drift.
- `## Notes` outliers (22 packages, most enum/resolve utilities) — feature falls just above the 75% threshold and the outlier cohort is a coherent semantic subset, not drift.

## Related Issues

None.

## Questions

No.

## Other

Generated by an automated cross-package drift-detection run (random-pick namespace selection; full per-feature distribution and dropped-candidate log live in the local report). The diff is mechanical: two new files, no edits to existing code, no observable behavior change.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift-detection routine. The drift was identified by structural feature extraction across `@stdlib/blas/base/`; the proposed fix was validated by parallel cross-reference and structural-review subagents (both `confirmed-drift`); the `.d.ts` and `.ts` content was generated by modeling on the existing `blas/base/gasum/docs/types/` (generic input typing) and `blas/base/idamax/docs/types/` (index-returning `Routine` interface) siblings.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01W5bvscmSv8wZVLqMWgVJga)_