### PR TITLE
fix: correct `ellipj` declaration signature, parameters, and examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ellipj/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/docs/types/index.d.ts
@@ -19,51 +19,43 @@
 // TypeScript Version: 4.1
 
 /**
-* Computes the Jacobi elliptic functions sn, cn, and dn.
+* Simultaneously computes the Jacobi elliptic functions sn, cn, and dn, and the Jacobi amplitude am.
 *
 * ## Notes
 *
-* -   The functions are evaluated using the [complete elliptic integral of the first kind](https://en.wikipedia.org/wiki/Elliptic_integral#Complete_elliptic_integral_of_the_first_kind) `K`.
+* -   Values are computed using the arithmetic-geometric mean from Abramowitz and Stegun 16.4.
 *
-* -   The `x` argument is converted to double-precision floating-point format.
+* -   When `m < 0` or `m > 1`, `sn`, `cn`, and `dn` are computed in terms of elliptic functions with `0 < m < 1` using the transformations from Abramowitz and Stegun 16.10 and 16.11, respectively. Thus, the domain of `m` is any real number. When `m < 0` or `m > 1`, `am` is not computed and is returned as `NaN`.
 *
-* -   The returned values are exact for `m` values where `|m| < 2**-24`.
+* -   Values for small `m` (`m < SQRT_EPS`) are computed using the approximations of Abramowitz and Stegun 16.13.
 *
-* -   The functions return `NaN` for `m >= 1`.
+* -   Values for `m` near unity (`m > 1 - SQRT_EPS`) are computed using the approximations of Abramowitz and Stegun 16.15.
 *
-* -   When `m < 1`, the following relations hold
-*
-*     ```tex
-*     \operatorname{sn}(x+x) = 2\operatorname{sn}(x)\operatorname{cn}(x)
-*     \operatorname{cn}(x+x) = 1 - 2\operatorname{sn}(x)^{2}
-*     \operatorname{dn}(x+x) = 1 - 2\operatorname{sn}(x)^{2}\operatorname{dn}(x)
-*     ```
-*
-* @param m - parameter
-* @param x - argument
-* @returns array containing four elements corresponding to the Jacobi elliptic functions and the Jacobi amplitude `am`.
+* @param u - input value
+* @param m - modulus `m`, equivalent to `k²`
+* @returns array containing the Jacobi elliptic functions sn, cn, and dn, and the Jacobi amplitude am
 *
 * @example
-* var v = ellipj( 0.5, 0 );
-* // returns [ ~0.479, ~0.878, 1 ]
+* var v = ellipj( 0.3, 0.5 );
+* // returns [ ~0.293, ~0.956, ~0.978, ~0.298 ]
 *
 * @example
-* var v = ellipj( 0.5, -1.0 );
-* // returns [ ~0.497, ~0.868, ~1.117 ]
+* var v = ellipj( 0.0, 0.0 );
+* // returns [ ~0.0, ~1.0, ~1.0, ~0.0 ]
 *
 * @example
-* var v = ellipj( Infinity, 0.5 );
-* // returns [ NaN, NaN, NaN ]
+* var v = ellipj( Infinity, 1.0 );
+* // returns [ ~1.0, ~0.0, ~0.0, ~1.571 ]
 *
 * @example
-* var v = ellipj( -Infinity );
-* // returns [ NaN, NaN, NaN ]
+* var v = ellipj( 0.0, -2.0 );
+* // returns [ ~0.0, ~1.0, ~1.0, NaN ]
 *
 * @example
-* var v = ellipj( NaN );
-* // returns [ NaN, NaN, NaN ]
+* var v = ellipj( NaN, NaN );
+* // returns [ NaN, NaN, NaN, NaN ]
 */
-declare function ellipj( m: number, x?: number ): Array<number>;
+declare function ellipj( u: number, m: number ): Array<number>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/math/base/special/ellipj/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/docs/types/index.d.ts
@@ -24,11 +24,8 @@
 * ## Notes
 *
 * -   Values are computed using the arithmetic-geometric mean from Abramowitz and Stegun 16.4.
-*
 * -   When `m < 0` or `m > 1`, `sn`, `cn`, and `dn` are computed in terms of elliptic functions with `0 < m < 1` using the transformations from Abramowitz and Stegun 16.10 and 16.11, respectively. Thus, the domain of `m` is any real number. When `m < 0` or `m > 1`, `am` is not computed and is returned as `NaN`.
