### PR TITLE
chore: fix JavaScript lint errors (issue #12434)

### DIFF
--- a/lib/node_modules/@stdlib/utils/parallel/test/test.node.worker.js
+++ b/lib/node_modules/@stdlib/utils/parallel/test/test.node.worker.js
@@ -26,13 +26,17 @@ var proxyquire = require( 'proxyquire' );
 
 // TESTS //
 
-tape( 'the file runs a worker script', function test( t ) {
+tape( 'main export is an entry-point script that runs a worker process', function test( t ) {
+	var called = false;
+
+	t.ok( true, __filename );
+
 	proxyquire( './../lib/node/worker/index.js', {
-		'./worker.js': done
+		'./worker.js': function onCall() {
+			called = true;
+		}
 	});
-	function done() {
-		t.ok( true, __filename );
-		t.ok( true, 'runs worker script' );
-		t.end();
-	}
+
+	t.strictEqual( called, true, 'requiring the file invokes the worker' );
+	t.end();
 });


### PR DESCRIPTION
Resolves #12434.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes the `stdlib/first-unit-test` lint error in `lib/node_modules/@stdlib/utils/parallel/test/test.node.worker.js` reported in the automated lint run linked from the issue.

The test file's first (and only) `tape()` call had the title `'the file runs a worker script'`. The `stdlib/first-unit-test` rule requires the first test in a test file to start with `'main export is'` (or `'command-line interface'` for CLI test files), and additionally requires the first non-variable statement in the test body to be `t.ok( true, __filename );`.

The file under test, `lib/node/worker/index.js`, is an entry-point script that simply requires `./worker.js` and invokes the exported function at module-load time. It does not assign `module.exports`, so the test cannot meaningfully assert a typeof shape on the export. Instead, the test asserts the script's load-time side effect: requiring it invokes the worker.

The new test:

-   Has a title starting with `'main export is'`, satisfying the lint rule's name check.
-   Has `t.ok( true, __filename );` as the first non-variable statement, satisfying the rule's structural check.
-   Captures the same behavior as the original test (a mocked `./worker.js` is invoked when the entry-point file is loaded), restructured so the side-effect assertion runs after `proxyquire()` returns rather than from inside the mock callback.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   resolves #12434

## Questions

> Any questions for reviewers of this pull request?

The script under test has no `module.exports`, so the new test asserts a side effect rather than a typeof on a named export. If a different convention exists for first-unit tests of entry-point scripts in stdlib (e.g., a project-wide pattern I missed while reading sibling test files in this directory), happy to follow it instead.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Rule source consulted: `lib/node_modules/@stdlib/_tools/eslint/rules/first-unit-test/lib/main.js`. The rule checks (1) the first `tape()` call's title starts with `'main export is'`, and (2) after skipping leading `VariableDeclaration` nodes, the first remaining statement is `t.ok( true, __filename );` with exactly those two arguments.

Sibling tests in the same directory that demonstrate the canonical pattern for function exports: `test.node.worker.close.js`, `test.node.worker.exec.js`, `test.node.worker.spawn.js`, `test.node.worker.worker.js`. The entry-point-script case is the only one in this directory without an obvious `typeof === 'function'` assertion target.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Truffle (Claude Opus 4.7 running on the Phantom platform, github.com/truffle-dev) working from the rule source at `lib/node_modules/@stdlib/_tools/eslint/rules/first-unit-test/lib/main.js` and the sibling test files in the same directory. The reasoning and test structure are documented in the body above so a reviewer can verify the fix against the rule code rather than the example output.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
