### PR TITLE
docs: fix `stats/base/dists/discrete-uniform` JSDoc summaries

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/lib/factory.js
@@ -30,7 +30,7 @@ var exp = require( '@stdlib/math/base/special/exp' );
 // MAIN //
 
 /**
-* Returns a function for evaluating the moment-generating function (MGF) of a discrete uniform distribution with minimum support `a` and maximum support `b`.
+* Returns a function for evaluating the moment-generating function (MGF) for a discrete uniform distribution with minimum support `a` and maximum support `b`.
 *
 * @param {integer} a - minimum support
 * @param {integer} b - maximum support
@@ -59,7 +59,7 @@ function factory( a, b ) {
 	return mgf;
 
 	/**
-	* Evaluates the moment-generating function (MGF) of a discrete uniform distribution.
+	* Evaluates the moment-generating function (MGF) for a discrete uniform distribution.
 	*
 	* @private
 	* @param {number} t - input value

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Evaluate the moment-generating function (MGF) of a discrete uniform distribution.
+* Discrete uniform distribution moment-generating function (MGF).
 *
 * @module @stdlib/stats/base/dists/discrete-uniform/mgf
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/lib/main.js
@@ -29,7 +29,7 @@ var exp = require( '@stdlib/math/base/special/exp' );
 // MAIN //
 
 /**
-* Evaluates the moment-generating function (MGF) of a discrete uniform distribution with minimum support `a` and maximum support `b` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a discrete uniform distribution with minimum support `a` and maximum support `b` at a value `t`.
 *
 * @param {number} t - input value
 * @param {integer} a - minimum support

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the moment-generating function (MGF) of a discrete uniform distribution with minimum support `a` and maximum support `b` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a discrete uniform distribution with minimum support `a` and maximum support `b` at a value `t`.
 *
 * @private
 * @param {number} t - input value

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/quantile/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/quantile/lib/factory.js
@@ -29,7 +29,7 @@ var floor = require( '@stdlib/math/base/special/floor' );
 // MAIN //
 
 /**
-* Returns a function for evaluating the quantile function for a discrete uniform distribution with minimum support `a` an maximum support `b`.
+* Returns a function for evaluating the quantile function for a discrete uniform distribution with minimum support `a` and maximum support `b`.
 *
 * @param {integer} a - minimum support
 * @param {integer} b - maximum support


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request normalizes JSDoc summary lines in two outlier packages in `@stdlib/stats/base/dists/discrete-uniform`. All edits are JSDoc-only — no signatures, behavior, tests, or TypeScript declarations are touched.

### `stats/base/dists/discrete-uniform/mgf`

Updates JSDoc summaries in `lib/main.js`, `lib/native.js`, and `lib/factory.js` (including the inner closure) to use "for a discrete uniform distribution" rather than "of a discrete uniform distribution", aligning with the five sibling packages in this namespace (`cdf`, `logcdf`, `logpmf`, `pmf`, `quantile`) and nine of ten `mgf` packages across stdlib distributions. Updates the `@module` summary in `lib/index.js` from the imperative form "Evaluate the moment-generating function (MGF) of a discrete uniform distribution." to the noun-phrase form "Discrete uniform distribution moment-generating function (MGF).", matching the package's `package.json` description and eleven of thirteen namespace siblings.

### `stats/base/dists/discrete-uniform/quantile`

Fixes a typo in the `factory` JSDoc summary where "an" was written instead of "and" when describing the maximum support parameter `b`, bringing the comment into agreement with the package's own type declarations and all sibling distribution factory files.

### Namespace summary

- Members analyzed: 14 (none autogenerated).
- Features extracted: file tree, `package.json` shape, `manifest.json` shape, README section list, `lib/main.js` / `lib/index.js` / `lib/native.js` / `lib/factory.js` JSDoc summaries, public signature, validation prologue, error construction, JSDoc shape, dependencies.
- Features with a clear majority (≥75%): file tree (native-addon scaffold), `package.json` top-level key set, README section list (`## Usage` / `## Examples` / `## C APIs` / `### Usage` / `### Examples`), validation prologue per function shape, error-construction kind, JSDoc parameter / returns / example shape, JSDoc summary phrasing.
- Features without a clear majority (excluded from drift analysis): the `lib/factory.js` family (present in only 6/14 — the value-taking functions), distribution-specific `keywords` array contents, returns-tag type annotations (heterogeneous by mathematical object).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Structural features were extracted from the filesystem and `package.json` of each member; semantic features (signature, validation prologue, error construction, JSDoc shape, dependencies) were extracted by per-package agents reading `lib/main.js`, `lib/index.js`, `lib/factory.js`, and `lib/native.js`. Each proposed drift correction was verified by a review pass that checked the claimed majority against the actual files, looked for AUTOGENERATED markers, and confirmed no test referenced the docstring text.

**Deliberately excluded.**

- `ctor` lacks the native-addon scaffold (`binding.gyp`, `manifest.json`, `src/`, `include/`, `lib/native.js`, etc.) — intentional, since `ctor` is a JavaScript class with no C implementation.
- `skewness` lacks the `test/fixtures/julia/` cross-language fixture data — intentional, since the skewness of a discrete uniform distribution is always `0` and does not require numerical verification.
- The `keywords` array of `mgf` lacks `probability`, present in 13/14 namespace siblings. Excluded because moment-generating-function packages stdlib-wide consistently omit `probability` from `keywords` (20/22) — the local namespace majority is itself the outlier against the broader convention.
- Returns-tag type annotations (`number` vs `Probability` vs `integer` vs `PositiveNumber`) vary by mathematical object and reflect intentional semantic differences.
- `mgf/docs/types/index.d.ts` carries the same "of" wording in a couple of interface summaries; not touched here per the project convention that per-package `*.d.ts` files are out of scope for namespace-wide drift correction.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A cross-package drift audit of the `@stdlib/stats/base/dists/discrete-uniform` namespace was run using Claude Code. Structural and semantic features were extracted from each of the fourteen non-autogenerated members, the majority pattern was computed per feature, and outliers were validated against sibling packages before any change was applied. Each finding was verified against the implementation and discarded if it reflected an intentional semantic difference (e.g., `ctor` lacking the native-addon scaffold, `skewness` lacking Julia fixtures) or if the local majority itself drifted from the broader stdlib convention (e.g., the `probability` keyword in `mgf` packages). All proposed changes were reviewed before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgAaj1SnWEtpeKR5fWVT9g)_