### PR TITLE
refactor: remove redundant union member in `ndarray/base/some`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/some/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/some/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { ndarray, typedndarray, genericndarray } from '@stdlib/types/ndarray';
+import { ndarray, typedndarray } from '@stdlib/types/ndarray';
 
 /**
 * Tests whether at least `n` elements in an ndarray are truthy.
@@ -55,7 +55,7 @@ import { ndarray, typedndarray, genericndarray } from '@stdlib/types/ndarray';
 * var out = some( [ x, n ] );
 * // returns true
 */
-declare function some( arrays: [ ndarray, typedndarray<number> | genericndarray<number> ] ): boolean;
+declare function some( arrays: [ ndarray, typedndarray<number> ] ): boolean;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes a redundant union member in `@stdlib/ndarray/base/some`. The second tuple element was typed `typedndarray<number> | genericndarray<number>`, but `genericndarray<number>` extends `typedndarray<number>`, so the union is redundant. It is reduced to `typedndarray<number>` and the now-unused `genericndarray` import is dropped, aligning the signature with the sibling `base/some-by`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
