### PR TITLE
chore: add missing classification keywords in `math/base/assert`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/package.json
@@ -71,6 +71,9 @@
     "negative",
     "neg",
     "isnegative",
-    "isfinite"
+    "isfinite",
+    "is",
+    "type",
+    "check"
   ]
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-nonnegative-finite/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-nonnegative-finite/package.json
@@ -70,6 +70,9 @@
     "finite",
     "nonnegative",
     "isnonnegative",
-    "isfinite"
+    "isfinite",
+    "is",
+    "type",
+    "check"
   ]
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-nonpositive-finite/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-nonpositive-finite/package.json
@@ -70,6 +70,9 @@
     "finite",
     "nonpositive",
     "isnonpositive",
-    "isfinite"
+    "isfinite",
+    "is",
+    "type",
+    "check"
   ]
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-positive-finite/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-positive-finite/package.json
@@ -71,6 +71,9 @@
     "positive",
     "pos",
     "ispositive",
-    "isfinite"
+    "isfinite",
+    "is",
+    "type",
+    "check"
   ]
 }

--- a/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/package.json
@@ -73,6 +73,9 @@
     "int",
     "unsigned",
     "signed",
-    "number"
+    "number",
+    "is",
+    "type",
+    "check"
   ]
 }


### PR DESCRIPTION
## Description

Adds the `is`, `type`, and `check` classification keywords to five `package.json` files in the `math/base/assert` namespace whose keyword arrays had drifted from the namespace convention.

### Namespace summary

