### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/utils/parallel/test/test.node.worker.js
+++ b/lib/node_modules/@stdlib/utils/parallel/test/test.node.worker.js
@@ -16,28 +16,24 @@
 * limitations under the License.
 */
 
+/* eslint-disable stdlib/first-unit-test */
+
 'use strict';
 
 // MODULES //
 
 var tape = require( 'tape' );
 var proxyquire = require( 'proxyquire' );
-var worker = require( './../lib/node/worker/worker.js' );
 
 
 // TESTS //
-
-tape( 'main export is a function', function test( t ) {
-	t.ok( true, __filename );
-	t.strictEqual( typeof worker, 'function', 'main export is a function' );
-	t.end();
-});
 
 tape( 'the file runs a worker script', function test( t ) {
 	proxyquire( './../lib/node/worker/index.js', {
 		'./worker.js': done
 	});
 	function done() {
+		t.ok( true, __filename );
 		t.ok( true, 'runs worker script' );
 		t.end();
 	}

--- a/lib/node_modules/@stdlib/utils/parallel/test/test.node.worker.js
+++ b/lib/node_modules/@stdlib/utils/parallel/test/test.node.worker.js
@@ -22,16 +22,22 @@
 
 var tape = require( 'tape' );
 var proxyquire = require( 'proxyquire' );
+var worker = require( './../lib/node/worker/worker.js' );
 
 
 // TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof worker, 'function', 'main export is a function' );
+	t.end();
+});
 
 tape( 'the file runs a worker script', function test( t ) {
 	proxyquire( './../lib/node/worker/index.js', {
 		'./worker.js': done
 	});
 	function done() {
-		t.ok( true, __filename );
 		t.ok( true, 'runs worker script' );
 		t.end();
 	}


### PR DESCRIPTION
## Description

Add missing first unit test to `lib/node_modules/@stdlib/utils/parallel/test/test.node.worker.js`, fixing the `stdlib/first-unit-test` ESLint rule violation. The added test follows the standard pattern observed in sibling test files.

## Related Issues

Resolves #12434

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored with assistance from Claude Code. The fix follows the convention used in sibling test files within the same package.