### PR TITLE
fix: decouple scalar `alpha` type from input ndarray type in `blas/base/ndarray/gaxpy`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/gaxpy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/gaxpy/docs/types/index.d.ts
@@ -53,7 +53,7 @@ import { typedndarray } from '@stdlib/types/ndarray';
 * var bool = ( z === y );
 * // returns true
 */
-declare function gaxpy<T extends typedndarray<number> = typedndarray<number>, U extends typedndarray<number> = typedndarray<number>>( arrays: [ T, U, T ] ): U;
+declare function gaxpy<T extends typedndarray<number> = typedndarray<number>, U extends typedndarray<number> = typedndarray<number>>( arrays: [ T, U, typedndarray<number> ] ): U;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes the generic typing of `blas/base/ndarray/gaxpy` so the scalar constant `alpha` (the third tuple element) is no longer constrained to the input ndarray type `T`.

The third element of the `arrays` tuple is a zero-dimensional ndarray holding a scalar constant and is independent of the one-dimensional input ndarray. Constraining it to `T` (`[ T, U, T ]`) incorrectly forces it to share the input ndarray's type. This changes the tuple to `[ T, U, typedndarray<number> ]`, matching the analogous decoupling already used by sibling `blas/base/ndarray/gscal` (`[ T, typedndarray<number> ]`).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff and confirmed the typing mirrors the sibling `gscal` declaration.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
