### PR TITLE
fix: refine `groups` type and remove redundant option in `levene-test`

### DIFF
--- a/lib/node_modules/@stdlib/stats/levene-test/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/levene-test/docs/types/index.d.ts
@@ -37,14 +37,9 @@ interface Options {
 */
 interface OptionsWithGroups extends Options {
 	/**
-	* Significance level (default: 0.05).
-	*/
-	alpha?: number;
-
-	/**
 	* Array of group indicators.
 	*/
-	groups: Array<any>;
+	groups: Array<string | number>;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request narrows the `groups` option type from `Array<any>` to `Array<string or number>` (the realistic group-indicator label types) and removes the redundant `alpha?` member from `OptionsWithGroups`, which already inherits it from `Options`.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
