### PR TITLE
chore: propagate recent develop fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-well-formed-string/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-well-formed-string/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /**
 * Interface defining `isWellFormedString` with methods for testing for primitives and objects, respectively.
 */
-interface isWellFormedString {
+interface IsWellFormedString {
 	/**
 	* Tests if a string is well-formed.
 	*
@@ -125,7 +125,7 @@ interface isWellFormedString {
 * var bool = isWellFormedString( null );
 * // returns false
 */
-declare var isWellFormedString: isWellFormedString;
+declare var isWellFormedString: IsWellFormedString;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/flatten-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/flatten-by/docs/types/index.d.ts
@@ -404,7 +404,7 @@ declare function flattenBy<T = unknown, U extends genericndarray<T> = genericnda
 * var y = flattenBy( x, opts, scale );
 * // returns <ndarray>[ 2.0, 4.0, 6.0, 8.0, 10.0, 12.0 ]
 */
-declare function flattenBy<T = unknown, U extends typedndarray<T> | genericndarray<T> = typedndarray<T>, V = unknown, W extends keyof DataTypeMap<T> = 'generic', ThisArg = unknown>( x: U, options: Options<W>, fcn: Callback<T, U, V, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, V, ThisArg>> ): DataTypeMap<V>[W];
+declare function flattenBy<T = unknown, U extends typedndarray<T> = typedndarray<T>, V = unknown, W extends keyof DataTypeMap<T> = 'generic', ThisArg = unknown>( x: U, options: Options<W>, fcn: Callback<T, U, V, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, V, ThisArg>> ): DataTypeMap<V>[W];
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/flatten-from-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/flatten-from-by/docs/types/index.d.ts
@@ -399,7 +399,7 @@ declare function flattenFromBy<T = unknown, U extends genericndarray<T> = generi
 * var y = flattenFromBy( x, 1, opts, scale );
 * // returns <ndarray>[ [ 2.0, 4.0 ], [ 6.0, 8.0 ], [ 10.0, 12.0 ] ]
 */
-declare function flattenFromBy<T = unknown, U extends typedndarray<T> | genericndarray<T> = typedndarray<T>, V = unknown, W extends keyof DataTypeMap<T> = 'generic', ThisArg = unknown>( x: U, dim: number, options: Options<W>, fcn: Callback<T, U, V, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, V, ThisArg>> ): DataTypeMap<V>[W];
+declare function flattenFromBy<T = unknown, U extends typedndarray<T> = typedndarray<T>, V = unknown, W extends keyof DataTypeMap<T> = 'generic', ThisArg = unknown>( x: U, dim: number, options: Options<W>, fcn: Callback<T, U, V, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, V, ThisArg>> ): DataTypeMap<V>[W];
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-06-04 14:06:38 -0500 (`39f37bf`) and 2026-06-05 02:06:31 -0700 (`6b0591c`) to sibling packages with the same underlying defect.

### Pattern: drop redundant `genericndarray` clause from `flatten-{,from-}by` overloads

`typedndarray<T>` already extends `genericndarray<T>`, making the union `typedndarray<unknown> | genericndarray<unknown>` in the `Options<W>` generic constraint redundant. The `genericndarray` import is retained in both files since other overloads reference it.

- `15a731b9` ([`refactor: remove redundant generic constraint in `blas/ext/base/ndarray/gsorthp``](https://github.com/stdlib-js/stdlib/commit/15a731b9aa63d384fa1d8d5cd3f9c20004714ad4))
- `c26d8b58` ([`refactor: remove redundant generic constraint in `blas/ext/base/ndarray/gsort``](https://github.com/stdlib-js/stdlib/commit/c26d8b58bd7f8254b6db66b8458128bed8e4beab))
  - `@stdlib/ndarray/flatten-by`
  - `@stdlib/ndarray/flatten-from-by`

### Pattern: PascalCase interface name in `assert/is-well-formed-string`

Renames `interface isWellFormedString` to `interface IsWellFormedString` in the TypeScript declaration, updating the `declare var` type reference accordingly; the export-value name `isWellFormedString` is unchanged. Aligns with every other `assert/is-*` package (`IsString`, `IsBoolean`, etc.) and the convention established in `608e415c`.

- `608e415c` ([`fix: rename interface to PascalCase `LastIndexOf` in `blas/ext/last-index-of``](https://github.com/stdlib-js/stdlib/commit/608e415c415a9d60e843d8a32043f3257195a11d))
  - `@stdlib/assert/is-well-formed-string`

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Search scope:** per pattern, scoped to the source commit's namespace first (`blas/ext/base/ndarray/*` and `ndarray/*` for the redundant-constraint sweep; `assert/is-*`, `array/base/cu*`, `math/base/special/*`, and `blas/ext/*` for the PascalCase-interface sweep), widened to all `lib/node_modules/@stdlib/**/docs/types/*.d.ts` where the pattern signature warranted it.
- **Two independent opus validation passes** confirmed at every candidate site that (a) the defect is present as cited, (b) surrounding context does not change the semantics — for the redundant-constraint pattern, that `typedndarray<T>` indeed subsumes `genericndarray<T>` and the simplification does not narrow accepted inputs; for the PascalCase pattern, that the `docs/types/test.ts` does not reference the camelCase interface name as `$ExpectType`, which would cascade — and (c) the proposed patch matches the source commit's exact shape.
- **A sonnet style-consistency pass** verified that each replacement matches the surrounding declaration style (default `= typedndarray<T>` preserved on the simplified constraint, single-line overload retained, `export = <value>` lines untouched).

### Deliberately excluded

- `fix: type `order` parameter as `Layout`` propagation (`a601344e` / `3bf760c6`): the four remaining `blas/ext/base/*cartesian-*` siblings (`dcartesian-power`, `scartesian-power`, `gcartesian-power`, `gcartesian-square`) already type `order` as `Layout` — no propagation sites.
- `docs: normalize dtype description in `random/hypergeometric`` (`fdfc2baa`): the `real-valued or "generic"` defect appears nowhere else; sibling `random/*` packages either use `real-valued floating-point or "generic"` (correct prose for the `real_floating_point` dtype kind) or already use `real or "generic"` (correct for integer-output distributions).
- `docs: correct `@throws` description for pulse duration` (`b2ef3a33`): the only remaining sibling, `simulate/iter/pulse`, validates `duration >= period` (not `duration > period`) and so the docstring `must be less than the period` is correct as-is — different semantics from the bartlett/hann/lanczos/etc. pulses already patched.
- PascalCase rename for `math/base/special/sincosd` (`Sincosd` vs `SinCosd`), `array/base/cusome` (`Cusome` vs `CuSome`), and `array/base/cunone` (`Cunone` vs `CuNone`): one of the two validation agents flagged `needs-human` on each because the per-package PascalCase form requires a sibling-convention call; will land in a follow-up.
- The active `strideX`/`offsetX` rename sweep across `blas/ext/base/*` (`f766a248`, `1a35c429`, `9f94bda2`, `a18215d3`, `e74dd953`, `45710f8f`, `37b53d20`): each remaining sibling is being landed as its own commit by the namespace owner — propagating in bulk here would duplicate that workflow.
- Autogenerated artefacts (assert TS decls regen `c415485e`, REPL namespace docs `ec39d31a`, related-packages sections `3d01e36f`, namespace list `6b0591c`): generator-owned files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalisable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two opus validation passes plus a sonnet style-consistency pass) before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_012ZpMh3aGsc6GVhcUJgVF6G)_