### PR TITLE
fix: preserve input ndarray type in `ndarray/base/maybe-broadcast-array-except-dimensions`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-array-except-dimensions/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-array-except-dimensions/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { ArrayLike } from '@stdlib/types/array';
+import { Collection } from '@stdlib/types/array';
 import { ndarray } from '@stdlib/types/ndarray';
 
 /**
@@ -53,7 +53,7 @@ import { ndarray } from '@stdlib/types/ndarray';
 * var y = maybeBroadcastArrayExceptDimensions( x, [ 2, 2, 3 ], [ -2 ] );
 * // returns <ndarray>[ [ [ 1, 2, 3 ] ], [ [ 1, 2, 3 ] ] ]
 */
-declare function maybeBroadcastArrayExceptDimensions<T extends ndarray>( arr: T, shape: ArrayLike<number>, dims: ArrayLike<number> ): T;
+declare function maybeBroadcastArrayExceptDimensions<T extends ndarray>( arr: T, shape: Collection<number>, dims: Collection<number> ): T;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-array-except-dimensions/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-array-except-dimensions/docs/types/index.d.ts
@@ -24,7 +24,7 @@ import { ArrayLike } from '@stdlib/types/array';
 import { ndarray } from '@stdlib/types/ndarray';
 
 /**
-* Broadcasts an ndarray to a specified shape if and only if the specified shape differs from the provided ndarray's shape.
+* Broadcasts an ndarray to a specified shape while keeping a list of specified dimensions unchanged if and only if the specified shape differs from the provided ndarray's shape.
 *
 * ## Notes
 *
@@ -53,7 +53,7 @@ import { ndarray } from '@stdlib/types/ndarray';
 * var y = maybeBroadcastArrayExceptDimensions( x, [ 2, 2, 3 ], [ -2 ] );
 * // returns <ndarray>[ [ [ 1, 2, 3 ] ], [ [ 1, 2, 3 ] ] ]
 */
-declare function maybeBroadcastArrayExceptDimensions( arr: ndarray, shape: ArrayLike<number>, dims: ArrayLike<number> ): ndarray;
+declare function maybeBroadcastArrayExceptDimensions<T extends ndarray>( arr: T, shape: ArrayLike<number>, dims: ArrayLike<number> ): T;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-array-except-dimensions/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-array-except-dimensions/docs/types/test.ts
@@ -28,7 +28,7 @@ import maybeBroadcastArrayExceptDimensions = require( './index' );
 {
 	const x = zeros( [ 2, 2 ] );
 
-	maybeBroadcastArrayExceptDimensions( x, [ 2, 2, 2 ], [ -2 ] ); // $ExpectType ndarray
+	maybeBroadcastArrayExceptDimensions( x, [ 2, 2, 2 ], [ -2 ] ); // $ExpectType float64ndarray
 }
 
 // The compiler throws an error if the function is not provided a first argument which is an ndarray...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   makes the `@stdlib/ndarray/base/maybe-broadcast-array-except-dimensions` signature generic (`<T extends ndarray>( arr: T, ... ): T`) so the input ndarray subtype is preserved (the function may return the input unchanged), matching the sibling `base/maybe-broadcast-array`. Also restores the `while keeping a list of specified dimensions unchanged` clause in the summary (copied verbatim from the no-dimensions sibling), matching the package's `lib/main.js` and README. Updates the `test.ts` `$ExpectType` assertion accordingly.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
