### PR TITLE
refactor: use shared `Iterator` type in `iter/cugmean`

### DIFF
--- a/lib/node_modules/@stdlib/stats/iter/cugmean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/iter/cugmean/docs/types/index.d.ts
@@ -20,10 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Iterator as Iter, IterableIterator } from '@stdlib/types/iter';
-
-// Define a union type representing both iterable and non-iterable iterators:
-type Iterator = Iter | IterableIterator;
+import { Iterator } from '@stdlib/types/iter';
 
 /**
 * Returns an iterator which iteratively computes a cumulative arithmetic geometric mean.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request replaces the local Iterator union type (Iter or IterableIterator) with the direct import { Iterator } from "@stdlib/types/iter" used by all eight sibling iter/cu*mean packages (e.g. cumean), which share an identical declaration shape and type test.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
