### PR TITLE
fix: improve type specificity for JSON serialization

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ztest/two-sample/results/to-json/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ztest/two-sample/results/to-json/docs/types/index.d.ts
@@ -74,6 +74,64 @@ interface Results {
 }
 
 /**
+* Interface describing a serialized results object.
+*/
+interface ResultsJSON {
+	/**
+	* Boolean indicating whether the null hypothesis was rejected.
+	*/
+	rejected: boolean;
+
+	/**
+	* Alternative hypothesis.
+	*/
+	alternative: string;
+
+	/**
+	* Significance level.
+	*/
+	alpha: number;
+
+	/**
+	* p-value.
+	*/
+	pValue: number;
+
+	/**
+	* Test statistic.
+	*/
+	statistic: number;
+
+	/**
+	* Confidence interval.
+	*/
+	ci: {
+		type: string;
+		data: Array<number>;
+	};
+
+	/**
+	* Difference in means under the null hypothesis.
+	*/
+	nullValue: number;
+
+	/**
+	* Sample mean of `x`.
+	*/
+	xmean: number;
+
+	/**
+	* Sample mean of `y`.
+	*/
+	ymean: number;
+
+	/**
+	* Test method.
+	*/
+	method: string;
+}
+
+/**
 * Serializes a two-sample Z-test results object as a JSON object.
 *
 * @param results - two-sample Z-test results object
@@ -98,7 +156,7 @@ interface Results {
 * var obj = res2json( results );
 * // returns {...}
 */
-declare function res2json( results: Results ): Results;
+declare function res2json( results: Results ): ResultsJSON;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/base/ztest/two-sample/results/to-json/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/base/ztest/two-sample/results/to-json/docs/types/test.ts
@@ -35,7 +35,7 @@ import res2json = require( './index' );
 		'alternative': 'two-sided',
 		'method': 'Two-sample Z-test'
 	};
-	res2json( res ); // $ExpectType Results
+	res2json( res ); // $ExpectType ResultsJSON
 }
 
 // The compiler throws an error if not provided a results object...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request introduces a dedicated `ResultsJSON` interface for the value returned by `res2json` instead of reusing the input `Results` type. The serialized object represents `ci` as a JSON object (`{ type: string; data: Array<number> }`, produced by `typedarray2json`), not as a `Float64Array`/`Float32Array`. The declaration type test is updated to expect `ResultsJSON`.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
