### PR TITLE
refactor: simplify `searchElement` type in `ndarray/includes`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/includes/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/includes/docs/types/index.d.ts
@@ -83,7 +83,7 @@ interface Includes {
 	* var v = out.get();
 	* // returns true
 	*/
-	( x: ndarray, searchElement: ndarray | unknown, options?: Options ): boolndarray;
+	( x: ndarray, searchElement: unknown, options?: Options ): boolndarray;
 
 	/**
 	* Tests whether an ndarray contains a specified value along one or more dimensions and assigns the results to a provided output ndarray.
@@ -127,7 +127,7 @@ interface Includes {
 	* var v = out.get();
 	* // returns true
 	*/
-	assign<T extends ndarray>( x: ndarray, searchElement: ndarray | unknown, y: T, options?: BaseOptions ): T;
+	assign<T extends ndarray>( x: ndarray, searchElement: unknown, y: T, options?: BaseOptions ): T;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   simplifies the `searchElement` parameter type in `@stdlib/ndarray/includes` from `ndarray | unknown` to `unknown`. `ndarray | unknown` collapses to `unknown` (the `ndarray` arm is absorbed), so this is a no-op for the type checker applied to both the call signature and the `assign` method; no assertions are affected.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
