### PR TITLE
fix: address typo in parameter name

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/acot-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/strided/special/acot-by/docs/types/index.d.ts
@@ -90,7 +90,7 @@ type Quinary<T, V> = ( this: V, value: T, idx: number, xi: number, yi: number, x
 * @param y - output array
 * @returns accessed value
 */
-type Senary<T, U, V> = ( thos: V, value: T, idx: number, xi: number, yi: number, x: Collection<T>, y: Collection<U> ) => number | void;
+type Senary<T, U, V> = ( this: V, value: T, idx: number, xi: number, yi: number, x: Collection<T>, y: Collection<U> ) => number | void;
 
 /**
 * Returns an accessed value.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Corrects the `Senary` callback type alias in the `@stdlib/math/strided/special/acot-by` TypeScript declarations, which declared its leading context parameter as `thos: V` instead of the reserved `this: V`. As written, TypeScript treats `thos` as an ordinary first positional parameter, shifting `value`, `idx`, `xi`, `yi`, `x`, and `y` each by one position and dropping the intended `this`-context typing entirely. The accompanying TSDoc documents no `thos` parameter, so the signature no longer matched the documentation.
-   Renames the parameter to `this`, matching the sibling `Quinary` type in the same file and the rest of the `-by` accessor family (e.g. `acos-by`, `acosh-by`, `acoth-by`, `acovercos-by`, `acoversin-by`).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

This issue was identified by an automated TypeScript-declaration audit run with Claude Code, and the fix was prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md