### PR TITLE
refactor: align parameter names in `ndarray/base/nullary-loop-interchange-order`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/nullary-loop-interchange-order/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/nullary-loop-interchange-order/docs/types/index.d.ts
@@ -57,8 +57,8 @@ interface LoopOrderObject {
 *
 *     The purpose of this function is to order ndarray dimensions according to the magnitude of array strides. By using the ordered dimensions and associated strides, one can construct nested loops (one for each dimension) such that the innermost loop iterates over the dimension in which array elements are closest in memory and the outermost loop iterates over the dimension in which array elements are farthest apart in memory. As a consequence, element iteration is optimized to minimize cache misses and ensure locality of reference.
 *
-* @param sh - array dimensions
-* @param sx - array stride lengths
+* @param shape - array dimensions
+* @param stridesX - array stride lengths
 * @returns loop interchange data
 *
 * @example
@@ -78,7 +78,7 @@ interface LoopOrderObject {
 * var idx = o.idx;
 * // returns [ 2, 1, 0 ]
 */
-declare function nullaryLoopOrder( sh: ArrayLike<number>, sx: ArrayLike<number> ): LoopOrderObject;
+declare function nullaryLoopOrder( shape: ArrayLike<number>, stridesX: ArrayLike<number> ): LoopOrderObject;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   aligns the parameter names in `@stdlib/ndarray/base/nullary-loop-interchange-order`. The function parameters were named `sh`/`sx`, diverging from the loop-interchange-order family (`unary`/`binary` use `shape`/`stridesX`). The parameters and their `@param` tags are renamed to `shape`/`stridesX`. The `LoopOrderObject` property names (`sh`/`sx`) and the example code are intentionally left unchanged, as those are part of the returned object's shape.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Found during a TypeScript-declaration audit of the `ndarray` namespace.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

These changes were identified by a Claude Code audit of the `ndarray` namespace's TypeScript declarations and applied with Claude Code assistance; the changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
