### PR TITLE
build(workflows): increase run_affected_benchmarks step timeout

### DIFF
--- a/.github/workflows/run_affected_benchmarks.yml
+++ b/.github/workflows/run_affected_benchmarks.yml
@@ -151,4 +151,4 @@ jobs:
             directories="${{ steps.changed-directories.outputs.directories }}"
           fi
           . "$GITHUB_WORKSPACE/.github/workflows/scripts/run_affected_benchmarks/run" "$directories"
-        timeout-minutes: 60
+        timeout-minutes: 90


### PR DESCRIPTION
## Description

This pull request:

- increases `timeout-minutes` from `60` to `90` on the "Run affected benchmarks" step in `.github/workflows/run_affected_benchmarks.yml`.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/26882401036

**Symptom:** `The action 'Run affected benchmarks' has timed out after 60 minutes.` — reproduced on four distinct `develop` SHAs in the last seven days: `d864f6f8`, `d2f751e2`, `e903f792`, `aac3a7c1`.

**Root cause:** New BLAS `ext/base` packages are merged in batch push events. Each package adds `benchmark/benchmark.js` and `benchmark/benchmark.ndarray.js`. The runner script executes all JavaScript benchmark files serially across all affected packages. When 7–15 packages fall within a single push event window, cumulative execution time exceeds 60 minutes. The benchmarks themselves are bounded (auto-tuned iteration counts, 5-min per-benchmark cap in the bench harness); only the aggregate is over budget.

**Fix:** Raising the step timeout to 90 minutes covers the observed 7–15 package batches with margin.

## Related Issues

No related issues.

## Questions

No.

## Other

Second run reference: https://github.com/stdlib-js/stdlib/actions/runs/26880759233

Note: this is a proportional fix rather than a structural one. If batch sizes grow beyond ~14 packages at current benchmark throughput, the timeout will need to increase again. Parallelizing or sharding the sequential benchmark execution would be a more durable long-term fix.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

#### Disclosure

This PR was proposed by Claude Code as part of an automated CI-failure investigation routine. The root-cause analysis (serial benchmark accumulation exceeding a 60-minute step limit), the fix (one-line timeout change), and the supporting evidence (four failing run logs reviewed) were produced by Claude Code. Final review and merge decision rest with the maintainers.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_016AUBPkd8dVJM2dVU534KQE)_