### PR TITLE
refactor: remove unused generic in `stats/base/ndarray/minsorted`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/minsorted/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/minsorted/docs/types/index.d.ts
@@ -42,7 +42,7 @@ import { typedndarray } from '@stdlib/types/ndarray';
 * var v = minsorted( [ x ] );
 * // returns 1.0
 */
-declare function minsorted<T extends typedndarray<number> = typedndarray<number>>( arrays: [ T ] ): number;
+declare function minsorted( arrays: [ typedndarray<number> ] ): number;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request removes the unused single-use generic type parameter from the `minsorted` signature, inlining the array element type to match the non-generic convention used by sibling reductions (e.g. `min`, `max`). The return type is the fixed `number`, so type-checking behavior is unchanged.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
