### PR TITLE
fix: constrain output dtype against the output element type in `ndarray/flatten-by`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/flatten-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/flatten-by/docs/types/index.d.ts
@@ -404,7 +404,7 @@ declare function flattenBy<T = unknown, U extends genericndarray<T> = genericnda
 * var y = flattenBy( x, opts, scale );
 * // returns <ndarray>[ 2.0, 4.0, 6.0, 8.0, 10.0, 12.0 ]
 */
-declare function flattenBy<T = unknown, U extends typedndarray<T> = typedndarray<T>, V = unknown, W extends keyof DataTypeMap<T> = 'generic', ThisArg = unknown>( x: U, options: Options<W>, fcn: Callback<T, U, V, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, V, ThisArg>> ): DataTypeMap<V>[W];
+declare function flattenBy<T = unknown, U extends typedndarray<T> = typedndarray<T>, V = unknown, W extends keyof DataTypeMap<V> = 'generic', ThisArg = unknown>( x: U, options: Options<W>, fcn: Callback<T, U, V, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, V, ThisArg>> ): DataTypeMap<V>[W];
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes the dtype constraint in the dtype-selecting overload of `@stdlib/ndarray/flatten-by`. The overload constrained the dtype key against the input element-type map (`W extends keyof DataTypeMap<T>`) while indexing the output map (`DataTypeMap<V>[W]`). Since the callback may map the input element type `T` to a different output type `V`, the constraint should reference the output map (`W extends keyof DataTypeMap<V>`), matching how the sibling `flatten` constrains its dtype key. `keyof DataTypeMap<T>` and `keyof DataTypeMap<V>` resolve to the same key set, so there is no change to emitted assertions; the fix is for correctness/consistency.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
