### PR TITLE
refactor: rename `value` parameter to `diagonal` in `blas/base/diagonal-type-enum2str`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/diagonal-type-enum2str/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/diagonal-type-enum2str/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /**
 * Returns the BLAS diagonal type string associated with a BLAS diagonal type enumeration constant.
 *
-* @param value - enumeration constant
+* @param diagonal - enumeration constant
 * @returns diagonal type string
 *
 * @example
@@ -33,7 +33,7 @@
 * var s = enum2str( v );
 * // returns 'unit'
 */
-declare function enum2str( value: number ): string | null;
+declare function enum2str( diagonal: number ): string | null;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   renames the `value` parameter to `diagonal`, matching the `diagonal-type-str2enum` counterpart and the dominant `*-enum2str` naming convention (e.g. `layout`, `operation`).

Declaration-only parameter rename for family consistency.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
