### PR TITLE
fix: rename `logpdf` to `logpmf` in `base/dists/geometric/ctor`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/ctor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/ctor/docs/types/index.d.ts
@@ -102,12 +102,12 @@ declare class Geometric {
 	logcdf( x: number ): number;
 
 	/**
-	* Evaluates the natural logarithm of the probability density function (PDF).
+	* Evaluates the natural logarithm of the probability mass function (PMF).
 	*
 	* @param x - input value
-	* @returns evaluated logPDF
+	* @returns evaluated logPMF
 	*/
-	logpdf( x: number ): number;
+	logpmf( x: number ): number;
 
 	/**
 	* Evaluates the moment-generating function (MGF).


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request renames the constructor `logpdf` method to `logpmf` and fixes its prose from "probability density function (PDF)" to "probability mass function (PMF)" for this discrete distribution, matching the implementation (`Geometric.prototype.logpmf`). No method named `logpdf` exists on the implementation.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
