### PR TITLE
docs: correct grammar in descriptions

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/ops/mul/README.md
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul/README.md
@@ -40,7 +40,7 @@ var mul = require( '@stdlib/math/strided/ops/mul' );
 
 #### mul( N, dtypeX, x, strideX, dtypeY, y, strideY, dtypeZ, z, strideZ )
 
-Multiplies each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+Multiplies each element in a strided array `x` by a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -100,7 +100,7 @@ mul( 3, 'float64', x1, -2, 'float64', y1, 1, 'float64', z1, 1 );
 
 #### mul.ndarray( N, dtypeX, x, strideX, offsetX, dtypeY, y, strideY, offsetY, dtypeZ, z, strideZ, offsetZ )
 
-Multiplies each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z` using alternative indexing semantics.
+Multiplies each element in a strided array `x` by a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z` using alternative indexing semantics.
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );

--- a/lib/node_modules/@stdlib/math/strided/ops/mul/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul/docs/repl.txt
@@ -1,6 +1,6 @@
 
 {{alias}}( N, dx, x, sx, dy, y, sy, dz, z, sz )
-    Multiplies each element in a strided array `x` to a corresponding element in
+    Multiplies each element in a strided array `x` by a corresponding element in
     a strided array `y` and assigns the results to elements in a strided array
     `z`.
 
@@ -76,7 +76,7 @@
 
 
 {{alias}}.ndarray( N, dx, x, sx, ox, dy, y, sy, oy, dz, z, sz, oz )
-    Multiplies each element in a strided array `x` to a corresponding element in
+    Multiplies each element in a strided array `x` by a corresponding element in
     a strided array `y` and assigns the results to elements in a strided array
     `z` using alternative indexing semantics.
 

