### PR TITLE
fix: narrow type guard in `@stdlib/assert/is-primitive-array`

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-primitive-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-primitive-array/docs/types/index.d.ts
@@ -34,7 +34,7 @@
 * bool = isPrimitiveArray( [ new String('abc'), '3.0' ] );
 * // returns false
 */
-declare function isPrimitiveArray( value: any ): value is Array<any>;
+declare function isPrimitiveArray( value: any ): value is Array<null | undefined | string | boolean | number | symbol>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/assert/is-primitive-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-primitive-array/docs/types/index.d.ts
@@ -34,7 +34,7 @@
 * bool = isPrimitiveArray( [ new String('abc'), '3.0' ] );
 * // returns false
 */
-declare function isPrimitiveArray( value: any ): value is Array<null | undefined | string | boolean | number | symbol>;
+declare function isPrimitiveArray( value: any ): value is Array<null | undefined | string | boolean | number | symbol | bigint>;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   narrows the type predicate of the `@stdlib/assert/is-primitive-array` declaration from `value is Array<any>` to `value is Array<null | undefined | string | boolean | number | symbol>`, mirroring the element union used by the sibling `is-primitive` predicate. A positive result now narrows to an array of JavaScript primitives rather than discarding the element-type information.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Identified via a TypeScript-declaration audit of the `@stdlib/assert` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored primarily by Claude Code (Anthropic's CLI), which audited the `@stdlib/assert` TypeScript declarations and proposed and applied the fix. I reviewed the changes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
