### PR TITLE
chore: fix JavaScript lint errors across `blas/base/*` test files

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dgemm/test/test.dgemm.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemm/test/test.dgemm.js
@@ -34,7 +34,6 @@ var cntantb = require( './fixtures/column_major_nta_ntb.json' );
 var ctantb = require( './fixtures/column_major_ta_ntb.json' );
 var cntatb = require( './fixtures/column_major_nta_tb.json' );
 var ctatb = require( './fixtures/column_major_ta_tb.json' );
-
 var rntantb = require( './fixtures/row_major_nta_ntb.json' );
 var rtantb = require( './fixtures/row_major_ta_ntb.json' );
 var rntatb = require( './fixtures/row_major_nta_tb.json' );

--- a/lib/node_modules/@stdlib/blas/base/dgemm/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemm/test/test.ndarray.js
@@ -48,7 +48,6 @@ var carbrcntantb = require( './fixtures/ca_rb_rc_nta_ntb.json' );
 var carbrcntatb = require( './fixtures/ca_rb_rc_nta_tb.json' );
 var carbrctantb = require( './fixtures/ca_rb_rc_ta_ntb.json' );
 var carbrctatb = require( './fixtures/ca_rb_rc_ta_tb.json' );
-
 var racbccntantb = require( './fixtures/ra_cb_cc_nta_ntb.json' );
 var racbccntatb = require( './fixtures/ra_cb_cc_nta_tb.json' );
 var racbcctantb = require( './fixtures/ra_cb_cc_ta_ntb.json' );
@@ -65,7 +64,6 @@ var rarbrcntantb = require( './fixtures/ra_rb_rc_nta_ntb.json' );
 var rarbrcntatb = require( './fixtures/ra_rb_rc_nta_tb.json' );
 var rarbrctantb = require( './fixtures/ra_rb_rc_ta_ntb.json' );
 var rarbrctatb = require( './fixtures/ra_rb_rc_ta_tb.json' );
-
 var carbcctantbsa1sa2 = require( './fixtures/ca_rb_cc_ta_ntb_sa1_sa2.json' );
 var carbcctantbsa1nsa2 = require( './fixtures/ca_rb_cc_ta_ntb_sa1n_sa2.json' );
 var carbcctantbsa1sa2n = require( './fixtures/ca_rb_cc_ta_ntb_sa1_sa2n.json' );

--- a/lib/node_modules/@stdlib/blas/base/dgemv/test/test.dgemv.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/test/test.dgemv.js
@@ -38,7 +38,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );

--- a/lib/node_modules/@stdlib/blas/base/dgemv/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/test/test.ndarray.native.js
@@ -45,7 +45,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rap = require( './fixtures/row_major_complex_access_pattern.json' );
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );

