### PR TITLE
docs: fix TSDoc errors and inconsistencies in random TypeScript declarations

### DIFF
--- a/lib/node_modules/@stdlib/random/array/pareto-type1/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/array/pareto-type1/docs/types/index.d.ts
@@ -207,6 +207,8 @@ interface Random extends PRNG {
 	* @param alpha - shape parameter
 	* @param beta - scale parameter
 	* @param options - function options
+	* @throws `alpha` must be a positive number
+	* @throws `beta` must be a positive number
 	* @throws must provide a valid state
 	* @returns function for creating arrays
 	*

--- a/lib/node_modules/@stdlib/random/array/weibull/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/array/weibull/docs/types/index.d.ts
@@ -207,6 +207,8 @@ interface Random extends PRNG {
 	* @param k - shape parameter
 	* @param lambda - scale parameter
 	* @param options - function options
+	* @throws `k` must be a positive number
+	* @throws `lambda` must be a positive number
 	* @throws must provide a valid state
 	* @returns function for creating arrays
 	*

--- a/lib/node_modules/@stdlib/random/base/cosine/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/cosine/docs/types/index.d.ts
@@ -152,7 +152,7 @@ interface Random extends PRNG {
 	*
 	* -   When provided `mu` and `s`, the returned PRNG returns random variates drawn from the specified distribution.
 	*
-	* @param mu - mean parameter
+	* @param mu - mean
 	* @param s - scale parameter
 	* @param options - function options
 	* @param options.prng - pseudorandom number generator which generates uniformly distributed pseudorandom numbers

--- a/lib/node_modules/@stdlib/random/base/frechet/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/frechet/docs/types/index.d.ts
@@ -144,7 +144,7 @@ interface Random extends PRNG {
 	*
 	* @example
 	* var v = frechet( 1.0, 1.0, 0.8 );
-	* // returns NaN
+	* // returns <number>
 	*/
 	( alpha: number, s: number, m: number ): number;
 

--- a/lib/node_modules/@stdlib/random/base/gumbel/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/gumbel/docs/types/index.d.ts
@@ -152,7 +152,7 @@ interface Random extends PRNG {
 	*
 	* -   When provided `mu` and `beta`, the returned PRNG returns random variates drawn from the specified distribution.
 	*
-	* @param mu - mean parameter
+	* @param mu - mean
 	* @param beta - scale parameter
 	* @param options - function options
 	* @param options.prng - pseudorandom number generator which generates uniformly distributed pseudorandom numbers

--- a/lib/node_modules/@stdlib/random/base/invgamma/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/invgamma/docs/types/index.d.ts
@@ -156,6 +156,8 @@ interface Random extends PRNG {
 	* @param options.seed - pseudorandom number generator seed
 	* @param options.state - pseudorandom number generator state
 	* @param options.copy - boolean indicating whether to copy a provided pseudorandom number generator state (default: true)
+	* @throws `alpha` must be a positive number
+	* @throws `beta` must be a positive number
 	* @throws must provide a valid state
 	* @returns pseudorandom number generator
 	*

--- a/lib/node_modules/@stdlib/random/base/kumaraswamy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/kumaraswamy/docs/types/index.d.ts
@@ -156,6 +156,8 @@ interface Random extends PRNG {
 	* @param options.seed - pseudorandom number generator seed
 	* @param options.state - pseudorandom number generator state
 	* @param options.copy - boolean indicating whether to copy a provided pseudorandom number generator state (default: true)
+	* @throws `a` must be a positive number
+	* @throws `b` must be a positive number
 	* @throws must provide a valid state
 	* @returns pseudorandom number generator
 	*

--- a/lib/node_modules/@stdlib/random/base/logistic/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/logistic/docs/types/index.d.ts
@@ -152,7 +152,7 @@ interface Random extends PRNG {
 	*
 	* -   When provided `mu` and `s`, the returned PRNG returns random variates drawn from the specified distribution.
 	*
-	* @param mu - mean parameter
+	* @param mu - mean
 	* @param s - scale parameter
 	* @param options - function options
 	* @param options.prng - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
@@ -194,7 +194,7 @@ interface Random extends PRNG {
 	* @returns pseudorandom number generator
 	*
 	* @example
-	* var mylogistic = factory();
+	* var mylogistic = logistic.factory();
 	*
 	* var v = mylogistic( 0.0, 1.0 );
 	* // returns <number>

--- a/lib/node_modules/@stdlib/random/base/poisson/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/poisson/docs/types/index.d.ts
@@ -153,6 +153,7 @@ interface Random extends PRNG {
 	* @param options.seed - pseudorandom number generator seed
 	* @param options.state - pseudorandom number generator state
 	* @param options.copy - boolean indicating whether to copy a provided pseudorandom number generator state (default: true)
+	* @throws `lambda` must be a positive number
 	* @throws must provide a valid state
 	* @returns pseudorandom number generator
 	*

--- a/lib/node_modules/@stdlib/random/base/randn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/randn/docs/types/index.d.ts
@@ -131,7 +131,7 @@ interface Random extends PRNG {
 	(): number;
 
 	/**
-	* Returns a pseudorandom number generator for generating exponential distributed random numbers.
+	* Returns a pseudorandom number generator for generating standard normally distributed random numbers.
 	*
 	* @param options - function options
 	* @param options.name - name of pseudorandom number generator (default: 'improved-ziggurat')
@@ -139,6 +139,8 @@ interface Random extends PRNG {
 	* @param options.seed - pseudorandom number generator seed
 	* @param options.state - pseudorandom number generator state
 	* @param options.copy - boolean indicating whether to copy a provided pseudorandom number generator state (default: true)
+	* @throws must provide valid options
+	* @throws must provide the name of a supported pseudorandom number generator
 	* @throws must provide a valid state
 	* @returns pseudorandom number generator
 	*

--- a/lib/node_modules/@stdlib/random/base/rayleigh/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/rayleigh/docs/types/index.d.ts
@@ -153,6 +153,7 @@ interface Random extends PRNG {
 	* @param options.seed - pseudorandom number generator seed
 	* @param options.state - pseudorandom number generator state
 	* @param options.copy - boolean indicating whether to copy a provided pseudorandom number generator state (default: true)
+	* @throws `sigma` must be a positive number
 	* @throws must provide a valid state
 	* @returns pseudorandom number generator
 	*

--- a/lib/node_modules/@stdlib/random/base/t/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/t/docs/types/index.d.ts
@@ -153,6 +153,7 @@ interface Random extends PRNG {
 	* @param options.seed - pseudorandom number generator seed
 	* @param options.state - pseudorandom number generator state
 	* @param options.copy - boolean indicating whether to copy a provided pseudorandom number generator state (default: true)
+	* @throws `v` must be a positive number
 	* @throws must provide a valid state
 	* @returns pseudorandom number generator
 	*

--- a/lib/node_modules/@stdlib/random/base/triangular/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/triangular/docs/types/index.d.ts
@@ -126,7 +126,7 @@ interface TernaryFunction extends PRNG {
 */
 interface Random extends PRNG {
 	/**
-	* Returns pseudorandom number drawn from a triangular distribution.
+	* Returns a pseudorandom number drawn from a triangular distribution.
 	*
 	* ## Notes
 	*
@@ -212,7 +212,7 @@ interface Random extends PRNG {
 }
 
 /**
-* Returns pseudorandom number drawn from a triangular distribution.
+* Returns a pseudorandom number drawn from a triangular distribution.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/random/base/weibull/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/base/weibull/docs/types/index.d.ts
@@ -156,6 +156,8 @@ interface Random extends PRNG {
 	* @param options.seed - pseudorandom number generator seed
 	* @param options.state - pseudorandom number generator state
 	* @param options.copy - boolean indicating whether to copy a provided pseudorandom number generator state (default: true)
+	* @throws `k` must be a positive number
+	* @throws `lambda` must be a positive number
 	* @throws must provide a valid state
 	* @returns pseudorandom number generator
 	*

--- a/lib/node_modules/@stdlib/random/iter/discrete-uniform/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/discrete-uniform/docs/types/index.d.ts
@@ -43,7 +43,7 @@ interface Options {
 	state?: random.PRNGStateMT19937;
 
 	/**
-	* Specifies whether to copy a provided pseudorandom number generator state (default: true).
+	* Specifies whether to copy a provided pseudorandom number generator state (default: `true`).
 	*/
 	copy?: boolean;
 
@@ -54,7 +54,7 @@ interface Options {
 }
 
 /**
-* Interface for iterators of pseudorandom numbers drawn from a continuous uniform distribution.
+* Interface for iterators of pseudorandom numbers drawn from a discrete uniform distribution.
 */
 interface Iterator<T> extends TypedIterator<T> {
 	/**
@@ -103,6 +103,7 @@ interface Iterator<T> extends TypedIterator<T> {
 * @throws `b` must be an integer
 * @throws `a` must be less than or equal to `b`
 * @throws must provide valid options
+* @throws must provide a valid state
 * @returns iterator
 *
 * @example

--- a/lib/node_modules/@stdlib/random/iter/erlang/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/erlang/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Iterator<T> extends TypedIterator<T> {
 * Returns an iterator for generating pseudorandom numbers drawn from an Erlang distribution.
 *
 * @param k - shape parameter
-* @param lambda  - rate parameter
+* @param lambda - rate parameter
 * @param options - function options
 * @throws `k` must be a positive integer
 * @throws `lambda` must be a positive number

--- a/lib/node_modules/@stdlib/random/iter/frechet/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/frechet/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Iterator<T> extends TypedIterator<T> {
 * Returns an iterator for generating pseudorandom numbers drawn from a Fréchet distribution.
 *
 * @param alpha - shape parameter
-* @param s - rate parameter
+* @param s - scale parameter
 * @param m - location parameter
 * @param options - function options
 * @throws `alpha` must be a positive number

--- a/lib/node_modules/@stdlib/random/iter/hypergeometric/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/hypergeometric/docs/types/index.d.ts
@@ -54,7 +54,7 @@ interface Options {
 }
 
 /**
-* Interface for iterators of pseudorandom numbers drawn from a logistic distribution.
+* Interface for iterators of pseudorandom numbers drawn from a hypergeometric distribution.
 */
 interface Iterator<T> extends TypedIterator<T> {
 	/**
@@ -106,6 +106,7 @@ interface Iterator<T> extends TypedIterator<T> {
 * @throws `n` must be less than or equal to `N`
 * @throws `K` must be less than or equal to `N`
 * @throws must provide valid options
+* @throws must provide a valid state
 * @returns iterator
 *
 * @example

--- a/lib/node_modules/@stdlib/random/iter/randn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/randn/docs/types/index.d.ts
@@ -59,7 +59,7 @@ interface Options {
 }
 
 /**
-* Interface for iterators of pseudorandom numbers having integer values.
+* Interface for iterators of pseudorandom numbers drawn from a standard normal distribution.
 */
 interface Iterator<T> extends TypedIterator<T> {
 	/**

--- a/lib/node_modules/@stdlib/random/iter/triangular/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/triangular/docs/types/index.d.ts
@@ -54,7 +54,7 @@ interface Options {
 }
 
 /**
-* Interface for iterators of pseudorandom numbers drawn from a logistic distribution.
+* Interface for iterators of pseudorandom numbers drawn from a triangular distribution.
 */
 interface Iterator<T> extends TypedIterator<T> {
 	/**
@@ -102,6 +102,7 @@ interface Iterator<T> extends TypedIterator<T> {
 * @param options.iter - number of iterations
 * @throws arguments must satisfy `a <= c <= b`
 * @throws must provide valid options
+* @throws must provide a valid state
 * @returns iterator
 *
 * @example

--- a/lib/node_modules/@stdlib/random/iter/weibull/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/weibull/docs/types/index.d.ts
@@ -91,8 +91,8 @@ interface Iterator<T> extends TypedIterator<T> {
 /**
 * Returns an iterator for generating pseudorandom numbers drawn from a Weibull distribution.
 *
-* @param k - scale parameter
-* @param lambda  - shape parameter
+* @param k - shape parameter
+* @param lambda - scale parameter
 * @param options - function options
 * @throws `k` must be a positive number
 * @throws `lambda` must be a positive number

--- a/lib/node_modules/@stdlib/random/streams/frechet/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/frechet/docs/types/index.d.ts
@@ -321,7 +321,6 @@ interface Constructor {
 	/**
 	* Returns an "objectMode" readable stream for generating a stream of pseudorandom numbers drawn from a Fréchet distribution.
 	*
-	*
 	* @param alpha - shape parameter
 	* @param s - scale parameter
 	* @param m - location parameter

--- a/lib/node_modules/@stdlib/random/streams/hypergeometric/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/hypergeometric/docs/types/index.d.ts
@@ -330,7 +330,6 @@ interface Constructor {
 	/**
 	* Returns an "objectMode" readable stream for generating a stream of pseudorandom numbers drawn from a hypergeometric distribution.
 	*
-	*
 	* @param N - population size
 	* @param K - subpopulation size
 	* @param n - number of draws

--- a/lib/node_modules/@stdlib/random/streams/improved-ziggurat/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/improved-ziggurat/docs/types/index.d.ts
@@ -216,7 +216,7 @@ interface Constructor {
 	* @param options.siter - number of iterations after which to emit the PRNG state
 	* @throws must provide valid options
 	* @throws must provide a valid state
-	* @returns Stream instance
+	* @returns stream instance
 	*
 	* @example
 	* var inspectStream = require( '@stdlib/streams/node/inspect-sink' );
@@ -252,7 +252,7 @@ interface Constructor {
 	* @param options.siter - number of iterations after which to emit the PRNG state
 	* @throws must provide valid options
 	* @throws must provide a valid state
-	* @returns Stream instance
+	* @returns stream instance
 	*
 	* @example
 	* var inspectStream = require( '@stdlib/streams/node/inspect-sink' );
@@ -320,7 +320,7 @@ interface Constructor {
 	* @param options.siter - number of iterations after which to emit the PRNG state
 	* @throws must provide valid options
 	* @throws must provide a valid state
-	* @returns Stream instance
+	* @returns stream instance
 	*
 	* @example
 	* var inspectStream = require( '@stdlib/streams/node/inspect-sink' );

--- a/lib/node_modules/@stdlib/random/streams/minstd-shuffle/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/minstd-shuffle/docs/types/index.d.ts
@@ -140,7 +140,7 @@ declare class RandomStream extends Readable {
 	private _i: number;
 
 	/**
-	* Pseudorandom number generator for generating standard normally distributed pseudorandom numbers.
+	* Pseudorandom number generator for generating pseudorandom numbers via a linear congruential pseudorandom number generator (LCG) whose output is shuffled.
 	*/
 	private readonly _prng: random.PRNG;
 

--- a/lib/node_modules/@stdlib/random/streams/minstd/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/minstd/docs/types/index.d.ts
@@ -140,7 +140,7 @@ declare class RandomStream extends Readable {
 	private _i: number;
 
 	/**
-	* Pseudorandom number generator for generating standard normally distributed pseudorandom numbers.
+	* Pseudorandom number generator for generating pseudorandom numbers via a linear congruential pseudorandom number generator (LCG) based on Park and Miller.
 	*/
 	private readonly _prng: random.PRNG;
 

--- a/lib/node_modules/@stdlib/random/streams/mt19937/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/mt19937/docs/types/index.d.ts
@@ -140,7 +140,7 @@ declare class RandomStream extends Readable {
 	private _i: number;
 
 	/**
-	* Pseudorandom number generator for generating standard normally distributed pseudorandom numbers.
+	* Pseudorandom number generator for generating pseudorandom numbers via a 32-bit Mersenne Twister pseudorandom number generator.
 	*/
 	private readonly _prng: random.PRNG;
 

--- a/lib/node_modules/@stdlib/random/streams/randi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/randi/docs/types/index.d.ts
@@ -140,7 +140,7 @@ declare class RandomStream extends Readable {
 	private _i: number;
 
 	/**
-	* Pseudorandom number generator for generating standard normally distributed pseudorandom numbers.
+	* Pseudorandom number generator for generating pseudorandom numbers having integer values.
 	*/
 	private readonly _prng: random.PRNG;
 

--- a/lib/node_modules/@stdlib/random/streams/randn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/randn/docs/types/index.d.ts
@@ -283,7 +283,7 @@ interface Constructor {
 	* @param options.highWaterMark - specifies the maximum number of bytes to store in an internal buffer before ceasing to generate additional pseudorandom numbers
 	* @param options.sep - separator used to join streamed data (default: '\n')
 	* @param options.iter - number of iterations
-	* @param options.name='improved-ziggurat' - name of a supported pseudorandom number generator (PRNG), which will serve as the underlying source of pseudorandom numbers
+	* @param options.name - name of a supported pseudorandom number generator (PRNG), which will serve as the underlying source of pseudorandom numbers (default: 'improved-ziggurat')
 	* @param options.prng - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
 	* @param options.seed - pseudorandom number generator seed
 	* @param options.state - pseudorandom number generator state

--- a/lib/node_modules/@stdlib/random/streams/randu/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/randu/docs/types/index.d.ts
@@ -140,7 +140,7 @@ declare class RandomStream extends Readable {
 	private _i: number;
 
 	/**
-	* Pseudorandom number generator for generating standard normally distributed pseudorandom numbers.
+	* Pseudorandom number generator for generating uniformly distributed pseudorandom numbers between `0` and `1`.
 	*/
 	private readonly _prng: random.PRNG;
 

--- a/lib/node_modules/@stdlib/random/strided/bernoulli/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/bernoulli/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param p - success probability
-	* @param sp - `p` strided length
+	* @param sp - `p` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @returns output array
@@ -113,7 +113,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param p - success probability
-	* @param sp - `p` strided length
+	* @param sp - `p` stride length
 	* @param op - starting index for `p`
 	* @param out - output array
 	* @param so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/chi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/chi/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param k - degrees of freedom
-	* @param sk - `k` strided length
+	* @param sk - `k` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @returns output array
@@ -113,7 +113,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param k - degrees of freedom
-	* @param sk - `k` strided length
+	* @param sk - `k` stride length
 	* @param ok - starting index for `k`
 	* @param out - output array
 	* @param so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/chisquare/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/chisquare/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param k - degrees of freedom
-	* @param sk - `k` strided length
+	* @param sk - `k` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @returns output array
@@ -113,7 +113,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param k - degrees of freedom
-	* @param sk - `k` strided length
+	* @param sk - `k` stride length
 	* @param ok - starting index for `k`
 	* @param out - output array
 	* @param so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/exponential/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/exponential/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param lambda - rate parameter
-	* @param sl - `lambda` strided length
+	* @param sl - `lambda` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @returns output array
@@ -113,7 +113,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param lambda - rate parameter
-	* @param sl - `lambda` strided length
+	* @param sl - `lambda` stride length
 	* @param ol - starting index for `lambda`
 	* @param out - output array
 	* @param so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/geometric/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/geometric/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param p - success probability
-	* @param sp - `p` strided length
+	* @param sp - `p` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @returns output array
@@ -113,7 +113,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param p - success probability
-	* @param sp - `p` strided length
+	* @param sp - `p` stride length
 	* @param op - starting index for `p`
 	* @param out - output array
 	* @param so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/poisson/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/poisson/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param lambda - mean parameter
-	* @param sl - `lambda` strided length
+	* @param sl - `lambda` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @returns output array
@@ -113,7 +113,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param lambda - mean parameter
-	* @param sl - `lambda` strided length
+	* @param sl - `lambda` stride length
 	* @param ol - starting index for `lambda`
 	* @param out - output array
 	* @param so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/rayleigh/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/rayleigh/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param sigma - scale parameter
-	* @param ss - `sigma` strided length
+	* @param ss - `sigma` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @returns output array
@@ -113,7 +113,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param sigma - scale parameter
-	* @param ss - `sigma` strided length
+	* @param ss - `sigma` stride length
 	* @param os - starting index for `sigma`
 	* @param out - output array
 	* @param so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/scripts/scaffolds/unary/data/docs/types/index__d__ts.txt
+++ b/lib/node_modules/@stdlib/random/strided/scripts/scaffolds/unary/data/docs/types/index__d__ts.txt
@@ -92,7 +92,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param {{PARAM_1}} - {{PARAM_1_DESC}}
-	* @param {{PARAM_1_STRIDE}} - `{{PARAM_1}}` strided length
+	* @param {{PARAM_1_STRIDE}} - `{{PARAM_1}}` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @returns output array
@@ -113,7 +113,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param {{PARAM_1}} - {{PARAM_1_DESC}}
-	* @param {{PARAM_1_STRIDE}} - `{{PARAM_1}}` strided length
+	* @param {{PARAM_1_STRIDE}} - `{{PARAM_1}}` stride length
 	* @param {{PARAM_1_OFFSET}} - starting index for `{{PARAM_1}}`
 	* @param out - output array
 	* @param so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/t/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/t/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param v - degrees of freedom
-	* @param sv - `v` strided length
+	* @param sv - `v` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @returns output array
@@ -113,7 +113,7 @@ interface Random extends PRNG {
 	*
 	* @param N - number of indexed elements
 	* @param v - degrees of freedom
-	* @param sv - `v` strided length
+	* @param sv - `v` stride length
 	* @param ov - starting index for `v`
 	* @param out - output array
 	* @param so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/types/index.d.ts
@@ -56,9 +56,9 @@ interface Routine {
 	* Fills a strided array with pseudorandom numbers drawn from a Weibull distribution.
 	*
 	* @param N - number of indexed elements
-	* @param k - scale parameter
+	* @param k - shape parameter
 	* @param sk - `k` stride length
-	* @param lambda - shape parameter
+	* @param lambda - scale parameter
 	* @param sl - `lambda` stride length
 	* @param out - output array
 	* @param so - `out` stride length
@@ -83,10 +83,10 @@ interface Routine {
 	* Fills a strided array with pseudorandom numbers drawn from a Weibull distribution using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
-	* @param k - scale parameter
+	* @param k - shape parameter
 	* @param sk - `k` stride length
 	* @param ok - starting index for `k`
-	* @param lambda - shape parameter
+	* @param lambda - scale parameter
 	* @param sl - `lambda` stride length
 	* @param ol - starting index for `lambda`
 	* @param out - output array
@@ -114,9 +114,9 @@ interface Routine {
 * Fills a strided array with pseudorandom numbers drawn from a Weibull distribution.
 *
 * @param N - number of indexed elements
-* @param k - scale parameter
+* @param k - shape parameter
 * @param sk - `k` stride length
-* @param lambda -  shape parameter
+* @param lambda - scale parameter
 * @param sl - `lambda` stride length
 * @param out - output array
 * @param so - `out` stride length


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request fixes a range of hand-written TypeScript declaration (`index.d.ts`) **documentation** issues across the `@stdlib/random` namespace, surfaced by a TSDoc audit. **No TypeScript types or signatures are modified — only TSDoc comments.**

Highlights:

-   **Swapped parameter roles** — Weibull `k`/`lambda` descriptions were reversed (`k` is the **shape** parameter, `lambda` the **scale** parameter) in `iter/weibull` and `strided/weibull`; the Fréchet `s` parameter was mislabeled "rate" instead of **scale** in `iter/frechet`. Verified against the canonical `base/*` implementations.
-   **Wrong distribution names** in `iter` interface summaries — `discrete-uniform` ("continuous uniform" → "discrete uniform"), `hypergeometric`/`triangular` ("logistic" → correct distribution), and `randn` ("having integer values" → "standard normal").
-   **Wrong `_prng` member comments** in `streams/{minstd,minstd-shuffle,mt19937,randi,randu}` — all incorrectly copied randn's "standard normally distributed"; corrected to each generator's actual output (LCG / Mersenne Twister / integer / uniform), derived from each package's own class summary.
-   **Missing `@throws` annotations** — added parameter-positivity / option-validation throws on the parameterized factory overloads of `base/{weibull,invgamma,kumaraswamy,rayleigh,poisson,t,randn}` and `array/{pareto-type1,weibull}`, and the missing `@throws must provide a valid state` in `iter/{discrete-uniform,hypergeometric,triangular}`. Each was verified against the implementation's actual `throw`/`validate` logic and sibling conventions.
-   **"strided length" → "stride length"** typo in `strided/{bernoulli,chi,chisquare,exponential,geometric,poisson,rayleigh,t}` and the unary scaffold template (the template fix prevents future regeneration of the typo).
-   **Other fixes** — `base/randn` factory summary ("exponential" → "standard normally distributed"); `base/frechet` example annotation (valid arguments do not return `NaN`); `mu` "mean parameter" → "mean" (`base/{cosine,gumbel,logistic}`); bare `factory()` → `logistic.factory()`; `base/triangular` summary article; `streams/improved-ziggurat` `Stream instance` → `stream instance`; `streams/randn` default-value syntax; and removal of doubled blank comment lines in `streams/{frechet,hypergeometric}`.

The corresponding namespace aggregator declaration files (`random/{iter,strided}/docs/types/index.d.ts` and the namespace root) are generated and intentionally not edited here; they will reflect these fixes upon regeneration.

A handful of audit candidates were investigated and **deliberately not changed** because they were valid as written: the `negativeBinomial( 11.9, ... )` example (`r` is a positive real, not required to be an integer), the `base/invgamma` example seed value, the `base/hypergeometric` second top-level factory example (matches the `base/binomial` convention), the `streams/improved-ziggurat` `prng` option description (the option's source generator is genuinely uniform), and the `streams/chisquare` example values.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Part of a TypeScript-declaration audit of the `@stdlib/random` namespace. Type-correctness fixes (e.g. `streams/triangular` factory arity, `streams/randn` `prng` option, MINSTD `state` unions, `_sek`→`_sep`) are submitted as separate per-package PRs.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A TypeScript-declaration audit surfaced these issues using Claude Code. Each finding was independently verified against the implementation and sibling packages; false positives were filtered out, and the changes were reviewed by myself before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
