### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dspr/test/test.dspr.js
+++ b/lib/node_modules/@stdlib/blas/base/dspr/test/test.dspr.js
@@ -33,7 +33,6 @@ var rl = require( './fixtures/row_major_l.json' );
 var ru = require( './fixtures/row_major_u.json' );
 var rxp = require( './fixtures/row_major_xp.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var cl = require( './fixtures/column_major_l.json' );
 var cu = require( './fixtures/column_major_u.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dtrsv/test/test.dtrsv.js
+++ b/lib/node_modules/@stdlib/blas/base/dtrsv/test/test.dtrsv.js
@@ -39,7 +39,6 @@ var rutnu = require( './fixtures/row_major_u_t_nu.json' );
 var rutu = require( './fixtures/row_major_u_t_u.json' );
 var rxt = require( './fixtures/row_major_xt.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
 var cltnu = require( './fixtures/column_major_l_t_nu.json' );
 var clntu = require( './fixtures/column_major_l_nt_u.json' );


### PR DESCRIPTION
## Description

Removed extra blank lines between require statements in the `dtrsv` and `dspr` tests to satisfy the JavaScript lint rule.

## Related Issues

Resolves #12305

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored with assistance from AI.