### PR TITLE
docs: rename `value` parameter in `@stdlib/assert/is-prng-like` declaration

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-prng-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-prng-like/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /**
 * Tests if a value is PRNG-like.
 *
-* @param v - value to test
+* @param value - value to test
 * @returns boolean indicating if a value is PRNG-like
 *
 * @example
@@ -33,7 +33,7 @@
 * bool = isPRNGLike( [] );
 * // returns false
 */
-declare function isPRNGLike( v: any ): boolean;
+declare function isPRNGLike( value: any ): boolean;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   renames the `value` parameter from `v` to `value` in the `@stdlib/assert/is-prng-like` TypeScript declaration (both the `@param` tag and the function signature), matching the parameter-naming convention used across the `@stdlib/assert` predicate declarations.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Identified via a TypeScript-declaration audit of the `@stdlib/assert` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored primarily by Claude Code (Anthropic's CLI), which audited the `@stdlib/assert` TypeScript declarations and proposed and applied the fix. I reviewed the changes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
