### PR TITLE
fix: type `alternative` as string union in `ztest` results struct-factory

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ztest/one-sample/results/struct-factory/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ztest/one-sample/results/struct-factory/docs/types/index.d.ts
@@ -19,6 +19,11 @@
 // TypeScript Version: 4.1
 
 /**
+* Alternative hypothesis.
+*/
+type Alternative = 'two-sided' | 'greater' | 'less';
+
+/**
 * Interface describing test results.
 */
 interface Results<T> {
@@ -30,7 +35,7 @@ interface Results<T> {
 	/**
 	* Alternative hypothesis.
 	*/
-	alternative?: number;
+	alternative?: Alternative;
 
 	/**
 	* Significance level.
@@ -85,7 +90,7 @@ declare class Struct<T> {
 	/**
 	* Alternative hypothesis.
 	*/
-	alternative: number;
+	alternative: Alternative;
 
 	/**
 	* Significance level.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request types the `alternative` field as the string-union `Alternative` (two-sided, greater, less) instead of `number`, matching the sibling `float64`/`float32` results declarations. Adds the `Alternative` type alias used by both the optional `Results` member and the required `Struct` field.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