--- a/lib/node_modules/@stdlib/math/strided/ops/mul/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul/docs/types/index.d.ts
@@ -32,7 +32,7 @@ type RealOrComplexArray = ArrayLike<number> | ComplexTypedArray;
 */
 interface Routine {
 	/**
-	* Multiplies each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+	* Multiplies each element in a strided array `x` by a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
 	*
 	* @param N - number of indexed elements
 	* @param dtypeX - `x` data type
@@ -63,7 +63,7 @@ interface Routine {
 	( N: number, dtypeX: any, x: RealOrComplexArray, strideX: number, dtypeY: any, y: RealOrComplexArray, strideY: number, dtypeZ: any, z: RealOrComplexArray, strideZ: number ): RealOrComplexArray;
 
 	/**
-	* Multiplies each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z` using alternative indexing semantics.
+	* Multiplies each element in a strided array `x` by a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z` using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param dtypeX - `x` data type
@@ -98,7 +98,7 @@ interface Routine {
 }
 
 /**
-* Multiplies each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Multiplies each element in a strided array `x` by a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
 *
 * @param N - number of indexed elements
 * @param dtypeX - `x` data type

--- a/lib/node_modules/@stdlib/math/strided/ops/mul/lib/mul.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul/lib/mul.js
@@ -38,7 +38,7 @@ var fcn = dispatch( binary, types, data, meta.nargs, meta.nin, meta.nout );
 // MAIN //
 
 /**
-* Multiplies each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Multiplies each element in a strided array `x` by a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
 *
 * @param {integer} N - number of indexed elements
 * @param {*} dtypeX - `x` data type

--- a/lib/node_modules/@stdlib/math/strided/ops/mul/lib/mul.native.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul/lib/mul.native.js
@@ -28,7 +28,7 @@ var js = require( './mul.js' );
 // MAIN //
 
 /**
-* Multiplies each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Multiplies each element in a strided array `x` by a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
 *
 * @name mul
 * @type {Function}

--- a/lib/node_modules/@stdlib/math/strided/ops/mul/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul/lib/ndarray.js
@@ -38,7 +38,7 @@ var fcn = dispatch( binary, types, data, meta.nargs+meta.nin+meta.nout, meta.nin
 // MAIN //
 
 /**
-* Multiplies each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Multiplies each element in a strided array `x` by a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
 *
 * @param {integer} N - number of indexed elements
 * @param {*} dtypeX - `x` data type

--- a/lib/node_modules/@stdlib/math/strided/ops/mul/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul/lib/ndarray.native.js
@@ -28,7 +28,7 @@ var js = require( './ndarray.js' );
 // MAIN //
 
 /**
-* Multiplies each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Multiplies each element in a strided array `x` by a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
 *
 * @name mul
 * @type {Function}

--- a/lib/node_modules/@stdlib/math/strided/ops/sub/README.md
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub/README.md
@@ -40,7 +40,7 @@ var sub = require( '@stdlib/math/strided/ops/sub' );
 
 #### sub( N, dtypeX, x, strideX, dtypeY, y, strideY, dtypeZ, z, strideZ )
 
-Subtracts each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+Subtracts each element in a strided array `y` from a corresponding element in a strided array `x` and assigns the results to elements in a strided array `z`.
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -95,12 +95,12 @@ var y1 = new Float64Array( y0.buffer, y0.BYTES_PER_ELEMENT*3 ); // start at 4th 
 var z1 = new Float64Array( z0.buffer, z0.BYTES_PER_ELEMENT*2 ); // start at 3rd element
 
 sub( 3, 'float64', x1, -2, 'float64', y1, 1, 'float64', z1, 1 );
-// z0 => <Float64Array>[ 0.0, 0.0, -4.0, 0.0, -5.0, 0.0 ]
+// z0 => <Float64Array>[ 0.0, 0.0, -4.0, -10.0, -5.0, 0.0 ]
 ```
 
 #### sub.ndarray( N, dtypeX, x, strideX, offsetX, dtypeY, y, strideY, offsetY, dtypeZ, z, strideZ, offsetZ )
 
-Subtracts each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z` using alternative indexing semantics.
+Subtracts each element in a strided array `y` from a corresponding element in a strided array `x` and assigns the results to elements in a strided array `z` using alternative indexing semantics.
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -129,7 +129,7 @@ var y = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 var z = new Float64Array( x.length );
 
 sub.ndarray( 3, 'float64', x, 2, 1, 'float64', y, -1, y.length-1, 'float64', z, 1, 0 );
-// z => <Float64Array>[ -5.0, 0.0, -4.0, 0.0, 0.0, 0.0 ]
+// z => <Float64Array>[ -5.0, -10.0, -4.0, 0.0, 0.0, 0.0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/strided/ops/sub/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub/docs/repl.txt
@@ -1,8 +1,8 @@
 
 {{alias}}( N, dx, x, sx, dy, y, sy, dz, z, sz )
-    Subtracts each element in a strided array `x` to a corresponding element in
-    a strided array `y` and assigns the results to elements in a strided array
-    `z`.
+    Subtracts each element in a strided array `y` from a corresponding element
+    in a strided array `x` and assigns the results to elements in a strided
+    array `z`.
 
     The `N` and stride parameters determine which elements in the strided arrays
     are accessed at runtime.
@@ -76,9 +76,9 @@
 
 
 {{alias}}.ndarray( N, dx, x, sx, ox, dy, y, sy, oy, dz, z, sz, oz )
-    Subtracts each element in a strided array `x` to a corresponding element in
-    a strided array `y` and assigns the results to elements in a strided array
-    `z` using alternative indexing semantics.
+    Subtracts each element in a strided array `y` from a corresponding element
+    in a strided array `x` and assigns the results to elements in a strided
+    array `z` using alternative indexing semantics.
 
     While typed array views mandate a view offset based on the underlying
     buffer, the offset parameters support indexing semantics based on starting

--- a/lib/node_modules/@stdlib/math/strided/ops/sub/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub/docs/types/index.d.ts
@@ -32,7 +32,7 @@ type RealOrComplexArray = ArrayLike<number> | ComplexTypedArray;
 */
 interface Routine {
 	/**
-	* Subtracts each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+	* Subtracts each element in a strided array `y` from a corresponding element in a strided array `x` and assigns the results to elements in a strided array `z`.
 	*
 	* @param N - number of indexed elements
 	* @param dtypeX - `x` data type
@@ -63,7 +63,7 @@ interface Routine {
 	( N: number, dtypeX: any, x: RealOrComplexArray, strideX: number, dtypeY: any, y: RealOrComplexArray, strideY: number, dtypeZ: any, z: RealOrComplexArray, strideZ: number ): RealOrComplexArray;
 
 	/**
-	* Subtracts each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z` using alternative indexing semantics.
+	* Subtracts each element in a strided array `y` from a corresponding element in a strided array `x` and assigns the results to elements in a strided array `z` using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param dtypeX - `x` data type
@@ -98,7 +98,7 @@ interface Routine {
 }
 
 /**
-* Subtracts each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Subtracts each element in a strided array `y` from a corresponding element in a strided array `x` and assigns the results to elements in a strided array `z`.
 *
 * @param N - number of indexed elements
 * @param dtypeX - `x` data type

--- a/lib/node_modules/@stdlib/math/strided/ops/sub/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub/lib/ndarray.js
@@ -38,7 +38,7 @@ var fcn = dispatch( binary, types, data, meta.nargs+meta.nin+meta.nout, meta.nin
 // MAIN //
 
 /**
-* Subtracts each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Subtracts each element in a strided array `y` from a corresponding element in a strided array `x` and assigns the results to elements in a strided array `z`.
 *
 * @param {integer} N - number of indexed elements
 * @param {*} dtypeX - `x` data type

--- a/lib/node_modules/@stdlib/math/strided/ops/sub/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub/lib/ndarray.native.js
@@ -28,7 +28,7 @@ var js = require( './ndarray.js' );
 // MAIN //
 
 /**
-* Subtracts each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Subtracts each element in a strided array `y` from a corresponding element in a strided array `x` and assigns the results to elements in a strided array `z`.
 *
 * @name sub
 * @type {Function}

--- a/lib/node_modules/@stdlib/math/strided/ops/sub/lib/sub.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub/lib/sub.js
@@ -38,7 +38,7 @@ var fcn = dispatch( binary, types, data, meta.nargs, meta.nin, meta.nout );
 // MAIN //
 
 /**
-* Subtracts each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Subtracts each element in a strided array `y` from a corresponding element in a strided array `x` and assigns the results to elements in a strided array `z`.
 *
 * @param {integer} N - number of indexed elements
 * @param {*} dtypeX - `x` data type

--- a/lib/node_modules/@stdlib/math/strided/ops/sub/lib/sub.native.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/sub/lib/sub.native.js
@@ -28,7 +28,7 @@ var js = require( './sub.js' );
 // MAIN //
 
 /**
-* Subtracts each element in a strided array `x` to a corresponding element in a strided array `y` and assigns the results to elements in a strided array `z`.
+* Subtracts each element in a strided array `y` from a corresponding element in a strided array `x` and assigns the results to elements in a strided array `z`.
 *
 * @name sub
 * @type {Function}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects copy-paste summary prose in the `@stdlib/math/strided/ops/mul` and `@stdlib/math/strided/ops/sub` packages. Both reused the `add` package's preposition "to" ("...each element in a strided array `x` to a corresponding element in a strided array `y`"), which is wrong for these operations:

-   `mul` computes `z = x * y` → "...`x` **by** a corresponding element...".
-   `sub` computes `z = x - y` → "Subtracts each element in a strided array `y` **from** a corresponding element in a strided array `x`...".

The element-wise math in the examples was already correct; only the prose was stale. The wording is corrected across each package's doc surfaces (declaration TSDoc, README, REPL help, and `lib` JSDoc summaries).

While here, two stale `sub` README example output annotations are corrected, where a `-10.0` result was shown as `0.0`.

The `math/strided/ops` namespace aggregator carries the same summary text but is generated and will pick up the fix on regeneration.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

These issues were identified by an automated TypeScript-declaration audit run with Claude Code, and the fixes were prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md