### PR TITLE
fix: update parameter name

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/docs/types/index.d.ts
@@ -62,7 +62,7 @@ interface LogCDF {
 	* var y = logcdf( NaN, 0.0, 1.0 );
 	* // returns NaN
 	*/
-	( x: number, mu: number, beta: number ): number;
+	( x: number, mu: number, s: number ): number;
 
 	/**
 	* Returns a function for evaluating the logarithm of the cumulative distribution function (CDF) for a logistic distribution with location parameter `mu` and scale parameter `s`.
@@ -80,7 +80,7 @@ interface LogCDF {
 	* y = mylogcdf( 4.0 );
 	* // returns ~-0.414
 	*/
-	factory( mu: number, beta: number ): Unary;
+	factory( mu: number, s: number ): Unary;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request renames the `logcdf` call-signature scale parameter from `beta` to `s` so it matches the documented `@param s` and the rest of the `logistic` family. Parameter names in declarations do not affect type-checking, so the `docs/types/test.ts` type tests are unaffected.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
