### PR TITLE
docs: qualify async behavior in function descriptions

### DIFF
--- a/lib/node_modules/@stdlib/fs/exists/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/exists/docs/types/index.d.ts
@@ -46,7 +46,7 @@ type Callback = Unary | Binary;
 */
 interface Exists {
 	/**
-	* Tests whether a path exists on the filesystem.
+	* Asynchronously tests whether a path exists on the filesystem.
 	*
 	* @param path - path to test
 	* @param clbk - callback to invoke after testing path existence
@@ -81,7 +81,7 @@ interface Exists {
 }
 
 /**
-* Tests whether a path exists on the filesystem.
+* Asynchronously tests whether a path exists on the filesystem.
 *
 * @param path - path to test
 * @param clbk - callback to invoke after testing path existence

--- a/lib/node_modules/@stdlib/fs/exists/lib/async.js
+++ b/lib/node_modules/@stdlib/fs/exists/lib/async.js
@@ -36,7 +36,7 @@ if ( typeof fs.access === 'function' ) {
 // MAIN //
 
 /**
-* Tests whether a path exists on the filesystem.
+* Asynchronously tests whether a path exists on the filesystem.
 *
 * @param {(string|Buffer)} path - path to test
 * @param {Function} clbk - callback to invoke after testing path existence

--- a/lib/node_modules/@stdlib/fs/read-wasm/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/read-wasm/docs/types/index.d.ts
@@ -45,7 +45,7 @@ type Callback = ( err: Error | null, file: Uint8Array ) => void;
 */
 interface ReadWASM {
 	/**
-	* Reads the entire contents of a WebAssembly file.
+	* Asynchronously reads the entire contents of a WebAssembly file.
 	*
 	* @param file - file path or file descriptor
 	* @param options - options
@@ -69,7 +69,7 @@ interface ReadWASM {
 	( file: string | Buffer | number, options: Options, clbk: Callback ): void;
 
 	/**
-	* Reads the entire contents of a WebAssembly file.
+	* Asynchronously reads the entire contents of a WebAssembly file.
 	*
 	* @param file - file path or file descriptor
 	* @param clbk - callback to invoke after reading a file
@@ -113,7 +113,7 @@ interface ReadWASM {
 }
 
 /**
-* Reads the entire contents of a WebAssembly file.
+* Asynchronously reads the entire contents of a WebAssembly file.
 *
 * @param file - file path or file descriptor
 * @param options - options

--- a/lib/node_modules/@stdlib/fs/read-wasm/lib/async.js
+++ b/lib/node_modules/@stdlib/fs/read-wasm/lib/async.js
@@ -31,7 +31,7 @@ var format = require( '@stdlib/string/format' );
 // MAIN //
 
 /**
-* Reads the entire contents of a WebAssembly file.
+* Asynchronously reads the entire contents of a WebAssembly file.
 *
 * @param {(string|Buffer|integer)} file - file path or file descriptor
 * @param {Options} [options] - options


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request prepends the `"Asynchronously"` qualifier to the async-entry JSDoc summaries in `@stdlib/fs/exists` and `@stdlib/fs/read-wasm`, where it was missing in both `lib/async.js` and `docs/types/index.d.ts`. The sync entries in both packages already correctly start with `"Synchronously"`, so the asymmetry was unintentional.

### Namespace summary

-   **Namespace:** `@stdlib/fs`
-   **Members analyzed:** 16 packages (all non-autogenerated). Members: `append-file`, `close`, `exists`, `open`, `read-dir`, `read-file-list`, `read-file`, `read-json`, `read-ndjson`, `read-wasm`, `rename`, `resolve-parent-path-by`, `resolve-parent-path`, `resolve-parent-paths`, `unlink`, `write-file`.
-   **Features analyzed:** file tree, `package.json` shape (top-level + `scripts` keys), `README` section list, `manifest.json` shape, `test`/`benchmark`/`examples` filenames, `lib/` file naming, public-signature shape, validation prologue, error-construction style, JSDoc shape (summary verb, `@throws` ordering, `@returns` presence), `'use strict';` directive, block-comment separators, `setReadOnly` import.
-   **Features with a clear majority (≥75%) and no surviving outlier corrections:** top-level directory set (100%), top-level files (100%), `package.json` top-level key set (100%), `'use strict';` directive (100%), `// MODULES // // MAIN // // EXPORTS //` separators (100%), `setReadOnly` import on `lib/index.js` (100%), error construction via `@stdlib/string/format` (100% of validating packages), `README` section ordering `Usage → Notes → Examples → [CLI] → [See Also]` (100% of present sections), `lib/sync.js` summary starts with `"Synchronously"` (16/16), `bin/cli` co-occurs with `etc/cli_opts.json` (10/10), `docs/types/{index.d.ts,test.ts}` presence (16/16).
-   **Features with a clear majority but corrections deliberately excluded:** `## See Also` section in `README` (12/16) and `## Notes` section in `README` (15/16, missing in `read-file-list`) — `See Also` is generator-owned per the routine's pre-validation gates, and `## Notes` content is package-specific prose that cannot be majority-derived (boilerplate would mislead readers).
-   **Features without a clear majority (excluded from drift analysis):** `lib/` file-naming split between `async.js + sync.js + index.js` (8/16) and `main.js + sync.js + index.js` (7/16) — a behavior-equivalent rename, not actionable as drift; presence of `bin`/`etc` (10/16) — CLI-applicability is package-semantic, not drift; presence of `lib/validate.js` (3/16) — tied to packages with options arguments, not drift; explicit `@returns` on private helper-function JSDoc — varies by helper-function count, not a public-API surface.

### `@stdlib/fs/exists`

Prepended `"Asynchronously "` to the JSDoc summary in `lib/async.js` and corrected the two corresponding async-entry summaries in `docs/types/index.d.ts` (the `exists` method on the interface and the default export). The sync-entry summary in both files already began with `"Synchronously"`, making the omission on the async side an unintentional asymmetry. 14 of 16 `@stdlib/fs` packages qualify their async-entry summaries with `"Asynchronously"` (87.5%).

### `@stdlib/fs/read-wasm`

Prepended `"Asynchronously "` to the JSDoc summary in `lib/async.js` and corrected the three corresponding async-entry summaries in `docs/types/index.d.ts` (two overload signatures for the async method on the interface and the default export). The sync-entry summary was already correct. 14 of 16 `@stdlib/fs` packages qualify their async-entry summaries with `"Asynchronously"` (87.5%).

### Validation

-   **Structural extraction** ran across all 16 `@stdlib/fs` members (file tree, `package.json` shape, `README` section list, `test/`/`benchmark/`/`examples/` filenames, `lib/` file naming, `docs/types` presence).
-   **Semantic extraction** ran across the async entries (`lib/async.js` or `lib/main.js`), `lib/sync.js`, and `lib/validate.js` where present (public signature, validation prologue, error construction, JSDoc shape).
-   **Three-axis drift validation** confirmed the two outliers (`exists`, `read-wasm`): both are genuine async-callback functions with sync siblings, both `docs/repl.txt` files already say `"Asynchronously …"` (so the JSDoc change aligns the source with the REPL help), no `test/` files depend on the summary text, and no package-generator artifact owns these surfaces.

#### Deliberately excluded

-   `## See Also` section absence in 4 packages — generator-owned per the routine's pre-validation gates.
-   `## Notes` section absence in `read-file-list/README.md` (15/16 sibling pattern) — adding a Notes heading requires package-specific prose, and a boilerplate stub would mislead.
-   `lib/` async-entry filename split (`async.js` vs `main.js`) — no 75% majority; would also touch `lib/index.js` `require()` lines as a rename rather than a drift correction.
-   Any change to a `## See Also` block, `docs/repl.txt`, or autogenerated artifact in this namespace.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found via an automated cross-package drift audit of the `@stdlib/fs` namespace. The audit's full per-feature report (conformance percentages, excluded features, all candidate outliers and why they advanced or were dropped) lives outside the working tree at `~/drift-reports/drift-fs-2026-06-03.md`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

The audit and the proposed JSDoc fixes were prepared by Claude Code under my review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01UP3L6as5W5sTo7vssqNsks)_