### PR TITLE
docs: fix TSDoc issues across many `math/base/special` declarations

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/absf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/absf/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Computes the absolute value of single-precision floating-point number `x`.
+* Computes the absolute value of a single-precision floating-point number `x`.
 *
 * @param x - input value
 * @returns absolute value

--- a/lib/node_modules/@stdlib/math/base/special/acsch/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/acsch/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Computes the hyperbolic arccosecant of a number.
+* Computes the hyperbolic arccosecant of a double-precision floating-point number.
 *
 * @param x - input value
 * @returns hyperbolic arccosecant

--- a/lib/node_modules/@stdlib/math/base/special/asech/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/asech/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Computes the hyperbolic arcsecant of a number.
+* Computes the hyperbolic arcsecant of a double-precision floating-point number.
 *
 * @param x - input value
 * @returns hyperbolic arcsecant

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /**
 * Computes the binomial coefficient of two integers.
 *
-* @param n - input value
+* @param n - first input value
 * @param k - second input value
 * @returns function value
 *

--- a/lib/node_modules/@stdlib/math/base/special/cfloor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cfloor/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 import { Complex128 } from '@stdlib/types/complex';
 
 /**
-* Rounds a double-precision complex floating-point number toward negative infinity.
+* Rounds each component of a double-precision complex floating-point number toward negative infinity.
 *
 * @param z - input value
 * @returns result

--- a/lib/node_modules/@stdlib/math/base/special/cotd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cotd/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Computes the cotangent of an angle measured in degrees
+* Computes the cotangent of an angle measured in degrees.
 *
 * @param x - input value (in degrees)
 * @returns cotangent

--- a/lib/node_modules/@stdlib/math/base/special/covercos/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/covercos/docs/types/index.d.ts
@@ -21,6 +21,10 @@
 /**
 * Computes the coversed cosine.
 *
+* ## Notes
+*
+* -   The coversed cosine is defined as `1 + sin(x)`.
+*
 * @param x - input value (in radians)
 * @returns coversed cosine
 *

--- a/lib/node_modules/@stdlib/math/base/special/coversin/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/coversin/docs/types/index.d.ts
@@ -21,6 +21,10 @@
 /**
 * Computes the coversed sine.
 *
+* ## Notes
+*
+* -   The coversed sine is defined as `1 - sin(x)`.
+*
 * @param x - input value (in radians)
 * @returns coversed sine
 *

--- a/lib/node_modules/@stdlib/math/base/special/cpolarf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cpolarf/docs/types/index.d.ts
@@ -26,7 +26,7 @@ import { Collection } from '@stdlib/types/array';
 /**
 * Interface describing `cpolarf`.
 */
