### PR TITLE
fix: widen `mode` option type in `ndarray/sub2ind` to accept a single mode

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/sub2ind/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/sub2ind/docs/types/index.d.ts
@@ -19,7 +19,6 @@
 // TypeScript Version: 4.1
 
 /// <reference types="@stdlib/types"/>
-/// <reference types="node"/>
 
 import { ArrayLike } from '@stdlib/types/array';
 import { Mode, Order } from '@stdlib/types/ndarray';

--- a/lib/node_modules/@stdlib/ndarray/sub2ind/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/sub2ind/docs/types/index.d.ts
@@ -22,7 +22,7 @@
 /// <reference types="node"/>
 
 import { ArrayLike } from '@stdlib/types/array';
-import { Order } from '@stdlib/types/ndarray';
+import { Mode, Order } from '@stdlib/types/ndarray';
 
 /**
 * Interface defining function options.
@@ -31,10 +31,10 @@ interface Options {
 	/**
 	* Specifies how to handle subscripts which exceed array dimensions (default: ['throw']).
 	*/
-	mode?: Array<string>;
+	mode?: Mode | Array<Mode>;
 
 	/**
-	* specifies whether an array is row-major (C-style) or column-major (Fortran-style) (default: 'row-major').
+	* Specifies whether an array is row-major (C-style) or column-major (Fortran-style) (default: 'row-major').
 	*/
 	order?: Order;
 }
@@ -57,9 +57,10 @@ interface Options {
 * @param args - subscripts followed by an optional options object
 * @throws first argument must be an array-like object containing nonnegative integers
 * @throws subscripts must be integer valued
+* @throws options argument must be an object
 * @throws must provide valid options
 * @throws must provide subscripts which do not exceed array dimensions
-* @throws number of subscripts much match the number of dimensions
+* @throws number of subscripts must match the number of dimensions
 * @returns linear index
 *
 * @example

--- a/lib/node_modules/@stdlib/ndarray/sub2ind/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/sub2ind/docs/types/test.ts
@@ -24,6 +24,7 @@ import subd2ind = require( './index' );
 // The function returns a number...
 {
 	const shape = [ 3, 3, 3 ];
+	subd2ind( shape, 1, 2, 2, { 'mode': 'throw' } ); // $ExpectType number
 	subd2ind( shape, 1, 2, 2, { 'mode': [ 'throw' ] } ); // $ExpectType number
 	subd2ind( shape, 1, 2, 2, { 'order': 'row-major' } ); // $ExpectType number
 }
@@ -65,7 +66,7 @@ import subd2ind = require( './index' );
 	subd2ind( shape, 1, 2, 2, { 'order': ( x: number ): number => x } ); // $ExpectError
 }
 
-// The compiler throws an error if the function is provided a `mode` option which is not an array of strings...
+// The compiler throws an error if the function is provided a `mode` option which is not a recognized mode or array of recognized modes...
 {
 	const shape = [ 3, 3, 3 ];
 	subd2ind( shape, 1, 2, 2, { 'mode': 'abc' } ); // $ExpectError


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   widens the `mode` option type in the `@stdlib/ndarray/sub2ind` declaration from `Array<string>` to `Mode | Array<Mode>`. The implementation accepts a single mode string (e.g. `{ 'mode': 'wrap' }`), which the previous type rejected, and the element type should be the `Mode` union rather than a loose `string` (mirroring the sibling `ind2sub` package). Also adds the missing `@throws options argument must be an object`, fixes a `much match` -> `must match` typo, capitalizes the `order` option description, and adds a positive single-string `mode` test case.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
