### PR TITLE
fix: widen instance `seed`/`state` types in random/streams/randu

### DIFF
--- a/lib/node_modules/@stdlib/random/streams/randu/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/randu/docs/types/index.d.ts
@@ -152,7 +152,7 @@ declare class RandomStream extends Readable {
 	/**
 	* PRNG seed.
 	*/
-	readonly seed: random.PRNGSeedMT19937;
+	readonly seed: random.PRNGSeedMT19937 | random.PRNGSeedMINSTD;
 
 	/**
 	* PRNG seed length.
@@ -162,7 +162,7 @@ declare class RandomStream extends Readable {
 	/**
 	* PRNG state.
 	*/
-	state: random.PRNGStateMT19937;
+	state: random.PRNGStateMT19937 | random.PRNGStateMINSTD;
 
 	/**
 	* PRNG state length.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   widens the instance `seed` and `state` member types in `random/streams/randu` to include the MINSTD variants.

The `Options` interface already permits selecting a MINSTD generator:

```ts
name?: 'mt19937' | 'minstd' | 'minstd-shuffle';
seed?: random.PRNGSeedMT19937 | random.PRNGSeedMINSTD;
state?: random.PRNGStateMT19937 | random.PRNGStateMINSTD;
```

and the stream forwards `seed`/`state` from the underlying PRNG (`@stdlib/random/base/randu`), which selects a MINSTD generator when `name` is `'minstd'`/`'minstd-shuffle'`. A MINSTD state is an `Int32Array` (`PRNGStateMINSTD`), distinct from MT19937's `Uint32Array`. However, the instance members were typed MT19937-only:

```ts
readonly seed: random.PRNGSeedMT19937;          // before
state: random.PRNGStateMT19937;                  // before
```

so the declared types rejected valid MINSTD shapes. This widens both to match the `Options` interface and the sibling `random/base/randu` declaration (which already uses the union):

```ts
readonly seed: random.PRNGSeedMT19937 | random.PRNGSeedMINSTD;
state: random.PRNGStateMT19937 | random.PRNGStateMINSTD;
```

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Identified during a TypeScript-declaration audit of the `@stdlib/random` namespace and verified against `lib/main.js`, the `base/randu` factory, and the `@stdlib/types/random` seed/state definitions.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A TypeScript-declaration audit surfaced this issue using Claude Code; the finding was independently verified against the implementation and the `base/randu` reference, and reviewed by myself before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
