### PR TITLE
build(workflows): remove Node.js v12/v14 from macOS test matrix (no arm64 binaries)

### DIFF
--- a/.github/workflows/macos_benchmark.yml
+++ b/.github/workflows/macos_benchmark.yml
@@ -87,7 +87,7 @@ jobs:
         BUILD_TASK: ['benchmark']
 
         # Define the list of Node.js versions:
-        NODE_VERSION: ['16', '14', '12']
+        NODE_VERSION: ['16']
 
         # Define the list of operating systems:
         OS: ['macOS-latest']
@@ -98,12 +98,6 @@ jobs:
             PLATFORM: 'macos'
 
           - NODE_VERSION: '16'
-            NPM_VERSION: '>2.7.0'
-
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0'
-
-          - NODE_VERSION: '12'
             NPM_VERSION: '>2.7.0'
 
           # - NODE_VERSION: '10'

--- a/.github/workflows/macos_test.yml
+++ b/.github/workflows/macos_test.yml
@@ -86,7 +86,7 @@ jobs:
 
         # Define the list of Node.js versions:
         # NODE_VERSION: ['16', '14', '12', '10', '8', '6', '4', '0.12', '0.10']
-        NODE_VERSION: ['16', '14', '12']
+        NODE_VERSION: ['16']
 
         # Define the list of operating systems:
         OS: ['macOS-latest']
@@ -98,12 +98,6 @@ jobs:
 
           - NODE_VERSION: '16'
             NPM_VERSION: '>2.7.0 <10.0.0'
-
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0 <10.0.0'
-
-          - NODE_VERSION: '12'
-            NPM_VERSION: '>2.7.0 <9.0.0'
 
           # - NODE_VERSION: '10'
           #   NPM_VERSION: '>2.7.0 <7.0.0'

--- a/.github/workflows/macos_test_cov.yml
+++ b/.github/workflows/macos_test_cov.yml
@@ -87,7 +87,7 @@ jobs:
         BUILD_TASK: ['test-coverage']
 
         # Define the list of Node.js versions:
-        NODE_VERSION: ['16', '14', '12']
+        NODE_VERSION: ['16']
 
         # Define the list of operating systems:
         OS: ['macOS-latest']
@@ -98,12 +98,6 @@ jobs:
             PLATFORM: 'macos'
 
           - NODE_VERSION: '16'
-            NPM_VERSION: '>2.7.0'
-
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0'
-
-          - NODE_VERSION: '12'
             NPM_VERSION: '>2.7.0'
 
           # - NODE_VERSION: '10'


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Removes Node.js v12 and v14 from the matrix in `macos_test.yml`, `macos_benchmark.yml`, and `macos_test_cov.yml`.

`macOS-latest` now resolves to macOS 15 running on arm64 (Apple Silicon). Node.js v12 and v14 were never released with official arm64 macOS binaries. The `actions/setup-node@v6.4.0` action fails at every daily run with:

```
Unable to find Node version '12' for platform darwin and architecture arm64
Unable to find Node version '14' for platform darwin and architecture arm64
```

Both versions are EOL:
- Node.js v12: EOL April 2022 (LTS ended December 2022)
- Node.js v14: EOL April 2023

x64 coverage for these versions is retained by `linux_test.yml`, which runs on `ubuntu-latest`. Removing them from the macOS matrix is consistent with `macos_test_npm_install.yml`, which already only tests `['20', '18', '16']`.

Affected workflows and change summary:

| Workflow | Before | After |
|---|---|---|
| `macos_test.yml` | `['16', '14', '12']` | `['16']` |
| `macos_benchmark.yml` | `['16', '14', '12']` | `['16']` |
| `macos_test_cov.yml` | `['16', '14', '12']` | `['16']` |

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   No open issue on file; identified via automated CI failure analysis on 2026-06-02.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Reference: failed workflow run showing the arm64 binary error — https://github.com/stdlib-js/stdlib/actions/runs/26814321669

`macos_test_npm_install.yml` already uses `['20', '18', '16']` and served as the precedent for this change.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI failure investigation routine. The root cause (macOS arm64 runner + no arm64 Node.js binaries for v12/v14) and the fix were identified and validated by the AI agent. A human should confirm the matrix reduction is acceptable before merging.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6HMgfZ1MCE9N74ZFrTYim)_