### PR TITLE
docs: add NaN notes to `stats/incr/covmat` and `stats/incr/pcorrmat`

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/covmat/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/covmat/README.md
@@ -160,6 +160,10 @@ out = accumulator();
 
 <section class="notes">
 
+## Notes
+
+-   Input values are **not** type checked. If provided `NaN` or a value which, when used in computations, results in `NaN`, the accumulated value is `NaN` for **all** future invocations. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+
 </section>
 
 <!-- /.notes -->

--- a/lib/node_modules/@stdlib/stats/incr/pcorrmat/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/pcorrmat/README.md
@@ -162,6 +162,10 @@ out = accumulator();
 
 <section class="notes">
 
+## Notes
+
+-   Input values are **not** type checked. If provided `NaN` or a value which, when used in computations, results in `NaN`, the accumulated value is `NaN` for **all** future invocations. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+
 </section>
 
 <!-- /.notes -->


### PR DESCRIPTION
## Description

Populates the empty `<section class="notes">` scaffold in two `@stdlib/stats/incr` package READMEs with the standard NaN-propagation warning used by 105 of the 108 packages in the namespace (97% conformance). No code, type, or test changes; documentation only.

**Namespace summary**

- Target: `@stdlib/stats/incr` — 108 non-autogenerated members.
- Features analyzed: file tree, `package.json` shape, README section list, REPL section list, test/benchmark/example filenames, JSDoc shape (`@param`/`@returns`/`@throws`/`@example`), validation prologue, error construction, dependencies, `keywords`.
- Features with a clear majority (≥75%): 10 package files at 100%, 18 `package.json` top-level keys at 100%, 8 `keywords` at 100%, `{## Usage, ## Notes, ## Examples, ## See Also}` README sections at ≥83%, JSDoc `@example` at 100%, `@returns {Function}` at 100%, `format`-based error construction at 100% (of the 60 packages that throw).
- Features without a clear majority (excluded): `package.json#scripts` keys (shape-driven), `bench(...)` call count (shape-driven), `validate.js` (only 2 packages — `grubbs`, `mgrubbs`).

### `stats/incr/covmat`

Empty `<section class="notes">` populated with the standard NaN-propagation warning. `incrcovmat` updates a persistent mean vector and co-moment matrix via Welford recursion; a single NaN input contaminates `mu` and `C` and poisons every subsequent covariance-matrix output. 105/108 packages (97%) in the namespace already document this caveat verbatim, including the scalar sibling `stats/incr/covariance`.

### `stats/incr/pcorrmat`

Same fix. `incrpcorrmat` carries persistent means, co-moments, and per-variable standard deviations, and divides by `sd[i]*sd[j]` to produce the correlation matrix; a NaN input permanently corrupts means, co-moments, and standard deviations and thereby every later correlation. Mirrors the wording used by the scalar sibling `stats/incr/pcorr`. Sibling matrix variant `stats/incr/pcorrdistmat` already carries a Notes section (with a package-specific floating-point note), confirming the matrix subgroup does not follow a "no Notes" convention.

## Related Issues

None.

## Questions

No.

## Other

**Validation**

Both candidates were filtered through three independent review agents before applying:

- Semantic review (opus): traced the Welford recursion in both `lib/main.js` files and verified that NaN propagation is the same behavior the standard warning describes — applies verbatim, no need for a package-specific rephrasing.
- Cross-reference (opus): confirmed no test in either package's `test/` directory parses the README, and no sibling package or generator depends on the `<section class="notes">` content of either file.
- Structural review (sonnet): confirmed the empty `<section class="notes">` blocks are scaffold placeholders rather than a deliberate "no Notes" convention in the matrix subgroup, citing `stats/incr/pcorrdistmat` as a counterexample.

Deliberately excluded from this PR:

- `stats/incr/count` — also missing `## Notes`. `incrcount` increments unconditionally, so NaN does not propagate; the boilerplate would be inaccurate. `intentional-deviation`.
- 15 `nan*` packages missing `## See Also` — generator-owned auto-populated section; gating rule disallows touching it.
- 7 `nan*` packages without a validation prologue (`nanmcv`, `nanmmape`, `nanmmse`, `nanmstdev`, `nanmsum`, `nanstdev`, `nanvariance`) — each delegates to a non-nan sibling that performs the validation. `intentional-deviation`.
- `grubbs` vs `mgrubbs` `validate.js` wording drift — only 2 data points, no majority to anchor a fix.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

Drafted by Claude Code as part of a cross-package drift detection routine: structural and semantic features were extracted from all 108 packages in `@stdlib/stats/incr`, the majority pattern was identified per feature, and outliers were flagged. Three independent agent reviews (two opus, one sonnet) confirmed both Notes-section additions as unintentional drift before the patches were applied verbatim from the namespace boilerplate. A maintainer should promote out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZ9amy9VuzphYDVvtxeiw9)_