### PR TITLE
refactor: add missing generic type-parameter defaults in `ndarray` reverse declarations

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/reverse/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/reverse/docs/types/index.d.ts
@@ -51,7 +51,7 @@ import { ndarray } from '@stdlib/types/ndarray';
 * sh = getShape( y );
 * // returns [ 3, 2 ]
 */
-declare function reverse<T extends ndarray>( x: T, writable: boolean ): T;
+declare function reverse<T extends ndarray = ndarray>( x: T, writable: boolean ): T;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/to-reversed-dimension/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/to-reversed-dimension/docs/types/index.d.ts
@@ -38,7 +38,7 @@ interface Options {
 * @param x - input array
 * @param options - function options
 * @param options.dim - index of dimension to reverse
-* @returns output array
+* @returns output ndarray
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
@@ -49,7 +49,7 @@ interface Options {
 * var y = toReversedDimension( x );
 * // returns <ndarray>[ [ 2.0, 1.0 ], [ 4.0, 3.0 ] ]
 */
-declare function toReversedDimension<T extends ndarray>( x: T, options?: Options ): T;
+declare function toReversedDimension<T extends ndarray = ndarray>( x: T, options?: Options ): T;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds missing `= ndarray` generic type-parameter defaults to the `@stdlib/ndarray/base/reverse` and `@stdlib/ndarray/to-reversed-dimension` declarations, matching their siblings (`base/remove-singleton-dimensions`, `to-reversed`). Inference is unchanged since `T` is always inferred from the input. Also corrects `to-reversed-dimension`'s `@returns output array` to `output ndarray`, matching the rest of the `to-*` family.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
