### PR TITLE
docs: fix notes concerning edge case behavior

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/docs/types/index.d.ts
@@ -71,7 +71,7 @@ interface Namespace {
 	* ## Notes
 	*
 	* -   If `a` or `b` is not an integer value, the function returns `NaN`.
-	* -   If provided `a >= b`, the function returns `NaN`.
+	* -   If provided `a > b`, the function returns `NaN`.
 	*
 	* @param a - minimum support
 	* @param b - maximum support
@@ -113,7 +113,7 @@ interface Namespace {
 	* ## Notes
 	*
 	* -   If `a` or `b` is not an integer value, the function returns `NaN`.
-	* -   If provided `a >= b`, the function returns `NaN`.
+	* -   If provided `a > b`, the function returns `NaN`.
 	*
 	* @param a - minimum support
 	* @param b - maximum support
@@ -197,7 +197,7 @@ interface Namespace {
 	* ## Notes
 	*
 	* -   If `a` or `b` is not an integer value, the function returns `NaN`.
-	* -   If provided `a >= b`, the function returns `NaN`.
+	* -   If provided `a > b`, the function returns `NaN`.
 	*
 	* @param a - minimum support
 	* @param b - maximum support
@@ -239,7 +239,7 @@ interface Namespace {
 	* ## Notes
 	*
 	* -   If `a` or `b` is not an integer value, the function returns `NaN`.
-	* -   If provided `a >= b`, the function returns `NaN`.
+	* -   If provided `a > b`, the function returns `NaN`.
 	*
 	* @param a - minimum support
 	* @param b - maximum support
@@ -350,7 +350,7 @@ interface Namespace {
 	* ## Notes
 	*
 	* -   If `a` or `b` is not an integer value, the function returns `NaN`.
-	* -   If provided `a >= b`, the function returns `NaN`.
+	* -   If provided `a > b`, the function returns `NaN`.
 	*
 	* @param a - minimum support
 	* @param b - maximum support
@@ -392,7 +392,7 @@ interface Namespace {
 	* ## Notes
 	*
 	* -   If `a` or `b` is not an integer value, the function returns `NaN`.
-	* -   If provided `a >= b`, the function returns `NaN`.
+	* -   If provided `a > b`, the function returns `NaN`.
 	*
 	* @param a - minimum support
 	* @param b - maximum support
@@ -434,7 +434,7 @@ interface Namespace {
 	* ## Notes
 	*
 	* -   If `a` or `b` is not an integer value, the function returns `NaN`.
-	* -   If provided `a >= b`, the function returns `NaN`.
+	* -   If provided `a > b`, the function returns `NaN`.
 	*
 	* @param a - minimum support
 	* @param b - maximum support

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/docs/types/index.d.ts
@@ -24,7 +24,7 @@
 * ## Notes
 *
 * -   If `a` or `b` is not an integer value, the function returns `NaN`.
-* -   If provided `a >= b`, the function returns `NaN`.
+* -   If provided `a > b`, the function returns `NaN`.
 *
 * @param a - minimum support
 * @param b - maximum support

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/docs/types/index.d.ts
@@ -24,7 +24,7 @@
 * ## Notes
 *
 * -   If `a` or `b` is not an integer value, the function returns `NaN`.
-* -   If provided `a >= b`, the function returns `NaN`.
+* -   If provided `a > b`, the function returns `NaN`.
 *
 * @param a - minimum support
 * @param b - maximum support

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/docs/types/index.d.ts
@@ -24,7 +24,7 @@
 * ## Notes
 *
 * -   If `a` or `b` is not an integer value, the function returns `NaN`.
-* -   If provided `a >= b`, the function returns `NaN`.
+* -   If provided `a > b`, the function returns `NaN`.
 *
 * @param a - minimum support
 * @param b - maximum support

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/docs/types/index.d.ts
@@ -24,7 +24,7 @@
 * ## Notes
 *
 * -   If `a` or `b` is not an integer value, the function returns `NaN`.
-* -   If provided `a >= b`, the function returns `NaN`.
+* -   If provided `a > b`, the function returns `NaN`.
 *
 * @param a - minimum support
 * @param b - maximum support

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/docs/types/index.d.ts
@@ -24,7 +24,7 @@
 * ## Notes
 *
 * -   If `a` or `b` is not an integer value, the function returns `NaN`.
-* -   If provided `a >= b`, the function returns `NaN`.
+* -   If provided `a > b`, the function returns `NaN`.
 *
 * @param a - minimum support
 * @param b - maximum support

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/docs/types/index.d.ts
@@ -24,7 +24,7 @@
 * ## Notes
 *
 * -   If `a` or `b` is not an integer value, the function returns `NaN`.
-* -   If provided `a >= b`, the function returns `NaN`.
+* -   If provided `a > b`, the function returns `NaN`.
 *
 * @param a - minimum support
 * @param b - maximum support

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/docs/types/index.d.ts
@@ -24,7 +24,7 @@
 * ## Notes
 *
 * -   If `a` or `b` is not an integer value, the function returns `NaN`.
-* -   If provided `a >= b`, the function returns `NaN`.
+* -   If provided `a > b`, the function returns `NaN`.
 *
 * @param a - minimum support
 * @param b - maximum support


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects a stale documentation claim in the `## Notes` JSDoc blocks of the seven summary-statistic packages in `stats/base/dists/discrete-uniform/`. Each package's TypeScript declaration stated that the function returns `NaN` when `a >= b`, but the underlying JavaScript implementation short-circuits only on strict `a > b`; the `a === b` (degenerate single-point) case returns a valid value in every case. The seven Notes occurrences in the namespace aggregator declaration file mirror the same defect and are corrected in the same PR for consistency.

### Namespace summary

-   Target: `stats/base/dists/discrete-uniform/`
-   Members: 14 (`cdf`, `ctor`, `entropy`, `kurtosis`, `logcdf`, `logpmf`, `mean`, `median`, `mgf`, `pmf`, `quantile`, `skewness`, `stdev`, `variance`).
-   Features analyzed: file tree, `package.json` shape, README section structure, `manifest.json` shape, public signature, validation prologue, error construction, JSDoc shape, dependencies, TypeScript declaration JSDoc.
-   Features with a clear (≥75%) majority: file tree, `package.json` shape, README section structure, public signature, validation prologue, error construction (no throws), JSDoc shape, TypeScript declaration JSDoc wording in the six evaluable-at-point siblings.
-   Features without a clear majority (excluded): none material; the structural difference between the constructor (`ctor`) and the thirteen numeric functions is a genuine semantic deviation and was filtered out at the validation step.

### Outlier packages

#### `stats/base/dists/discrete-uniform/entropy`

`docs/types/index.d.ts` Notes claimed `a >= b` returns `NaN`. Source returns `NaN` only on strict `a > b`; `entropy( N, N )` returns `0` (entropy of a degenerate distribution). Conformance: 100% of sibling JS sources and 100% of sibling READMEs use the strict form.

#### `stats/base/dists/discrete-uniform/kurtosis`

Same Notes defect. Source short-circuits on `a > b`; `kurtosis( N, N )` evaluates the formula (which is finite by construction). Conformance: 6/6 evaluable siblings use the strict form in their TS Notes.

#### `stats/base/dists/discrete-uniform/mean`

Same Notes defect. Source short-circuits on `a > b`; `mean( N, N )` returns `N`. Conformance: 6/6 evaluable siblings use the strict form.

#### `stats/base/dists/discrete-uniform/median`

Same Notes defect. Source short-circuits on `a > b`; `median( N, N )` returns `N`. Conformance: 6/6 evaluable siblings use the strict form.

#### `stats/base/dists/discrete-uniform/skewness`

Same Notes defect. Source short-circuits on `a > b`; `skewness( N, N )` returns `0`. Conformance: 6/6 evaluable siblings use the strict form.

#### `stats/base/dists/discrete-uniform/stdev`

Same Notes defect. Source short-circuits on `a > b`; `stdev( N, N )` returns `0`. Conformance: 6/6 evaluable siblings use the strict form.

#### `stats/base/dists/discrete-uniform/variance`

Same Notes defect. Source short-circuits on `a > b`; `variance( N, N )` returns `0`. Conformance: 6/6 evaluable siblings use the strict form.

#### `stats/base/dists/discrete-uniform` (namespace aggregator)

The namespace-level `docs/types/index.d.ts` mirrors the per-package JSDoc Notes for the same seven interfaces, all with the `a >= b` defect. All seven occurrences corrected.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

The corrections were derived by an automated cross-package drift sweep over `stats/base/dists/discrete-uniform/`:

-   **Structural extraction** — per-package file trees, `package.json` keys, `manifest.json` keys, README section order, and `test`/`benchmark`/`examples` filenames.
-   **Semantic extraction** — per-package agents read `lib/main.js` and `lib/index.js` and emitted public signature, validation prologue, return kind, error construction, JSDoc shape, and dependency list.
-   **Three-agent drift validation** — semantic-review (read each outlier's source and confirmed the deviation is a stale JSDoc claim, not an intentional semantic difference), cross-reference (read each outlier's `test/test.js`, `test/test.native.js`, `examples/index.js`, and `docs/types/test.ts` and confirmed no test asserts NaN-for-equal-inputs; verified no sibling README contradicts the fix), and structural-review (confirmed the six reference packages consistently use the strict-`>` wording and that only the one Notes line per outlier needs editing).

Deliberately excluded from this PR:

-   The structural differences between `ctor` (constructor, no native bindings, distinct JSDoc shape) and the thirteen numeric functions — intentional, not drift.
-   The cross-package observation that `docs/types/index.d.ts` Notes wording splits 6/13 vs. 7/13 across the namespace was treated as an internal-consistency defect (TS docs disagree with the package's own JS source and README) rather than as a majority-vs-outlier vote, since neither value clears the 75% bar in isolation.
-   No autogenerated artifacts (`## See Also` sections, REPL fixtures) were touched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift sweep. Per-package feature extraction and three-agent drift validation were performed by Claude subagents; each correction was confirmed against the JS source, README, and sibling-package TS declarations before being applied. A human maintainer should verify before promoting out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUyejHHVcY4RSFPbri96Jc)_