### PR TITLE
fix: use `NumericArray` type in `blas/gswap`

### DIFF
--- a/lib/node_modules/@stdlib/blas/gswap/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/gswap/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { ArrayLike } from '@stdlib/types/array';
+import { NumericArray } from '@stdlib/types/array';
 import { ndarray } from '@stdlib/types/ndarray';
 
 /**
@@ -45,7 +45,7 @@ import { ndarray } from '@stdlib/types/ndarray';
 * // x => [ 2.0, 6.0, -1.0, -4.0, 8.0 ]
 * // y => [ 4.0, 2.0, -3.0, 5.0, -1.0 ]
 */
-declare function gswap( x: ndarray | ArrayLike<any>, y: ndarray | ArrayLike<any> ): ndarray | ArrayLike<any>;
+declare function gswap( x: ndarray | NumericArray, y: ndarray | NumericArray ): ndarray | NumericArray;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/gswap/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/gswap/docs/types/test.ts
@@ -58,8 +58,8 @@ function createArray(): ndarray {
 
 // The function returns an ndarray or array-like object...
 {
-	gswap( [ 1, 2, 3 ], [ 4, 5, 6 ] ); // $ExpectType ndarray | ArrayLike<any>
-	gswap( createArray(), createArray() ); // $ExpectType ndarray | ArrayLike<any>
+	gswap( [ 1, 2, 3 ], [ 4, 5, 6 ] ); // $ExpectType ndarray | NumericArray
+	gswap( createArray(), createArray() ); // $ExpectType ndarray | NumericArray
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an ndarray or array-like object...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   replaces the over-broad `ArrayLike<any>` type in `blas/gswap` with `NumericArray`, for both parameters and the return type, removing the use of `any`.

`gswap` interchanges two numeric vectors, so `NumericArray` precisely describes the accepted array-like inputs. This aligns the declaration with sibling `blas/gdot`, which already types its inputs as `ndarray | NumericArray`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff and confirmed the typing mirrors the sibling `gdot` declaration.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
