### PR TITLE
docs: propagate TSDoc declaration fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-date-object-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-date-object-array/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Test if a value is an array-like object containing only `Date` objects.
+* Tests if a value is an array-like object containing only `Date` objects.
 *
 * @param value - value to test
 * @returns boolean indicating if a value is an array-like object containing only `Date` objects

--- a/lib/node_modules/@stdlib/assert/is-falsy-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-falsy-array/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Test if a value is an array-like object containing only falsy values.
+* Tests if a value is an array-like object containing only falsy values.
 *
 * @param value - value to test
 * @returns boolean indicating whether a value is an array-like object containing only falsy values

--- a/lib/node_modules/@stdlib/assert/is-function-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-function-array/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Test if a value is an array-like object containing only functions.
+* Tests if a value is an array-like object containing only functions.
 *
 * @param value - value to test
 * @returns boolean indicating whether an input value is an array-like object containing only functions

--- a/lib/node_modules/@stdlib/assert/is-object-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-object-array/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Test if a value is an array-like object containing only objects.
+* Tests if a value is an array-like object containing only objects.
 *
 * @param value - value to test
 * @returns boolean indicating whether an input value is an array-like object containing only objects

--- a/lib/node_modules/@stdlib/blas/ext/base/dcartesian-product/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcartesian-product/docs/types/index.d.ts
@@ -45,7 +45,7 @@ interface Routine {
 	* @returns output array
 	*
 	* @example
-	* var Float64Array = require( `@stdlib/array/float64` );
+	* var Float64Array = require( '@stdlib/array/float64' );
 	*
 	* var x = new Float64Array( [ 1.0, 2.0 ] );
 	* var y = new Float64Array( [ 3.0, 4.0 ] );
@@ -78,7 +78,7 @@ interface Routine {
 	* @returns output array
 	*
 	* @example
-	* var Float64Array = require( `@stdlib/array/float64` );
+	* var Float64Array = require( '@stdlib/array/float64' );
 	*
 	* var x = new Float64Array( [ 1.0, 2.0 ] );
 	* var y = new Float64Array( [ 3.0, 4.0 ] );
@@ -109,7 +109,7 @@ interface Routine {
 * @returns output array
 *
 * @example
-* var Float64Array = require( `@stdlib/array/float64` );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
 * var x = new Float64Array( [ 1.0, 2.0 ] );
 * var y = new Float64Array( [ 3.0, 4.0 ] );
@@ -119,7 +119,7 @@ interface Routine {
 * // out => <Float64Array>[ 1.0, 3.0, 1.0, 4.0, 2.0, 3.0, 2.0, 4.0 ]
 *
 * @example
-* var Float64Array = require( `@stdlib/array/float64` );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
 * var x = new Float64Array( [ 1.0, 2.0 ] );
 * var y = new Float64Array( [ 3.0, 4.0 ] );

--- a/lib/node_modules/@stdlib/complex/float32/reviver/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/complex/float32/reviver/docs/types/index.d.ts
@@ -22,7 +22,7 @@
 * Revives a JSON-serialized 64-bit complex number.
 *
 * @param key - key
-* @param  value - value
+* @param value - value
 * @returns value or 64-bit complex number
 *
 * @example

--- a/lib/node_modules/@stdlib/ndarray/base/ind/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/ind/docs/types/index.d.ts
@@ -88,8 +88,8 @@ interface Routine {
 	/**
 	* Returns a function for returning an index according to a provided index mode.
 	*
-	* @param {string} mode - specifies how to handle an out-of-bounds index
-	* @returns {Function} function for returning an index
+	* @param mode - specifies how to handle an out-of-bounds index
+	* @returns function for returning an index
 	*
 	* @example
 	* var fcn = ind.factory( 'clamp' );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /**
 * Evaluates the probability density function (PDF) for a raised cosine distribution.
 *
-* @param  x - input value
+* @param x - input value
 * @returns evaluated PDF
 */
 type Unary = ( x: number ) => number;

--- a/lib/node_modules/@stdlib/utils/copy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/copy/docs/types/index.d.ts
@@ -32,7 +32,7 @@
 * -   Support for copying class instances is inherently fragile. Any instances with privileged access to variables (e.g., within closures) cannot be cloned. This stated, basic copying of class instances is supported. Provided an environment which supports ES5, the implementation is greedy and performs a deep clone of any arbitrary class instance and its properties. The implementation assumes that the concept of `level` applies only to the class instance reference, but not to its internal state.
 *
 * @param value - value to copy
-* @param  level - copy depth (default: +infinity)
+* @param level - copy depth (default: +infinity)
 * @throws `level` must be a nonnegative integer
 * @returns value copy
 *


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-06-03 17:58 CDT and 2026-06-04 01:15 CDT to sibling packages.

The source commit `9ad27d6` ("docs: fix TSDoc errors in `assert` declarations") corrected four distinct TSDoc-level defects in `@stdlib/assert/*` declarations. Each commit on this branch corresponds to one of those source-fix patterns and applies the equivalent change to every sibling that exhibited the same defect after independent validation.

### `docs: use third-person singular in ``assert/is-*-array`` declarations` (commit 9c6cada2)

Source: `9ad27d6`. The same `Test if a value is` → `Tests if a value is` correction landed for `assert/is-probability-array` was outstanding in four additional `assert/is-*-array` summaries. Aligns with the project-wide convention used in 192 sibling assert declarations.

-   `@stdlib/assert/is-date-object-array`
-   `@stdlib/assert/is-falsy-array`
-   `@stdlib/assert/is-function-array`
-   `@stdlib/assert/is-object-array`

### `docs: collapse double space after ``@param`` in TSDoc declarations` (commit 86e7de22)

Source: `9ad27d6`. Mirrors the `@returns  ` (two-space) collapse applied to `assert/is-boolean-array` and `assert/is-readable-property`. The same two-space `@param  ` slip survives in three sibling declarations across `utils/`, `complex/`, and `stats/`.

-   `@stdlib/utils/copy`
-   `@stdlib/complex/float32/reviver`
-   `@stdlib/stats/base/dists/cosine/pdf`

### `docs: remove JSDoc-style type braces from ``ndarray/base/ind`` declaration` (commit f9c658eb)

Source: `9ad27d6`. The `factory` method on `ndarray/base/ind` carries `@param {string}` / `@returns {Function}` braces — the JSDoc form. Same fix shape as the `assert/is-nonnegative-finite` cleanup: TSDoc declarations derive types from the signature, so the braces are redundant and inconsistent with the rest of the same file.

-   `@stdlib/ndarray/base/ind`

### `docs: use single-quote string literals in ``blas/ext/base/dcartesian-product`` examples` (commit e64a1cb5)

Source: `9ad27d6`. Mirrors the backtick → single-quote replacement applied to `assert/is-kebabcase`. The `dcartesianProduct` declaration's four `@example` blocks all spell `require( \`@stdlib/array/float64\` )` with template literals where the project consistently uses single quotes.

-   `@stdlib/blas/ext/base/dcartesian-product`

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

### Validation

Search scope was restricted per source pattern: `lib/node_modules/@stdlib/**/docs/types/index.d.ts` with pattern-specific ripgrep signatures (`^\s*\*\s+Test if`, `@param\s\s+\S`, `@param\s+\{[^}]+\}` / `@returns\s+\{[^}]+\}`, and `require\(\s*\`[^`]*\`\s*\)`). Auto-generated namespace aggregator declarations (e.g., `@stdlib/assert/docs/types/index.d.ts`, `@stdlib/utils/docs/types/index.d.ts`) were excluded — those regenerate from the package-level declarations and the `stdlib-bot` will pick up the propagated fixes on its next run.

Each candidate site was confirmed by reading the file in full to verify the defect was present and the surrounding context did not change semantics, an adaptation pass that confirmed the source-commit patch applies verbatim, and a style-consistency pass that compared the patches against the already-fixed source declarations. Only sites that survived all passes appear in this PR.

Deliberately excluded:

-   Source-commit fixes that are per-package corrections (copy-paste typos in `@returns` descriptions, restructured `@example` blocks for `is-bigint` / `is-symbol`, removed stray `@throws` in `contains`, added `## Notes` block in `is-same-typed-array-like`, off-by-one in `is-positive-finite`): each has a unique semantic context, so they do not propagate from a single shared pattern.
-   Adjacent `@example` blocks without a blank-line separator (sibling to the `is-integer-array` / `is-number-array` fix): no package-level declarations matched; only the auto-generated `@stdlib/assert` aggregator had the pattern, and it will regenerate.
-   `@returns boolean whether` (sibling to the `is-leap-year` fix): only the auto-generated `@stdlib/assert` aggregator matched.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated fix-propagation routine driven by Claude Code: source commits merged to `develop` in the prior 24 hours were filtered to those describing generalizable defects, candidate sibling sites were enumerated by ripgrep searches scoped to each pattern's namespace, and each candidate was independently validated against the full file before patches were applied. Commit messages and this PR body were drafted by Claude Code and reviewed before pushing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bt6bmqKCCWnTcNJsZmr1yg)_