### PR TITLE
docs: correct overflow note in `math/base/special/factorial2f`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/factorial2f/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2f/README.md
@@ -55,7 +55,7 @@ v = factorial2f( 10 );
 // returns 3840
 ```
 
-If `n > 56`, the function returns `NaN`, as larger [double factorial][double-factorial] values cannot be safely represented in [single-precision floating-point format][ieee754].
+If `n > 56`, the function returns `Infinity`, as larger [double factorial][double-factorial] values cannot be safely represented in [single-precision floating-point format][ieee754].
 
 ```javascript
 var v = factorial2f( 57 );

--- a/lib/node_modules/@stdlib/math/base/special/factorial2f/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2f/docs/repl.txt
@@ -3,9 +3,9 @@
     Evaluates the double factorial of `n` as a single-precision floating-point
     number.
 
-    If `n` is greater than `56`, the function returns `NaN`, as larger double
-    factorial values cannot be accurately represented due to limitations of
-    single-precision floating-point format.
+    If `n` is greater than `56`, the function returns `Infinity`, as larger
+    double factorial values cannot be accurately represented due to limitations
+    of single-precision floating-point format.
 
     If not provided a nonnegative integer value, the function returns `NaN`.
 

--- a/lib/node_modules/@stdlib/math/base/special/factorial2f/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2f/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 *
 * ## Notes
 *
-* -   If `n` is greater than `56`, the function returns `NaN`, as larger double factorial values cannot be accurately represented due to limitations of single-precision floating-point format.
+* -   If `n` is greater than `56`, the function returns `Infinity`, as larger double factorial values cannot be accurately represented due to limitations of single-precision floating-point format.
 * -   If not provided a nonnegative integer value, the function returns `NaN`.
 *
 * @param n - input value


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects a behavioral note in `@stdlib/math/base/special/factorial2f`. The Notes claimed that for `n > 56` the function returns `NaN`, but the implementation returns `Infinity` (positive overflow) once `n` exceeds `FLOAT32_MAX_NTH_DOUBLE_FACTORIAL` (= 56), as the adjacent `@example` (`factorial2f( 57 )` // returns `Infinity`) and `lib/main.js` confirm.

The wording is corrected from `NaN` to `Infinity` in:

-   the declaration TSDoc (`docs/types/index.d.ts`),
-   the `README.md`, and
-   the REPL help text (`docs/repl.txt`).

The separate "not a nonnegative integer → `NaN`" note is correct and left unchanged.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

This issue was identified by an automated TypeScript-declaration audit run with Claude Code, and the fix was prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md