### PR TITLE
fix: rename interface to PascalCase `LastIndexOf` in `blas/ext/last-index-of`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/last-index-of/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/last-index-of/docs/types/index.d.ts
@@ -75,7 +75,7 @@ interface Options extends BaseOptions {
 /**
 * Interface describing `lastIndexOf`.
 */
-interface lastIndexOf {
+interface LastIndexOf {
 	/**
 	* Returns the last index of a specified search element along an ndarray dimension.
 	*
@@ -224,7 +224,7 @@ interface lastIndexOf {
 * var bool = ( out === y );
 * // returns true
 */
-declare const lastIndexOf: lastIndexOf;
+declare const lastIndexOf: LastIndexOf;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   renames the `lastIndexOf` interface to PascalCase `LastIndexOf`, so the interface name no longer collides (by case) with the exported `lastIndexOf` value, matching sibling `index-of` (`IndexOf`).

Declaration-only rename of an internal interface type; the exported value name is unchanged.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
