### PR TITLE
refactor: align iterator-validation error construction in three `@stdlib/iter` packages

### DIFF
--- a/lib/node_modules/@stdlib/iter/dedupe-by/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/dedupe-by/lib/main.js
@@ -73,7 +73,7 @@ function iterDedupeBy( iterator, limit, clbk ) { // eslint-disable-line no-unuse
 	var N;
 	var i;
 	if ( !isIteratorLike( iterator ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must an iterator protocol-compliant object. Value: `%s`.', iterator ) );
+		throw new TypeError( format( 'invalid argument. First argument must be an iterator protocol-compliant object. Value: `%s`.', iterator ) );
 	}
 	fcn = arguments[ arguments.length-1 ];
 	if ( !isFunction( fcn ) ) {

--- a/lib/node_modules/@stdlib/iter/dedupe/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/dedupe/lib/main.js
@@ -63,7 +63,7 @@ function iterDedupe( iterator, limit ) {
 	var FLG;
 	var N;
 	if ( !isIteratorLike( iterator ) ) {
-		throw new TypeError( format( 'invalid argument. First argument must an iterator protocol-compliant object. Value: `%s`.', iterator ) );
+		throw new TypeError( format( 'invalid argument. First argument must be an iterator protocol-compliant object. Value: `%s`.', iterator ) );
 	}
 	if ( arguments.length > 1 ) {
 		if ( !isPositiveInteger( limit ) ) {

--- a/lib/node_modules/@stdlib/iter/intersection-by-hash/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/intersection-by-hash/lib/main.js
@@ -199,7 +199,7 @@ function iterIntersectionByHash() {
 	}
 	if ( arguments.length > niter+2 ) {
 		// Addresses the case: fcn( it, it, null, it, it, hashFcn )
-		throw new TypeError( 'invalid argument. Iterator arguments must be iterator protocol-compliant objects.' );
+		throw new TypeError( format( 'invalid argument. Must provide an iterator protocol-compliant object. Argument: `%u`. Value: `%s`.', i, arguments[ i ] ) );
 	}
 	hashFcn = arguments[ i ];
 	if ( !isFunction( hashFcn ) ) {


### PR DESCRIPTION
## Description

This pull request normalizes three pre-existing drifts in `@stdlib/iter` that were uncovered by an automated cross-package convention audit of the namespace:

-   In `@stdlib/iter/intersection-by-hash`, the "extra trailing arguments" branch threw a plain-string `TypeError`, despite every other variadic-iterator package in the namespace (`concat`, `union`, `intersection`, `mapn`) using a `format()`-based message that surfaces the offending argument index and value. Each commit corresponds to one outlier package.
-   In `@stdlib/iter/dedupe` and `@stdlib/iter/dedupe-by`, the first-argument validation message read "First argument must an iterator protocol-compliant object" (missing "be"); 24 packages stdlib-wide use the grammatically correct phrasing, and only these two carried the typo.

No public signatures change, no test fixtures are touched, and no behaviour observable beyond error-message text shifts. Tests in this namespace assert `t.throws(fn, TypeError, msg)`, which is a class-only check.

### Namespace summary

-   Members analysed: 65 (none autogenerated)
-   Majority threshold: ⌈65 × 0.75⌉ = 49
-   Features with a clear majority: file tree, `package.json` top-level keys, `package.json` keywords, `test/` filenames, `benchmark/` filenames, `examples/` filenames, README `Usage` / `Examples` / `Notes` / `See Also`, `errorConstruction`
-   Features without a clear majority (excluded): single-iterator error-message phrasing — 24 / 12 / 9 split between "First argument must be an iterator protocol-compliant object" / "First argument must be an iterator" / "Must provide an iterator", below the 75% threshold; `package.json` `scripts` / `stdlib` keys (empty in all members; no signal)

### `@stdlib/iter/intersection-by-hash`

Conformance: 4/4 sibling variadic-iterator packages (`concat`, `union`, `intersection`, `mapn`) use `format( 'invalid argument. Must provide an iterator protocol-compliant object. Argument: \`%u\`. Value: \`%s\`.', i, arguments[ i ] )` for the analogous validation. `i` already pointed at the first non-iterator (the preceding `for`-loop terminates with `break` at that index), and `format` was already imported. The plain-string `'Iterator arguments must be iterator protocol-compliant objects.'` is replaced by the canonical `format()` call without otherwise touching the validation flow.

### `@stdlib/iter/dedupe`

Conformance: 24/26 stdlib-wide. The first-argument check now reads `'First argument must be an iterator protocol-compliant object. Value: \`%s\`.'`, matching the established phrasing. No other line is modified.

### `@stdlib/iter/dedupe-by`

Conformance: 24/26 stdlib-wide. Same typo as `iter/dedupe`, fixed in the same way.

### Validation

What was checked:

-   Structural extraction over all 65 packages: file tree, `package.json` shape, `manifest.json` presence, README section sets, `test/`/`benchmark/`/`examples/` filenames, `keywords`.
-   Semantic extraction over `lib/main.js` for each package: error-construction style, JSDoc tag counts, validation-prologue ordering within signature-shape groups.
-   Three-agent-equivalent drift validation (collapsed to a single adversarial review when all surviving findings were semantic-only): confirmed that each deviation is unintentional, that no tests / examples / REPL docs depend on the current error-message text, that `format` is already imported in each modified file, and that all proposed lines stay within stdlib's line-length conventions.

What was deliberately excluded:

-   `flow`'s plain-string `'invalid invocation. \`this\` is not a fluent interface iterator.'` throws: 87% of stdlib (149 / 171) uses plain strings for invariant `this`-check errors with no value to interpolate. Not drift.
-   Missing `Notes` README section (7 packages): content is intrinsically package-specific, so no mechanical fix is possible.
-   Missing `See Also` section (10 packages): auto-populated by the package generator; out of scope per the routine's pre-validation gate.
-   Single-iterator error-message phrasing: no ≥75% majority across the namespace.
-   Drift in the auto-generated error-database CSV / JSON (`@stdlib/error/tools/database/data/`): regenerated from source, so corrections to source propagate on the next build.

## Related Issues

None.

## Questions

None.

## Other

Per-commit conformance percentages are recorded in each commit body. A full local report (drift matrix, per-feature conformance, outliers, drops, random seed for the namespace pick) is retained outside the working tree at `~/drift-reports/drift-iter-2026-06-02.md`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated cross-package drift-detection routine over `@stdlib/iter`. The routine extracted structural and semantic features from all 65 packages in the namespace, identified deviations from ≥75%-conformant patterns, ran an adversarial validation pass to discard intentional deviations and behaviour-changing fixes, and produced the three mechanical corrections committed here. All three commits were reviewed before being staged.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tn11Y8BqfbdAoEsyyGbThq)_