### PR TITLE
chore: fix description and `dist` keyword

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/pareto-type1/pdf",
   "version": "0.0.0",
-  "description": "Pareto distribution (Type I) probability density function (PDF).",
+  "description": "Pareto (Type I) distribution probability density function (PDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -57,7 +57,7 @@
     "statistics",
     "stats",
     "distribution",
-    "dists",
+    "dist",
     "probability",
     "pdf",
     "density",


### PR DESCRIPTION
## Description

Within `@stdlib/stats/base/dists/pareto-type1` (14 members), `pdf/package.json` was the lone outlier on two metadata features. Fixes both.

### `stats/base/dists/pareto-type1/pdf`

- `description` reordered to `"Pareto (Type I) distribution probability density function (PDF)."`, matching the canonical `"<Distribution> distribution <function>."` pattern used by 12/14 namespace siblings, all 30 sibling `pdf/package.json` descriptions across other distributions, and the parent namespace README. The previous wording placed `distribution` between `Pareto` and `(Type I)`.
- `keywords` entry `"dists"` replaced with the singular `"dist"`, matching 13/14 siblings within the namespace and 29/31 sibling `pdf` packages across stdlib.

Metadata-only; no source, test, signature, or behavioral changes.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: structural features were extracted from every member of `stats/base/dists/pareto-type1`, majority patterns were computed at a 75% conformance threshold, and an independent structural-review agent confirmed the corrections were high-signal mechanical drift before any file was edited. Both edits are pure `package.json` metadata; no source, test, or behavioral changes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017vc1By1diquUAsjgL4RYRE)_