### PR TITLE
chore: remove unused types reference

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-empty-collection/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-empty-collection/docs/types/index.d.ts
@@ -18,8 +18,6 @@
 
 // TypeScript Version: 4.1
 
-/// <reference types="@stdlib/types"/>
-
 /**
 * Tests if a value is an empty collection.
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes the unused `/// <reference types="@stdlib/types"/>` triple-slash directive from the `@stdlib/assert/is-empty-collection` TypeScript declaration. The declaration only references the built-in `any` and `boolean` types, so the directive is unnecessary; the sibling `is-empty-array-like-object`, which declares an analogous predicate, omits it.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Identified via a TypeScript-declaration audit of the `@stdlib/assert` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored primarily by Claude Code (Anthropic's CLI), which audited the `@stdlib/assert` TypeScript declarations and proposed and applied the fix. I reviewed the changes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
