### PR TITLE
docs: add missing intro section placeholders

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/idamax/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/idamax/README.md
@@ -22,6 +22,12 @@ limitations under the License.
 
 > Find the index of the first element having the maximum absolute value for all elements in a one-dimensional double-precision floating-point ndarray.
 
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
 <section class="usage">
 
 ## Usage

--- a/lib/node_modules/@stdlib/blas/base/ndarray/igamax/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/igamax/README.md
@@ -22,6 +22,12 @@ limitations under the License.
 
 > Find the index of the first element having the maximum absolute value for all elements in a one-dimensional ndarray.
 
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
 <section class="usage">
 
 ## Usage

--- a/lib/node_modules/@stdlib/blas/base/ndarray/isamax/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/isamax/README.md
@@ -22,6 +22,12 @@ limitations under the License.
 
 > Find the index of the first element having the maximum absolute value for all elements in a one-dimensional single-precision floating-point ndarray.
 
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
 <section class="usage">
 
 ## Usage


### PR DESCRIPTION
## Description

This pull request:

-   docs: insert the empty `<section class="intro">` placeholder block in `blas/base/ndarray/idamax`, `blas/base/ndarray/igamax`, and `blas/base/ndarray/isamax` READMEs, bringing them in line with the rest of the namespace.

### Namespace summary

-   **Target:** `@stdlib/blas/base/ndarray`
-   **Members:** 40 manually-maintained packages; no autogenerated members to exclude.
-   **Features extracted:** file tree, `package.json` shape (top-level keys, `scripts`, `keywords`, `directories`, `engines`, `os`, dependencies), `manifest.json` shape, README section sequence (HTML `<section>` boundaries, `##` / `###` headings), `test/`, `benchmark/`, `examples/` filenames, `lib/main.js` JSDoc tag shape, signature, `require()` set, and error-construction patterns.
-   **Features with a clear majority (≥75%):** file tree (100% — identical 10/11-file layout), `package.json` top-level keys (100%), `engines` / `os` / `directories` / `main` / `types` / `bugs` / `homepage` (100% identical), 11 canonical keywords (100%: `stdlib`, `stdmath`, `mathematics`, `math`, `blas`, `level 1`, `linear`, `algebra`, `subroutines`, `vector`, `ndarray`), README `## Usage` / `## Examples` H2 sequence (100%), README HTML section sequence `intro` → `usage` → `notes` → `examples` → `related` → `links` (92.5%), `lib/main.js` JSDoc tags `(license, param, returns, example)` (100%), `lib/main.js` signature `<pkg>( arrays )` (100%), 4 canonical `require()`s from `@stdlib/ndarray/base/{numel-dimension,stride,offset,data-buffer}` (100%), `index.js` description prefix `BLAS level 1 routine to …` (100%).
-   **Features without a clear majority (excluded):** `array` keyword (22/40 = 55% — semantically split between scal/copy/swap/axpy and reduce/scan operations), `ndarraylike2scalar` require (32% — only when a scalar argument is unpacked), per-package equation `<!-- <equation -->` blocks (varies by math).

### `blas/base/ndarray/idamax`

`idamax` is one of three outliers (`idamax`, `igamax`, `isamax`) missing the empty `<section class="intro">` placeholder between the description blockquote and the usage section. 37 of the 40 namespace siblings carry the placeholder — 92.5% conformance — and the recently-opened `srot` package (PR #12510) adds it too, so the convention is current, not legacy. The fix is a six-line markdown insertion; no source or test change.

### `blas/base/ndarray/igamax`

Same drift as `idamax`: the README jumps directly from the description blockquote to `<section class="usage">`, omitting the empty intro placeholder. The generic-typed `g*` sibling line (`gasum`, `gaxpy`, `gcopy`, `gdot`, `gnrm2`, `gscal`, `gswap`) all carry it. Mechanical six-line insertion.

### `blas/base/ndarray/isamax`

Same drift as `idamax` and `igamax`. The single-precision `s*` siblings (`sasum`, `saxpy`, `sdot`, `snrm2`, `sscal`, `sswap`, etc.) all carry the placeholder. Mechanical six-line insertion.

### Validation

Checked:

-   Structural feature extraction across all 40 members (file tree, `package.json` keys/values, `manifest.json` keys where present, README HTML section sequence, README `##` / `###` heading sequence, test/benchmark/example filenames).
-   Semantic feature extraction via `lib/main.js` source scan: signature shape, JSDoc tags, require set, `throw` / `format` presence (none in this namespace — base wrappers have no validation prologue).
-   Three-agent drift validation on the surviving candidate: semantic, cross-reference, and structural reviewers all returned `confirmed-drift` for each of the three outliers.
-   Pre-validation open-PR collision check via GitHub MCP: no open or recently-merged PR proposes the same intro-placeholder fix; the open `srot` (#12510) and `drot` (#12456) PRs add new packages and do not touch the three outliers' READMEs.

Deliberately excluded:

-   The 3 packages with `Copyright (c) 2025` (`ddot`, `gdot`, `sdot`) — copyright year reflects file-creation year by stdlib convention, not staleness; not drift.
-   The `array` keyword distribution (22/40 = 55%) — semantically split between in-place vector ops and reductions; below the 75% threshold and the split is not random.
-   Per-package equation `<!-- <equation -->` blocks inside the intro section — content is mathematics-specific (L1-norm, L2-norm, dot product) and not a structural drift.

## Related Issues

None.

## Questions

No.

## Other

Generated by an automated cross-package drift-detection run (random-pick namespace selection; full per-feature distribution and dropped-candidate log live in the local report). The diff is mechanical: three READMEs gain six lines each of empty markdown placeholder; no source, test, or example file is touched; no observable behavior changes.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift-detection routine. The drift was identified by structural feature extraction across `@stdlib/blas/base/ndarray/`; the proposed fix was validated by parallel semantic, cross-reference, and structural-review subagents (all returned `confirmed-drift`); the patch is a six-line markdown insertion in each of the three outlier READMEs.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_011ns6ZZdbxp1pNtgpVck1Uo)_