### PR TITLE
fix: separate import and JSDoc comment in `math/tools/unary` types

### DIFF
--- a/lib/node_modules/@stdlib/math/tools/unary/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/tools/unary/docs/types/index.d.ts
@@ -21,7 +21,9 @@
 /// <reference types="@stdlib/types"/>
 
 import { ArrayLike } from '@stdlib/types/array';
-import { OutputPolicy, InputCastingPolicy, DataType, Order, typedndarray } from '@stdlib/types/ndarray';/**
+import { OutputPolicy, InputCastingPolicy, DataType, Order, typedndarray } from '@stdlib/types/ndarray';
+
+/**
 * Input array.
 */
 type InputArray<T> = typedndarray<T>;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request fixes a formatting issue in the `@stdlib/math/tools/unary` TypeScript declarations: the `import { ... } from '@stdlib/types/ndarray';` statement was jammed onto the same physical line as the `/**` opening the `InputArray` JSDoc comment, with no separating newline (`...ndarray';/**`). The line is split so the import ends at its semicolon and the JSDoc comment begins on its own lines, matching the surrounding declarations.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

This issue was identified by an automated TypeScript-declaration audit run with Claude Code, and the fix was prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md