### PR TITLE
docs: fix stale identifier in `math/base/special/expm1rel` C comment

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/expm1rel/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/expm1rel/src/main.c
@@ -59,7 +59,7 @@ double stdlib_base_expm1rel( const double x ) {
 	if ( x >= OVERFLOW_THRESHOLD ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF; // L'Hopital's Rule
 	}
-	// HUGE_VALUE <= x < OVERFLOW_THRESHOLD
+	// HUGE_THRESHOLD <= x < OVERFLOW_THRESHOLD
 	tmp = stdlib_base_expm1( x/2.0 );
 	return ( tmp/x ) * ( tmp+2.0 ); // note: we keep the `+2` term in order to prevent compiler optimizations from rearranging terms, even though `tmp + 2 = tmp` due to the limits of floating-point precision
 }


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-06-01 13:24:01 -0700 and 2026-06-02 03:02:00 -0700 (SHA range `f7a08b6ce..2013317f8`, 11 commits).

## Description

This pull request:

-   **`math/base/special/expm1rel`** — In `0a659c4`, fix a stale copy-paste in `lib/node_modules/@stdlib/math/base/special/expm1rel/src/main.c`: the half-angle-identity branch comment referenced `HUGE_VALUE` (the JS-side name) instead of `HUGE_THRESHOLD` (the constant defined in the C file).

## Related Issues

None.

## Questions

No.

## Other

Reviewed the 11 commits merged to `develop` in the trailing 24h window for typos, bugs, and style-guide violations.

**Validation performed:**

-   stdlib JavaScript / TypeScript / README / `package.json` style guide compliance
-   stdlib C style and macro-suffix compliance, plus JS/C cross-language parity in paired implementations
-   Diff-only objective-bug scan (off-by-one, wrong operator, inverted condition, wrong return)
-   Semantic / logic scan over introduced code (focus: `expm1rel` half-angle identity, new `igamax` TS overloads, error-message format strings, `See Also` cross-link integrity, `OVERFLOW_THRESHOLD` boundary)

**Deliberately excluded** (per "high-signal only" filter):

-   Single-agent findings that could not be independently re-verified from the diff
-   Findings whose fix would require touching code outside the 24h diff window (e.g., relocating a pre-existing link definition into a `<related-links>` sentinel block in `random/rayleigh/README.md`)
-   Style preferences not anchored to an explicit guideline (e.g., renaming the C constant `HUGE_THRESHOLD` to match the JS-side `HUGE_VALUE` — judgment call, paired-file naming parity is not a stated rule)

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated 24-hour follow-up audit of commits merged to `develop`. The reviewer pipeline used four parallel agents (two style, two bug) over the union diff; findings were filtered to those independently corroborated and verifiable from the diff alone before any edits were applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rbrj2m1PBTSG9Mv1EEqnNV)_