### PR TITLE
docs: normalize dtype description in `random/hypergeometric`

### DIFF
--- a/lib/node_modules/@stdlib/random/hypergeometric/README.md
+++ b/lib/node_modules/@stdlib/random/hypergeometric/README.md
@@ -86,7 +86,7 @@ var v = arr.get();
 
 The function accepts the following options:
 
--   **dtype**: output ndarray data type. Must be a real-valued or "generic" [data type][@stdlib/ndarray/dtypes].
+-   **dtype**: output ndarray data type. Must be a real or "generic" [data type][@stdlib/ndarray/dtypes].
 -   **order**: ndarray order (i.e., memory layout), which is either `row-major` (C-style) or `column-major` (Fortran-style). Default: `'row-major'`.
 -   **mode**: specifies how to handle indices which exceed ndarray dimensions. For a list of supported modes, see [`ndarray`][@stdlib/ndarray/ctor]. Default: `'throw'`.
 -   **submode**: a mode array which specifies for each dimension how to handle subscripts which exceed ndarray dimensions. If provided fewer modes than dimensions, an [ndarray][@stdlib/ndarray/ctor] instance recycles modes using modulo arithmetic. Default: `[ options.mode ]`.
@@ -312,7 +312,7 @@ var sz = random.byteLength;
 
 -   If PRNG state is "shared" (meaning a state array was provided during function creation and **not** copied) and one sets the underlying generator state to a state array having a different length, the function returned by the `factory` method does **not** update the existing shared state and, instead, points to the newly provided state array. In order to synchronize the output of the underlying generator according to the new shared state array, the state array for **each** relevant creation function and/or PRNG must be **explicitly** set.
 -   If PRNG state is "shared" and one sets the underlying generator state to a state array of the same length, the PRNG state is updated (along with the state of all other creation functions and/or PRNGs sharing the PRNG's state array).
--   The output data type [policy][@stdlib/ndarray/output-dtype-policies] only applies to the main function and specifies that, by default, the function must return an [ndarray][@stdlib/ndarray/ctor] having a real-valued or "generic" [data type][@stdlib/ndarray/dtypes]. For the `assign` method, the output [ndarray][@stdlib/ndarray/ctor] is allowed to have any supported output [data type][@stdlib/ndarray/dtypes].
+-   The output data type [policy][@stdlib/ndarray/output-dtype-policies] only applies to the main function and specifies that, by default, the function must return an [ndarray][@stdlib/ndarray/ctor] having a real or "generic" [data type][@stdlib/ndarray/dtypes]. For the `assign` method, the output [ndarray][@stdlib/ndarray/ctor] is allowed to have any supported output [data type][@stdlib/ndarray/dtypes].
 
 </section>
 

--- a/lib/node_modules/@stdlib/random/hypergeometric/docs/repl.txt
+++ b/lib/node_modules/@stdlib/random/hypergeometric/docs/repl.txt
@@ -24,7 +24,7 @@
         Options.
 
     options.dtype: string|DataType (optional)
-        Array data type. Must be a real-valued or "generic" data type.
+        Array data type. Must be a real or "generic" data type.
 
     options.order: string (optional)
         Specifies whether an array is row-major (C-style) or column-major

--- a/lib/node_modules/@stdlib/random/scripts/scaffolds/ternary/scripts/data/hypergeometric.json
+++ b/lib/node_modules/@stdlib/random/scripts/scaffolds/ternary/scripts/data/hypergeometric.json
@@ -39,7 +39,7 @@
   "readme_from_desc": "a [hypergeometric][@stdlib/random/base/hypergeometric] distribution",
 
   "readme_heading": "Hypergeometric Random Numbers",
-  "readme_dtype_kind_desc": "a real-valued",
+  "readme_dtype_kind_desc": "a real",
   "readme_dtype_kind_pkg": "stdlib/ndarray/dtypes",
 
   "repl_text_main_desc": "Returns an ndarray containing pseudorandom numbers drawn from a hypergeometric distribution.",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Normalizes the `dtype` option phrasing in `random/hypergeometric` README and REPL help to match the convention used by every other distribution in `random/` whose output policy is `real_and_generic`. The package was the lone outlier (6/7 = 85% sibling conformance).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### `random/hypergeometric`

The `dtype` option description read `real-valued or "generic"` in three places — `README.md` (option list and Notes bullet on the output-dtype policy) and `docs/repl.txt` (the `options.dtype` line). Every other discrete distribution in `random/` that shares the `real_and_generic` output policy — `bernoulli`, `binomial`, `discrete-uniform`, `geometric`, `negative-binomial`, `poisson` — describes the same option as `real or "generic"`. The other 26 distributions, which carry the `real_floating_point_and_generic` policy, use `real-valued floating-point or "generic"`; that phrasing is not applicable to `hypergeometric`. No code, types, or tests change.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code as part of a cross-package API drift detection routine over the `random/` namespace. The agent extracted structural and semantic features from each of the 41 direct members, computed per-feature majority patterns, and surfaced this lone documentation outlier in `hypergeometric`. The textual edits were applied mechanically against the sibling-package convention.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_016FQMMY9GEdrNJvS97bGryG)_