### PR TITLE
fix: narrow `fresnel` return type to a two-element tuple

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fresnel/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/docs/types/index.d.ts
@@ -52,7 +52,7 @@ interface Fresnel {
 	* var v = fresnel( NaN );
 	* // returns [ NaN, NaN ]
 	*/
-	( x: number ): Array<number>;
+	( x: number ): [ number, number ];
 
 	/**
 	* Computes the Fresnel integrals S(x) and C(x) and assigns results to a provided output array.

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/docs/types/test.ts
@@ -23,9 +23,9 @@ import fresnel = require( './index' );
 
 // TESTS //
 
-// The function returns a collection...
+// The function returns a two-element array...
 {
-	fresnel( 1.0 ); // $ExpectType number[]
+	fresnel( 1.0 ); // $ExpectType [number, number]
 }
 
 // The compiler throws an error if the function is provided an argument which is not a number...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

`@stdlib/math/base/special/fresnel` always returns a fixed two-element array `[ S(x), C(x) ]`, but the declaration typed the return as the over-broad `Array<number>`. This pull request narrows it to `[ number, number ]`, matching the sibling `frexp` (which returns `[ number, number ]`), and updates the declaration test's `$ExpectType` accordingly.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

This issue was identified by an automated TypeScript-declaration audit run with Claude Code, and the fix was prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md