### PR TITLE
fix: use correct export names

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/binary-input-casting-dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/binary-input-casting-dtype/docs/types/index.d.ts
@@ -29,15 +29,17 @@ import { DataType, InputCastingPolicy } from '@stdlib/types/ndarray';
 * @param idtype2 - additional input ndarray data type
 * @param odtype - output ndarray data type
 * @param policy - input ndarray casting data type policy
+* @throws fourth argument must be a recognized data type policy
+* @throws unexpected error
 * @returns input ndarray casting data type
 *
 * @example
-* var dt = outputDataType( 'float64', 'float64', 'float64', 'none' );
+* var dt = inputCastingDataType( 'float64', 'float64', 'float64', 'none' );
 * // returns <string>
 */
-declare function outputDataType( idtype1: DataType, idtype2: DataType, odtype: DataType, policy: InputCastingPolicy | DataType ): DataType;
+declare function inputCastingDataType( idtype1: DataType, idtype2: DataType, odtype: DataType, policy: InputCastingPolicy | DataType ): DataType;
 
 
 // EXPORTS //
 
-export = outputDataType;
+export = inputCastingDataType;

--- a/lib/node_modules/@stdlib/ndarray/base/binary-input-casting-dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/binary-input-casting-dtype/docs/types/index.d.ts
@@ -29,8 +29,6 @@ import { DataType, InputCastingPolicy } from '@stdlib/types/ndarray';
 * @param idtype2 - additional input ndarray data type
 * @param odtype - output ndarray data type
 * @param policy - input ndarray casting data type policy
-* @throws fourth argument must be a recognized data type policy
-* @throws unexpected error
 * @returns input ndarray casting data type
 *
 * @example

--- a/lib/node_modules/@stdlib/ndarray/base/unary-input-casting-dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-input-casting-dtype/docs/types/index.d.ts
@@ -28,8 +28,6 @@ import { DataType, InputCastingPolicy } from '@stdlib/types/ndarray';
 * @param idtype - input ndarray data type
 * @param odtype - output ndarray data type
 * @param policy - input ndarray casting data type policy
-* @throws third argument must be a recognized data type policy
-* @throws unexpected error
 * @returns input ndarray casting data type
 *
 * @example

--- a/lib/node_modules/@stdlib/ndarray/base/unary-input-casting-dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-input-casting-dtype/docs/types/index.d.ts
@@ -28,15 +28,17 @@ import { DataType, InputCastingPolicy } from '@stdlib/types/ndarray';
 * @param idtype - input ndarray data type
 * @param odtype - output ndarray data type
 * @param policy - input ndarray casting data type policy
+* @throws third argument must be a recognized data type policy
+* @throws unexpected error
 * @returns input ndarray casting data type
 *
 * @example
-* var dt = outputDataType( 'float64', 'float64', 'none' );
+* var dt = inputCastingDataType( 'float64', 'float64', 'none' );
 * // returns <string>
 */
-declare function outputDataType( idtype: DataType, odtype: DataType, policy: InputCastingPolicy | DataType ): DataType;
+declare function inputCastingDataType( idtype: DataType, odtype: DataType, policy: InputCastingPolicy | DataType ): DataType;
 
 
 // EXPORTS //
 
-export = outputDataType;
+export = inputCastingDataType;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   corrects copy-pasted `outputDataType` naming in the `@stdlib/ndarray/base/binary-input-casting-dtype` and `@stdlib/ndarray/base/unary-input-casting-dtype` declarations. Both declared the function as `outputDataType` (and used it in their `@example`), copy-pasted from the `*-output-dtype` packages, whereas the `test.ts` files and the packages' purpose use `inputCastingDataType`. The local identifier is not part of the public API (the modules use `export =`), so emitted types are unchanged. The PR also adds the `@throws` tags thrown by the implementations (recognized data type policy; unexpected error), which were missing from both declarations.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
