### PR TITLE
docs: harmonize description and README intro in `stats/base/dists/exponential/logpdf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> Evaluate the natural logarithm of the probability density function (PDF) for an [exponential][exponential-distribution] distribution.
+> [Exponential][exponential-distribution] distribution logarithm of [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/exponential/logpdf",
   "version": "0.0.0",
-  "description": "Natural logarithm of the probability density function (PDF) for an exponential distribution.",
+  "description": "Exponential distribution logarithm of probability density function (PDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

`@stdlib/stats/base/dists/exponential/logpdf`: rewrite the `package.json` `description` and `README.md` short-description line to match the `Exponential distribution <X>.` template used by the rest of the `stats/base/dists/exponential` namespace (14/15 = 93% conformance; `logpdf` was the sole outlier). The new wording mirrors sibling `logcdf`'s phrasing; the `[pdf]` and `[exponential-distribution]` link references invoked from the rewritten README intro are already defined at the bottom of the file. Metadata and README prose only — no source, test, or behavioral changes.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: structural and semantic features were extracted from every member of `stats/base/dists/exponential`, the majority pattern for each feature was computed at a 75% conformance threshold, and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed each correction was high-signal mechanical drift before any file was edited. The diff is two single-line metadata/prose edits in `logpdf`'s `package.json` and `README.md`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01HSGsU3JewEWtAFaUGR2XVL)_