- **Target:** `@stdlib/math/base/assert`
- **Members analyzed:** 35 (`int32-is-even`, `int32-is-odd`, `is-composite`, `is-coprime`, `is-even`, `is-evenf`, `is-finite`, `is-finitef`, `is-infinite`, `is-infinitef`, `is-integer`, `is-integerf`, `is-nan`, `is-nanf`, `is-negative-finite`, `is-negative-integer`, `is-negative-integerf`, `is-negative-zero`, `is-negative-zerof`, `is-nonnegative-finite`, `is-nonnegative-integer`, `is-nonnegative-integerf`, `is-nonpositive-finite`, `is-nonpositive-integer`, `is-odd`, `is-oddf`, `is-positive-finite`, `is-positive-integer`, `is-positive-zero`, `is-positive-zerof`, `is-prime`, `is-probability`, `is-probabilityf`, `is-safe-integer`, `uint32-is-pow2`).
- **Features analyzed:** file tree, `package.json` top-level keys, `package.json` `keywords`, README section sequence, test/benchmark/examples filenames, dependency sets (`require` calls in `lib/main.js`), `manifest.json` shape.
- **Features with clear majority (≥75% conformance):** full file tree of native-bindings sources (`binding.gyp`, `include.gypi`, `manifest.json`, `lib/native.js`, `src/addon.{c,cpp}`, `src/Makefile`, `examples/c/`, `benchmark/benchmark.native.js`, `test/test.native.js`) at 34/35 (97.1%); `package.json` `gypfile: true` at 34/35 (97.1%); `package.json` keyword triplet `is`/`type`/`check` at 30/35 (85.7%); `package.json` keyword `number` at 33/35 (94.3%); `lib/index.js` re-export pattern (single `require('./main.js')`) at 35/35 (100%).
- **Features without clear majority (excluded from drift detection):** README section sequence (split across five distinct templates, none ≥75%; longest common prefix is `## Usage` → `## Examples` only); `src/addon.c` vs. `src/addon.cpp` (28/35 = 80% C, 6/35 = 17% C++ — `is-infinite`, `is-nan`, `is-negative-zero`, `is-negative-zerof`, `is-positive-zero`, `is-positive-zerof` — already being migrated under PR #4613 and follow-ons); `benchmark/benchmark.js` random-source choice (17 `discrete-uniform`, 17 `uniform`, 1 none); `examples/index.js` output style (27 `console.log`, 8 `logEachMap` — stylistic, not metadata drift).

### `math/base/assert/is-negative-finite`

Adds the three classification keywords `is`, `type`, and `check` to `package.json`. All three are present in 30/35 sibling packages (85.7%); their absence here was a copy-from-template oversight when the four `is-*-finite` predicates were introduced as a batch. The package's `lib/main.js` already implements the canonical `is-` predicate signature `function isNegativeFinite( x )` returning `boolean`, so the categorization is unambiguous. Metadata-only change; no source or behavioral modification.

### `math/base/assert/is-nonnegative-finite`

Adds `is`, `type`, and `check` to `package.json` keywords. Same batch-template oversight as `is-negative-finite`, `is-nonpositive-finite`, and `is-positive-finite` — all four `is-*-finite` predicates share identical structural metadata otherwise (same `directories`, same `gypfile`, same dependency-free `lib/main.js` shape) and lack only this triplet relative to 30/35 siblings (85.7% conformance). Metadata-only.

### `math/base/assert/is-nonpositive-finite`

Adds `is`, `type`, and `check` to `package.json` keywords (30/35 = 85.7% sibling conformance). Same batch-template oversight as the three other `is-*-finite` predicates. Metadata-only.

### `math/base/assert/is-positive-finite`

Adds `is`, `type`, and `check` to `package.json` keywords (30/35 = 85.7% sibling conformance). Same batch-template oversight as the three other `is-*-finite` predicates. Metadata-only.

### `math/base/assert/uint32-is-pow2`

Adds `is`, `type`, and `check` to `package.json` keywords. Distinct from the `is-*-finite` cluster — `uint32-is-pow2` carries the full integer-typed keyword set (`uint32`, `int32`, `integer`, `int`, `unsigned`, `signed`) but, like the four finite predicates, omits the generic classification triplet present in 30/35 siblings (85.7%). The package's predicate shape (`isPow2( x )` returning `boolean` for a `uint32`) is no different in category from `is-positive-integer` or `is-safe-integer`, both of which carry the triplet. Metadata-only.

### Validation

Checked:

- Structural feature extraction across all 35 members (file tree, `package.json` shape, `manifest.json` shape, README section list, test/benchmark/example filenames).
- Semantic feature extraction across all 35 members (`lib/main.js` signature, return kind, dependency set via `require` calls, JSDoc shape).
- Three-agent drift validation on the five proposed keyword additions:
  - **opus semantic-review** confirmed each of the five packages is an `is-*` boolean predicate matching the convention behind the `is`/`type`/`check` triplet.
  - **opus cross-reference** confirmed no test, README, REPL fixture, or stdlib-internal tool (`_tools/markdown/namespace-toc`, `_tools/search/pkg-index`, publish-topics script) depends on the current keyword set; all keyword consumers are additive.
  - **sonnet structural-review** confirmed `is`, `type`, `check` are the correct missing elements (not some other adjacent triplet) and that the canonical position is at the end of the keywords array.

Deliberately excluded:

- **`is-coprime` missing the entire native-bindings file group** (`binding.gyp`, `include.gypi`, `manifest.json`, `lib/native.js`, `src/`, `examples/c/`, `benchmark/benchmark.native.js`, `test/test.native.js`). Already being addressed under PR #4169 ("feat: add C implementation for `math/base/assert/is-coprime`"). Not a mechanical fix in any case — adding a C addon requires authoring a GCD implementation.
- **`src/addon.cpp` → `src/addon.c` migration** in `is-infinite`, `is-nan`, `is-negative-zero`, `is-negative-zerof`, `is-positive-zero`, `is-positive-zerof` (6/35 = 17% C++). Already being addressed under PR #4613 ("refactor: update `math/base/assert/is-nan` native addon from C++ to C") and its follow-ons.
- **`is-negative-integerf` missing `docs/repl.txt`** (34/35 = 97.1% present). `repl.txt` is a generator-owned artifact; excluded per the drift-routine's auto-populated-sections gate.
- **README `## See Also` section** (26/35 = 74.3%, just below threshold and generator-populated).
- **`int32-is-even` and `int32-is-odd` missing the `number` keyword** (33/35 = 94.3% present). Marked **intentional deviation** — these packages explicitly operate on `int32` integer-typed input, not `number`-valued inputs, so the omission is semantically warranted.
- **`examples/index.js` output style** (`console.log` vs. `@stdlib/console/log-each-map`) — stylistic, not metadata drift, and at 77.1% it sits right at the threshold boundary.
- **`benchmark/benchmark.js` random-source choice** (`discrete-uniform` vs. `uniform`) — no clear majority (49% / 49% / 6%).

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

Random namespace pick, seed `drift-2026-06-02-philipp`. Eligibility criteria: ≥8 non-autogenerated direct child packages, leaf-like membership (mean nested-package count <3). Cross-run dedup against open PRs targeting the same namespace performed via `mcp__github__search_pull_requests` — overlapping PRs #4169 (`is-coprime` native bindings) and #4613 (`is-nan` addon C++→C) drove the exclusions documented above.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: structural and semantic features were extracted from every member of `math/base/assert`, majority patterns were computed at a 75% conformance threshold, and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed each correction was high-signal mechanical drift before any file was edited. All edits are pure `package.json` `keywords` additions; no source, test, or behavioral changes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017T4zjqBqDAx63wiuY5mPu3)_