### PR TITLE
docs: normalize stride parameter descriptions in `stats/base/cumin`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/cumin/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/cumin/lib/main.js
@@ -31,9 +31,9 @@ var ndarray = require( './ndarray.js' );
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NumericArray} x - input array
-* @param {integer} strideX - `x` stride length
+* @param {integer} strideX - stride length for `x`
 * @param {NumericArray} y - output array
-* @param {integer} strideY - `y` stride length
+* @param {integer} strideY - stride length for `y`
 * @returns {NumericArray} output array
 *
 * @example


### PR DESCRIPTION
## Description

This pull request:

-   normalizes the `strideX` and `strideY` `@param` descriptions in `lib/node_modules/@stdlib/stats/base/cumin/lib/main.js` to match the form used by the three sibling cumulative-reducer packages (`cumax`, `cumaxabs`, `cuminabs`).

### `stats/base/cumin`

The `lib/main.js` JSDoc described `strideX` as `` `x` stride length `` and `strideY` as `` `y` stride length ``. Every other source in this cohort — the three sibling packages, this package's own `lib/ndarray.js`, and this package's own `README.md` parameter table — uses `` stride length for `x` `` / `` stride length for `y` ``. Conformance with the corrected form is 3/4 = 75% across siblings, and 100% within `cumin` once `main.js` is updated.

## Related Issues

None.

## Questions

No.

## Other

No observable behavior change. The diff is a 2-line text adjustment inside a JSDoc comment block; no test or example references the old phrasing.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated cross-package drift detector run by Claude Code. The detector enumerated all 19 direct children of `lib/node_modules/@stdlib/stats/base/`, computed per-feature majority patterns across the 17 non-aggregator members, and flagged this single outlier after three independent agent reviews returned `confirmed-drift`. A human (Philipp Burckhardt) reviewed the diff before opening.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018AmpyMVUUzBNhudFkJELgW)_