--- a/lib/node_modules/@stdlib/blas/base/dspmv/test/test.dspmv.js
+++ b/lib/node_modules/@stdlib/blas/base/dspmv/test/test.dspmv.js
@@ -37,7 +37,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cxoyt = require( './fixtures/column_major_xoyt.json' );
 var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cxnyp = require( './fixtures/column_major_xnyp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dspmv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dspmv/test/test.ndarray.js
@@ -37,7 +37,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cxoyt = require( './fixtures/column_major_xoyt.json' );
 var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cxnyp = require( './fixtures/column_major_xnyp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dspr/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dspr/test/test.ndarray.js
@@ -38,7 +38,6 @@ var rsap = require( './fixtures/row_major_sap.json' );
 var rsapn = require( './fixtures/row_major_sapn.json' );
 var roap = require( './fixtures/row_major_oap.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cl = require( './fixtures/column_major_l.json' );
 var cu = require( './fixtures/column_major_u.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dsymv/test/test.dsymv.js
+++ b/lib/node_modules/@stdlib/blas/base/dsymv/test/test.dsymv.js
@@ -37,7 +37,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cxoyt = require( './fixtures/column_major_xoyt.json' );
 var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cxnyp = require( './fixtures/column_major_xnyp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dsymv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dsymv/test/test.ndarray.js
@@ -37,7 +37,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cxoyt = require( './fixtures/column_major_xoyt.json' );
 var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cxnyp = require( './fixtures/column_major_xnyp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dsyr/test/test.dsyr.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr/test/test.dsyr.js
@@ -33,7 +33,6 @@ var ru = require( './fixtures/row_major_u.json' );
 var rl = require( './fixtures/row_major_l.json' );
 var rxp = require( './fixtures/row_major_xp.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dsyr/test/test.dsyr.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr/test/test.dsyr.native.js
@@ -34,7 +34,6 @@ var ru = require( './fixtures/row_major_u.json' );
 var rl = require( './fixtures/row_major_l.json' );
 var rxp = require( './fixtures/row_major_xp.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dsyr/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr/test/test.ndarray.js
@@ -40,7 +40,6 @@ var rsa1nsa2 = require( './fixtures/row_major_sa1n_sa2.json' );
 var rsa1sa2n = require( './fixtures/row_major_sa1_sa2n.json' );
 var rsa1nsa2n = require( './fixtures/row_major_sa1n_sa2n.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.dsyr2.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.dsyr2.native.js
@@ -37,7 +37,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cx0 = require( './fixtures/column_major_x0.json' );

--- a/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.ndarray.js
@@ -44,7 +44,6 @@ var rsa1nsa2 = require( './fixtures/row_major_sa1n_sa2.json' );
 var rsa1sa2n = require( './fixtures/row_major_sa1_sa2n.json' );
 var rsa1nsa2n = require( './fixtures/row_major_sa1n_sa2n.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cx0 = require( './fixtures/column_major_x0.json' );

--- a/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dsyr2/test/test.ndarray.native.js
@@ -45,7 +45,6 @@ var rsa1nsa2 = require( './fixtures/row_major_sa1n_sa2.json' );
 var rsa1sa2n = require( './fixtures/row_major_sa1_sa2n.json' );
 var rsa1nsa2n = require( './fixtures/row_major_sa1n_sa2n.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cx0 = require( './fixtures/column_major_x0.json' );

--- a/lib/node_modules/@stdlib/blas/base/dtrmv/test/test.dtrmv.js
+++ b/lib/node_modules/@stdlib/blas/base/dtrmv/test/test.dtrmv.js
@@ -39,7 +39,6 @@ var rutnu = require( './fixtures/row_major_u_t_nu.json' );
 var rutu = require( './fixtures/row_major_u_t_u.json' );
 var rxt = require( './fixtures/row_major_xt.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
 var cltnu = require( './fixtures/column_major_l_t_nu.json' );
 var clntu = require( './fixtures/column_major_l_nt_u.json' );

--- a/lib/node_modules/@stdlib/blas/base/dtrmv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dtrmv/test/test.ndarray.js
@@ -46,7 +46,6 @@ var rsa1nsa2 = require( './fixtures/row_major_sa1n_sa2.json' );
 var rsa1sa2n = require( './fixtures/row_major_sa1_sa2n.json' );
 var rsa1nsa2n = require( './fixtures/row_major_sa1n_sa2n.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
 var cltnu = require( './fixtures/column_major_l_t_nu.json' );
 var clntu = require( './fixtures/column_major_l_nt_u.json' );

--- a/lib/node_modules/@stdlib/blas/base/ggemv/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemv/test/test.main.js
@@ -39,7 +39,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );

--- a/lib/node_modules/@stdlib/blas/base/ggemv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/ggemv/test/test.ndarray.js
@@ -45,7 +45,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rap = require( './fixtures/row_major_complex_access_pattern.json' );
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );

--- a/lib/node_modules/@stdlib/blas/base/gsyr/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/base/gsyr/test/test.main.js
@@ -34,7 +34,6 @@ var ru = require( './fixtures/row_major_u.json' );
 var rl = require( './fixtures/row_major_l.json' );
 var rxp = require( './fixtures/row_major_xp.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/sgemv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/test/test.ndarray.js
@@ -44,7 +44,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rap = require( './fixtures/row_major_complex_access_pattern.json' );
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );

--- a/lib/node_modules/@stdlib/blas/base/sgemv/test/test.sgemv.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/test/test.sgemv.js
@@ -38,7 +38,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );

--- a/lib/node_modules/@stdlib/blas/base/sgemv/test/test.sgemv.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/test/test.sgemv.native.js
@@ -40,7 +40,6 @@ var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cx = require( './fixtures/column_major_x_zeros.json' );
 var cxb = require( './fixtures/column_major_x_zeros_beta_one.json' );
 var ca = require( './fixtures/column_major_alpha_zero.json' );
-
 var rnt = require( './fixtures/row_major_nt.json' );
 var rt = require( './fixtures/row_major_t.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );

--- a/lib/node_modules/@stdlib/blas/base/sspmv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sspmv/test/test.ndarray.js
@@ -37,7 +37,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cxoyt = require( './fixtures/column_major_xoyt.json' );
 var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cxnyp = require( './fixtures/column_major_xnyp.json' );

--- a/lib/node_modules/@stdlib/blas/base/sspmv/test/test.sspmv.js
+++ b/lib/node_modules/@stdlib/blas/base/sspmv/test/test.sspmv.js
@@ -37,7 +37,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cxoyt = require( './fixtures/column_major_xoyt.json' );
 var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cxnyp = require( './fixtures/column_major_xnyp.json' );

--- a/lib/node_modules/@stdlib/blas/base/sspr/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/test/test.ndarray.js
@@ -38,7 +38,6 @@ var rsap = require( './fixtures/row_major_sap.json' );
 var rsapn = require( './fixtures/row_major_sapn.json' );
 var roap = require( './fixtures/row_major_oap.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cl = require( './fixtures/column_major_l.json' );
 var cu = require( './fixtures/column_major_u.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/sspr/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/test/test.ndarray.native.js
@@ -39,7 +39,6 @@ var rsap = require( './fixtures/row_major_sap.json' );
 var rsapn = require( './fixtures/row_major_sapn.json' );
 var roap = require( './fixtures/row_major_oap.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cl = require( './fixtures/column_major_l.json' );
 var cu = require( './fixtures/column_major_u.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/sspr/test/test.sspr.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/test/test.sspr.js
@@ -33,7 +33,6 @@ var rl = require( './fixtures/row_major_l.json' );
 var ru = require( './fixtures/row_major_u.json' );
 var rxp = require( './fixtures/row_major_xp.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var cl = require( './fixtures/column_major_l.json' );
 var cu = require( './fixtures/column_major_u.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/sspr/test/test.sspr.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sspr/test/test.sspr.native.js
@@ -34,7 +34,6 @@ var rl = require( './fixtures/row_major_l.json' );
 var ru = require( './fixtures/row_major_u.json' );
 var rxp = require( './fixtures/row_major_xp.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var cl = require( './fixtures/column_major_l.json' );
 var cu = require( './fixtures/column_major_u.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/ssymv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/ssymv/test/test.ndarray.js
@@ -44,7 +44,6 @@ var roa = require( './fixtures/row_major_oa.json' );
 var rox = require( './fixtures/row_major_ox.json' );
 var roy = require( './fixtures/row_major_oy.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cu = require( './fixtures/column_major_upper.json' );
 var cl = require( './fixtures/column_major_lower.json' );
 var cxpyp = require( './fixtures/column_major_xpyp.json' );

--- a/lib/node_modules/@stdlib/blas/base/ssyr/test/test.ssyr.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr/test/test.ssyr.js
@@ -33,7 +33,6 @@ var ru = require( './fixtures/row_major_u.json' );
 var rl = require( './fixtures/row_major_l.json' );
 var rxp = require( './fixtures/row_major_xp.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/ssyr/test/test.ssyr.native.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr/test/test.ssyr.native.js
@@ -34,7 +34,6 @@ var ru = require( './fixtures/row_major_u.json' );
 var rl = require( './fixtures/row_major_l.json' );
 var rxp = require( './fixtures/row_major_xp.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cxp = require( './fixtures/column_major_xp.json' );

--- a/lib/node_modules/@stdlib/blas/base/ssyr2/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr2/test/test.ndarray.js
@@ -44,7 +44,6 @@ var rsa1nsa2 = require( './fixtures/row_major_sa1n_sa2.json' );
 var rsa1sa2n = require( './fixtures/row_major_sa1_sa2n.json' );
 var rsa1nsa2n = require( './fixtures/row_major_sa1n_sa2n.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cx0 = require( './fixtures/column_major_x0.json' );

--- a/lib/node_modules/@stdlib/blas/base/ssyr2/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr2/test/test.ndarray.native.js
@@ -45,7 +45,6 @@ var rsa1nsa2 = require( './fixtures/row_major_sa1n_sa2.json' );
 var rsa1sa2n = require( './fixtures/row_major_sa1_sa2n.json' );
 var rsa1nsa2n = require( './fixtures/row_major_sa1n_sa2n.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cx0 = require( './fixtures/column_major_x0.json' );

--- a/lib/node_modules/@stdlib/blas/base/ssyr2/test/test.ssyr2.js
+++ b/lib/node_modules/@stdlib/blas/base/ssyr2/test/test.ssyr2.js
@@ -36,7 +36,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cu = require( './fixtures/column_major_u.json' );
 var cl = require( './fixtures/column_major_l.json' );
 var cx0 = require( './fixtures/column_major_x0.json' );

--- a/lib/node_modules/@stdlib/blas/base/strmv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/strmv/test/test.ndarray.js
@@ -46,7 +46,6 @@ var rsa1nsa2 = require( './fixtures/row_major_sa1n_sa2.json' );
 var rsa1sa2n = require( './fixtures/row_major_sa1_sa2n.json' );
 var rsa1nsa2n = require( './fixtures/row_major_sa1n_sa2n.json' );
 var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
-
 var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
 var cltnu = require( './fixtures/column_major_l_t_nu.json' );
 var clntu = require( './fixtures/column_major_l_nt_u.json' );

--- a/lib/node_modules/@stdlib/blas/base/strmv/test/test.strmv.js
+++ b/lib/node_modules/@stdlib/blas/base/strmv/test/test.strmv.js
@@ -39,7 +39,6 @@ var rutnu = require( './fixtures/row_major_u_t_nu.json' );
 var rutu = require( './fixtures/row_major_u_t_u.json' );
 var rxt = require( './fixtures/row_major_xt.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
 var cltnu = require( './fixtures/column_major_l_t_nu.json' );
 var clntu = require( './fixtures/column_major_l_nt_u.json' );

--- a/lib/node_modules/@stdlib/blas/base/strsv/test/test.strsv.js
+++ b/lib/node_modules/@stdlib/blas/base/strsv/test/test.strsv.js
@@ -39,7 +39,6 @@ var rutnu = require( './fixtures/row_major_u_t_nu.json' );
 var rutu = require( './fixtures/row_major_u_t_u.json' );
 var rxt = require( './fixtures/row_major_xt.json' );
 var rxn = require( './fixtures/row_major_xn.json' );
-
 var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
 var cltnu = require( './fixtures/column_major_l_t_nu.json' );
 var clntu = require( './fixtures/column_major_l_nt_u.json' );


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-06-07 and 2026-06-08 to sibling packages.

### `chore: fix JavaScript lint errors` (32b7db28)

PR #12678 removed a stray blank line between two contiguous `var X = require( './fixtures/...' );` declarations within the `// FIXTURES //` block of `blas/base/dspr/test/test.dspr.js` and `blas/base/dtrsv/test/test.dtrsv.js`, satisfying the `stdlib/no-empty-lines-between-requires` lint rule. The same defect — a row-major/column-major fixture group separated by a blank line where the section header `// FIXTURES //` already sits above — exists in 38 sibling test files. Removing the offending blank line clears the violation while leaving every other line untouched.

Target packages (one blank line removed per file unless noted):

- `blas/base/dgemm/test/test.dgemm.js`
- `blas/base/dgemm/test/test.ndarray.js` (2)
- `blas/base/dgemv/test/test.dgemv.js`
- `blas/base/dgemv/test/test.ndarray.native.js`
- `blas/base/dspmv/test/test.dspmv.js`
- `blas/base/dspmv/test/test.ndarray.js`
- `blas/base/dspr/test/test.ndarray.js`
- `blas/base/dsymv/test/test.dsymv.js`
- `blas/base/dsymv/test/test.ndarray.js`
- `blas/base/dsyr/test/test.dsyr.js`
- `blas/base/dsyr/test/test.dsyr.native.js`
- `blas/base/dsyr/test/test.ndarray.js`
- `blas/base/dsyr2/test/test.dsyr2.native.js`
- `blas/base/dsyr2/test/test.ndarray.js`
- `blas/base/dsyr2/test/test.ndarray.native.js`
- `blas/base/dtrmv/test/test.dtrmv.js`
- `blas/base/dtrmv/test/test.ndarray.js`
- `blas/base/ggemv/test/test.main.js`
- `blas/base/ggemv/test/test.ndarray.js`
- `blas/base/gsyr/test/test.main.js`
- `blas/base/sgemv/test/test.ndarray.js`
- `blas/base/sgemv/test/test.sgemv.js`
- `blas/base/sgemv/test/test.sgemv.native.js`
- `blas/base/sspmv/test/test.ndarray.js`
- `blas/base/sspmv/test/test.sspmv.js`
- `blas/base/sspr/test/test.ndarray.js`
- `blas/base/sspr/test/test.ndarray.native.js`
- `blas/base/sspr/test/test.sspr.js`
- `blas/base/sspr/test/test.sspr.native.js`
- `blas/base/ssymv/test/test.ndarray.js`
- `blas/base/ssyr/test/test.ssyr.js`
- `blas/base/ssyr/test/test.ssyr.native.js`
- `blas/base/ssyr2/test/test.ndarray.js`
- `blas/base/ssyr2/test/test.ndarray.native.js`
- `blas/base/ssyr2/test/test.ssyr2.js`
- `blas/base/strmv/test/test.ndarray.js`
- `blas/base/strmv/test/test.strmv.js`
- `blas/base/strsv/test/test.strsv.js`

## Related Issues

None.

## Questions

No.

## Other

### Validation

- Search scope: `lib/node_modules/@stdlib/blas/**/test/*.js`. Pattern: two consecutive top-level `var X = require(...);` declarations separated only by a blank line, with no intervening section-header comment — exactly what `stdlib/no-empty-lines-between-requires` flags.
- Two independent validation passes confirmed each candidate site matches the source-commit pattern.
- A style-consistency pass dropped 13 sites across `blas/base/ggemm/test/*`, `blas/base/ggemv/test/*` (none), `blas/base/sgemv/test/test.ndarray.native.js`, `blas/base/sger/test/*`, `blas/base/sgemm/test/*`, and `blas/base/gger/test/*` whose top-of-file directives include `stdlib/no-empty-lines-between-requires` in the `eslint-disable` list — the blank lines there are intentionally permitted, so propagation would either no-op or leave a misleading suppression.
- Deliberately excluded: bench-description fix from PRs #12694–#12696 (search across `lib/node_modules/@stdlib/{blas,stats,math,lapack,ndarray,strided,complex}` returned no remaining sites with the wrong `'%s:native:len=%d'` / `'%s:ndarray:native:len=%d'` formats), and `caxpby` intermediate-variable refactor (sole complex sibling `blas/ext/base/zaxpby` does not carry the same intermediates).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine: scanning recent `develop` commits for generalizable fixes, locating sibling sites with the same defect via the rule's AST semantics, validating each site against the original commit's pattern, and applying verbatim single-line patches.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01PEzK3iHcPjbX3Po1JDK1Dm)_