### PR TITLE
chore: follow-up corrections for recent commits

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gcusome/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusome/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var bernoulli = require( '@stdlib/random/array/bernoulli' );
-var isBoolean = require( '@stdlib/assert/is-boolean' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var filled = require( '@stdlib/array/base/filled' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusome/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusome/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var bernoulli = require( '@stdlib/random/array/bernoulli' );
-var isBoolean = require( '@stdlib/assert/is-boolean' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var filled = require( '@stdlib/array/base/filled' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );

--- a/lib/node_modules/@stdlib/fft/base/fftpack/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/docs/types/index.d.ts
@@ -20,7 +20,8 @@
 
 /* eslint-disable max-lines */
 
-import decompose = require( '@stdlib/fft/base/fftpack' );
+import decompose = require( '@stdlib/fft/base/fftpack/decompose' );
+import rffti = require( '@stdlib/fft/base/fftpack/rffti' );
 
 /**
 * Interface describing the `fftpack` namespace.
@@ -30,6 +31,11 @@ interface Namespace {
 	* TODO
 	*/
 	decompose: typeof decompose;
+
+	/**
+	* TODO
+	*/
+	rffti: typeof rffti;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request applies follow-up fixes for commits merged to `develop` between 2026-06-04 14:06:38 -0500 (`39f37bf`) and 2026-06-05 02:06:31 -0700 (`6b0591c`), surfaced by an automated review pass over the 33-commit, 158-file window.

Themes covered by the review window: new `fft` / `fft/base` / `fft/base/fftpack` namespace scaffolding (Athan Reines), new `blas/ext/base/gcuany` and `gcusome` packages (Muhammad Haris), and a broad TypeScript declaration normalization sweep across `blas` and `stats` (Philipp Burckhardt). Fixes below address concrete inconsistencies introduced in two of those namespaces:

-   Fix `e55fddc`: use `require( '@stdlib/assert/is-boolean' ).isPrimitive` instead of the base `isBoolean` import in `blas/ext/base/gcusome/benchmark/benchmark.js` and `benchmark.ndarray.js`, consistent with `gcuany`, `gcuevery`, and `gcunone` sibling benchmarks.
-   Fix circular self-import in `lib/node_modules/@stdlib/fft/base/fftpack/docs/types/index.d.ts` (`3a0597c`) by importing `decompose` from its own package path and adding the missing `rffti` member so the `Namespace` interface mirrors `lib/index.js`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation performed:**

-   Style-guide compliance pass against the new `fft` namespace scaffolding and the new `blas/ext/base/gcuany` and `gcusome` packages, comparing each against established sibling packages (`gcuevery`, `gcunone`, `blas/ext/base/docs/types/index.d.ts`).
-   Style-guide compliance pass over Philipp Burckhardt's TypeScript declaration sweep (stride/offset renames, `Layout` enum adoption, TSDoc text normalization, generic constraint cleanup, `gaxpy` alpha-type decoupling, `LastIndexOf` PascalCase rename).
-   Two independent diff-only bug scans (one focused on objective coding errors verifiable from the diff, one on introduced-code semantics and security).
-   stdlib-bot auto-regenerated artefacts (assert TS decls, REPL namespace docs, related-packages sections) were excluded — they are mechanical regenerations and not human-authored.

**Deliberately excluded from this PR:**

-   Subjective concerns, "could be better" suggestions, and anything requiring code outside the diff window to validate.
-   The `ftt/base` typo in commit `7fd86dd`'s subject line (typo on `develop`; not editable from a follow-up branch).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code as a scheduled follow-up review pass over the last 24 hours of commits merged to `develop`. Four parallel reviewer agents (two style-guide audits, two diff-only bug scans) surfaced candidate issues; only issues independently re-verifiable from the diff and the corresponding sibling files in-tree were applied here. A maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_014RPC3TzqNKiB3aNvY1o4be)_