### PR TITLE
fix: widen `seed`/`state` types in random/base/randi

### DIFF
--- a/lib/node_modules/@stdlib/random/base/randi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/randi/docs/types/index.d.ts
@@ -34,12 +34,12 @@ interface Options {
 	/**
 	* Pseudorandom number generator seed.
 	*/
-	seed?: random.PRNGSeedMT19937;
+	seed?: random.PRNGSeedMT19937 | random.PRNGSeedMINSTD;
 
 	/**
 	* Pseudorandom number generator state.
 	*/
-	state?: random.PRNGStateMT19937;
+	state?: random.PRNGStateMT19937 | random.PRNGStateMINSTD;
 
 	/**
 	* Specifies whether to copy a provided pseudorandom number generator state.
@@ -74,7 +74,7 @@ interface PRNG {
 	/**
 	* PRNG seed.
 	*/
-	readonly seed: random.PRNGSeedMT19937;
+	readonly seed: random.PRNGSeedMT19937 | random.PRNGSeedMINSTD;
 
 	/**
 	* PRNG seed length.
@@ -84,7 +84,7 @@ interface PRNG {
 	/**
 	* PRNG state.
 	*/
-	state: random.PRNGStateMT19937;
+	state: random.PRNGStateMT19937 | random.PRNGStateMINSTD;
 
 	/**
 	* PRNG state length.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   widens the `seed` and `state` types in `random/base/randi` to include the MINSTD variants.

The `Options.name` field already permits MINSTD generators:

```ts
name?: 'mt19937' | 'minstd' | 'minstd-shuffle';
```

and `randi` delegates `seed`/`state` to the selected underlying PRNG (`getState() { return rand.state; }`). When `name` is `'minstd'`/`'minstd-shuffle'`, `.state` returns an `Int32Array` (`PRNGStateMINSTD`), which the MT19937-only `Uint32Array` (`PRNGStateMT19937`) type rejected.

This widens all four members — the `Options` `seed`/`state` and the `PRNG` interface `seed`/`state` — to include the MINSTD variants, matching the sibling `random/base/randu` declaration (which already uses the union):

```ts
seed?: random.PRNGSeedMT19937 | random.PRNGSeedMINSTD;
state?: random.PRNGStateMT19937 | random.PRNGStateMINSTD;
```

The `state` widening is the load-bearing correctness fix; the `seed` union is included for consistency with `randu`, since `PRNGSeedMINSTD` and `PRNGSeedMT19937` are structurally identical (`number | ArrayLike<number>`).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Identified during a TypeScript-declaration audit of the `@stdlib/random` namespace and verified against `lib/factory.js`, `lib/prngs.js`, and the `@stdlib/types/random` seed/state definitions.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A TypeScript-declaration audit surfaced this issue using Claude Code; the finding was independently verified against the implementation and the `base/randu` reference, and reviewed by myself before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
