### PR TITLE
chore: add keywords

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mean/package.json
@@ -60,6 +60,9 @@
     "dist",
     "parameter",
     "discrete",
+    "mean",
+    "average",
+    "avg",
     "hypergeometric",
     "univariate"
   ]


### PR DESCRIPTION
## Description

`@stdlib/stats/base/dists/hypergeometric/mean`: add the three keywords `mean`, `average`, and `avg` to `package.json`. Each is present in 35 of 37 sibling `mean` packages across `stats/base/dists/*` (94.6%); `hypergeometric/mean` was the sole outlier within scope (`negative-binomial/mean` is the other namespace-wide outlier and out of scope here). The insertion point — between `discrete` and `hypergeometric` — mirrors the placement used by `poisson/mean`, `geometric/mean`, `bernoulli/mean`, and `planck/mean`. Metadata only; no source, test, or behavioral changes.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine. The within-namespace majority vote across the 11 members of `stats/base/dists/hypergeometric` did not surface any drift on its own (the namespace splits cleanly into a 4-package distribution-function cluster, a 6-package summary-statistic cluster, and the `ctor`, with each cluster internally consistent); the surfaced correction came from the routine's ecosystem-wide ≥90% pre-validation gate when sibling sub-package types were cross-referenced. Two validation agents (opus cross-reference, sonnet structural-review) independently returned `confirmed-drift` before any file was edited.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYrJW2eBFyH2ZRA68f1z8w)_