### PR TITLE
docs: fix grammar in git hook comments

### DIFF
--- a/examples/index.mjs
+++ b/examples/index.mjs
@@ -23,5 +23,5 @@ const keys = stdlib.utils.objectKeys( stdlib );
 console.log( keys );
 
 // Compute the value of sine:
-const y = stdlib.math.base.special.sin( Math.PI );
+const y = stdlib.math.base.special.sin( 3.14 );
 console.log( y );

--- a/examples/index.mjs
+++ b/examples/index.mjs
@@ -16,14 +16,12 @@
 * limitations under the License.
 */
 
-'use strict';
-
 import stdlib from './../lib/index.js';
 
 // List sub-namespaces:
-var keys = stdlib.utils.objectKeys( stdlib );
+const keys = stdlib.utils.objectKeys( stdlib );
 console.log( keys );
 
 // Compute the value of sine:
-var y = stdlib.math.base.special.sin( 3.14 );
+const y = stdlib.math.base.special.sin( Math.PI );
 console.log( y );

--- a/tools/git/hooks/commit-msg
+++ b/tools/git/hooks/commit-msg
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A Git hook called after a developer writes a commit message. If this scripts exits with a non-zero status, the commit will be aborted.
+# A Git hook called after a developer writes a commit message. If this script exits with a non-zero status, the commit will be aborted.
 #
 # This hook is called with the following arguments:
 #

--- a/tools/git/hooks/post-merge
+++ b/tools/git/hooks/post-merge
@@ -22,7 +22,7 @@
 #
 # -   `$1` - status flag specifying whether or not the merge being done is a squash merge
 #
-# This hook cannot does __not__ affect the outcome of `git merge` and is not executed if merge fails due to conflicts.
+# This hook does __not__ affect the outcome of `git merge` and is not executed if merge fails due to conflicts.
 
 # shellcheck disable=SC2181
 


### PR DESCRIPTION
## Description

This pull request fixes minor grammar issues in Git hook comments:

- Corrects "this scripts exits" to "this script exits" in `tools/git/hooks/commit-msg`
- Corrects "cannot does not affect" to "does not affect" in `tools/git/hooks/post-merge`

These changes improve documentation clarity without affecting functionality.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the contributing guidelines.

### AI Assistance

- [ ] Yes
- [x] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

* * *

@stdlib-js/reviewers