### PR TITLE
chore: address follow-up review findings for commits merged to `develop` on 2026-05-31

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/docs/types/index.d.ts
@@ -677,7 +677,7 @@ interface Namespace {
 	* var x = new Float64Vector( [ 1.0, -2.0, 3.0, -4.0, 5.0 ] );
 	*
 	* var y = ns.idamax( [ x ] );
-	* // returns 4.0
+	* // returns 4
 	*/
 	idamax: typeof idamax;
 
@@ -721,7 +721,7 @@ interface Namespace {
 	* var x = new Float32Vector( [ 1.0, -2.0, 3.0, -4.0, 5.0 ] );
 	*
 	* var y = ns.isamax( [ x ] );
-	* // returns 4.0
+	* // returns 4
 	*/
 	isamax: typeof isamax;
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/igamax/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/igamax/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* BLAS level 1 routine to Find the index of the first element having the maximum absolute value for all elements in a one-dimensional ndarray.
+* BLAS level 1 routine to find the index of the first element having the maximum absolute value for all elements in a one-dimensional ndarray.
 *
 * @module @stdlib/blas/base/ndarray/igamax
 *

--- a/lib/node_modules/@stdlib/blas/base/ndarray/isamax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/isamax/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/uniform' );
-var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -62,12 +62,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = isamax( [ x ] );
-			if ( isnanf( z ) ) {
+			if ( isnan( z ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnanf( z ) ) {
+		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/ndarray/isamax/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/isamax/docs/types/index.d.ts
@@ -40,7 +40,7 @@ import { float32ndarray } from '@stdlib/types/ndarray';
 * var x = new Float32Vector( [ 1.0, -2.0, 3.0, -4.0, 5.0 ] );
 *
 * var y = isamax( [ x ] );
-* // returns 4.0
+* // returns 4
 */
 declare function isamax( arrays: [ float32ndarray ] ): number;
 

--- a/lib/node_modules/@stdlib/fft/base/fftpack/rffti/lib/main.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/rffti/lib/main.js
@@ -158,7 +158,7 @@ function rffti( N, workspace, strideW, offsetW ) {
 
 	// When a sub-sequence is a single data point, the FFT is the identity, so no initialization necessary...
 	if ( N === 1 ) {
-		return;
+		return workspace;
 	}
 	// Resolve the starting indices for storing twiddle factors and factorization results:
 	offsetT = offsetW + ( N*strideW ); // index offset for twiddle factors


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between `afb44ae` (2026-05-31 15:54 -0500) and `d2f751e` (2026-06-01 04:32 -0700).

## Description

This pull request:

-   Fixes `rffti` to return the workspace array when `N === 1` (62ee5f8, `lib/node_modules/@stdlib/fft/base/fftpack/rffti/lib/main.js`); the early-exit branch silently returned `undefined`, violating the documented return contract and breaking reference equality with the caller's workspace.
-   Corrects the capitalization of "Find" to "find" in the module JSDoc description of `lib/node_modules/@stdlib/blas/base/ndarray/igamax/lib/index.js` (1d9f9d1) to match every other BLAS ndarray package.
-   Replaces `is-nanf` with `is-nan` in `lib/node_modules/@stdlib/blas/base/ndarray/isamax/benchmark/benchmark.js` (4302ca2); `isamax` returns an integer index, and the sibling `igamax` benchmark already uses `is-nan`.
-   Drops the spurious `.0` from the `isamax` JSDoc example in `lib/node_modules/@stdlib/blas/base/ndarray/isamax/docs/types/index.d.ts` (4302ca2); the return value is an integer index.
-   Drops the spurious `.0` from the `idamax` and `isamax` JSDoc examples in `lib/node_modules/@stdlib/blas/base/ndarray/docs/types/index.d.ts` (52ca9a6); both routines return an integer index, consistent with the `igamax` entry already in the same file.

## Related Issues

No.

## Questions

No.

## Other

Validation audit:

-   Checked: stdlib code style compliance (`docs/style-guides/`) and bug scan across the union diff of all first-parent commits merged to `develop` in the trailing 24-hour window.
-   Deliberately excluded: subjective concerns, possible/might-be issues, anything requiring context outside the diff to validate, and the pre-existing `// returns 4.0` in `lib/node_modules/@stdlib/blas/base/ndarray/idamax/docs/types/index.d.ts` (out of window).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code: a sonnet summarizer agent extracted author intent for the 36 commits in window, two sonnet style-compliance agents and two opus bug-scan agents reviewed the union diff in parallel, and findings reported by a single agent were independently re-verified against the diff before being applied. Only high-signal issues survived filtering. A maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_018eHkHD7fNZ8mHBcbeppDGB)_