### PR TITLE
refactor: use `strideX` parameter name in `blas/ext/base/dnansum`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dnansum/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dnansum/docs/types/index.d.ts
@@ -38,7 +38,7 @@ interface Routine {
 	* var v = dnansum( x.length, x, 1 );
 	* // returns 1.0
 	*/
-	( N: number, x: Float64Array, stride: number ): number;
+	( N: number, x: Float64Array, strideX: number ): number;
 
 	/**
 	* Computes the sum of double-precision floating-point strided array elements, ignoring `NaN` values and using alternative indexing semantics.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   renames the first overload's `stride` signature parameter to `strideX`, so the signature matches its own TSDoc (`@param strideX`) and the `ndarray` overload.

Declaration-only parameter rename aligning the signature with its documentation.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
