### PR TITLE
refactor: update parameter names

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/meanpn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/meanpn/docs/types/index.d.ts
@@ -45,7 +45,7 @@ interface Routine {
 	* var v = meanpn( x.length, x, 1 );
 	* // returns ~0.3333
 	*/
-	( N: number, x: InputArray, stride: number ): number;
+	( N: number, x: InputArray, strideX: number ): number;
 
 	/**
 	* Computes the arithmetic mean of a strided array using a two-pass error correction algorithm and alternative indexing semantics.
@@ -62,7 +62,7 @@ interface Routine {
 	* var v = meanpn.ndarray( x.length, x, 1, 0 );
 	* // returns ~0.3333
 	*/
-	ndarray( N: number, x: InputArray, stride: number, offsetX: number ): number;
+	ndarray( N: number, x: InputArray, strideX: number, offsetX: number ): number;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request renames the strided call-signature stride parameter from `stride` to `strideX` so it matches the documented `@param strideX` and sibling packages. Parameter names do not affect type-checking.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
