### PR TITLE
docs: align `package.json` descriptions with imperative-mood convention

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/cgemv/package.json
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/base/cgemv",
   "version": "0.0.0",
-  "description": "Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y` or `y = α*A^H*x + β*y`.",
+  "description": "Perform one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y` or `y = α*A^H*x + β*y`.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/ndarray/with/package.json
+++ b/lib/node_modules/@stdlib/ndarray/with/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/ndarray/with",
   "version": "0.0.0",
-  "description": "Returns a new ndarray with the element at a specified index replaced by a provided value.",
+  "description": "Return a new ndarray with the element at a specified index replaced by a provided value.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/string/base/distances/levenshtein/package.json
+++ b/lib/node_modules/@stdlib/string/base/distances/levenshtein/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/string/base/distances/levenshtein",
   "version": "0.0.0",
-  "description": "Calculates the Levenshtein (edit) distance between two strings.",
+  "description": "Calculate the Levenshtein (edit) distance between two strings.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between `afb44ae` (2026-05-31 15:54 -0500) and `d2f751e` (2026-06-01 04:32 -0700) to sibling packages exhibiting the same defect.

- `docs: fix descriptions` (`fa63e96`): the `package.json` `description` field began with a third-person singular verb form ("Finds the…") rather than the imperative form ("Find the…") used in the package's own README intro and in the overwhelming majority (1700+) of stdlib `package.json` descriptions. The same defect remains in three sibling packages, each of which already uses the imperative form in its README and in adjacent sibling `package.json` descriptions:
  - `blas/base/cgemv` ("Performs" → "Perform"; siblings `sgemv`, `dgemv`, `sgemm`, `dgemm` all use "Perform")
  - `ndarray/with` ("Returns" → "Return"; siblings `at`, `copy`, `concat`, `fill`, `filter`, `slice` all use the imperative form)
  - `string/base/distances/levenshtein` ("Calculates" → "Calculate"; sibling `string/base/distances/hamming` uses "Calculate the Hamming distance…")

## Related Issues

No.

## Questions

No.

## Other

**Validation.** Source-commit window enumerated with `git log --since="24 hours ago" --first-parent develop` (36 commits). Candidates filtered to fixes with a concretely specifiable propagation signature: `da8dc3bf` (multidimensional `mapNd` callback `index: number` → `indices: Array<number>`), `fa63e96` (this), `afb44ae0` (`quantile` C API heading parameter name), and `0e3aa564` (`t.deepEqual` on complex arrays). Three of the four patterns yielded zero remaining candidates after sibling-package search — the original commits had already covered every site within scope. The fourth pattern (`fa63e96`) yielded six third-person `package.json` description outliers stdlib-wide; three were rejected because their package's own README also uses third-person form, so changing only `package.json` would create internal inconsistency.

Each surviving site was confirmed by two independent opus validation agents (defect present, fix is a direct analog of `fa63e96`, README and sibling-package convention both imperative) and a sonnet style-consistency agent (patch preserves indentation, quote style, and trailing comma; result reads grammatically as an imperative sentence).

**Deliberately excluded:**
- `math/base/special/hyp2f1` ("Evaluates"), `math/base/special/gammasgnf` ("Computes"), `object/none-own-by` ("Tests") — each package's README intro also uses the third-person form, so changing only `package.json` would introduce a new mismatch. Fold into a future README+`package.json` cleanup rather than this propagation.
- Capitalized JSDoc `@returns` descriptions and quantile-README C API heading subpatterns — zero remaining matches under the in-scope search across `lib/node_modules/@stdlib/`.
- Open follow-up PR #12430 (same source-commit window) already covers `igamax`, `isamax`, `idamax`, and `rffti` follow-ups; this PR does not touch any file it modifies.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated routine that scans recent fixes merged to `develop` and propagates equivalent corrections to sibling packages. A sonnet agent specified each source commit's fix pattern; structural searches enumerated candidate sites; two independent opus validators and a sonnet style-consistency agent reviewed each site against the target file and sibling-package conventions. Only sites confirmed by every agent were applied. A maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwvpuuQSs99MRKrmCPh8sS)_