### PR TITLE
refactor: remove redundant overload in `ndarray/base/transpose`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/transpose/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/transpose/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { ndarray, typedndarray, genericndarray } from '@stdlib/types/ndarray';
+import { ndarray, typedndarray } from '@stdlib/types/ndarray';
 
 /**
 * Transposes a matrix (or a stack of matrices).
@@ -46,31 +46,6 @@ import { ndarray, typedndarray, genericndarray } from '@stdlib/types/ndarray';
 * // returns true
 */
 declare function transpose<T extends typedndarray<unknown> = typedndarray<unknown>>( x: T, writable: boolean ): T;
-
-/**
-* Transposes a matrix (or a stack of matrices).
-*
-* @param x - input array
-* @param writable - boolean indicating whether the returned ndarray should be writable
-* @returns ndarray view
-*
-* @example
-* var getData = require( '@stdlib/ndarray/data-buffer' );
-* var array = require( '@stdlib/ndarray/array' );
-*
-* var x = array( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ], {
-*     'dtype': 'generic',
-*     'casting': 'unsafe'
-* });
-* // returns <ndarray>[ [ 1, 2, 3 ], [ 4, 5, 6 ] ]
-*
-* var y = transpose( x, false );
-* // returns <ndarray>[ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
-*
-* var bool = ( getData( x ) === getData( y ) );
-* // returns true
-*/
-declare function transpose<T extends genericndarray<unknown> = genericndarray<unknown>>( x: T, writable: boolean ): T;
 
 /**
 * Transposes a matrix (or a stack of matrices).


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes a redundant overload in `@stdlib/ndarray/base/transpose`. The second overload constrained the input to `genericndarray<unknown>`, but `genericndarray<T>` extends `typedndarray<T>`, so the first (`typedndarray`) overload already matches generic ndarrays and preserves the precise input type. The existing `$ExpectType genericndarray<number>` assertion still resolves via the first overload. The now-unused `genericndarray` import is removed, and the broad `ndarray` fallback overload is retained.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
