### PR TITLE
refactor: use `strideX`/`offsetX` parameter names in `blas/ext/base/gsorthp`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gsorthp/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsorthp/docs/types/index.d.ts
@@ -46,7 +46,7 @@ interface Routine {
 	* gsorthp( x.length, 1, x, 1 );
 	* // x => [ -4.0, -2.0, 1.0, 3.0 ]
 	*/
-	<T extends InputArray>( N: number, order: number, x: T, stride: number ): T;
+	<T extends InputArray>( N: number, order: number, x: T, strideX: number ): T;
 
 	/**
 	* Sorts a strided array using heapsort and alternative indexing semantics.
@@ -64,7 +64,7 @@ interface Routine {
 	* gsorthp.ndarray( x.length, 1, x, 1, 0 );
 	* // x => [ -4.0, -2.0, 1.0, 3.0 ]
 	*/
-	ndarray<T extends InputArray>( N: number, order: number, x: T, stride: number, offset: number ): T;
+	ndarray<T extends InputArray>( N: number, order: number, x: T, strideX: number, offsetX: number ): T;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   renames the `stride`/`offset` signature parameters to `strideX`/`offsetX`, so the signatures match the TSDoc and the `gsortins`/`gsortsh` siblings.

Declaration-only parameter rename aligning the signatures with their documentation and siblings.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
