### PR TITLE
build: fix team reviewer slug in `namespace_declarations` workflow

### DIFF
--- a/.github/workflows/namespace_declarations.yml
+++ b/.github/workflows/namespace_declarations.yml
@@ -154,7 +154,7 @@ jobs:
           - [ ] Approve the PR once you are confident about the classification and changes made." \
                   --label "Documentation" \
                   --label "automated-pr" \
-                  --reviewer "@stdlib-js/reviewers" \
+                  --reviewer "stdlib-js/reviewers" \
                   --base develop \
                   --head "$branch_name"
               fi


### PR DESCRIPTION
No related issue.

## Description

> What is the purpose of this pull request?

This pull request:

-   removes the leading `@` from the `--reviewer` flag argument in the `namespace_declarations` workflow so the team slug resolves correctly

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Failing run: https://github.com/stdlib-js/stdlib/actions/runs/26993196933

Symptom: `GraphQL: Could not resolve team with slug '@stdlib-js/reviewers'. (requestReviewsByLogin)` — exit code 1, fired on every daily run of the `namespace_declarations` workflow.

Root cause: `gh pr create --reviewer` expects `ORG/TEAM` for team slugs, not `@ORG/TEAM`. The `@` prefix applies to usernames; passing it for a team causes GitHub's GraphQL layer to fail resolution.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was generated by Claude Code as part of an automated CI failure investigation routine.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01PViqkGg5qiKKVKMcoaw9Hm)_