### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-empty-object/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-empty-object/benchmark/benchmark.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-object, object-curly-newline, no-empty-function */
+/* eslint-disable object-curly-newline, no-empty-function */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/assert/is-empty-object/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-empty-object/benchmark/benchmark.js
@@ -24,6 +24,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var Object = require( '@stdlib/object/ctor' );
 var pkg = require( './../package.json' ).name;
 var isEmptyObject = require( './../lib' );
 


### PR DESCRIPTION
## Description

Add missing `require( '@stdlib/object/ctor' )` call for `Object` global in `lib/node_modules/@stdlib/assert/is-empty-object/benchmark/benchmark.js`, fixing the `stdlib/require-globals` ESLint rule violation.

## Related Issues

Resolves #12651

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored with assistance from Claude Code. The fix follows the pattern used in the package's own `examples/index.js`.