### PR TITLE
docs: add missing empty `notes` section blocks

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/cdf/README.md
@@ -134,6 +134,16 @@ y = mycdf( 0.3 );
 
 <!-- /.usage -->
 
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
 <section class="examples">
 
 ## Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/pdf/README.md
@@ -134,6 +134,16 @@ y = mypdf( 0.3 );
 
 <!-- /.usage -->
 
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
 <section class="examples">
 
 ## Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/quantile/README.md
@@ -132,6 +132,16 @@ y = myQuantile( 0.3 );
 
 <!-- /.usage -->
 
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
 <section class="examples">
 
 ## Examples


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds an empty `<section class="notes">` block (with the standard `<!-- Package usage notes ... -->` and `<!-- /.notes -->` markers) between the JavaScript `## Usage` and `## Examples` sections in the `README.md` files of three outlier packages in the `stats/base/dists/kumaraswamy` namespace: `cdf`, `pdf`, and `quantile`. The block is already present in 10/13 sibling packages (77% conformance); these three were the structural outliers. Documentation scaffolding only; no behavior change.

### Namespace summary

- Namespace: `@stdlib/stats/base/dists/kumaraswamy`
- Members analyzed: 13 (`cdf`, `ctor`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `median`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`)
- Features extracted: README section structure, `package.json` shape, file-tree composition, JSDoc shape, public signatures, validation prologues, dependency graphs
- Features with a clear majority (≥75%): JS `<section class="notes">` block presence, native C-binding presence, `## C APIs` section presence, `[a-isnan, b-isnan]` validation subsequence, JSDoc tag completeness
- Features without clear majority (excluded): `<section class="references">` block, `lib/factory.js` presence, `test/fixtures/julia/` presence (each reflects a sub-shape semantic split, not drift)

### Per outlier package

#### `@stdlib/stats/base/dists/kumaraswamy/cdf`

Adds an empty `<section class="notes">` block to `README.md` in `@stdlib/stats/base/dists/kumaraswamy/cdf`, bringing it in line with the documentation structure used by 10 of 13 sibling packages in the `stats/base/dists/kumaraswamy` namespace. The block sits between the JavaScript Usage and Examples sections and contains the standard `<!-- Package usage notes. -->` and `<!-- /.notes -->` markers. No functional changes.

#### `@stdlib/stats/base/dists/kumaraswamy/pdf`

Adds an empty `<section class="notes">` block to the `README.md` for `@stdlib/stats/base/dists/kumaraswamy/pdf`, matching the structure present in 10 of 13 sibling packages in the `stats/base/dists/kumaraswamy` namespace. The block is inserted between the JavaScript Usage and Examples sections, consistent with the established ordering convention. No functional changes. Note: this package separately lacks the `## C APIs` section that 11/13 siblings carry; that gap is out of scope here (prior PR #10067 attempted the C implementation and was closed unmerged).

#### `@stdlib/stats/base/dists/kumaraswamy/quantile`

Adds a `<section class="notes">` block to the `README.md` for `@stdlib/stats/base/dists/kumaraswamy/quantile`, bringing it in line with 10 of 13 sibling packages in the `stats/base/dists/kumaraswamy` namespace. The section is empty — placeholder markers only — and carries no behavioral change. Restores structural conformance across the namespace.

### Validation

Checked:

- Structural feature extraction across all 13 members (file trees, `package.json` shape, README section ordering, manifest keys, test/benchmark/example naming).
- Semantic feature extraction via per-package agent reads of `lib/main.js`, `lib/index.js`, `lib/factory.js` (signatures, validation prologues, error construction, JSDoc shape, dependencies).
- Three-agent drift validation: semantic review (opus), cross-reference review against tests/examples/`docs/types`/`docs/repl.txt` (opus), and structural review (sonnet). All three returned `confirmed-drift` for `cdf`, `pdf`, and `quantile`. Tests, examples, and type declarations do not reference README block presence.
- GitHub-side cross-run dedup: no open PRs against this namespace propose the same change; no merges in the last 14 days overlap.

Deliberately excluded:

- `pdf` missing native C bindings (and the `## C APIs` block): non-mechanical fix; requires writing C math. PR #10067 already attempted this and was closed unmerged.
- `stdev` missing validation prologue: intentional delegation — `stdev(a, b)` returns `sqrt(variance(a, b))` and `variance` handles invalid-input checks. Adding redundant validation would be a "while we're here" change.
- `ctor` deviating on signature, validation, error construction, and absence of C APIs: intentional — `ctor` is a constructor class, not a unary math function.
- `mode` validation guard using `< 1` instead of `<= 0`: correct per the mode's mathematical definition.
- Extra `## Notes` content in `logcdf` / `logpdf`: intentional — log forms document numerical-stability considerations.
- Features without a ≥75% majority: `<section class="references">` block (6/13), `lib/factory.js` presence (5/13), `lib/index.js` variable naming (10/13, but stylistic with no documented convention).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Each commit corresponds to a single outlier package. Per-package drift findings, the dropped-correction log, and the full feature extraction tables are recorded in a local report outside the repository tree.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was prepared with Claude Code. An agent extracted structural and semantic features for each member of the `stats/base/dists/kumaraswamy` namespace, identified the majority pattern per feature, and ran a three-agent validation (semantic, cross-reference, structural) before applying the documentation-scaffolding fix to the three confirmed outliers. Each insertion was verified by re-reading the modified file against the majority template.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01UfDAR5uk1yXkgTgPT9rWNK)_