### PR TITLE
docs: follow-up fixes for commits merged to `develop` on 2026-06-03

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/quantile/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/quantile/docs/types/index.d.ts
@@ -25,10 +25,10 @@
 *
 * -   If `p < 0` or `p > 1`, the function returns `NaN`.
 *
-* @param x - input value
+* @param p - input value
 * @returns evaluated quantile function
 */
-type Unary = ( x: number ) => number;
+type Unary = ( p: number ) => number;
 
 /**
 * Interface for the quantile function of an arcsine distribution.

--- a/lib/node_modules/@stdlib/types/index.d.ts
+++ b/lib/node_modules/@stdlib/types/index.d.ts
@@ -5423,7 +5423,7 @@ declare module '@stdlib/types/number' {
 	type NumberDataType = IntegerDataType;
 
 	/**
-	* A unsigned 64-bit integer.
+	* An unsigned 64-bit integer.
 	*
 	* @example
 	* const x: Uint64 = {


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-06-02 20:44:52 -0500 and 2026-06-03 04:40:23 -0700 (SHAs `b4c05f93`..`aac3a7c1`, 49 commits reviewed).

This pull request:

-   **`stats/base/dists/arcsine/quantile`**: Commit `f59b324c` incorrectly renamed the `Unary` parameter from `p` to `x` in `lib/node_modules/@stdlib/stats/base/dists/arcsine/quantile/docs/types/index.d.ts`, leaving a mismatch with the `## Notes` block and every sibling distribution's quantile `Unary` signature; this reverts the parameter name to `p`.
-   **`types`**: Fixes a grammatical error ("A unsigned" → "An unsigned") in the `Uint64` JSDoc introduced in `6d18f6bf` (`lib/node_modules/@stdlib/types/index.d.ts`).

## Related Issues

This pull request does not have any related issues.

## Questions

No.

## Other

### Validation

-   stdlib style-guide compliance audited across the changed files in the window.
-   Diff-only bug scan against the introduced code.
-   Cross-checked each finding against the surrounding package and sibling packages before applying.

Deliberately excluded:

-   Subjective preferences and suggestions.
-   Anything requiring code outside the diff window to validate.
-   Coordinated parameter renames in `stats`/`math`/`strided` declarations (intentional alignment with sibling packages).
-   `lognormal/ctor` casing, `levy/cdf` `c` parameter, and `geometric/ctor` `logpmf` — deliberate breaking/correctness changes per their commit messages.
-   `[out]` annotations on `X` in `blas/ext/base/dones`/`sones` READMEs — matches the convention used by the direct analogues `dfill`/`sfill`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code: parallel reviewer agents audited the last 24 hours of commits merged to `develop` for typos, bugs, and style-guide violations, the findings were cross-validated against the diff and sibling packages, and the surviving high-signal fixes were applied verbatim.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfmiUNrwzpZF163ATs7ceo)_