### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ssymv/test/test.ssymv.js
+++ b/lib/node_modules/@stdlib/blas/base/ssymv/test/test.ssymv.js
@@ -36,7 +36,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cu = require( './fixtures/column_major_upper.json' );
 var cl = require( './fixtures/column_major_lower.json' );
 var cxpyp = require( './fixtures/column_major_xpyp.json' );


### PR DESCRIPTION
## Summary

- Removes the extra blank line between consecutive fixture `require` statements in the `ssymv` test file.

## Related Issue

Resolves #12548

## Questions

None.

## Other

I used AI assistance to identify and verify this lint-only fix.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
- [x] Read and understood the contribution guidelines.
- [x] Ran `make JAVASCRIPT_LINTER=eslint ESLINT_CONF='etc/eslint/.eslintrc.tests.js' lint-javascript-files FILES='lib/node_modules/@stdlib/blas/base/ssymv/test/test.ssymv.js'`.
- [x] Ran `git diff --check`.
