### PR TITLE
test: add missing opts guard in native tests

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/hyp2f1/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/hyp2f1/test/test.native.js
@@ -256,7 +256,7 @@ tape( 'the function correctly evaluates the hypergeometric function', opts, func
 	t.end();
 });
 
-tape( 'the function correctly evaluates the hypergeometric function', function test( t ) {
+tape( 'the function correctly evaluates the hypergeometric function', opts, function test( t ) {
 	var expected;
 	var a;
 	var b;
@@ -278,7 +278,7 @@ tape( 'the function correctly evaluates the hypergeometric function', function t
 	t.end();
 });
 
-tape( 'the function correctly evaluates the hypergeometric function (edge case 6)', function test( t ) {
+tape( 'the function correctly evaluates the hypergeometric function (edge case 6)', opts, function test( t ) {
 	var expected;
 	var a;
 	var b;


### PR DESCRIPTION
## Description

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/26945794220

**Symptom:** `linux_test` → `Run build task` fails on all Node.js versions (v12, v14, v16) with `TypeError: hyp2f1 is not a function` at `test.native.js:275`.

**Root cause:** The `edgeCases5` and `edgeCases6` tape calls in `test.native.js` were missing the `opts` skip guard present on all 11 other tests in the file. When `tryRequire` fails to load the native addon it returns an `Error`; `opts = { skip: hyp2f1 instanceof Error }` is then truthy, and tests that pass `opts` skip cleanly. The two unguarded calls crash with `TypeError` instead of skipping.

**Fix:** Add `opts` as the second argument to the tape call at line 259 (`edgeCases5` fixture) and line 281 (`edgeCases6` fixture), matching the pattern used by every sibling test in the file.

## Related Issues

None.

## Questions

No.

## Other

Three-reviewer validation (correctness, regression scope, style) — all approved, no blocking findings.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was produced by Claude Code as part of an automated CI-failure investigation routine. The fix (two `opts` insertions in a test file) was validated by three independent Claude sub-agents acting as reviewers for correctness, regression scope, and style conformance.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_0118Tf2BgppBbjHwYRXjD3oP)_