### PR TITLE
refactor: remove redundant generic constraint in `blas/ext/base/ndarray/gsort`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsort/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsort/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { typedndarray, genericndarray } from '@stdlib/types/ndarray';
+import { typedndarray } from '@stdlib/types/ndarray';
 
 /**
 * Sorts a one-dimensional ndarray.
@@ -50,7 +50,7 @@ import { typedndarray, genericndarray } from '@stdlib/types/ndarray';
 * var out = gsort( [ x, ord ] );
 * // returns <ndarray>[ -4.0, -2.0, 1.0, 3.0 ]
 */
-declare function gsort<T extends typedndarray<unknown> | genericndarray<unknown> = typedndarray<unknown>>( arrays: [ T, typedndarray<number> ] ): T;
+declare function gsort<T extends typedndarray<unknown> = typedndarray<unknown>>( arrays: [ T, typedndarray<number> ] ): T;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes the redundant `genericndarray<unknown>` arm from the `T` generic constraint (`genericndarray` extends `typedndarray`, so the arm is subsumed) and the now-unused `genericndarray` import, matching sibling `gone-to`.

Declaration-only simplification; the constraint is unchanged in meaning, so inferred return types (and the type tests) are unaffected.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an audit of the `blas` namespace TypeScript declarations. Declaration-only change; no runtime behavior is affected.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This change was identified by an AI-assisted (Claude Code) audit of the `blas` TypeScript declarations and authored with Claude Code. I reviewed the diff.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
