### PR TITLE
fix: ensure BigInts are coerced to number primitives

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
@@ -31,6 +31,7 @@ var isBetween = require( '@stdlib/assert/is-between' );
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var setReadOnlyAccessor = require( '@stdlib/utils/define-nonenumerable-read-only-accessor' );
 var BigInt = require( '@stdlib/bigint/ctor' );
+var Number = require( '@stdlib/number/ctor' );
 var Uint32Array = require( '@stdlib/array/uint32' );
 var join = require( '@stdlib/array/base/join' );
 var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
@@ -73,8 +74,8 @@ function Uint64( value ) {
 		if ( v !== value ) {
 			throw new TypeError( format( 'invalid argument. Must provide an integer on the interval [0, 2^64-1]. Value: `%s`.', value ) );
 		}
-		buffer[ indices.HIGH ] = v >> BigInt( 32 );
-		buffer[ indices.LOW ] = v & BigInt( UINT32_MAX );
+		buffer[ indices.HIGH ] = Number( v >> BigInt( 32 ) );
+		buffer[ indices.LOW ] = Number( v & BigInt( UINT32_MAX ) );
 	} else if ( isInteger( value ) && isBetween( value, 0, MAX_SAFE_INTEGER ) ) {
 		buffer[ indices.HIGH ] = ( value / TWO_32 ) >>> 0;
 		buffer[ indices.LOW ] = value >>> 0;

--- a/lib/node_modules/@stdlib/number/uint64/ctor/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/test/test.js
@@ -131,6 +131,32 @@ tape( 'the constructor throws an error if provided an invalid/unsupported BigInt
 	}
 });
 
+tape( 'the constructor returns an unsigned 64-bit integer', function test( t ) {
+	var x;
+
+	x = new Uint64( 0 );
+	t.strictEqual( x instanceof Uint64, true, 'returns expected value' );
+
+	x = new Uint64( 1234 );
+	t.strictEqual( x instanceof Uint64, true, 'returns expected value' );
+
+	x = new Uint64( MAX_SAFE_INTEGER );
+	t.strictEqual( x instanceof Uint64, true, 'returns expected value' );
+
+	if ( HAS_BIGINT ) {
+		x = new Uint64( BigInt( 0 ) );
+		t.strictEqual( x instanceof Uint64, true, 'returns expected value' );
+
+		x = new Uint64( BigInt( 1234 ) );
+		t.strictEqual( x instanceof Uint64, true, 'returns expected value' );
+
+		x = new Uint64( BigInt( '0xffffffffffffffff' ) ); // 2^64 - 1
+		t.strictEqual( x instanceof Uint64, true, 'returns expected value' );
+	}
+
+	t.end();
+});
+
 tape( 'the constructor has a read-only `name` property', function test( t ) {
 	t.strictEqual( hasOwnProp( Uint64, 'name' ), true, 'has property' );
 	t.strictEqual( Uint64.name, 'Uint64', 'returns expected value' );


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates the implementation for the BigInt path in the contructor to use the `Number` constructor to convert `BigInt` values to primitive numbers.
-   Adds unit tests for this previously unexplored branch.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
