### PR TITLE
fix: type `order` parameter as `Layout` in `blas/ext/base/dcartesian-square`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dcartesian-square/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcartesian-square/docs/types/index.d.ts
@@ -18,6 +18,10 @@
 
 // TypeScript Version: 4.1
 
+/// <reference types="@stdlib/types"/>
+
+import { Layout } from '@stdlib/types/blas';
+
 /**
 * Interface describing `dcartesianSquare`.
 */
@@ -46,7 +50,7 @@ interface Routine {
 	* dcartesianSquare( 'row-major', x.length, x, 1, out, 2 );
 	* // out => <Float64Array>[ 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 2.0, 2.0 ]
 	*/
-	( order: string, N: number, x: Float64Array, strideX: number, out: Float64Array, LDO: number ): Float64Array;
+	( order: Layout, N: number, x: Float64Array, strideX: number, out: Float64Array, LDO: number ): Float64Array;
 
 	/**
 	* Computes the Cartesian square for a double-precision floating-point strided array using alternative indexing semantics.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   types the `order` parameter of `blas/ext/base/dcartesianSquare` as `Layout` (from `@stdlib/types/blas`) instead of the over-broad `string`.
-   adds the `/// <reference types="@stdlib/types"/>` directive and the `import { Layout } from '@stdlib/types/blas';` import required for the type.

The function only accepts the BLAS memory layouts (`'row-major'` / `'column-major'`), so `string` is an over-broad type. This aligns the declaration with sibling `blas/ext/base/dcartesianPower`, which already types `order` as `Layout`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff and confirmed the fix mirrors the sibling `dcartesianPower` declaration.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
