### PR TITLE
refactor!: correct class name casing in `base/dists/lognormal/ctor`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/ctor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/ctor/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /**
 * Lognormal distribution.
 */
-declare class Lognormal {
+declare class LogNormal {
 	/**
 	* Lognormal distribution constructor.
 	*
@@ -151,4 +151,4 @@ declare class Lognormal {
 
 // EXPORTS //
 
-export = Lognormal;
+export = LogNormal;

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/ctor/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/ctor/docs/types/test.ts
@@ -18,36 +18,36 @@
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-import Lognormal = require( './index' );
+import LogNormal = require( './index' );
 
 
 // TESTS //
 
 // The function returns a distribution instance...
 {
-	new Lognormal(); // $ExpectType Lognormal
-	new Lognormal( 1.0, 2.0 ); // $ExpectType Lognormal
+	new LogNormal(); // $ExpectType LogNormal
+	new LogNormal( 1.0, 2.0 ); // $ExpectType LogNormal
 }
 
 // The compiler throws an error if the function is provided values other than two numbers...
 {
-	new Lognormal( true, 2.0 ); // $ExpectError
-	new Lognormal( false, 2.0 ); // $ExpectError
-	new Lognormal( '5', 2.0 ); // $ExpectError
-	new Lognormal( [], 2.0 ); // $ExpectError
-	new Lognormal( {}, 2.0 ); // $ExpectError
-	new Lognormal( ( x: number ): number => x, 2.0 ); // $ExpectError
+	new LogNormal( true, 2.0 ); // $ExpectError
+	new LogNormal( false, 2.0 ); // $ExpectError
+	new LogNormal( '5', 2.0 ); // $ExpectError
+	new LogNormal( [], 2.0 ); // $ExpectError
+	new LogNormal( {}, 2.0 ); // $ExpectError
+	new LogNormal( ( x: number ): number => x, 2.0 ); // $ExpectError
 
-	new Lognormal( 1.0, true ); // $ExpectError
-	new Lognormal( 1.0, false ); // $ExpectError
-	new Lognormal( 1.0, '5' ); // $ExpectError
-	new Lognormal( 1.0, [] ); // $ExpectError
-	new Lognormal( 1.0, {} ); // $ExpectError
-	new Lognormal( 1.0, ( x: number ): number => x ); // $ExpectError
+	new LogNormal( 1.0, true ); // $ExpectError
+	new LogNormal( 1.0, false ); // $ExpectError
+	new LogNormal( 1.0, '5' ); // $ExpectError
+	new LogNormal( 1.0, [] ); // $ExpectError
+	new LogNormal( 1.0, {} ); // $ExpectError
+	new LogNormal( 1.0, ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
-	new Lognormal( 1.0 ); // $ExpectError
-	new Lognormal( 1.0, 1.0, 2.0 ); // $ExpectError
+	new LogNormal( 1.0 ); // $ExpectError
+	new LogNormal( 1.0, 1.0, 2.0 ); // $ExpectError
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request renames the exported class from `Lognormal` to `LogNormal` (class declaration and `export =`) to match the implementation (`function LogNormal` / `module.exports = LogNormal`), the namespace aggregator import, the README, and the file own `@example` blocks. The declaration type test is updated to match.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
