### PR TITLE
bench: fix bool dtype setup in `empty-like` and `full-like` benchmarks

### DIFF
--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
 var isArray = require( '@stdlib/assert/is-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
@@ -102,7 +103,7 @@ bench( format( '%s:dtype=%s', pkg, 'bool' ), function benchmark( b ) {
 	var x;
 	var i;
 
-	x = zeros( 0, 'bool' );
+	x = new BooleanArray( 0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.bool.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.bool.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
-var zeros = require( '@stdlib/array/zeros' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
@@ -39,7 +39,7 @@ var emptyLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( len, 'bool' );
+	var x = new BooleanArray( len );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
 var isArray = require( '@stdlib/assert/is-array' );
 var zeros = require( '@stdlib/array/zeros' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var format = require( '@stdlib/string/format' );
@@ -104,7 +105,7 @@ bench( format( '%s:dtype=bool', pkg ), function benchmark( b ) {
 	var x;
 	var i;
 
-	x = zeros( 0, 'bool' );
+	x = new BooleanArray( 0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.length.bool.js
+++ b/lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.length.bool.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
-var zeros = require( '@stdlib/array/zeros' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var fullLike = require( './../lib' );
@@ -39,7 +39,7 @@ var fullLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( len, 'bool' );
+	var x = new BooleanArray( len );
 	return benchmark;
 
 	/**


### PR DESCRIPTION
## Description

`@stdlib/array/zeros` accepts only `numeric_and_generic` dtypes. `'bool'` is not in that set. Four benchmark files called `zeros(n,'bool')` to construct the source array for bool-typed array benchmarks, which threw a `TypeError` before any benchmark iteration could run.

Fix: add `var BooleanArray = require('@stdlib/array/bool');` to each affected file and replace `zeros(n,'bool')` with `new BooleanArray(n)`. In `benchmark.length.bool.js` for both packages, the `zeros` require is removed entirely because `'bool'` was its only call site. In `benchmark.js` for both packages, the `zeros` require is retained to serve the remaining numeric dtype sections.

Files changed:

-   `lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.js`
-   `lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.bool.js`
-   `lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.js`
-   `lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.length.bool.js`

## Related Issues

None.

## Questions

No.

## Other

Failing runs: https://github.com/stdlib-js/stdlib/actions/runs/27060639823 and https://github.com/stdlib-js/stdlib/actions/runs/27060900306

Three reviewers examined the diff. All approved with no blocking findings. Reviewer A flagged a non-blocking issue: `lib/node_modules/@stdlib/array/full-like/docs/types/index.d.ts` line 330 still contains `zeros(2,'bool')` in a TypeScript documentation example. That is a pre-existing issue in the type declaration file and is out of scope for this benchmark fix; it should be addressed in a separate PR.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_016wWjGkveutBTFw9coY9FrP)_