### PR TITLE
refactor: remove unused generics

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/dstdev/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dstdev/docs/types/index.d.ts
@@ -49,7 +49,7 @@ import { float64ndarray, typedndarray } from '@stdlib/types/ndarray';
 * var v = dstdev( [ x, correction ] );
 * // returns ~2.0817
 */
-declare function dstdev<T extends typedndarray<number> = typedndarray<number>>( arrays: [ float64ndarray, T ] ): number;
+declare function dstdev( arrays: [ float64ndarray, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dstdevch/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dstdevch/docs/types/index.d.ts
@@ -49,7 +49,7 @@ import { float64ndarray, typedndarray } from '@stdlib/types/ndarray';
 * var v = dstdevch( [ x, correction ] );
 * // returns ~2.0817
 */
-declare function dstdevch<T extends typedndarray<number> = typedndarray<number>>( arrays: [ float64ndarray, T ] ): number;
+declare function dstdevch( arrays: [ float64ndarray, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dstdevpn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dstdevpn/docs/types/index.d.ts
@@ -49,7 +49,7 @@ import { float64ndarray, typedndarray } from '@stdlib/types/ndarray';
 * var v = dstdevpn( [ x, correction ] );
 * // returns ~2.0817
 */
-declare function dstdevpn<T extends typedndarray<number> = typedndarray<number>>( arrays: [ float64ndarray, T ] ): number;
+declare function dstdevpn( arrays: [ float64ndarray, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dstdevtk/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dstdevtk/docs/types/index.d.ts
@@ -49,7 +49,7 @@ import { float64ndarray, typedndarray } from '@stdlib/types/ndarray';
 * var v = dstdevtk( [ x, correction ] );
 * // returns ~2.0817
 */
-declare function dstdevtk<T extends typedndarray<number> = typedndarray<number>>( arrays: [ float64ndarray, T ] ): number;
+declare function dstdevtk( arrays: [ float64ndarray, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dstdevwd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dstdevwd/docs/types/index.d.ts
@@ -49,7 +49,7 @@ import { float64ndarray, typedndarray } from '@stdlib/types/ndarray';
 * var v = dstdevwd( [ x, correction ] );
 * // returns ~2.0817
 */
-declare function dstdevwd<T extends typedndarray<number> = typedndarray<number>>( arrays: [ float64ndarray, T ] ): number;
+declare function dstdevwd( arrays: [ float64ndarray, typedndarray<number> ] ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dstdevyc/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dstdevyc/docs/types/index.d.ts
@@ -49,7 +49,7 @@ import { float64ndarray, typedndarray } from '@stdlib/types/ndarray';
 * var v = dstdevyc( [ x, correction ] );
 * // returns ~2.0817
 */
-declare function dstdevyc<T extends typedndarray<number> = typedndarray<number>>( arrays: [ float64ndarray, T ] ): number;
+declare function dstdevyc( arrays: [ float64ndarray, typedndarray<number> ] ): number;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request removes the unused single-use generic type parameter from all six `dstdev*` signatures (`dstdev`, `dstdevch`, `dstdevpn`, `dstdevtk`, `dstdevwd`, `dstdevyc`), inlining the array element type to match the non-generic convention already used by `dvariance`, `variance`, and `stdev`. The return type is the fixed `number`, so type-checking behavior is unchanged.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
