### PR TITLE
fix: add missing `prng` option

### DIFF
--- a/lib/node_modules/@stdlib/random/streams/randn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/randn/docs/types/index.d.ts
@@ -59,6 +59,11 @@ interface Options {
 	name?: 'improved-ziggurat' | 'box-muller';
 
 	/**
+	* Pseudorandom number generator which generates uniformly distributed pseudorandom numbers.
+	*/
+	prng?: random.PRNG;
+
+	/**
 	* Pseudorandom number generator seed.
 	*/
 	seed?: random.PRNGSeedMT19937;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds the missing `prng` option to the `Options` interface in `random/streams/randn`.

The `RandomStream` constructor and `factory` method already document an `options.prng` parameter ("pseudorandom number generator which generates uniformly distributed pseudorandom numbers"), and the underlying `lib/validate.js` accepts a `prng` option:

```js
if ( hasOwnProp( options, 'prng' ) ) {
	opts.prng = options.prng;
	// ...
}
```

However, the `Options` interface omitted the corresponding property, so supplying `{ prng: ... }` raised a spurious type error. This adds:

```ts
prng?: random.PRNG;
```

matching the sibling `random/streams/pareto-type1` declaration (which already includes `prng?: random.PRNG;`).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This change was identified during a TypeScript-declaration audit of the `@stdlib/random` namespace and verified against `lib/validate.js`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A TypeScript-declaration audit surfaced this issue using Claude Code; the finding was independently verified against the implementation (`lib/validate.js`) and the sibling `pareto-type1` declaration, and reviewed by myself before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
