### PR TITLE
refactor: use `strideX`/`offsetX` parameter names in `blas/ext/base/dssumors`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dssumors/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumors/docs/types/index.d.ts
@@ -38,7 +38,7 @@ interface Routine {
 	* var v = dssumors( x.length, x, 1 );
 	* // returns 1.0
 	*/
-	( N: number, x: Float32Array, stride: number ): number;
+	( N: number, x: Float32Array, strideX: number ): number;
 
 	/**
 	* Computes the sum of single-precision floating-point strided array elements using ordinary recursive summation with extended accumulation and alternative indexing semantics and returning an extended precision result.
@@ -57,7 +57,7 @@ interface Routine {
 	* var v = dssumors.ndarray( x.length, x, 1, 0 );
 	* // returns 1.0
 	*/
-	ndarray( N: number, x: Float32Array, stride: number, offset: number ): number;
+	ndarray( N: number, x: Float32Array, strideX: number, offsetX: number ): number;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   renames the `stride`/`offset` signature parameters to `strideX`/`offsetX`, so the signatures match the TSDoc and sibling `dssum`.

Declaration-only parameter rename aligning the signatures with their documentation and siblings.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
