### PR TITLE
fix: type `kde2d` output `z` field as an ndarray

### DIFF
--- a/lib/node_modules/@stdlib/stats/kde2d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/kde2d/docs/types/index.d.ts
@@ -80,7 +80,7 @@ interface Output {
 	/**
 	* Density values.
 	*/
-	z: Array<number>;
+	z: ndarray;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request types the `kde2d` `Output.z` field as an `ndarray` (already imported) instead of `Array<number>`, matching the implementation, which builds `z` via `ndarray(...)` and stores it with `setReadOnly`. The `x` and `y` fields remain `Array<number>` (produced by `linspace`).

See: https://github.com/stdlib-js/stdlib/blob/b02f4b16a34379230f3a492e55d8ed266e46301a/lib/node_modules/%40stdlib/stats/kde2d/lib/main.js#L147-L150

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
