### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-even/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-even/package.json
@@ -63,6 +63,7 @@
     "math",
     "mathematics",
     "integer",
+    "number",
     "int",
     "32-bit",
     "long",

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/package.json
@@ -63,6 +63,7 @@
     "math",
     "mathematics",
     "integer",
+    "number",
     "int",
     "32-bit",
     "long",


### PR DESCRIPTION
## Description

Adds the missing `"number"` keyword to `package.json` in two outlier packages in the `@stdlib/math/base/assert` namespace, where 33/35 siblings (94.3%) already carry this keyword.

### `math/base/assert/int32-is-even`

Package `@stdlib/math/base/assert/int32-is-even` was missing the `"number"` keyword from `package.json`. 33 of 35 sibling packages in `@stdlib/math/base/assert` carry this keyword (94.3% conformance), including all analogous integer-checking siblings (`is-integer`, `is-safe-integer`, `is-positive-integer`, `is-negative-integer`, `is-nonnegative-integer`, etc.). Added `"number"` after `"integer"` to match the thematic ordering established by `is-integer` and its siblings.

### `math/base/assert/int32-is-odd`

Package `@stdlib/math/base/assert/int32-is-odd` was missing the `"number"` keyword from `package.json`. 33 of 35 sibling packages in `@stdlib/math/base/assert` carry this keyword (94.3% conformance), including all analogous integer-checking siblings. Added `"number"` after `"integer"` to match the thematic ordering established by `is-integer` and its siblings.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

Metadata-only change; no source, test, or behavioral changes. Total diff: 2 lines across 2 files.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine. Structural and semantic features were extracted from every member of `@stdlib/math/base/assert` (35 packages); majority patterns were computed at a 75% conformance threshold; three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) each returned `confirmed-drift` for both outliers before any file was edited. Only `package.json` `keywords` were modified.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018LRTNfzNcoBUdSsQUNkhWw)_