### PR TITLE
docs: update `x` JSDoc type in `@stdlib/blas/ext/sum`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/sum/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/sum/lib/main.js
@@ -61,7 +61,7 @@ var table = {
 *
 * @name sum
 * @type {Function}
-* @param {ndarray} x - input ndarray
+* @param {ndarrayLike} x - input ndarray
 * @param {Options} [options] - function options
 * @param {IntegerArray} [options.dims] - list of dimensions over which to perform a reduction
 * @param {boolean} [options.keepdims=false] - boolean indicating whether the reduced dimensions should be included in the returned ndarray as singleton dimensions


### PR DESCRIPTION
## Description

`@stdlib/blas/ext/sum`: widen the JSDoc `@param` type for `x` in `lib/main.js` from `{ndarray}` to `{ndarrayLike}`. `sum` was the sole outlier among the 12 `blas/ext/*` sibling packages whose primary function takes `x` as its first parameter — 11/12 (~92%) use `{ndarrayLike}`. The narrower type also contradicted this package's own `@throws` clause two lines below, which states that `x` "must be an ndarray-like object", and the underlying `ndarray/base/unary-reduce-strided1d-dispatch-factory` it wraps documents its input parameter the same way. Pure documentation change; no source, test, or behavioral changes.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: structural and semantic features were extracted from every direct-child leaf member of `@stdlib/blas/ext`, majority patterns were computed at a 75% conformance threshold, and two independent opus validation agents (semantic-review, cross-reference) confirmed the candidate before any file was edited. The diff is a single JSDoc-type-tag change on one line.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqXnYvQczsM2ea7NUfwW4x)_