### PR TITLE
docs: propagate recent develop fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gapx/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapx/lib/accessors.js
@@ -52,7 +52,7 @@ function gapx( N, alpha, x, strideX, offsetX ) {
 	// Cache reference to array data:
 	xbuf = x.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	get = x.accessors[ 0 ];
 	set = x.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gaxpb/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gaxpb/lib/accessors.js
@@ -53,7 +53,7 @@ function gaxpb( N, alpha, beta, x, strideX, offsetX ) {
 	// Cache reference to array data:
 	xbuf = x.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	get = x.accessors[ 0 ];
 	set = x.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn/lib/accessors.js
@@ -74,11 +74,11 @@ function gcusumkbn( N, sum, x, strideX, offsetX, y, strideY, offsetY ) {
 	var c;
 	var i;
 
-	// Cache reference to array data:
+	// Cache references to array data:
 	xbuf = x.data;
 	ybuf = y.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	yset = y.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn2/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn2/lib/accessors.js
@@ -76,11 +76,11 @@ function gcusumkbn2( N, sum, x, strideX, offsetX, y, strideY, offsetY ) {
 	var c;
 	var i;
 
-	// Cache reference to array data:
+	// Cache references to array data:
 	xbuf = x.data;
 	ybuf = y.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	yset = y.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumors/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumors/lib/accessors.js
@@ -57,11 +57,11 @@ function gcusumors( N, sum, x, strideX, offsetX, y, strideY, offsetY ) {
 	var iy;
 	var i;
 
-	// Cache reference to array data:
+	// Cache references to array data:
 	xbuf = x.data;
 	ybuf = y.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	yset = y.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumpw/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumpw/lib/accessors.js
@@ -79,7 +79,7 @@ function gcusumpw( N, sum, x, strideX, offsetX, y, strideY, offsetY ) {
 	var n;
 	var i;
 
-	// Cache reference to array data:
+	// Cache references to array data:
 	xbuf = x.data;
 	ybuf = y.data;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gnannsumkbn/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gnannsumkbn/lib/accessors.js
@@ -74,11 +74,11 @@ function gnannsumkbn( N, x, strideX, offsetX, out, strideOut, offsetOut ) {
 	var n;
 	var i;
 
-	// Cache reference to array data:
+	// Cache references to array data:
 	xbuf = x.data;
 	obuf = out.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	oset = out.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2hp/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2hp/lib/accessors.js
@@ -88,11 +88,11 @@ function gsort2hp( N, order, x, strideX, offsetX, y, strideY, offsetY ) {
 	var j;
 	var k;
 
-	// Cache reference to array data:
+	// Cache references to array data:
 	xbuf = x.data;
 	ybuf = y.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	xset = x.accessors[ 1 ];
 	yget = y.accessors[ 0 ];

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2ins/lib/accessors.js
@@ -80,11 +80,11 @@ function gsort2ins( N, order, x, strideX, offsetX, y, strideY, offsetY ) {
 	var ux;
 	var i;
 
-	// Cache reference to array data:
+	// Cache references to array data:
 	xbuf = x.data;
 	ybuf = y.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	xset = x.accessors[ 1 ];
 	yget = y.accessors[ 0 ];

--- a/lib/node_modules/@stdlib/blas/ext/base/gsort2sh/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsort2sh/lib/accessors.js
@@ -90,11 +90,11 @@ function gsort2sh( N, order, x, strideX, offsetX, y, strideY, offsetY ) {
 	var j;
 	var k;
 
-	// Cache reference to array data:
+	// Cache references to array data:
 	xbuf = x.data;
 	ybuf = y.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	xset = x.accessors[ 1 ];
 	yget = y.accessors[ 0 ];

--- a/lib/node_modules/@stdlib/blas/ext/base/gsorthp/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsorthp/lib/accessors.js
@@ -77,7 +77,7 @@ function gsorthp( N, order, x, strideX, offsetX ) {
 	// Cache reference to array data:
 	xbuf = x.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	xset = x.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gsortins/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsortins/lib/accessors.js
@@ -66,7 +66,7 @@ function gsortins( N, order, x, strideX, offsetX ) {
 	// Cache reference to array data:
 	xbuf = x.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	xset = x.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gsortsh/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsortsh/lib/accessors.js
@@ -80,7 +80,7 @@ function gsortsh( N, order, x, strideX, offsetX ) {
 	// Cache reference to array data:
 	xbuf = x.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
 	xset = x.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gxsa/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxsa/lib/accessors.js
@@ -52,7 +52,7 @@ function gxsa( N, alpha, x, strideX, offsetX ) {
 	// Cache reference to array data:
 	xbuf = x.data;
 
-	// Cache reference to the element accessors:
+	// Cache references to element accessors:
 	get = x.accessors[ 0 ];
 	set = x.accessors[ 1 ];
 

--- a/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-arrays/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/maybe-broadcast-arrays/docs/repl.txt
@@ -19,7 +19,7 @@
     broadcast ndarray-like objects within internal implementations and to do so
     with minimal overhead.
 
-    The function throws an error if a provided broadcast-incompatible ndarrays.
+    The function throws an error if provided broadcast-incompatible ndarrays.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/ndarray/base/to-unflattened/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/to-unflattened/docs/types/index.d.ts
@@ -20,6 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
+import { Collection } from '@stdlib/types/array';
 import { ndarray } from '@stdlib/types/ndarray';
 
 /**
@@ -39,7 +40,7 @@ import { ndarray } from '@stdlib/types/ndarray';
 * var y = toUnflattened( x, 0, [ 2, 3 ] );
 * // returns <ndarray>[ [ 1.0, 2.0, 3.0 ], [ 4.0, 5.0, 6.0 ] ]
 */
-declare function toUnflattened<U extends ndarray = ndarray>( x: U, dim: number, sizes: ArrayLike<number> ): U;
+declare function toUnflattened<U extends ndarray = ndarray>( x: U, dim: number, sizes: Collection<number> ): U;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/iter/interleave-subarrays/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/iter/interleave-subarrays/docs/repl.txt
@@ -9,7 +9,7 @@
     may affect multiple elements. If you need to write to a subarray, copy the
     subarray before attempting mutation.
 
-    The function throws an error if a provided broadcast-incompatible ndarrays.
+    The function throws an error if provided broadcast-incompatible ndarrays.
 
     If an environment supports Symbol.iterator, the returned iterator is
     iterable.

--- a/lib/node_modules/@stdlib/ndarray/maybe-broadcast-arrays/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/maybe-broadcast-arrays/docs/repl.txt
@@ -18,7 +18,7 @@
     writing to a view may affect multiple elements. If you need to write to an
     input ndarray, copy the input ndarray before broadcasting.
 
-    The function throws an error if a provided broadcast-incompatible ndarrays.
+    The function throws an error if provided broadcast-incompatible ndarrays.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-06-05 20:40:09 -0700 (`5c51a78e`) and 2026-06-06 04:44:41 -0700 (`f3b8c813`) to sibling packages with the same underlying defect.

### Pattern: missing `Collection` import in `ndarray/base/to-unflattened` declarations

This propagates the fix from 95016b8c to `@stdlib/ndarray/base/to-unflattened`, which has the identical defect: the `sizes` parameter was typed as the TypeScript built-in `ArrayLike<number>` rather than stdlib's `Collection<number>`, and the corresponding `import { Collection } from '@stdlib/types/array'` was absent from the declaration file. The fix adds the missing import and updates the parameter type, bringing the declaration into alignment with the rest of `ndarray/base`.

- `95016b8c` ([`fix: add missing import in `ndarray/base/unflatten` declarations`](https://github.com/stdlib-js/stdlib/commit/95016b8c7179f978fb8ef5b272cff36b523e06e6))
  - `@stdlib/ndarray/base/to-unflattened`

### Pattern: drop spurious article in REPL docs

Propagates the TSDoc fix from 3116666b, which dropped the ungrammatical article "a" from the phrase "if a provided broadcast-incompatible ndarrays," to the corresponding `docs/repl.txt` files in `@stdlib/ndarray/base/maybe-broadcast-arrays`, `@stdlib/ndarray/maybe-broadcast-arrays`, and `@stdlib/ndarray/iter/interleave-subarrays`. The source PR corrected the TypeScript declarations but left the same wording in the REPL help text untouched. This commit brings the three `repl.txt` files into agreement with the corrected declarations.

- `3116666b` ([`docs: correct TSDoc across `ndarray` TypeScript declarations`](https://github.com/stdlib-js/stdlib/commit/3116666b3e530b2e6fb161924ae4c43cdf02905b))
  - `@stdlib/ndarray/base/maybe-broadcast-arrays`
  - `@stdlib/ndarray/maybe-broadcast-arrays`
  - `@stdlib/ndarray/iter/interleave-subarrays`

### Pattern: pluralize cache-reference comments in `blas/ext/base/*` accessors

Propagates the comment clean-ups from f3b8c813 across sibling `blas/ext/base/*/lib/accessors.js` files that carry the same stale singular phrasing. Two defects are addressed per file: Defect A pluralizes `// Cache reference to array data:` where two or more `.data` buffers are cached, and Defect B pluralizes `// Cache reference to the element accessors:` (also dropping the redundant article) where two or more `.accessors[N]` entries are cached. Files with only a single such reference are left untouched, as pluralizing there would be grammatically incorrect.

- `f3b8c813` ([`chore: clean-up examples and benchmarks`](https://github.com/stdlib-js/stdlib/commit/f3b8c8138f75478315e5ad7176e97a2078dbd91d))
  - Defect A (multi-`.data`):
    - `@stdlib/blas/ext/base/gcusumkbn`
    - `@stdlib/blas/ext/base/gcusumkbn2`
    - `@stdlib/blas/ext/base/gcusumors`
    - `@stdlib/blas/ext/base/gcusumpw`
    - `@stdlib/blas/ext/base/gnannsumkbn`
    - `@stdlib/blas/ext/base/gsort2hp`
    - `@stdlib/blas/ext/base/gsort2ins`
    - `@stdlib/blas/ext/base/gsort2sh`
  - Defect B (multi-`.accessors[N]`):
    - `@stdlib/blas/ext/base/gapx`
    - `@stdlib/blas/ext/base/gaxpb`
    - `@stdlib/blas/ext/base/gcusumkbn`
    - `@stdlib/blas/ext/base/gcusumkbn2`
    - `@stdlib/blas/ext/base/gcusumors`
    - `@stdlib/blas/ext/base/gnannsumkbn`
    - `@stdlib/blas/ext/base/gsort2hp`
    - `@stdlib/blas/ext/base/gsort2ins`
    - `@stdlib/blas/ext/base/gsort2sh`
    - `@stdlib/blas/ext/base/gsorthp`
    - `@stdlib/blas/ext/base/gsortins`
    - `@stdlib/blas/ext/base/gsortsh`
    - `@stdlib/blas/ext/base/gxsa`

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Search scope:** per pattern, scoped to the source commit's namespace first (`ndarray/base/*/docs/types/*.d.ts` for the missing-import sweep; `**/docs/repl.txt` for the broadcast-wording sweep; `blas/ext/base/*/lib/accessors.js` for the cache-comment sweep).
- **Two independent opus validation passes** confirmed at every candidate site that (a) the defect is present as cited, (b) surrounding context does not change the semantics — for the `to-unflattened` declaration, that the `sizes` parameter is semantically a list of dimension sizes (matching `unflatten`'s `sizes` semantics); for each REPL doc, that the file is hand-authored (no autogen marker) and the typo is verbatim; for each accessors file, that the comment text matches exactly and is followed by ≥2 immediately-following `.data` / `.accessors[N]` lines without an intervening blank — and (c) the proposed patch matches the source commit's exact shape.
- **An opus adaptation pass** produced per-site Edits, confirming the `Collection` import slots in before the `ndarray` import (alphabetical) and matches the source-commit ordering, and that the per-file `accessors.js` patches each replace a unique single-line occurrence.
- **A sonnet style-consistency pass** verified that each replacement matches the surrounding declaration / comment style and flagged `gcusumpw`'s Defect-B line as already-plural (only its Defect-A line is patched here).

### Deliberately excluded

- The wider 46-site `ArrayLike<number>` → `Collection<number>` sweep across `ndarray/base/*/docs/types/*.d.ts`: those files are not broken (TypeScript's lib provides `ArrayLike` as a global), so this is a codebase-convention question that should be a deliberate human decision rather than an automated propagation. Flagged for follow-up.
- Namespace-aggregate declaration files (`ndarray/docs/types/index.d.ts`, `ndarray/base/docs/types/index.d.ts`, `ndarray/iter/docs/types/index.d.ts`) and the `repl/help/data/data.{csv,json}` files that still carry the broadcast-incompatible typo: these are generator-owned aggregates and will be regenerated from the per-package sources patched here.
- `gcusumpw` Defect-B line: the comment already reads `Cache references to the element accessors:` (plural, but retains the redundant article). The exact source-commit old-string does not match, so this propagation deliberately does not touch it.
- The `filled(false, len)` → `falses(len, dtype)` / `Uint8Array` → `BooleanArray` modernization in `f3b8c813`'s examples / benchmarks / READMEs: this is an API adoption rather than a defect propagation, and applying it across `blas/ext/base/*` would cascade into example/benchmark rewrites that exceed self-contained-patch scope.
- `array/trues` dtype-default audit (`517d71c3`): already correct in the new `array/trues` package — no propagation site.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalisable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two opus validation passes, one opus adaptation pass, one sonnet style-consistency pass) before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwnR7Joi5CgwJcxwpYNgyX)_