### PR TITLE
fix: update parameter names

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mgf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mgf/docs/types/index.d.ts
@@ -78,7 +78,7 @@ interface MGF {
 	* var y = mgf( 0.2, 0.5, 0.0 );
 	* // returns NaN
 	*/
-	( t: number, alpha: number, beta: number ): number;
+	( t: number, k: number, lambda: number ): number;
 
 	/**
 	* Returns a function for evaluating the moment-generating function (MGF) of a Weibull distribution with shape `k` and scale `lambda`.
@@ -96,7 +96,7 @@ interface MGF {
 	* y = myMGF( 0.08 );
 	* // returns ~2.137
 	*/
-	factory( alpha: number, beta: number ): Unary;
+	factory( k: number, lambda: number ): Unary;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request renames the `mgf` call-signature shape and scale parameters from `alpha`/`beta` to `k`/`lambda` so they match the documented `@param k`/`@param lambda` and the rest of the `weibull` family. Parameter names do not affect type-checking.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
