### PR TITLE
chore: fix JavaScript lint errors (issue #10870)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/math/strided/ops/mul-by/test/test.ndarray.js
@@ -76,11 +76,11 @@ tape( 'the function performs element-wise multiplication via a callback function
 	mulBy( x.length, x, 1, 0, y, 1, 0, z, 1, 0, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
-	// eslint-disable-next-line stdlib/no-new-array
-	x = new Array( 5 ); // sparse array
+	x = []; // sparse array
+	x.length = 5;
 
-	// eslint-disable-next-line stdlib/no-new-array
-	y = new Array( 5 ); // sparse array
+	y = []; // sparse array
+	y.length = 5;
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -88,12 +88,12 @@ tape( 'the function performs element-wise multiplication via a callback function
 	mulBy( x.length, x, 1, 0, y, 1, 0, z, 1, 0, accessor );
 	t.deepEqual( z, expected, 'deep equal' );
 
-	// eslint-disable-next-line stdlib/no-new-array
-	x = new Array( 5 ); // sparse array
+	x = []; // sparse array
+	x.length = 5;
 	x[ 2 ] = rand();
 
-	// eslint-disable-next-line stdlib/no-new-array
-	y = new Array( 5 ); // sparse array
+	y = []; // sparse array
+	y.length = 5;
 	y[ 2 ] = rand();
 	z = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
## Description

Replaces sparse array creation via `new Array()` in the `mul-by` ndarray tests with array literals whose length is set explicitly, removing the lint suppressions for `stdlib/no-new-array`.

## Related Issues

Resolves #10870

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored with assistance from AI.