### PR TITLE
refactor: replace `Object` with `Record<string, unknown>` in `ndarray/to-locale-string`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/to-locale-string/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/to-locale-string/docs/types/index.d.ts
@@ -43,7 +43,7 @@ import { ndarray } from '@stdlib/types/ndarray';
 * var str = ndarray2localeString( x );
 * // returns <string>
 */
-declare function ndarray2localeString( x: ndarray, locales?: string | Array<string>, options?: Object ): string;
+declare function ndarray2localeString( x: ndarray, locales?: string | Array<string>, options?: Record<string, unknown> ): string;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   replaces the broad `Object` type for the `options` parameter of `@stdlib/ndarray/to-locale-string` with `Record<string, unknown>`. The function forwards options opaquely to the native `Array.prototype.toLocaleString`, so a dedicated `Options` interface is not warranted.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
