### PR TITLE
docs: add Git note

### DIFF
--- a/docs/git-notes/7fd86dd7de37071f3357f99615354b1287c6d23a.txt
+++ b/docs/git-notes/7fd86dd7de37071f3357f99615354b1287c6d23a.txt
@@ -1,0 +1,54 @@
+---
+type: amend-message
+---
+feat: add `fft/base` namespace
+
+---
+type: pre_commit_static_analysis_report
+description: Results of running static analysis checks when committing changes.
+report:
+  - task: lint_filenames
+    status: passed
+  - task: lint_editorconfig
+    status: passed
+  - task: lint_markdown_pkg_readmes
+    status: passed
+  - task: lint_markdown_docs
+    status: na
+  - task: lint_markdown
+    status: na
+  - task: lint_package_json
+    status: passed
+  - task: lint_repl_help
+    status: na
+  - task: lint_javascript_src
+    status: passed
+  - task: lint_javascript_cli
+    status: na
+  - task: lint_javascript_examples
+    status: passed
+  - task: lint_javascript_tests
+    status: passed
+  - task: lint_javascript_benchmarks
+    status: na
+  - task: lint_python
+    status: na
+  - task: lint_r
+    status: na
+  - task: lint_c_src
+    status: na
+  - task: lint_c_examples
+    status: na
+  - task: lint_c_benchmarks
+    status: na
+  - task: lint_c_tests_fixtures
+    status: na
+  - task: lint_shell
+    status: na
+  - task: lint_typescript_declarations
+    status: passed
+  - task: lint_typescript_tests
+    status: passed
+  - task: lint_license_headers
+    status: passed
+---


### PR DESCRIPTION
This PR adds one Git note file correcting a commit message error found in the last 24 hours of `develop`.

## Notes

- `7fd86dd7de3`: typo in subject — original said `` feat: add `ftt/base` namespace ``; correct package name is `fft/base` (transposed `f` and first `t`). All files changed by the commit are under `lib/node_modules/@stdlib/fft/base/`.

## Verification

- `git diff develop --stat` shows one new file under `docs/git-notes/`.
- PR-URLs for all other commits in the 24-hour window were verified against the GitHub API; all were valid and matched their subjects.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)