### PR TITLE
fix: type `dtype` parameter as `DataType`

### DIFF
--- a/lib/node_modules/@stdlib/blas/tools/swap-factory/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/tools/swap-factory/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { ndarray } from '@stdlib/types/ndarray';
+import { ndarray, DataType } from '@stdlib/types/ndarray';
 import { Collection, AccessorArrayLike } from '@stdlib/types/array';
 
 /**
@@ -81,7 +81,7 @@ type SwapFunction = ( x: ndarray, y: ndarray, dim?: number ) => ndarray;
 * var ybuf = y.data;
 * // returns <Float64Array>[ 4.0, 2.0, -3.0, 5.0, -1.0 ]
 */
-declare function factory<T extends Collection | AccessorArrayLike<any>>( base: BaseFunction<T>, dtype: any ): SwapFunction;
+declare function factory<T extends Collection | AccessorArrayLike<any>>( base: BaseFunction<T>, dtype: DataType ): SwapFunction;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   types the `dtype` parameter of `blas/tools/swap-factory`'s `factory` function as `DataType` (from `@stdlib/types/ndarray`) instead of `any`, and adds `DataType` to the existing `@stdlib/types/ndarray` import.

The `dtype` argument is an ndarray data type (e.g. `'float64'`), so `DataType` precisely describes it. This removes the use of `any` and matches the `dtype: DataType` typing already used by sibling declarations in the namespace.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff and confirmed `DataType` is exported from `@stdlib/types/ndarray` and used by sibling declarations.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
