### PR TITLE
docs: drop erroneous "(in radians)" qualifier from `math/base/special/sincf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sincf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # sincf
 
-> Compute the [cardinal sine][sinc] of a single-precision floating-point number (in radians).
+> Compute the [cardinal sine][sinc] of a single-precision floating-point number.
 
 <section class="intro">
 
@@ -50,7 +50,7 @@ var sincf = require( '@stdlib/math/base/special/sincf' );
 
 #### sincf( x )
 
-Computes the normalized [cardinal sine][sinc] of a single-precision floating-point number (in radians).
+Computes the normalized [cardinal sine][sinc] of a single-precision floating-point number.
 
 ```javascript
 var v = sincf( 0.5 );
@@ -121,7 +121,7 @@ logEachMap( 'sincf( %0.4f ) = %0.4f', x, sincf );
 
 #### stdlib_base_sincf( x )
 
-Computes the normalized [cardinal sine][sinc] of a single-precision floating-point number (in radians).
+Computes the normalized [cardinal sine][sinc] of a single-precision floating-point number.
 
 ```c
 float y = stdlib_base_sincf( 0.5f );

--- a/lib/node_modules/@stdlib/math/base/special/sincf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/sincf/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( x )
     Computes the normalized cardinal sine of a single-precision floating-point
-    number (in radians).
+    number.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/math/base/special/sincf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/sincf/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Computes the normalized cardinal sine of a single-precision floating-point number (in radians).
+* Computes the normalized cardinal sine of a single-precision floating-point number.
 *
 * @param x - input value
 * @returns cardinal sine

--- a/lib/node_modules/@stdlib/math/base/special/sincf/include/stdlib/math/base/special/sincf.h
+++ b/lib/node_modules/@stdlib/math/base/special/sincf/include/stdlib/math/base/special/sincf.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Computes the normalized cardinal sine of a single-precision floating-point number (in radians).
+* Computes the normalized cardinal sine of a single-precision floating-point number.
 */
 float stdlib_base_sincf( const float x );
 

--- a/lib/node_modules/@stdlib/math/base/special/sincf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Compute the normalized cardinal sine of a single-precision floating-point number (in radians).
+* Compute the normalized cardinal sine of a single-precision floating-point number.
 *
 * @module @stdlib/math/base/special/sincf
 *

--- a/lib/node_modules/@stdlib/math/base/special/sincf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincf/lib/main.js
@@ -36,7 +36,7 @@ var ZERO = f32( 0.0 );
 // MAIN //
 
 /**
-* Computes the normalized cardinal sine of a single-precision floating-point number (in radians).
+* Computes the normalized cardinal sine of a single-precision floating-point number.
 *
 * ## Method
 *

--- a/lib/node_modules/@stdlib/math/base/special/sincf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincf/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Computes the normalized cardinal sine of a single-precision floating-point number (in radians).
+* Computes the normalized cardinal sine of a single-precision floating-point number.
 *
 * @private
 * @param {number} x - input value

--- a/lib/node_modules/@stdlib/math/base/special/sincf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/sincf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/math/base/special/sincf",
   "version": "0.0.0",
-  "description": "Compute the normalized cardinal sine of a single-precision floating-point number (in radians).",
+  "description": "Compute the normalized cardinal sine of a single-precision floating-point number.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -69,13 +69,13 @@
       "$schema": "math/base@v1.0",
       "base_alias": "sinc",
       "alias": "sincf",
-      "pkg_desc": "compute the normalized cardinal sine of a single-precision floating-point number (in radians)",
-      "desc": "computes the normalized cardinal sine of a single-precision floating-point number (in radians)",
+      "pkg_desc": "compute the normalized cardinal sine of a single-precision floating-point number",
+      "desc": "computes the normalized cardinal sine of a single-precision floating-point number",
       "short_desc": "normalized cardinal sine",
       "parameters": [
         {
           "name": "x",
-          "desc": "input value (in radians)",
+          "desc": "input value",
           "type": {
             "javascript": "number",
             "jsdoc": "number",

--- a/lib/node_modules/@stdlib/math/base/special/sincf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincf/src/main.c
@@ -23,7 +23,7 @@
 #include "stdlib/constants/float32/pi.h"
 
 /**
-* Computes the normalized cardinal sine of a single-precision floating-point number (in radians).
+* Computes the normalized cardinal sine of a single-precision floating-point number.
 *
 * ## Method
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

The normalized cardinal sine takes a dimensionless argument, so the "(in radians)" qualifier in the `@stdlib/math/base/special/sincf` summaries and input-parameter description is incorrect — the double-precision sibling `sinc` carries no such qualifier.

This pull request removes "(in radians)" across all of the package's documentation surfaces:

-   the TypeScript declaration (`docs/types/index.d.ts`),
-   `README.md` (package tagline + JS and C usage sections),
-   the REPL help text (`docs/repl.txt`),
-   the `lib` JSDoc comments (`index.js`, `main.js`, `native.js`),
-   the C header and source comments (`include/.../sincf.h`, `src/main.c`), and
-   the `package.json` description and the `x` parameter metadata.

No code or behavior changes — comment/description text only.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace; split out from the broader `math/base/special` declarations PR so the fix can be applied consistently across all of the package's documentation surfaces.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

This issue was identified by an automated TypeScript-declaration audit run with Claude Code, and the fix was prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md