### PR TITLE
fix: correct return type of the options-only `factory` overload in random/streams/triangular

### DIFF
--- a/lib/node_modules/@stdlib/random/streams/triangular/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/triangular/docs/types/index.d.ts
@@ -313,7 +313,7 @@ interface Constructor {
 	*     streams.push( createStream( 2.0, 5.0, 4.0 ) );
 	* }
 	*/
-	factory( options?: Options ): ( a: number, b: number ) => RandomStream;
+	factory( options?: Options ): ( a: number, b: number, c: number ) => RandomStream;
 
 	/**
 	* Returns an "objectMode" readable stream for generating a stream of pseudorandom numbers drawn from a triangular distribution.

--- a/lib/node_modules/@stdlib/random/streams/triangular/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/streams/triangular/docs/types/test.ts
@@ -71,7 +71,7 @@ import RandomStream = require( './index' );
 
 	f = RandomStream.factory( {} );
 	f( 2.0, 5.0, 4.0 ); // $ExpectType RandomStream
-	f( 1.0, 2.0 ); // $ExpectType RandomStream
+	f( 1.0, 2.0, 1.5 ); // $ExpectType RandomStream
 	f( 1.0, 3.0, 2.0 ); // $ExpectType RandomStream
 
 	f = RandomStream.factory( { 'iter': 10 } );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   corrects the return type of the options-only `factory` overload in `random/streams/triangular`.

The function returned by the options-only `RandomStream.factory( options? )` overload creates streams generating pseudorandom numbers drawn from a triangular distribution, which is parameterized by the minimum support `a`, the maximum support `b`, and the mode `c`. The returned function therefore accepts **three** arguments, but the declared type listed only `a` and `b`:

```ts
factory( options?: Options ): ( a: number, b: number ) => RandomStream;          // before
factory( options?: Options ): ( a: number, b: number, c: number ) => RandomStream; // after
```

This matches the implementation (`lib/main.js` / `lib/factory.js`, whose returned creator takes `( a, b, c )`) and the overload's own documented `@example`, which calls `createStream( 2.0, 5.0, 4.0 )`. The corresponding `$ExpectType` assertion in `test.ts` is aligned to use three arguments.

The existing type test continued to pass against the buggy type only because, in the positive-assertion block, the test variable is first assigned from the four-argument `factory( a, b, c, options )` overload (whose return type is `( ...args: Array<any> ) => RandomStream`), masking the arity of the options-only overload.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This change was identified during a TypeScript-declaration audit of the `@stdlib/random` namespace.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A TypeScript-declaration audit surfaced this issue using Claude Code; the finding was independently verified against the implementation, and the proposed change was reviewed by myself before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
