### PR TITLE
refactor: align parameter names with sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/snanmaxabs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/snanmaxabs/docs/types/index.d.ts
@@ -27,7 +27,7 @@ interface Routine {
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
-	* @param stride - stride length
+	* @param strideX - stride length
 	* @returns maximum absolute value
 	*
 	* @example
@@ -38,15 +38,15 @@ interface Routine {
 	* var v = snanmaxabs( x.length, x, 1 );
 	* // returns 2.0
 	*/
-	( N: number, x: Float32Array, stride: number ): number;
+	( N: number, x: Float32Array, strideX: number ): number;
 
 	/**
 	* Computes the maximum absolute value of a single-precision floating-point strided array, ignoring `NaN` values and using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
-	* @param stride - stride length
-	* @param offset - starting index
+	* @param strideX - stride length
+	* @param offsetX - starting index
 	* @returns maximum absolute value
 	*
 	* @example
@@ -57,7 +57,7 @@ interface Routine {
 	* var v = snanmaxabs.ndarray( x.length, x, 1, 0 );
 	* // returns 2.0
 	*/
-	ndarray( N: number, x: Float32Array, stride: number, offset: number ): number;
+	ndarray( N: number, x: Float32Array, strideX: number, offsetX: number ): number;
 }
 
 /**
@@ -65,7 +65,7 @@ interface Routine {
 *
 * @param N - number of indexed elements
 * @param x - input array
-* @param stride - stride length
+* @param strideX - stride length
 * @returns maximum absolute value
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request renames the `stride`/`offset` parameters to `strideX`/`offsetX` (signatures and `@param` comments) for consistency with `snanmax` and the modern strided declaration convention. Parameter names do not affect type-checking.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