-*
 * -   Values for small `m` (`m < SQRT_EPS`) are computed using the approximations of Abramowitz and Stegun 16.13.
-*
 * -   Values for `m` near unity (`m > 1 - SQRT_EPS`) are computed using the approximations of Abramowitz and Stegun 16.15.
 *
 * @param u - input value
@@ -55,7 +52,7 @@
 * var v = ellipj( NaN, NaN );
 * // returns [ NaN, NaN, NaN, NaN ]
 */
-declare function ellipj( u: number, m: number ): Array<number>;
+declare function ellipj( u: number, m: number ): [ number, number, number, number ];
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/math/base/special/ellipj/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/docs/types/test.ts
@@ -24,23 +24,34 @@ import ellipj = require( './index' );
 
 // The function returns an array of numbers...
 {
-	ellipj( 8 ); // $ExpectType number[]
 	ellipj( 8, 2 ); // $ExpectType number[]
 }
 
-// The compiler throws an error if the function is provided a value other than a number...
+// The compiler throws an error if the function is provided a first argument which is not a number...
 {
-	ellipj( true ); // $ExpectError
-	ellipj( false ); // $ExpectError
-	ellipj( null ); // $ExpectError
-	ellipj( undefined ); // $ExpectError
-	ellipj( '5' ); // $ExpectError
-	ellipj( [] ); // $ExpectError
-	ellipj( {} ); // $ExpectError
-	ellipj( ( x: number ): number => x ); // $ExpectError
+	ellipj( true, 2 ); // $ExpectError
+	ellipj( false, 2 ); // $ExpectError
+	ellipj( null, 2 ); // $ExpectError
+	ellipj( undefined, 2 ); // $ExpectError
+	ellipj( '5', 2 ); // $ExpectError
+	ellipj( [], 2 ); // $ExpectError
+	ellipj( {}, 2 ); // $ExpectError
+	ellipj( ( x: number ): number => x, 2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a number...
+{
+	ellipj( 8, true ); // $ExpectError
+	ellipj( 8, false ); // $ExpectError
+	ellipj( 8, null ); // $ExpectError
+	ellipj( 8, '5' ); // $ExpectError
+	ellipj( 8, [] ); // $ExpectError
+	ellipj( 8, {} ); // $ExpectError
+	ellipj( 8, ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided insufficient arguments...
 {
 	ellipj(); // $ExpectError
+	ellipj( 8 ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/math/base/special/ellipj/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/docs/types/test.ts
@@ -24,7 +24,7 @@ import ellipj = require( './index' );
 
 // The function returns an array of numbers...
 {
-	ellipj( 8, 2 ); // $ExpectType number[]
+	ellipj( 8, 2 ); // $ExpectType [number, number, number, number]
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a number...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects the `@stdlib/math/base/special/ellipj` TypeScript declaration, which diverged from the implementation (`ellipj( u, m )`) in several ways:

-   The second parameter `m` (the modulus) was incorrectly marked **optional** (`x?: number`), even though the implementation requires both arguments and provides no default.
-   The `@param` names and order were **swapped** relative to the implementation: the declaration named the input value `m` and the modulus `x`.
-   The Notes described behavior the implementation does not have, claiming the functions "return `NaN` for `m >= 1`" and are "exact for `|m| < 2**-24`". In fact, the implementation handles all real `m` via the Abramowitz and Stegun 16.10/16.11 transformations, and only the Jacobi amplitude `am` is returned as `NaN` when `m < 0` or `m > 1`.
-   The `@returns` documents four elements (sn, cn, dn, and `am`), but every `@example` showed only three.

This PR aligns the signature, parameter names, Notes, and examples with the implementation JSDoc, and updates the declaration tests for the now-required second argument. See [main.js](https://github.com/stdlib-js/stdlib/blob/068448c128d499da9f26134b087fb3faa475982e/lib/node_modules/%40stdlib/math/base/special/ellipj/lib/main.js) for reference.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace. The namespace aggregator (`math/base/special/docs/types/index.d.ts`) carries the same stale examples; it is generated and will pick up the fix on regeneration.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

This issue was identified by an automated TypeScript-declaration audit run with Claude Code, and the fix (including the updated declaration tests) was prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md