### PR TITLE
docs: document `@throws` for `math/base/utils/float64-epsilon-difference`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/utils/float64-epsilon-difference/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-epsilon-difference/docs/types/index.d.ts
@@ -60,6 +60,7 @@ type ScaleNames = 'max-abs' | 'max' | 'min-abs' | 'min' | 'mean-abs' | 'mean' | 
 * @param x - first number
 * @param y - second number
 * @param scale - scale function (default: 'max-abs')
+* @throws must provide a recognized scale function name
 * @returns relative difference in units of double-precision floating-point epsilon
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds the `@throws must provide a recognized scale function name` tag to the `@stdlib/math/base/utils/float64-epsilon-difference` declaration, which the sibling `relative-difference` documents. `epsilonDifference` accepts the same `scale` argument and delegates to `reldiff`, which throws on an unrecognized scale-name string, so the declaration should document it.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

This issue was identified by an automated TypeScript-declaration audit run with Claude Code, and the fix was prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md