### PR TITLE
docs: fix JSDoc descriptions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/logcdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/logcdf/lib/factory.js
@@ -60,7 +60,7 @@ function factory( x0, gamma ) {
 	return logcdf;
 
 	/**
-	* Evaluates the  natural logarithm of the cumulative distribution function (logCDF) for a Cauchy distribution.
+	* Evaluates the natural logarithm of the cumulative distribution function (logCDF) for a Cauchy distribution.
 	*
 	* @private
 	* @param {number} x - input value

--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/logcdf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/logcdf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Cauchy distribution cumulative distribution function (CDF).
+* Cauchy distribution natural logarithm of cumulative distribution function (CDF).
 *
 * @module @stdlib/stats/base/dists/cauchy/logcdf
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/logcdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/logcdf/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the logarithm of the cumulative distribution function (logCDF) for a Cauchy distribution with location parameter `x0` and scale parameter `gamma` at a value `x`.
+* Evaluates the natural logarithm of the cumulative distribution function (logCDF) for a Cauchy distribution with location parameter `x0` and scale parameter `gamma` at a value `x`.
 *
 * @private
 * @param {number} x - input value


### PR DESCRIPTION
## Description

`@stdlib/stats/base/dists/cauchy/logcdf`: correct three JSDoc description copy-paste/spacing errors surfaced by a within-namespace majority vote across the 9 members of `stats/base/dists/cauchy`. `lib/index.js`'s module description was a copy of `cdf`'s description (8/9 = 88.9% of cauchy siblings have an `index.js` module description that matches their own `package.json` `description` field; `logcdf` was the sole outlier). `lib/native.js` dropped the word `natural` from `natural logarithm` in the function-level description (7/8 = 87.5% of cauchy siblings with a `native.js` have identical function-level descriptions in `main.js` and `native.js`; `logcdf` was the sole outlier). `lib/factory.js` line 63 had a double space between `the` and `natural` in the inner-function description (4/5 = 80% of cauchy `factory.js` files use single spacing). All three edits are JSDoc-comment text changes; no source, test, or behavioral changes.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: structural and semantic features were extracted from every member of `stats/base/dists/cauchy`, majority patterns were computed at a 75% conformance threshold, and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed each correction was high-signal mechanical drift before any file was edited. The diff is three single-line JSDoc-comment edits in `logcdf`'s `lib/index.js`, `lib/native.js`, and `lib/factory.js`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0125Zg57rgvaAAtLJznqcP9K)_