### PR TITLE
fix: infer input ndarray type in `ndarray/some-by` assign overloads

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/some-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/some-by/docs/types/index.d.ts
@@ -209,7 +209,7 @@ interface SomeBy {
 	* var out = someBy.assign( x, 3, y, isEven );
 	* // returns <ndarray>[ true ]
 	*/
-	assign<T = unknown, U extends InputArray<T> = InputArray<T>, V extends ndarray = ndarray, ThisArg = unknown>( x: ndarray, n: integerndarray | number, y: V, predicate: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): V;
+	assign<T = unknown, U extends InputArray<T> = InputArray<T>, V extends ndarray = ndarray, ThisArg = unknown>( x: U, n: integerndarray | number, y: V, predicate: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): V;
 
 	/**
 	* Tests whether at least `n` elements along one or more ndarray dimensions pass a test implemented by a predicate function.
@@ -253,7 +253,7 @@ interface SomeBy {
 	* var out = someBy.assign( x, 3, y, {}, isEven );
 	* // returns <ndarray>[ true ]
 	*/
-	assign<T = unknown, U extends InputArray<T> = InputArray<T>, V extends ndarray = ndarray, ThisArg = unknown>( x: ndarray, n: integerndarray | number, y: V, options: BaseOptions, predicate: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): V;
+	assign<T = unknown, U extends InputArray<T> = InputArray<T>, V extends ndarray = ndarray, ThisArg = unknown>( x: U, n: integerndarray | number, y: V, options: BaseOptions, predicate: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): V;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   types the input as `x: U` in both `some-by.assign` overloads of the `@stdlib/ndarray/some-by` declaration, so the input element type is inferred. Previously the input was typed `x: ndarray`, preventing inference and degrading the `predicate` argument to `Predicate<unknown, ...>`. This matches the non-assign overloads and the sibling `any-by`/`every-by` packages. Existing `$ExpectType boolndarray` assertions are unaffected.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
