### PR TITLE
refactor: align stream constructor parameter names with documentation in random/streams

### DIFF
--- a/lib/node_modules/@stdlib/random/streams/chisquare/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/chisquare/docs/types/index.d.ts
@@ -108,7 +108,7 @@ declare class RandomStream extends Readable {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	constructor( p: number, options?: Options );
+	constructor( k: number, options?: Options );
 
 	/**
 	* Destruction state.
@@ -227,7 +227,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	new( p: number, options?: Options ): RandomStream; // newable
+	new( k: number, options?: Options ): RandomStream; // newable
 
 	/**
 	* Returns a readable stream for generating a stream of pseudorandom numbers drawn from a chi-square distribution.
@@ -254,7 +254,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	( p: number, options?: Options ): RandomStream; // callable
+	( k: number, options?: Options ): RandomStream; // callable
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from a chi-square distribution.
@@ -281,7 +281,7 @@ interface Constructor {
 	*     streams.push( createStream() );
 	* }
 	*/
-	factory( p: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
+	factory( k: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from a chi-square distribution.
@@ -306,7 +306,7 @@ interface Constructor {
 	*     streams.push( createStream( 0.7 ) );
 	* }
 	*/
-	factory( options?: Options ): ( p: number ) => RandomStream;
+	factory( options?: Options ): ( k: number ) => RandomStream;
 
 	/**
 	* Returns an "objectMode" readable stream for generating a stream of pseudorandom numbers drawn from a chi-square distribution.
@@ -333,7 +333,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream.objectMode( log )  );
 	*/
-	objectMode( p: number, options?: Options ): RandomStream;
+	objectMode( k: number, options?: Options ): RandomStream;
 }
 
 /**

--- a/lib/node_modules/@stdlib/random/streams/exponential/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/exponential/docs/types/index.d.ts
@@ -108,7 +108,7 @@ declare class RandomStream extends Readable {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	constructor( p: number, options?: Options );
+	constructor( lambda: number, options?: Options );
 
 	/**
 	* Destruction state.
@@ -227,7 +227,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	new( p: number, options?: Options ): RandomStream; // newable
+	new( lambda: number, options?: Options ): RandomStream; // newable
 
 	/**
 	* Returns a readable stream for generating a stream of pseudorandom numbers drawn from an exponential distribution.
@@ -254,7 +254,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	( p: number, options?: Options ): RandomStream; // callable
+	( lambda: number, options?: Options ): RandomStream; // callable
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from an exponential distribution.
@@ -281,7 +281,7 @@ interface Constructor {
 	*     streams.push( createStream() );
 	* }
 	*/
-	factory( p: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
+	factory( lambda: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from an exponential distribution.
@@ -306,7 +306,7 @@ interface Constructor {
 	*     streams.push( createStream( 0.7 ) );
 	* }
 	*/
-	factory( options?: Options ): ( p: number ) => RandomStream;
+	factory( options?: Options ): ( lambda: number ) => RandomStream;
 
 	/**
 	* Returns an "objectMode" readable stream for generating a stream of pseudorandom numbers drawn from an exponential distribution.
@@ -333,7 +333,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream.objectMode( log )  );
 	*/
-	objectMode( p: number, options?: Options ): RandomStream;
+	objectMode( lambda: number, options?: Options ): RandomStream;
 }
 
 /**

--- a/lib/node_modules/@stdlib/random/streams/poisson/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/poisson/docs/types/index.d.ts
@@ -108,7 +108,7 @@ declare class RandomStream extends Readable {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	constructor( p: number, options?: Options );
+	constructor( lambda: number, options?: Options );
 
 	/**
 	* Destruction state.
@@ -227,7 +227,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	new( p: number, options?: Options ): RandomStream; // newable
+	new( lambda: number, options?: Options ): RandomStream; // newable
 
 	/**
 	* Returns a readable stream for generating a stream of pseudorandom numbers drawn from a Poisson distribution.
@@ -254,7 +254,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	( p: number, options?: Options ): RandomStream; // callable
+	( lambda: number, options?: Options ): RandomStream; // callable
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from a Poisson distribution.
@@ -281,7 +281,7 @@ interface Constructor {
 	*     streams.push( createStream() );
 	* }
 	*/
-	factory( p: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
+	factory( lambda: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from a Poisson distribution.
@@ -306,7 +306,7 @@ interface Constructor {
 	*     streams.push( createStream( 0.7 ) );
 	* }
 	*/
-	factory( options?: Options ): ( p: number ) => RandomStream;
+	factory( options?: Options ): ( lambda: number ) => RandomStream;
 
 	/**
 	* Returns an "objectMode" readable stream for generating a stream of pseudorandom numbers drawn from a Poisson distribution.
@@ -333,7 +333,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream.objectMode( log )  );
 	*/
-	objectMode( p: number, options?: Options ): RandomStream;
+	objectMode( lambda: number, options?: Options ): RandomStream;
 }
 
 /**

--- a/lib/node_modules/@stdlib/random/streams/rayleigh/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/rayleigh/docs/types/index.d.ts
@@ -108,7 +108,7 @@ declare class RandomStream extends Readable {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	constructor( p: number, options?: Options );
+	constructor( sigma: number, options?: Options );
 
 	/**
 	* Destruction state.
@@ -227,7 +227,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	new( p: number, options?: Options ): RandomStream; // newable
+	new( sigma: number, options?: Options ): RandomStream; // newable
 
 	/**
 	* Returns a readable stream for generating a stream of pseudorandom numbers drawn from a Rayleigh distribution.
@@ -254,7 +254,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	( p: number, options?: Options ): RandomStream; // callable
+	( sigma: number, options?: Options ): RandomStream; // callable
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from a Rayleigh distribution.
@@ -281,7 +281,7 @@ interface Constructor {
 	*     streams.push( createStream() );
 	* }
 	*/
-	factory( p: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
+	factory( sigma: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from a Rayleigh distribution.
@@ -306,7 +306,7 @@ interface Constructor {
 	*     streams.push( createStream( 0.7 ) );
 	* }
 	*/
-	factory( options?: Options ): ( p: number ) => RandomStream;
+	factory( options?: Options ): ( sigma: number ) => RandomStream;
 
 	/**
 	* Returns an "objectMode" readable stream for generating a stream of pseudorandom numbers drawn from a Rayleigh distribution.
@@ -333,7 +333,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream.objectMode( log )  );
 	*/
-	objectMode( p: number, options?: Options ): RandomStream;
+	objectMode( sigma: number, options?: Options ): RandomStream;
 }
 
 /**

--- a/lib/node_modules/@stdlib/random/streams/t/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/streams/t/docs/types/index.d.ts
@@ -108,7 +108,7 @@ declare class RandomStream extends Readable {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	constructor( k: number, options?: Options );
+	constructor( v: number, options?: Options );
 
 	/**
 	* Destruction state.
@@ -227,7 +227,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	new( k: number, options?: Options ): RandomStream; // newable
+	new( v: number, options?: Options ): RandomStream; // newable
 
 	/**
 	* Returns a readable stream for generating a stream of pseudorandom numbers drawn from a Student's t distribution.
@@ -254,7 +254,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream( log )  );
 	*/
-	( k: number, options?: Options ): RandomStream; // callable
+	( v: number, options?: Options ): RandomStream; // callable
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from a Student's t distribution.
@@ -281,7 +281,7 @@ interface Constructor {
 	*     streams.push( createStream() );
 	* }
 	*/
-	factory( k: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
+	factory( v: number, options?: Options ): ( ...args: Array<any> ) => RandomStream;
 
 	/**
 	* Returns a function for creating readable streams which generate pseudorandom numbers drawn from a Student's t distribution.
@@ -306,7 +306,7 @@ interface Constructor {
 	*     streams.push( createStream( 2.0 ) );
 	* }
 	*/
-	factory( options?: Options ): ( k: number ) => RandomStream;
+	factory( options?: Options ): ( v: number ) => RandomStream;
 
 	/**
 	* Returns an "objectMode" readable stream for generating a stream of pseudorandom numbers drawn from a Student's t distribution.
@@ -333,7 +333,7 @@ interface Constructor {
 	*
 	* stream.pipe( inspectStream.objectMode( log )  );
 	*/
-	objectMode( k: number, options?: Options ): RandomStream;
+	objectMode( v: number, options?: Options ): RandomStream;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request aligns the distribution parameter name in five `random/streams` declaration files with their own `@param`/`@throws` TSDoc and the underlying implementation. The `RandomStream` constructor, callable/newable, `factory`, and `objectMode` signatures named the parameter `p` (or `k` for the Student's t distribution), which did not match the documented/implemented name:

| Package | Signature param | Documented & impl name |
|---|---|---|
| `streams/exponential` | `p` | `lambda` (rate parameter) |
| `streams/poisson` | `p` | `lambda` (mean) |
| `streams/rayleigh` | `p` | `sigma` (scale parameter) |
| `streams/chisquare` | `p` | `k` (degrees of freedom) |
| `streams/t` | `k` | `v` (degrees of freedom) |

Each rename touches the six signature occurrences per package (constructor, `new`, callable, `factory`, the options-only `factory` return, and `objectMode`). Verified against each package's `lib/main.js` (`function RandomStream( lambda, ... )`, etc.) and its TSDoc `@param`/`@throws` tags.

Parameter names in ambient declarations are documentation only and do **not** affect type-checking, so this is a non-behavioral refactor; no `$ExpectType`/`$ExpectError` assertions are affected.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Part of a TypeScript-declaration audit of the `@stdlib/random` namespace, batched into a single PR at the maintainer's request. (The `streams/t` `_sek`→`_sep` private-member fix is handled in a separate type PR.)

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A TypeScript-declaration audit surfaced these inconsistencies using Claude Code; each rename target was independently verified against the implementation and TSDoc, and the changes were reviewed by myself before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
