### PR TITLE
docs: correct `mu` description and `b` JSDoc type in `stats/base/dists/laplace/mgf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/docs/types/index.d.ts
@@ -38,7 +38,7 @@ interface MGF {
 	* -   If provided `b <= 0`, the function returns `NaN`.
 	*
 	* @param t - input value
-	* @param mu - mean
+	* @param mu - location parameter
 	* @param b - scale parameter
 	* @returns evaluated MGF
 	*
@@ -87,7 +87,7 @@ interface MGF {
 	/**
 	* Returns a function for evaluating the moment-generating function (MGF) of a Laplace (double exponential) distribution with location parameter `mu` and scale parameter `b`.
 	*
-	* @param mu - mean
+	* @param mu - location parameter
 	* @param b - scale parameter
 	* @returns MGF
 	*

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/factory.js
@@ -32,8 +32,8 @@ var pow = require( '@stdlib/math/base/special/pow' );
 /**
 * Returns a function for evaluating the moment-generating function (MGF) of a Laplace (double exponential) distribution with location parameter `mu` and scale parameter `b`.
 *
-* @param {number} mu - mean
-* @param {NonNegativeNumber} b - scale parameter
+* @param {number} mu - location parameter
+* @param {PositiveNumber} b - scale parameter
 * @returns {Function} MGF
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/main.js
@@ -32,8 +32,8 @@ var pow = require( '@stdlib/math/base/special/pow' );
 * Evaluates the moment-generating function (MGF) for a Laplace (double exponential) distribution with location parameter `mu` and scale parameter `b` at a value `t`.
 *
 * @param {number} t - input value
-* @param {number} mu - mean
-* @param {NonNegativeNumber} b - scale parameter
+* @param {number} mu - location parameter
+* @param {PositiveNumber} b - scale parameter
 * @returns {number} evaluated MGF
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/native.js
@@ -30,8 +30,8 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {number} t - input value
-* @param {number} mu - mean
-* @param {NonNegativeNumber} b - scale parameter
+* @param {number} mu - location parameter
+* @param {PositiveNumber} b - scale parameter
 * @returns {number} evaluated MGF
 *
 * @example


### PR DESCRIPTION
## Description

This pull request normalizes the JSDoc `@param` descriptions and types in `@stdlib/stats/base/dists/laplace/mgf` so they match the rest of the `stats/base/dists/laplace/` namespace and the package's own runtime contract.

### Namespace summary

- **Target:** `stats/base/dists/laplace/`
- **Members analyzed:** 15 (cdf, ctor, entropy, kurtosis, logcdf, logpdf, mean, median, mgf, mode, pdf, quantile, skewness, stdev, variance)
- **Features with clear majority (≥75%) used as anchors:** file tree, top-level `package.json` keys, README section list, `manifest.json` keys, test/benchmark filenames, JSDoc `@param mu` description, JSDoc `@param b` type, source-file structure.
- **Features excluded for no clear majority:** JSDoc `@returns` type (genuine semantic split — `number` vs `Probability` vs `PositiveNumber`).

### `@stdlib/stats/base/dists/laplace/mgf`

Tighten `b` JSDoc type from `{NonNegativeNumber}` to `{PositiveNumber}` across `lib/main.js`, `lib/factory.js`, and `lib/native.js` to match the `b <= 0.0` rejection and the README contract. Rename `mu` from "mean" to "location parameter" in the same files and in `docs/types/index.d.ts`, aligning with every sibling in `stats/base/dists/laplace/` and the package's own top-level description.

Conformance:

-   `@param {PositiveNumber} b`: 13/14 sibling function packages (~93%).
-   `@param mu - location parameter`: 13/14 sibling function packages and all >30 other `@param mu` occurrences in the namespace (~93%).

## Related Issues

None.

## Questions

None.

## Other

### Validation

-   **Structural extraction:** file trees, `package.json` shapes, README section lists, `manifest.json` shapes, and test/benchmark/example filenames captured for all 15 members.
-   **Semantic extraction:** public signature, return kind, validation prologue, error-construction style, JSDoc shape, and dependencies extracted per package via a sub-agent reading `lib/main.js`, `lib/index.js`, and `lib/validate.js`.
-   **Three-agent drift validation:**
    -   Agent 1 (semantic-review) confirmed all three candidate drift items.
    -   Agent 2 (cross-reference) confirmed no test, example, `docs/types/test.ts`, or external stdlib reference relies on the deviating wording; surfaced additional drift in `lib/factory.js` and `lib/native.js` (same strings), which are included in this patch.
    -   Agent 3 (structural-review) confirmed filtering of the `ctor` structural deltas (intentional pure-JS class) and the `stdev` python-fixtures delta (would cascade to test expectations).
-   **Deliberately excluded:**
    -   `ctor` lacking `location-scale` and `exponential family` keywords — ecosystem-wide ctor convention; verified `normal/ctor`, `logistic/ctor`, `gumbel/ctor`, `cauchy/ctor`, `beta/ctor` follow the same convention.
    -   `ctor` lacking native-binding files (`binding.gyp`, `manifest.json`, `src/`, `lib/native.js`, `## C APIs` README section, `test.native.js`, `benchmark.native.js`) — `ctor` is a pure-JS constructor class.
    -   `stdev` using python rather than julia test fixtures — out of scope per the routine (fixture-format change cascades to expected values).
    -   `mgf` validation-prologue extension `abs(t) >= 1/b` — math-correct, not drift.
    -   JSDoc `@returns` types — no ≥75% majority; the variation reflects genuine semantic differences.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift-detection sweep. The routine extracted structural and semantic features from every package in `stats/base/dists/laplace/`, computed a per-feature majority pattern, and validated each candidate correction through three independent review agents before any edit. The corrections in this PR are pure JSDoc/typing changes; no behavior, signatures, or tests changed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cv7Lh8wtQoKzrem6gXstiK)_