### PR TITLE
docs: fix package-wide doc errors in two `math/iter` packages

### DIFF
--- a/lib/node_modules/@stdlib/math/iter/sequences/integers/README.md
+++ b/lib/node_modules/@stdlib/math/iter/sequences/integers/README.md
@@ -73,7 +73,7 @@ The returned iterator protocol-compliant object has the following properties:
 
 The function supports the following `options`:
 
--   **iter**: number of iterations. Default: `18014398509481984`.
+-   **iter**: number of iterations. Default: `18014398509481982`.
 
 By default, the function returns a finite iterator to avoid exceeding the maximum safe double-precision floating-point integer. To adjust the number of iterations, set the `iter` option.
 

--- a/lib/node_modules/@stdlib/math/iter/sequences/integers/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/iter/sequences/integers/docs/repl.txt
@@ -11,7 +11,7 @@
         Function options.
 
     options.iter: integer (optional)
-        Number of iterations. Default: 18014398509481984.
+        Number of iterations. Default: 18014398509481982.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/math/iter/sequences/integers/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/iter/sequences/integers/docs/types/index.d.ts
@@ -43,7 +43,7 @@ interface Options {
 * -   If an environment supports `Symbol.iterator`, the returned iterator is iterable.
 *
 * @param options - function options
-* @param options.iter - number of iterations (default: 18014398509481984)
+* @param options.iter - number of iterations (default: 18014398509481982)
 * @throws `iter` option must be a nonnegative integer
 * @returns iterator
 *

--- a/lib/node_modules/@stdlib/math/iter/sequences/integers/lib/main.js
+++ b/lib/node_modules/@stdlib/math/iter/sequences/integers/lib/main.js
@@ -41,7 +41,7 @@ var MAX_ITER = FLOAT64_MAX_SAFE_INTEGER * 2;
 * -   If an environment supports `Symbol.iterator`, the returned iterator is iterable.
 *
 * @param {Options} [options] - function options
-* @param {NonNegativeInteger} [options.iter=18014398509481984] - number of iterations
+* @param {NonNegativeInteger} [options.iter=18014398509481982] - number of iterations
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
 * @returns {Iterator} iterator

--- a/lib/node_modules/@stdlib/math/iter/special/pow/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/pow/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # iterPow
 
-> Create an [iterator][mdn-iterator-protocol] which iteratively evaluates the [exponential function][@stdlib/math/base/special/pow].
+> Create an [iterator][mdn-iterator-protocol] which iteratively evaluates the [power function][@stdlib/math/base/special/pow] (i.e., `base` raised to the power `exponent`).
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var iterPow = require( '@stdlib/math/iter/special/pow' );
 
 #### iterPow( base, exponent )
 
-Returns an [iterator][mdn-iterator-protocol] which iteratively evaluates the [exponential function][@stdlib/math/base/special/pow].
+Returns an [iterator][mdn-iterator-protocol] which iteratively evaluates the [power function][@stdlib/math/base/special/pow] (i.e., `base` raised to the power `exponent`).
 
 ```javascript
 var array2iterator = require( '@stdlib/array/to-iterator' );

--- a/lib/node_modules/@stdlib/math/iter/special/pow/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/iter/special/pow/docs/repl.txt
@@ -1,6 +1,7 @@
 
 {{alias}}( base, exponent )
-    Returns an iterator which iteratively evaluates the exponential function.
+    Returns an iterator which iteratively evaluates the power function (i.e.,
+    `base` raised to the power `exponent`).
 
     The length of the returned iterator is equal to the length of the shortest
     provided iterator. In other words, the returned iterator ends once *one* of

--- a/lib/node_modules/@stdlib/math/iter/special/pow/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/iter/special/pow/docs/types/index.d.ts
@@ -26,7 +26,7 @@ import { Iterator as Iter, IterableIterator } from '@stdlib/types/iter';
 type Iterator = Iter | IterableIterator;
 
 /**
-* Returns an iterator which iteratively evaluates the exponential function.
+* Returns an iterator which iteratively evaluates the power function (i.e., `base` raised to the power `exponent`).
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/iter/special/pow/lib/index.js
+++ b/lib/node_modules/@stdlib/math/iter/special/pow/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Create an iterator which iteratively evaluates the exponential function.
+* Create an iterator which iteratively evaluates the power function (i.e., `base` raised to the power `exponent`).
 *
 * @module @stdlib/math/iter/special/pow
 *

--- a/lib/node_modules/@stdlib/math/iter/special/pow/lib/main.js
+++ b/lib/node_modules/@stdlib/math/iter/special/pow/lib/main.js
@@ -27,7 +27,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 // MAIN //
 
 /**
-* Returns an iterator which iteratively evaluates the exponential function.
+* Returns an iterator which iteratively evaluates the power function (i.e., `base` raised to the power `exponent`).
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/iter/special/pow/package.json
+++ b/lib/node_modules/@stdlib/math/iter/special/pow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/math/iter/special/pow",
   "version": "0.0.0",
-  "description": "Create an iterator which evaluates the exponential function.",
+  "description": "Create an iterator which evaluates the power function (i.e., `base` raised to the power `exponent`).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Two `@stdlib/math/iter` findings are not specific to the TypeScript declarations — the same errors appear consistently across each package's documentation surfaces — so they are fixed package-wide here:

-   **`special/pow`** — the summary called the operation the "exponential function", but the iterator evaluates `base^exponent` (the power function). Reworded to "power function (i.e., `base` raised to the power `exponent`)" in the declaration, README, REPL help, `lib` JSDoc, and `package.json` description. The auto-generated "See Also" entries (which derive from other packages' metadata) are left untouched.
-   **`sequences/integers`** — the documented default for the `iter` option was `18014398509481984`, two more than the actual default `FLOAT64_MAX_SAFE_INTEGER * 2 = 18014398509481982`. Corrected in the declaration, README, REPL help, and `lib/main.js` JSDoc.

Split out from the `@stdlib/math/iter` declarations PR (#12462) so the fixes apply consistently across all documentation surfaces.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via a TypeScript-declaration audit of the `@stdlib/math` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure.

These issues were identified by an automated TypeScript-declaration audit run with Claude Code, and the fixes were prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md