### PR TITLE
docs: move JS examples before C API documentation

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/cdf/README.md
@@ -132,6 +132,31 @@ y = mycdf( 8.0 );
 
 <!-- /.usage -->
 
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var cdf = require( '@stdlib/stats/base/dists/gamma/cdf' );
+
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 10, 0.0, 3.0, opts );
+var alpha = uniform( 10, 0.0, 5.0, opts );
+var beta = uniform( 10, 0.0, 5.0, opts );
+
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, F(x;α,β): %0.4f', x, alpha, beta, cdf );
+```
+
+</section>
+
+<!-- /.examples -->
+
 * * *
 
 <section class="c">
@@ -216,33 +241,6 @@ int main( void ) {
 </section>
 
 <!-- /.c -->
-
-* * *
-
-<section class="examples">
-
-## Examples
-
-<!-- eslint no-undef: "error" -->
-
-```javascript
-var uniform = require( '@stdlib/random/array/uniform' );
-var logEachMap = require( '@stdlib/console/log-each-map' );
-var cdf = require( '@stdlib/stats/base/dists/gamma/cdf' );
-
-var opts = {
-    'dtype': 'float64'
-};
-var x = uniform( 10, 0.0, 3.0, opts );
-var alpha = uniform( 10, 0.0, 5.0, opts );
-var beta = uniform( 10, 0.0, 5.0, opts );
-
-logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, F(x;α,β): %0.4f', x, alpha, beta, cdf );
-```
-
-</section>
-
-<!-- /.examples -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 


### PR DESCRIPTION
## Description

Reorders the README in `stats/base/dists/gamma/cdf` so the JavaScript `## Examples` section sits between the JS `## Usage` and `## C APIs` sections — the layout shared by every other native-addon package in the namespace.

### Namespace summary

-   Namespace: `@stdlib/stats/base/dists/gamma`
-   Members analyzed: 14 (`cdf`, `ctor`, `entropy`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `mgf`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`)
-   Features extracted: file tree, `package.json` shape, `manifest.json` shape, README heading sequence, `test/`/`benchmark/`/`examples/` naming, public signature, validation prologue, error construction, JSDoc shape, `require`-graph dependencies.
-   Features with a clear majority (≥75%): README heading order, factory-style validation prologue, public signatures, JSDoc layout, dependency surface, scripts/keywords composition (per function family).
-   Features without a clear majority (excluded): scalar-prologue `isnan` usage (5 of 7 omit it, 71% — under threshold).

### `stats/base/dists/gamma/cdf`

The README ordered sections as `## Usage` → `## C APIs` → `## Examples`, with the JS example block buried after the C interface. Every other native-addon sibling in the namespace (`entropy`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `mgf`, `mode`, `pdf`, `skewness`, `stdev`, `variance` — 11 of 12, 92%) places the JS `## Examples` before the `## C APIs` separator. The block, its enclosing `<section class="examples">` wrapper, and the surrounding `* * *` separator move as a unit; section content is byte-identical.

## Related Issues

None.

## Questions

No.

## Other

### Validation

Structural features were extracted by walking each package's tree and parsing `package.json`, `manifest.json`, and README headings. Semantic features (public signatures, validation prologue, error construction, JSDoc shape, `require`-graph dependencies) were read directly from each package's `lib/main.js`, `lib/factory.js`, and `lib/index.js`. The single advancing candidate was vetted by a structural-review agent (confirmed the entropy-style ordering as the correct target and the block move as content-preserving) and a cross-reference agent (confirmed no anchor links, no test/benchmark code, no umbrella-namespace tooling, and no markdown-lint rule depends on the current ordering).

Deliberately excluded:

-   `ctor`, `quantile` lacking `gypfile`/`binding.gyp`/`src/`/`include/`/`manifest.json` — intentional: `ctor` is a constructor with no native math kernel, `quantile` is awaiting the in-flight `math/base/special/gammaincinv` C implementation (PR #9982). Per gate "Ecosystem-wide intentional absence."
-   `pdf/LICENSE` (only gamma member with a per-package LICENSE file) — direction of fix would be removal, but per-package LICENSEs appear in <2% of stdlib; without git-blame intent the safe call is to log and defer to a maintainer.
-   `mgf` package.json missing `probability` keyword (13/14 of gamma siblings have it) — but only 2 of 22 MGF packages across `stats/base/dists` (9% stdlib-wide) carry it, so the namespace-local majority reflects the local minority, not drift. Gate "Ecosystem-wide intentional absence" applies.
-   Scalar-prologue `isnan` usage — 5 of 7 scalar functions (`entropy`, `mean`, `mode`, `stdev`, `variance`) omit explicit `isnan` checks; 2 (`kurtosis`, `skewness`) include them. 71% conformance is below the 75% threshold, no clear majority.

PR #12677 (open draft) touches `gamma/mgf/lib/factory.js` only for wording propagation — no overlap with this diff.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of the cross-package drift-detection routine. Structural and semantic features were extracted programmatically across the namespace; the single advancing candidate was independently vetted by a structural-review agent and a cross-reference agent before the section reorder was applied. A human maintainer should verify the diff before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_013BWXWY2PZ3UF2BrcuC65Zg)_