### PR TITLE
fix: correct private member name `_sek` to `_sep` in random/streams/t

### DIFF
--- a/lib/node_modules/@stdlib/random/streams/t/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/t/docs/types/index.d.ts
@@ -123,7 +123,7 @@ declare class RandomStream extends Readable {
 	/**
 	* Data separator.
 	*/
-	private readonly _sek: string;
+	private readonly _sep: string;
 
 	/**
 	* Total number of iterations.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   corrects a private member name typo in the `random/streams/t` TypeScript declaration.

The member documented as the "Data separator" was named `_sek`:

```ts
/**
* Data separator.
*/
private readonly _sek: string;
```

but the implementation defines and uses `_sep`:

```js
setNonEnumerableReadOnly( this, '_sep', opts.sep );
// ...
r = string2buffer( this._sep+r );
```

This corrects `_sek` to `_sep` so the declaration matches the implementation.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Identified during a TypeScript-declaration audit of the `@stdlib/random` namespace and verified against `lib/main.js`. The identical typo in `random/streams/chi` is addressed in a separate PR.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A TypeScript-declaration audit surfaced this issue using Claude Code; the finding was independently verified against the implementation (`lib/main.js`) and reviewed by myself before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
