### PR TITLE
fix: add missing `correction` argument

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/wasm/dnanvariancewd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/strided/wasm/dnanvariancewd/docs/types/index.d.ts
@@ -224,7 +224,7 @@ interface Routine extends ModuleWrapper {
 	* var y = dnanvariancewd.main( 4, 1, x, 1 );
 	* // returns ~4.3333
 	*/
-	main( N: number, x: Float64Array, strideX: number ): number;
+	main( N: number, correction: number, x: Float64Array, strideX: number ): number;
 
 	/**
 	* Computes the variance of a double-precision floating-point strided array ignoring `NaN` values and using Welford's algorithm and alternative indexing semantics.

--- a/lib/node_modules/@stdlib/stats/strided/wasm/dnanvariancewd/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/strided/wasm/dnanvariancewd/docs/types/test.ts
@@ -49,7 +49,6 @@ import dnanvariancewd = require( './index' );
 {
 	const x = new Float64Array( 10 );
 
-	dnanvariancewd.main( x.length, 10, x, 1 ); // $ExpectError
 	dnanvariancewd.main( x.length, '10', x, 1 ); // $ExpectError
 	dnanvariancewd.main( x.length, true, x, 1 ); // $ExpectError
 	dnanvariancewd.main( x.length, false, x, 1 ); // $ExpectError


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds the missing `correction` parameter to the `Routine.main` signature so it matches the declaration own `@example`, the `ndarray` overload, and the `Module.main` signature, which all include `correction` as the second argument. The signature was `main( N, x, strideX )` but the WASM routine takes `main( N, correction, x, strideX )`. Also removes a bogus `$ExpectError` line in the declaration test (`main( x.length, 10, x, 1 )`) that asserted an error for a valid numeric `correction` argument, contradicting its own "second argument which is not a number" block.

This is part of a series of follow-up PRs addressing findings from a TypeScript declaration audit of the `stats` namespace (documentation-only fixes landed separately in #12482).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced by a Claude Code audit of the `stats` namespace TypeScript declarations. The fix was verified against the implementation and declaration test before submission, and reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
