### PR TITLE
docs: fix REPL text notes

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mean/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mean/docs/repl.txt
@@ -4,7 +4,7 @@
 
     If provided `NaN` as any argument, the function returns `NaN`.
 
-    If provided `σ <= 0`, the function returns `NaN`.
+    If provided `σ < 0`, the function returns `NaN`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/quantile/docs/repl.txt
@@ -7,7 +7,7 @@
 
     If provided `NaN` as any argument, the function returns `NaN`.
 
-    If provided a negative probability for `sigma`, the function returns `NaN`.
+    If provided a negative value for `sigma`, the function returns `NaN`.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

This pull request corrects two REPL documentation inaccuracies in `@stdlib/stats/base/dists/rayleigh` that were surfaced by a cross-package drift scan of the namespace's 15 members. Both fixes are documentation-only and do not change runtime behavior.

### `stats/base/dists/rayleigh/mean`

The REPL documentation for `@stdlib/stats/base/dists/rayleigh/mean` incorrectly stated that the function returns `NaN` for `σ <= 0`, contradicting both the implementation, which only rejects `sigma < 0`, and the package README and TypeScript declarations, which correctly specify `σ < 0`. A scale parameter of zero is degenerate but accepted by convention across the Rayleigh namespace — every other zero-arity package (`entropy`, `kurtosis`, `median`, `mode`, `skewness`, `stdev`, `variance`) documents `σ < 0`, and `mean(0)` returns `0`. This commit aligns the REPL text with the actual behavior and the rest of the namespace (7/8 = 87% conformance).

### `stats/base/dists/rayleigh/quantile`

The `repl.txt` documentation for `quantile` incorrectly described a negative value for the scale parameter `sigma` as a "negative probability" — copy-paste residue from the adjacent guard on the probability argument `p`. The parameter `sigma` is a scale parameter, not a probability, so the original phrasing was nonsensical. This aligns the wording with the five other factory packages in the namespace (`cdf`, `logcdf`, `logpdf`, `mgf`, `pdf`), all of which use "negative value for `sigma`" (5/6 = 83% conformance).

## Related Issues

No.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a cross-package drift-detection routine over the `stats/base/dists/rayleigh` namespace. The two corrections that survived the drift filter were structural documentation fixes verified against each package's own implementation, README, and TypeScript declarations, as well as the conventions used by sibling packages. A human maintainer should verify the fixes before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pmj29nsFKFc1iZvDdydYzG)_