### PR TITLE
docs: add backticks in `blas/ext/base/dcusome` descriptions

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dcusome/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusome/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # dcusome
 
-> Cumulatively test whether at least k elements in a double-precision floating-point strided array are truthy.
+> Cumulatively test whether at least `k` elements in a double-precision floating-point strided array are truthy.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusome/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusome/docs/repl.txt
@@ -1,6 +1,6 @@
 
 {{alias}}( N, k, x, strideX, out, strideOut )
-    Cumulatively tests whether at least k elements in a double-precision
+    Cumulatively tests whether at least `k` elements in a double-precision
     floating-point strided array are truthy.
 
     The `N` and stride parameters determine which elements in the strided arrays
@@ -52,7 +52,7 @@
 
 
 {{alias}}.ndarray( N, k, x, strideX, offsetX, out, strideOut, offsetOut )
-    Cumulatively tests whether at least k elements in a double-precision
+    Cumulatively tests whether at least `k` elements in a double-precision
     floating-point strided array are truthy using alternative indexing
     semantics.
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusome/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusome/docs/types/index.d.ts
@@ -27,7 +27,7 @@ import { BooleanArray } from '@stdlib/types/array';
 */
 interface Routine {
 	/**
-	* Cumulatively tests whether at least k elements in a double-precision floating-point strided array are truthy.
+	* Cumulatively tests whether at least `k` elements in a double-precision floating-point strided array are truthy.
 	*
 	* @param N - number of indexed elements
 	* @param k - minimum number of truthy elements
@@ -50,7 +50,7 @@ interface Routine {
 	( N: number, k: number, x: Float64Array, strideX: number, out: BooleanArray, strideOut: number ): BooleanArray;
 
 	/**
-	* Cumulatively tests whether at least k elements in a double-precision floating-point strided array are truthy using alternative indexing semantics.
+	* Cumulatively tests whether at least `k` elements in a double-precision floating-point strided array are truthy using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param k - minimum number of truthy elements
@@ -76,7 +76,7 @@ interface Routine {
 }
 
 /**
-* Cumulatively tests whether at least k elements in a double-precision floating-point strided array are truthy.
+* Cumulatively tests whether at least `k` elements in a double-precision floating-point strided array are truthy.
 *
 * @param N - number of indexed elements
 * @param k - minimum number of truthy elements

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusome/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusome/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Cumulatively test whether at least k elements in a double-precision floating-point strided array are truthy.
+* Cumulatively test whether at least `k` elements in a double-precision floating-point strided array are truthy.
 *
 * @module @stdlib/blas/ext/base/dcusome
 *


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-06-07 05:19 PDT and 2026-06-08 01:55 PDT (SHA range `81c49c2f`..`f31e14972`, 22 first-parent commits).

## Description

This pull request:

-   Aligns `blas/ext/base/dcusome` user-facing documentation with the `blas/ext/base/gcusome` reference convention by wrapping the `k` parameter in backticks in `README.md`, `docs/repl.txt`, `docs/types/index.d.ts`, and `lib/index.js` (originating commit `98254d8e`).

### Fixes by package

-   **`blas/ext/base/dcusome`** — Fixes missing backtick formatting around `k` in `README.md`, `docs/repl.txt`, `docs/types/index.d.ts`, and `lib/index.js`, introduced in `98254d8e`; `gcusome` consistently wraps `k` in backticks across the same surfaces.

## Related Issues

No.

## Questions

No.

## Other

### Commit window

22 first-parent commits merged to `develop` between 2026-06-07 05:19 PDT and 2026-06-08 01:55 PDT (`81c49c2f`..`f31e14972`). The window centers on `@stdlib/blas/ext/base` expansion: new `dcuany`, `dcuevery`, `dcusome`, `scunone`, `dwxsa`, `gminheap-sift-down` packages; new `ndarray/{caxpby,daxpby,saxpby}` wrappers; a `caxpby/src/main.c` refactor; benchmark description format fixes; and namespace + TypeScript declaration updates.

### Validation

Scope of review:

-   stdlib code-style compliance against `docs/style-guides/` and against established sibling reference packages (`gcusome`, `dcunone`, `scuany`, `dnansum`, `swxsa`, `zaxpby`).
-   Bug scan across all introduced JavaScript and C sources, with focused attention on `gminheap-sift-down` index arithmetic, `dcusome` `k`-threshold semantics, the `caxpby` C refactor, `dwxsa` sign direction, and the `ndarray/{caxpby,daxpby,saxpby}` argument forwarding.

Deliberately excluded:

-   Subjective or "could be improved" suggestions.
-   Findings requiring changes to code outside the 24-hour window (e.g., the `dcusome` `k <= 0` semantic matches the `gcusome` reference exactly and is covered by an explicit reference test — not a regression).
-   Bench-description format reordering in the three `bench: fix description` commits, confirmed to be intentional alignment with the new sibling-package convention.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was assembled by Claude Code as part of a scheduled review of commits merged to `develop` in the last 24 hours. The documentation fix was identified by automated style auditors, validated against the `gcusome` reference package, and applied by Claude Code. A maintainer should audit before promoting from draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01BatBtDbBUpbzLTHtZXi4sM)_