### PR TITLE
chore: add missing precision keywords

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/caxpby/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/caxpby/package.json
@@ -75,7 +75,8 @@
     "complex",
     "complex64",
     "complex64array",
-    "float32"
+    "float32",
+    "single"
   ],
   "__stdlib__": {
     "wasm": false

--- a/lib/node_modules/@stdlib/blas/ext/base/zaxpby/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/zaxpby/package.json
@@ -75,7 +75,8 @@
     "complex",
     "complex128",
     "complex128array",
-    "float64"
+    "float64",
+    "double"
   ],
   "__stdlib__": {
     "wasm": false


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-06-06 14:40 PDT (`f2640a213`) and 2026-06-07 04:02 PDT (`86dc341d3`).

Two new complex-precision BLAS extension packages landed without the precision keyword that every sibling carries:

### `blas/ext/base`

- **`caxpby/package.json`** — Fix `db04ac04` (`blas/ext/base/caxpby/package.json`): `"single"` was missing from the `keywords` array, inconsistent with sibling single-precision packages `saxpby` and `caxpy`; appended `"single"` after `"float32"`.
- **`zaxpby/package.json`** — Fix `2aa1270d` (`blas/ext/base/zaxpby/package.json`): `"double"` was missing from the `keywords` array, inconsistent with sibling double-precision packages `daxpby` and `zaxpy`; appended `"double"` after `"float64"`.

## Related Issues

None.

## Questions

None.

## Other

### Validation

Reviewed all 33 commits merged to `develop` in the window for typos, bugs, and style-guide violations. The audit was performed by four independent reviewer agents (two style, two bug) on top of a shared change summary.

- **Checked:** stdlib code style compliance against sibling reference packages; JSDoc/REPL/TypeScript declaration consistency; obvious bugs (off-by-one, swapped operands, copy-paste errors, complex-number real/imag handling); security and incorrect-logic concerns in the introduced C and JS kernels.
- **Deliberately excluded:** subjective polish, anything requiring interpretation, "could be improved" suggestions, anything that would require touching code outside the diff window to validate, drift in auto-generated namespace ToC / REPL `data.csv` / `data.json` files, and intentional patterns like the mass `zeros` → `empty` benchmark setup change.

False positives that were considered and dropped:

- `array/falses/lib/main.js` JSDoc `@param` default — actual file already reads `[dtype="bool"]`; agent misread the source.
- `dcunone/src/main.c` missing `const` on offset locals — the `const` vs no-`const` pattern is mixed across `blas/ext/base` C sources (81 vs 30 occurrences), so this is not an unambiguous style violation.
- `swxsa/src/main.c` using literal `5` instead of `static const CBLAS_INT M = 5` — sibling `sapx` (closest single-precision in-place unrolled-loop kernel) uses the literal as well, so the family pattern is not uniform.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

Drafted by Claude Code as a follow-up audit of the last 24 hours of commits to `develop`. Independent style and bug reviewer agents produced a candidate finding set; each surviving finding was manually re-verified against the relevant sibling reference packages before being applied. PR left in draft for human maintainer audit.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bns6bUaVueYHkEQAEVtSFs)_