-interface Cpolar {
+interface Cpolarf {
 	/**
 	* Computes the absolute value and the phase of a single-precision complex floating-point number.
 	*
@@ -77,7 +77,7 @@ interface Cpolar {
 * var v = cpolarf( new Complex64( 5.0, 3.0 ) );
 * // returns [ ~5.83, ~0.5404 ]
 */
-declare var cpolarf: Cpolar;
+declare var cpolarf: Cpolarf;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/math/base/special/cround/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cround/docs/types/index.d.ts
@@ -30,8 +30,6 @@ import { Complex128 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cround( new Complex128( -4.2, 5.5 ) );
 * // returns <Complex128>[ -4.0, 6.0 ]

--- a/lib/node_modules/@stdlib/math/base/special/fast/hypot/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/fast/hypot/docs/types/index.d.ts
@@ -21,8 +21,8 @@
 /**
 * Computes the hypotenuse.
 *
-* @param x - number
-* @param y - number
+* @param x - first number
+* @param y - second number
 * @returns hypotenuse
 *
 * @example

--- a/lib/node_modules/@stdlib/math/base/special/fast/hypotf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/fast/hypotf/docs/types/index.d.ts
@@ -21,8 +21,8 @@
 /**
 * Computes the hypotenuse of two single-precision floating-point numbers.
 *
-* @param x - number
-* @param y - number
+* @param x - first number
+* @param y - second number
 * @returns hypotenuse
 *
 * @example

--- a/lib/node_modules/@stdlib/math/base/special/fast/maxf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/fast/maxf/docs/types/index.d.ts
@@ -49,7 +49,6 @@
 * var v = maxf( +0.0, -0.0 );
 * // returns -0.0
 */
-
 declare function maxf( x: number, y: number ): number;
 
 

--- a/lib/node_modules/@stdlib/math/base/special/floorn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/floorn/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Rounds a double-precision floating-point number to the nearest multiple of `10^n` toward negative infinity.
+* Rounds a numeric value to the nearest multiple of `10^n` toward negative infinity.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/special/frexp/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/frexp/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 import { Collection } from '@stdlib/types/array';
 
 /**
-* Inteface describing `frexp`.
+* Interface describing `frexp`.
 */
 interface Frexp {
 	/**

--- a/lib/node_modules/@stdlib/math/base/special/frexpf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/frexpf/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 import { Collection } from '@stdlib/types/array';
 
 /**
-* Inteface describing `frexpf`.
+* Interface describing `frexpf`.
 */
 interface Frexpf {
 	/**

--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaled/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaled/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Calculates the Lanczos sum for the approximation of the gamma function (scaled by `exp(-g)`, where `g = 10.900511`.
+* Calculates the Lanczos sum for the approximation of the gamma function (scaled by `exp(-g)`, where `g = 10.900511`).
 *
 * @param x - input value
 * @returns Lanczos sum approximation

--- a/lib/node_modules/@stdlib/math/base/special/gammainc/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/gammainc/docs/types/index.d.ts
@@ -23,8 +23,9 @@
 *
 * ## Notes
 *
-* -   The `regularized` and `upper` parameters specify whether to evaluate the non-regularized and/or upper incomplete gamma functions, respectively.
-* -   If provided `x < 0` or `s <= 0`, the function returns `NaN`.
+* -   The `regularized` parameter specifies whether to evaluate the regularized (default) or non-regularized incomplete gamma function.
+* -   The `upper` parameter specifies whether to evaluate the lower (default) or upper incomplete gamma function.
+* -   If provided `x < 0` or `a <= 0`, the function returns `NaN`.
 *
 * @param x - function parameter
 * @param a - function parameter

--- a/lib/node_modules/@stdlib/math/base/special/gammaincinv/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/gammaincinv/docs/types/index.d.ts
@@ -24,7 +24,7 @@
 * ## Notes
 *
 * -   In contrast to a more commonly used definition, the first argument is the probability `p` and the second argument is the scale factor `a`.
-* -   By default, the function inverts the lower regularized incomplete gamma function, `P(x,a)`. To invert the upper function `Q(x,a)`, set the `upper` argument to `true`.
+* -   By default, the function inverts the lower regularized incomplete gamma function, `P(a,x)`. To invert the upper function `Q(a,x)`, set the `upper` argument to `true`.
 * -   If provided `p < 0` or `p > 1`, the function returns `NaN`.
 *
 * @param p - probability value

--- a/lib/node_modules/@stdlib/math/base/special/havercos/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/havercos/docs/types/index.d.ts
@@ -21,6 +21,10 @@
 /**
 * Computes the half-value versed cosine.
 *
+* ## Notes
+*
+* -   The half-value versed cosine is defined as `(1 + cos(x)) / 2`.
+*
 * @param x - input value (in radians)
 * @returns half-value versed cosine
 *

--- a/lib/node_modules/@stdlib/math/base/special/kernel-betainc/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-betainc/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 import { Collection } from '@stdlib/types/array';
 
 /**
-* Interface describing `kernalBetaInc`.
+* Interface describing `kernelBetainc`.
 */
 interface Routine {
 	/**
@@ -38,8 +38,8 @@ interface Routine {
 	* @param x - function input
 	* @param a - function parameter
 	* @param b - function parameter
-	* @param invert - boolean indicating if the function should return the upper tail of the incomplete beta function instead
-	* @param normalized - boolean indicating if the function should evaluate the regularized boolean beta function
+	* @param regularized - boolean indicating if the function should evaluate the regularized incomplete beta function
+	* @param upper - boolean indicating if the function should return the upper tail of the incomplete beta function instead
 	* @returns function value and first derivative
 	*
 	* @example
@@ -50,7 +50,7 @@ interface Routine {
 	* var out = kernelBetainc( 0.2, 1.0, 2.0, true, false );
 	* // returns [ 0.36, 1.6 ]
 	*/
-	( x: number, a: number, b: number, invert: boolean, normalized: boolean ): Array<number>;
+	( x: number, a: number, b: number, regularized: boolean, upper: boolean ): Array<number>;
 
 	/**
 	* Evaluates the incomplete beta function and its first derivative and assigns results to a provided output array.
@@ -64,8 +64,8 @@ interface Routine {
 	* @param x - function input
 	* @param a - function parameter
 	* @param b - function parameter
-	* @param invert - boolean indicating if the function should return the upper tail of the incomplete beta function instead
-	* @param normalized - boolean indicating if the function should evaluate the regularized boolean beta function
+	* @param regularized - boolean indicating if the function should evaluate the regularized incomplete beta function
+	* @param upper - boolean indicating if the function should return the upper tail of the incomplete beta function instead
 	* @param out - output array
 	* @param stride - output array stride
 	* @param offset - output array index offset
@@ -79,7 +79,7 @@ interface Routine {
 	* var bool = ( arr === out );
 	* // returns true
 	*/
-	assign<T = unknown>( x: number, a: number, b: number, invert: boolean, normalized: boolean, out: Collection<T>, stride: number, offset: number ): Collection<T | number>;
+	assign<T = unknown>( x: number, a: number, b: number, regularized: boolean, upper: boolean, out: Collection<T>, stride: number, offset: number ): Collection<T | number>;
 }
 
 /**
@@ -94,8 +94,8 @@ interface Routine {
 * @param x - function input
 * @param a - function parameter
 * @param b - function parameter
-* @param invert - boolean indicating if the function should return the upper tail of the incomplete beta function instead
-* @param normalized - boolean indicating if the function should evaluate the regularized boolean beta function
+* @param regularized - boolean indicating if the function should evaluate the regularized incomplete beta function
+* @param upper - boolean indicating if the function should return the upper tail of the incomplete beta function instead
 * @returns function value and first derivative
 *
 * @example

--- a/lib/node_modules/@stdlib/math/base/special/kernel-betainc/lib/assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-betainc/lib/assign.js
@@ -78,7 +78,7 @@ var ONE_OVER_PI = 1.0 / PI;
 * @param {Probability} x - function input
 * @param {NonNegativeNumber} a - function parameter
 * @param {NonNegativeNumber} b - function parameter
-* @param {boolean} regularized - boolean indicating if the function should evaluate the regularized boolean beta function
+* @param {boolean} regularized - boolean indicating if the function should evaluate the regularized incomplete beta function
 * @param {boolean} upper - boolean indicating if the function should return the upper tail of the incomplete beta function instead
 * @param {(Array|TypedArray|Object)} out - output array
 * @param {integer} stride - output array stride

--- a/lib/node_modules/@stdlib/math/base/special/kernel-betainc/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-betainc/lib/main.js
@@ -31,7 +31,7 @@ var compute = require( './assign.js' );
 * @param {Probability} x - function input
 * @param {NonNegativeNumber} a - function parameter
 * @param {NonNegativeNumber} b - function parameter
-* @param {boolean} regularized - boolean indicating if the function should evaluate the regularized boolean beta function
+* @param {boolean} regularized - boolean indicating if the function should evaluate the regularized incomplete beta function
 * @param {boolean} upper - boolean indicating if the function should return the upper tail of the incomplete beta function instead
 * @returns {Array} function value and first derivative
 *

--- a/lib/node_modules/@stdlib/math/base/special/lnf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/lnf/docs/types/index.d.ts
@@ -22,7 +22,7 @@
 * Evaluates the natural logarithm of a single-precision floating-point number.
 *
 * @param x - input value
-* @returns function value
+* @returns natural logarithm
 *
 * @example
 * var v = lnf( 4.0 );

--- a/lib/node_modules/@stdlib/math/base/special/maxabsn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsn/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 *
 * ## Notes
 *
-* -   When an empty set is considered a subset of the extended reals (all real numbers, including positive and negative infinity), negative infinity is the least upper bound. Similar to zero being the identity element for the sum of an empty set and to one being the identity element for the product of an empty set, negative infinity is the identity element for the maximum, and thus, if not provided any arguments, the function returns `+infinity` (i.e., the absolute value of `-infinity`).
+* -   When an empty set is considered a subset of the extended reals (all real numbers, including positive and negative infinity), negative infinity is the identity element for the maximum. Because the absolute value of negative infinity is positive infinity, if not provided any arguments, the function returns `+infinity`.
 *
 * @param x - first number
 * @param y - second number

--- a/lib/node_modules/@stdlib/math/base/special/minabs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minabs/docs/types/index.d.ts
@@ -21,10 +21,6 @@
 /**
 * Returns the minimum absolute value.
 *
-* ## Notes
-*
-* -   When an empty set is considered a subset of the extended reals (all real numbers, including positive and negative infinity), positive infinity is the greatest upper bound. Similar to zero being the identity element for the sum of an empty set and to one being the identity element for the product of an empty set, positive infinity is the identity element for the minimum, and thus, if not provided any arguments, the function returns positive infinity.
-*
 * @param x - first number
 * @param y - second number
 * @returns minimum absolute value

--- a/lib/node_modules/@stdlib/math/base/special/minabsn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minabsn/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 *
 * ## Notes
 *
-* -   When an empty set is considered a subset of the extended reals (all real numbers, including positive and negative infinity), positive infinity is the greatest upper bound. Similar to zero being the identity element for the sum of an empty set and to one being the identity element for the product of an empty set, positive infinity is the identity element for the minimum, and thus, if not provided any arguments, the function returns positive infinity.
+* -   When an empty set is considered a subset of the extended reals (all real numbers, including positive and negative infinity), positive infinity is the greatest lower bound. Similar to zero being the identity element for the sum of an empty set and to one being the identity element for the product of an empty set, positive infinity is the identity element for the minimum, and thus, if not provided any arguments, the function returns positive infinity.
 *
 * @param x - first number
 * @param y - second number

--- a/lib/node_modules/@stdlib/math/base/special/minmax/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/docs/types/index.d.ts
@@ -37,6 +37,7 @@ interface MinMax {
 	* var v = minmax( 3.14, 4.2 );
 	* // returns [ 3.14, 4.2 ]
 	*
+	* @example
 	* var v = minmax( 3.14, NaN );
 	* // returns [ NaN, NaN ]
 	*
@@ -58,7 +59,7 @@ interface MinMax {
 	*
 	* @example
 	* var out = [ 0.0, 0.0 ];
-	* var v = minmax( 5.9, 3.14, out, 1, 0 );
+	* var v = minmax.assign( 5.9, 3.14, out, 1, 0 );
 	* // returns [ 3.14, 5.9 ]
 	*
 	* var bool = ( v === out );
@@ -78,6 +79,7 @@ interface MinMax {
 * var v = minmax( 3.14, 4.2 );
 * // returns [ 3.14, 4.2 ]
 *
+* @example
 * var v = minmax( 3.14, NaN );
 * // returns [ NaN, NaN ]
 *

--- a/lib/node_modules/@stdlib/math/base/special/minmaxabsn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxabsn/docs/types/index.d.ts
@@ -22,13 +22,16 @@
 
 import { Collection } from '@stdlib/types/array';
 
+/**
+* Interface describing an interface for computing minimum and maximum absolute values.
+*/
 interface MinMaxAbsN {
 	/**
 	* Returns the minimum and maximum absolute values.
 	*
 	* ## Notes
 	*
-	* -   When an empty set is considered a subset of the extended reals (all real numbers, including positive and negative infinity), positive infinity is the greatest lower bound and negative infinity is the least upper bound. Similar to zero being the identity element for the sum of an empty set and to one being the identity element for the product of an empty set, positive infinity is the identity element for the minimum and negative infinity is the identity element for the maximum, and thus, if not provided any arguments, the function returns positive infinity for both the minimum and maximum absolute values.
+	* -   When an empty set is considered a subset of the extended reals (all real numbers, including positive and negative infinity), positive infinity is the greatest lower bound and negative infinity is the least upper bound. Similar to zero being the identity element for the sum of an empty set and to one being the identity element for the product of an empty set, positive infinity is the identity element for the minimum and negative infinity is the identity element for the maximum; because both the minimum (+infinity) and the maximum (-infinity) have an absolute value of positive infinity, if not provided any arguments, the function returns positive infinity for both the minimum and maximum absolute values.
 	*
 	* @returns minimum and maximum absolute values
 	*

--- a/lib/node_modules/@stdlib/math/base/special/minmaxf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxf/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 import { Collection } from '@stdlib/types/array';
 
 /**
-* Interface describing an interface for computing minimum and maximum of two single-precision floating-point numbers.
+* Interface describing a function for computing the minimum and maximum of two single-precision floating-point numbers.
 */
 interface MinMaxf {
 	/**
@@ -58,7 +58,7 @@ interface MinMaxf {
 	*
 	* @example
 	* var out = [ 0.0, 0.0 ];
-	* var v = minmaxf( 5.9, 3.14, out, 1, 0 );
+	* var v = minmaxf.assign( 5.9, 3.14, out, 1, 0 );
 	* // returns [ 3.14, 5.9 ]
 	*
 	* var bool = ( v === out );

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 import { Collection } from '@stdlib/types/array';
 
 /**
-* Interface describing an interface for computing minimum and maximum values.
+* Interface describing a function for computing the minimum and maximum values.
 */
 interface MinMaxN {
 	/**
@@ -52,6 +52,7 @@ interface MinMaxN {
 	* // returns [ 3.14, 3.14 ]
 	*/
 	( x: number ): Array<number>; // eslint-disable-line @typescript-eslint/unified-signatures
+
 	/**
 	* Returns the minimum and maximum values.
 	*
@@ -63,6 +64,7 @@ interface MinMaxN {
 	* var v = minmaxn( 3.14, 4.2 );
 	* // returns [ 3.14, 4.2 ]
 	*
+	* @example
 	* var v = minmaxn( 3.14, NaN );
 	* // returns [ NaN, NaN ]
 	*
@@ -129,6 +131,7 @@ interface MinMaxN {
 	* var v = minmaxn( 3.14, 4.2 );
 	* // returns [ 3.14, 4.2 ]
 	*
+	* @example
 	* var v = minmaxn( 3.14, NaN );
 	* // returns [ NaN, NaN ]
 	*
@@ -148,7 +151,7 @@ interface MinMaxN {
 	*
 	* @example
 	* var out = [ 0.0, 0.0 ];
-	* var v = minmaxn( out, 1, 0 );
+	* var v = minmaxn.assign( out, 1, 0 );
 	* // returns [ Infinity, -Infinity ]
 	*
 	* var bool = ( v === out );
@@ -167,7 +170,7 @@ interface MinMaxN {
 	*
 	* @example
 	* var out = [ 0.0, 0.0 ];
-	* var v = minmaxn( 5.9, out, 1, 0 );
+	* var v = minmaxn.assign( 5.9, out, 1, 0 );
 	* // returns [ 5.9, 5.9 ]
 	*
 	* var bool = ( v === out );
@@ -187,7 +190,7 @@ interface MinMaxN {
 	*
 	* @example
 	* var out = [ 0.0, 0.0 ];
-	* var v = minmaxn( 5.9, 3.14, out, 1, 0 );
+	* var v = minmaxn.assign( 5.9, 3.14, out, 1, 0 );
 	* // returns [ 3.14, 5.9 ]
 	*
 	* var bool = ( v === out );
@@ -208,7 +211,7 @@ interface MinMaxN {
 	*
 	* @example
 	* var out = [ 0.0, 0.0 ];
-	* var v = minmaxn( 5.9, 3.14, 4.2, out, 1, 0 );
+	* var v = minmaxn.assign( 5.9, 3.14, 4.2, out, 1, 0 );
 	* // returns [ 3.14, 5.9 ]
 	*
 	* var bool = ( v === out );
@@ -230,7 +233,7 @@ interface MinMaxN {
 	*
 	* @example
 	* var out = [ 0.0, 0.0 ];
-	* var v = minmaxn( 5.9, 3.14, 4.2, 3.9, out, 1, 0 );
+	* var v = minmaxn.assign( 5.9, 3.14, 4.2, 3.9, out, 1, 0 );
 	* // returns [ 3.14, 5.9 ]
 	*
 	* var bool = ( v === out );
@@ -253,7 +256,7 @@ interface MinMaxN {
 	*
 	* @example
 	* var out = [ 0.0, 0.0 ];
-	* var v = minmaxn( 5.9, 3.14, 4.2, 3.9, 3.8, out, 1, 0 );
+	* var v = minmaxn.assign( 5.9, 3.14, 4.2, 3.9, 3.8, out, 1, 0 );
 	* // returns [ 3.14, 5.9 ]
 	*
 	* var bool = ( v === out );
@@ -274,7 +277,7 @@ interface MinMaxN {
 	*
 	* @example
 	* var out = [ 0.0, 0.0 ];
-	* var v = minmaxn( 5.9, 3.14, 4.2, 3.9, 3.8, 3.7, out, 1, 0 );
+	* var v = minmaxn.assign( 5.9, 3.14, 4.2, 3.9, 3.8, 3.7, out, 1, 0 );
 	* // returns [ 3.14, 5.9 ]
 	*
 	* var bool = ( v === out );

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Computes the nth negaLucas number in single-precision floating-point format.
+* Computes the nth negaLucas number as a single-precision floating-point number.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/special/round/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/round/docs/types/index.d.ts
@@ -26,7 +26,7 @@
 * -   Ties are rounded toward positive infinity.
 *
 * @param x - input value
-* @returns function value
+* @returns rounded value
 *
 * @example
 * var v = round( -4.2 );

--- a/lib/node_modules/@stdlib/math/base/special/sincosd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/sincosd/docs/types/index.d.ts
@@ -22,7 +22,7 @@
 
 import { NumericArray } from '@stdlib/types/array';
 
-interface sincosd {
+interface SinCosd {
 	/**
 	* Simultaneously computes the sine and cosine of an angle measured in degrees.
 	*
@@ -67,7 +67,7 @@ interface sincosd {
 	* var bool = ( v === out );
 	* // returns true
 	*/
-	assign<T extends NumericArray>( x: number, out: T, stride: number, offset: number ): T ;
+	assign<T extends NumericArray>( x: number, out: T, stride: number, offset: number ): T;
 }
 
 /**
@@ -92,7 +92,7 @@ interface sincosd {
 * var v = sincosd( NaN );
 * // returns [ NaN, NaN ]
 */
-declare var sincosd: sincosd;
+declare var sincosd: SinCosd;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/docs/types/index.d.ts
@@ -51,20 +51,20 @@ interface SinCosPi {
 	( x: number ): Array<number>;
 
 	/**
-	* Simultaneously computes the sine and cosine of a number times π.
+	* Simultaneously computes the sine and cosine of a number times π and assigns the results to a provided output array.
 	*
 	* @param x - input value
 	* @param out - output array
 	* @param stride - output array stride
 	* @param offset - output array index offset
-	* @returns two-element array containing sin(πx) and cos(πx)
+	* @returns output array
 	*
 	* @example
 	* var Float64Array = require( '@stdlib/array/float64' );
 	*
 	* var out = new Float64Array( 2 );
 	*
-	* var v = sincospi( 0.0, out, 1, 0 );
+	* var v = sincospi.assign( 0.0, out, 1, 0 );
 	* // returns <Float64Array>[ 0.0, 1.0 ]
 	*
 	* var bool = ( v === out );

--- a/lib/node_modules/@stdlib/math/base/special/sind/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/sind/docs/types/index.d.ts
@@ -33,7 +33,7 @@
 * // returns ~0.5
 *
 * @example
-* var v = sind( 90.0);
+* var v = sind( 90.0 );
 * // returns 1.0
 *
 * @example

--- a/lib/node_modules/@stdlib/math/base/special/tand/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/tand/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Computes the tangent of an angle measured in degrees
+* Computes the tangent of an angle measured in degrees.
 *
 * @param x - input value (in degrees)
 * @returns tangent

--- a/lib/node_modules/@stdlib/math/base/special/truncsd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/truncsd/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 *
 * @param x - input value
 * @param n - number of significant figures
-* @param b - integer base
+* @param b - base
 * @returns rounded value
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects documentation-only issues in TypeScript declaration files across many `@stdlib/math/base/special` packages, flagged by an audit. No emitted types change in a behavior-affecting way; the edits are limited to TSDoc prose, examples, parameter names/descriptions, and internal interface names.

Highlights:

-   **`kernel-betainc`** — the 4th/5th parameters were named `invert`/`normalized` with descriptions swapped relative to the implementation `kernelBetainc( x, a, b, regularized, upper )`; renamed to `regularized`/`upper` with descriptions re-paired, fixed the garbled "regularized boolean beta function" → "incomplete beta function" (in the declaration and the `lib/main.js`/`lib/assign.js` JSDoc), and fixed the interface doc-comment misspelling `kernalBetaInc`.
-   **`gammainc`** — split the muddled `regularized`/`upper` Notes into two clear bullets and fixed a stale `s <= 0` → `a <= 0` reference.
-   **`cfloor`** — summary now reads "Rounds each component of..." like its siblings; **`cpolarf`**/**`sincosd`** — fixed copy-pasted/lowercase interface names (`Cpolar` → `Cpolarf`, `sincosd` → `SinCosd`).
-   **`minmax`/`minmaxn`/`minmaxf`/`sincospi`** — `assign` `@example`s now call the `.assign` method instead of the bare function (so `v === out` is actually `true`); corrected the `assign` summary/`@returns` for `sincospi`; split merged `@example` blocks.
-   **`minabs`** — dropped the empty-set Notes paragraph (the function is binary); **`minabsn`/`maxabsn`/`minmaxabsn`** — corrected the empty-args identity Notes.
-   **`covercos`/`coversin`/`havercos`** — added the defining-formula Notes block their forward-trig siblings include.
-   Assorted prose fixes: `frexp`/`frexpf` "Inteface" typo; `absf`/`acsch`/`asech`/`negalucasf` summary wording; `floorn` summary ("numeric value", matching `ceiln`/`roundn`/`truncn`); `cotd`/`tand` trailing periods; `cround` unused requires; `gammaincinv` argument-order notation; `lnf`/`round` `@returns`; `truncsd`/`binomcoef`/`fast/hypot`/`fast/hypotf` `@param` descriptions; `gamma-lanczos-sum-expg-scaled` unbalanced parenthesis; `sind` example spacing; `fast/maxf` stray blank line; and a few missing `@example` tags and interface doc comments.

This PR addresses the TypeScript declarations (plus the `kernel-betainc` `lib` JSDoc, to keep that package's fix whole); the generated namespace aggregator will pick up these fixes on regeneration. Several findings that are errors replicated across a package's other doc surfaces — `cscd`, `nonfibonaccif`, `nonfibonacci`, `powf` — are handled package-wide in a separate PR (#12474). The non-docs `fresnel` return-type narrowing and higher-severity `ellipj`/`factorial2f` fixes are in their own PRs.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace. Several findings were verified against the package implementations (e.g. `kernel-betainc`, `gammainc`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

These issues were identified by an automated TypeScript-declaration audit run with Claude Code, and the fixes were prepared by Claude Code (with parallel sub-agents per package group) under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md