### PR TITLE
refactor: use `offsetX` parameter name in `strided/nanrangeabs`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/nanrangeabs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/nanrangeabs/docs/types/index.d.ts
@@ -53,7 +53,7 @@ interface Routine {
 	* @param N - number of indexed elements
 	* @param x - input array
 	* @param strideX - stride length
-	* @param offset - starting index
+	* @param offsetX - starting index
 	* @returns range of absolute values
 	*
 	* @example
@@ -62,7 +62,7 @@ interface Routine {
 	* var v = nanrangeabs.ndarray( x.length, x, 1, 0 );
 	* // returns 1.0
 	*/
-	ndarray( N: number, x: InputArray, strideX: number, offset: number ): number;
+	ndarray( N: number, x: InputArray, strideX: number, offsetX: number ): number;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request renames the `ndarray` offset parameter from `offset` to `offsetX` (signature and `@param`) for consistency with the `strideX` parameter and sibling strided packages.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
