### PR TITLE
fix: bind generic type parameter to input ndarray in `ndarray/with`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/with/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/with/docs/types/index.d.ts
@@ -44,7 +44,7 @@ import { typedndarray } from '@stdlib/types/ndarray';
 * var out = ndarrayWith( x, [ 0, 0 ], 5 );
 * // returns <ndarray>[ [ 5, 2 ], [ 3, 4 ] ]
 */
-declare function ndarrayWith<T = unknown, U extends typedndarray<T> = typedndarray<T>>( x: typedndarray<T>, indices: Array<number>, value: T ): U;
+declare function ndarrayWith<T = unknown, U extends typedndarray<T> = typedndarray<T>>( x: U, indices: Array<number>, value: T ): U;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   binds the `U` generic type parameter to the input ndarray in the `@stdlib/ndarray/with` TypeScript declaration.

Previously, `U` appeared only in the return position and was never tied to a parameter, so it always resolved to its default `typedndarray<T>` and the more specific input subtype was discarded. Typing the input as `x: U` allows `U` to be inferred from the argument so the returned ndarray type matches the input. The existing `$ExpectType typedndarray<number>` assertion still holds (the test input resolves to `typedndarray<number>`).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This fix was identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the change was reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
