### PR TITLE
propagate child process exit code in CLI

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -180,6 +180,7 @@ function main() {
 	// Invoke the command in a sub-process:
 	proc = spawn( 'node', subargs, opts );
 	proc.on( 'error', onError );
+	proc.on( 'close', onClose );
 
 	/**
 	* Callback invoked upon encountering an error while running a command.
@@ -189,6 +190,16 @@ function main() {
 	*/
 	function onError( error ) {
 		cli.error( error );
+	}
+
+	/**
+	* Callback invoked upon child process close.
+	*
+	* @private
+	* @param {integer} code - exit code
+	*/
+	function onClose( code ) {
+		process.exit( code || 0 );
 	}
 }
 


### PR DESCRIPTION

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a bug where the exit code of spawned child processes was not propagated back to the parent process. A `close` event listener has been added to the child process which calls `process.exit( code )`, ensuring that CI/CD pipelines and other tooling receive the correct exit code.


## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md