### PR TITLE
refactor: align parameter name with implementation in `incr/nanstdev`

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanstdev/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanstdev/docs/types/index.d.ts
@@ -29,7 +29,7 @@ type accumulator = ( x?: number ) => number | null;
 /**
 * Returns an accumulator function which incrementally computes a corrected sample standard deviation, ignoring `NaN` values.
 *
-* @param mu - known mean
+* @param mean - known mean
 * @returns accumulator function
 *
 * @example
@@ -50,7 +50,7 @@ type accumulator = ( x?: number ) => number | null;
 * s = accumulator();
 * // returns ~4.95
 */
-declare function incrnanstdev( mu?: number ): accumulator;
+declare function incrnanstdev( mean?: number ): accumulator;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request renames the accumulator parameter from `mu` to `mean` (signature and `@param`) so the declaration matches the implementation, REPL docs, and sibling packages.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
