### PR TITLE
chore: fix typo in interface name and error message

### DIFF
--- a/lib/node_modules/@stdlib/regexp/dirname/lib/main.js
+++ b/lib/node_modules/@stdlib/regexp/dirname/lib/main.js
@@ -50,7 +50,7 @@ var isPlatform = contains( PLATFORMS );
 function reDirname( platform ) {
 	if ( arguments.length > 0 ) {
 		if ( !isPlatform( platform ) ) {
-			throw new Error( format( 'invalid argument.  Must be one of the following: "%s". Value: `%s`.', PLATFORMS.join( '", "' ), platform ) );
+			throw new Error( format( 'invalid argument. Must be one of the following: "%s". Value: `%s`.', PLATFORMS.join( '", "' ), platform ) );
 		}
 	}
 	if ( platform === 'win32' || IS_WINDOWS ) {

--- a/lib/node_modules/@stdlib/regexp/regexp/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/regexp/regexp/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /**
 * Interface for a regular expression to parse a regular expression string.
 */
-interface ReNativeFunction {
+interface ReRegExp {
 	/**
 	* Returns a regular expression to parse a regular expression string.
 	*
@@ -66,7 +66,7 @@ interface ReNativeFunction {
 * var bool = reRegExp.REGEXP.test( '/^beep$/' );
 * // returns true
 */
-declare var reRegExp: ReNativeFunction;
+declare var reRegExp: ReRegExp;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

This pull request corrects two unintentional drifts in `@stdlib/regexp/*` flagged by a cross-package drift audit over the 27 non-autogenerated members of the namespace: a copy-paste interface name in `regexp/regexp`'s TypeScript declaration, and a double-space typo in `regexp/dirname`'s error-message format string. Both fixes are purely textual; neither changes observable runtime behavior beyond the literal `error.message` text in `dirname`.

### Namespace summary

- Members analyzed: 27 leaf packages under `lib/node_modules/@stdlib/regexp/`.
- Features with a clear majority (≥75%) considered for correction: file tree, `package.json` shape, `directories` keys, README `##` section set, error-construction style, validation prologues, JSDoc shape, and TypeScript interface naming.
- Features without a clear majority (excluded from drift analysis): `lib/regexp.js` / `test/test.regexp.js` presence (20/27 = 74%, just under threshold), `## Notes` README section (11/27 = 41%).
- Features confirmed drift-free: every package shares an identical `package.json` top-level key set, identical `directories` map, and `format`-based error construction. No package constructs errors via concatenation or plain strings.

### `regexp/regexp`

Rename the TypeScript interface in `docs/types/index.d.ts` from `ReNativeFunction` (a copy-paste leftover from `regexp/native-function`) to `ReRegExp`, conforming to the namespace-wide `Re<PascalCasedPackageName>` convention followed by 26 of 27 sibling packages (96%). The change is confined to `docs/types/index.d.ts`; `docs/types/test.ts` does not reference the interface by name, no other file in the repository imports it, and TypeScript interface names carry no runtime effect.

### `regexp/dirname`

Collapsed a double space in the `format` template at `lib/main.js:53` so the error message reads `'invalid argument. Must be one of the following...'`. Brings the package in line with its siblings `basename`, `extname`, and `filename`, which were already single-spaced; grep confirms `regexp/dirname` was the sole occurrence of `"invalid argument.  Must"` across the entire stdlib `.js` corpus (100% of siblings conform). No test or doc churn — nothing pins the exact message text.

### Validation

- Structural extraction over all 27 members: file tree, `package.json` keys/`scripts`/`directories`, README `##` headings, error-construction style.
- Semantic extraction over the four platform-dispatch packages (`basename`, `dirname`, `extname`, `filename`) and the three options-taking packages (`decimal-number`, `eol`, `whitespace`).
- Three-agent drift validation (semantic-review, cross-reference, structural-review) confirmed `confirmed-drift` for both outliers; no outlier was marked `intentional-deviation`, `needs-human`, or `insufficient-evidence`.

Deliberately excluded:
- `## See Also` README drift in five packages (`color-hexadecimal`, `decimal-number`, `duration-string`, `eol`, `extended-length-path`) — gated as auto-populated by the package-generator.
- Missing `test/test.main.js` in `reviver` and `to-json` — flagged in a prior audit as an intentional architectural deviation (those packages' `lib/index.js` are pure pass-throughs with no platform dispatch, so a separate `test.main.js` would only duplicate `test.js`).
- `lib/regexp.js` / `test/test.regexp.js` extraction pattern (20/27, just under the 75% threshold) — leaf packages without a separate file inline their regex into `main.js`, which is a deliberate organizational choice rather than drift.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

Drift candidates produced by an automated cross-package audit; corrections were applied only after all three reviewer agents (semantic, cross-reference, structural) returned `confirmed-drift`. The materiality, auto-populated-section, ecosystem-wide-absence, and open-PR-collision gates were checked before validation. A previous drift PR on this namespace (#12363, merged 2026-05-30) addressed a separate `README.md` typo in `regexp/dirname` and is not duplicated here.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift detection routine over `@stdlib/regexp/*`. Three independent reviewer agents (semantic, cross-reference, structural) confirmed both candidates before the fixes were applied. A maintainer should promote out of draft after review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUB29CHisrZfee88dVdyng)_