### PR TITLE
chore: add `univariate` keyword to outliers in `stats/base/dists`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/package.json
@@ -60,6 +60,7 @@
     "prob",
     "distribution",
     "dist",
-    "degenerate"
+    "degenerate",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/package.json
@@ -60,6 +60,7 @@
     "distribution",
     "dist",
     "uniform",
+    "univariate",
     "discrete"
   ]
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Aligns the `package.json` `keywords` array of two outliers in `@stdlib/stats/base/dists` with the namespace majority pattern. `"univariate"` is present in 37/39 (94.9%) of member packages; this PR adds it to the remaining two, both of which are univariate distributions by definition.

### Namespace summary

-   **Target namespace:** `@stdlib/stats/base/dists`
-   **Member count:** 39 (all non-autogenerated; `halfnormal` and `wald` excluded as incomplete WIP directories lacking a `package.json`)
-   **Features analyzed:** file tree, top-level files/dirs, registered sub-packages, `package.json` top-level keys, `package.json` `scripts`/`directories`/`keywords`, README `<section>` markup, README `##`/`###` headings, `test/`/`benchmark/`/`examples/`/`lib/` file names, `manifest.json` shape, `lib/index.js` registration pattern (`setReadOnly`, `// MODULES //`, alphabetical-order comment, `'use strict'`).
-   **Features with clear majority (≥75%):** file tree top-level files (`README.md`, `package.json` — 100%); non-package directories (`docs`, `examples`, `lib`, `test` — 100%); `package.json` top-level key set (18 keys — 100%); `package.json` `directories` keys (`doc`, `example`, `lib`, `test` — 100%); README `<section>` markup (`usage`, `examples`, `related`, `links` — 100%); README markdown headings (`## Usage`, `## Examples` — 100%); `test/test.js`, `examples/index.js`, `lib/index.js` (100%); `lib/index.js` structure (`'use strict'`, `// MODULES //` comment, alphabetical-order comment, `setReadOnly`-based namespace assembly — 100%); 11 common keywords (`stdlib`, `stdmath`, `standard`, `library`, `std`, `lib`, `statistics`, `stats`, `probability`, `distribution`, `dist` — 100%); `"univariate"` keyword (**37/39 = 95%**).
-   **Features without clear majority (excluded):** `"continuous"` keyword (29/39 = 74%, just under threshold and category-specific); sub-package presence for `cdf`/`quantile` (38/39 = 97%, but only `truncated-normal` lacks them — adding new sub-packages is not a mechanical fix and falls outside this routine's scope); sub-package presence for `mean`/`stdev`/`variance` (35/39 = 90%, same reason); deeper sub-package presence (`pmf`, `logpmf`, `mgf`, `mode`, `entropy`, etc.) — same reason; `bench_files` (no namespace package has `benchmark/` — 100% absent but intentional for namespace-only packages); `manifest.json` (100% absent — same).

### `@stdlib/stats/base/dists/discrete-uniform`

Adds `"univariate"` to `package.json` keywords, between `"uniform"` and `"discrete"`. Matches the exact sibling pattern `..., <distname>, "univariate", "discrete"` carried by every other discrete distribution in the namespace (`bernoulli`, `binomial`, `geometric`, `hypergeometric`, `negative-binomial`, `planck`, `poisson` — 7/7 discrete siblings). The discrete uniform distribution is univariate by definition. Metadata only.

### `@stdlib/stats/base/dists/degenerate`

Adds `"univariate"` to `package.json` keywords after `"degenerate"`. Sibling convention places `"univariate"` immediately after the distribution-name keyword and before any `discrete`/`continuous` classifier; `degenerate` carries no classifier keyword, so `"univariate"` trails as the final entry. The degenerate distribution is a point-mass univariate distribution by definition. Metadata only.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Checked:

-   Structural feature extraction across all 39 non-autogenerated members (file tree, `package.json` shape, `keywords`, `directories`, `manifest.json`, README headings and `<section>` markup, test/benchmark/example/lib file names, `lib/index.js` registration pattern).
-   Semantic feature extraction was waived per the routine: every member is a namespace package (`lib/index.js` only — no `lib/main.js`, no `lib/validate.js`); the semantic schema (`publicSignature`, `validationPrologue`, `errorConstruction`, `jsdocShape`) does not apply at this level. The `lib/index.js` registration pattern was instead examined structurally and confirmed 100% uniform across all 39 members.
-   Three-agent drift validation on the keyword finding:
    -   Agent 1 (semantic-review): auto-pass — feature is purely structural.
    -   Agent 2 (cross-reference, opus): both outliers `confirmed-drift`. The only consumer of `package.json` `keywords` across the repo is the search-index builder at `_tools/search/pkg-index/lib/create.js`, which joins keywords into a free-text blob — no order or membership dependency. No test, example, or sibling-package code references the existing keyword arrays.
    -   Agent 3 (structural-review, sonnet): both outliers `confirmed-drift`. Confirmed both are mathematically univariate. Confirmed insertion positions match sibling conventions exactly.
-   Cross-run dedup: no open or recently-merged PR proposes `"univariate"` keyword additions to either package. The existing PR [#11902](https://github.com/stdlib-js/stdlib/pull/11902) targets the unrelated child namespace `stats/base/dists/binomial`.

Deliberately excluded:

-   `"continuous"` keyword drift (29/39 = 74%, below 75% threshold).
-   Sub-package presence drift (`cdf`, `quantile`, `pdf`, `mean`, etc.) — adding missing sub-modules requires real implementation work and is outside the scope of mechanical drift correction. Three WIP packages (`signrank` with 3 sub-modules, `studentized-range` with 2, `truncated-normal` with 1) are flagged in the local drift report for future implementation work but receive no edits here.
-   Generator-owned content (`<section class="related">`, `<section class="links">`) — uniform across all members at 100%, no drift.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: the namespace `@stdlib/stats/base/dists` was selected by uniform-random pick (seed `drift-2026-06-03`), structural features were extracted from every member, majority patterns were computed at the 75% conformance threshold, and two independent validation agents (opus cross-reference, sonnet structural-review) confirmed each correction was high-signal mechanical drift before any file was edited. The semantic-review agent was a no-op (the feature is purely structural; members are namespace packages with no `lib/main.js`). All edits are `package.json` `keywords` string insertions; no source, behavior, test, doc, or generator output is touched.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxjgihgXgtrySLFBYZfw4R)_