### PR TITLE
refactor: use `strideX`/`offsetX` parameter names in `blas/ext/base/ssortins`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ssortins/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssortins/docs/types/index.d.ts
@@ -28,7 +28,7 @@ interface Routine {
 	* @param N - number of indexed elements
 	* @param order - sort order
 	* @param x - input array
-	* @param stride - stride length
+	* @param strideX - stride length
 	* @returns input array
 	*
 	* @example
@@ -39,7 +39,7 @@ interface Routine {
 	* ssortins( x.length, 1, x, 1 );
 	* // x => <Float32Array>[ -4.0, -2.0, 1.0, 3.0 ]
 	*/
-	( N: number, order: number, x: Float32Array, stride: number ): Float32Array;
+	( N: number, order: number, x: Float32Array, strideX: number ): Float32Array;
 
 	/**
 	* Sorts a single-precision floating-point strided array using insertion sort and alternative indexing semantics.
@@ -47,8 +47,8 @@ interface Routine {
 	* @param N - number of indexed elements
 	* @param order - sort order
 	* @param x - input array
-	* @param stride - stride length
-	* @param offset - starting index
+	* @param strideX - stride length
+	* @param offsetX - starting index
 	* @returns input array
 	*
 	* @example
@@ -59,7 +59,7 @@ interface Routine {
 	* ssortins.ndarray( x.length, 1, x, 1, 0 );
 	* // x => <Float32Array>[ -4.0, -2.0, 1.0, 3.0 ]
 	*/
-	ndarray( N: number, order: number, x: Float32Array, stride: number, offset: number ): Float32Array;
+	ndarray( N: number, order: number, x: Float32Array, strideX: number, offsetX: number ): Float32Array;
 }
 
 /**
@@ -68,7 +68,7 @@ interface Routine {
 * @param N - number of indexed elements
 * @param order - sort order
 * @param x - input array
-* @param stride - stride length
+* @param strideX - stride length
 * @returns input array
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   renames the `stride`/`offset` parameters (both signatures and TSDoc) to `strideX`/`offsetX`, for consistency with sibling sort packages (e.g. `ssort`, `ssorthp`).

Declaration-only parameter rename for family consistency.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
