### PR TITLE
test: add missing closing brace in TypeScript test files

### DIFF
--- a/lib/node_modules/@stdlib/random/array/minstd-shuffle/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/array/minstd-shuffle/docs/types/test.ts
@@ -156,7 +156,7 @@ import random = require( './index' );
 	random.factory( { 'name': null } ); // $ExpectError
 	random.factory( { 'name': [] } ); // $ExpectError
 	random.factory( { 'name': {} } ); // $ExpectError
-	random.factory( { 'name': true ); // $ExpectError
+	random.factory( { 'name': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -176,7 +176,7 @@ import random = require( './index' );
 	random.factory( { 'state': null } ); // $ExpectError
 	random.factory( { 'state': [] } ); // $ExpectError
 	random.factory( { 'state': {} } ); // $ExpectError
-	random.factory( { 'state': true ); // $ExpectError
+	random.factory( { 'state': true } ); // $ExpectError
 	random.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/array/minstd/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/array/minstd/docs/types/test.ts
@@ -156,7 +156,7 @@ import random = require( './index' );
 	random.factory( { 'name': null } ); // $ExpectError
 	random.factory( { 'name': [] } ); // $ExpectError
 	random.factory( { 'name': {} } ); // $ExpectError
-	random.factory( { 'name': true ); // $ExpectError
+	random.factory( { 'name': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -176,7 +176,7 @@ import random = require( './index' );
 	random.factory( { 'state': null } ); // $ExpectError
 	random.factory( { 'state': [] } ); // $ExpectError
 	random.factory( { 'state': {} } ); // $ExpectError
-	random.factory( { 'state': true ); // $ExpectError
+	random.factory( { 'state': true } ); // $ExpectError
 	random.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/array/mt19937/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/array/mt19937/docs/types/test.ts
@@ -156,7 +156,7 @@ import random = require( './index' );
 	random.factory( { 'name': null } ); // $ExpectError
 	random.factory( { 'name': [] } ); // $ExpectError
 	random.factory( { 'name': {} } ); // $ExpectError
-	random.factory( { 'name': true ); // $ExpectError
+	random.factory( { 'name': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -176,7 +176,7 @@ import random = require( './index' );
 	random.factory( { 'state': null } ); // $ExpectError
 	random.factory( { 'state': [] } ); // $ExpectError
 	random.factory( { 'state': {} } ); // $ExpectError
-	random.factory( { 'state': true ); // $ExpectError
+	random.factory( { 'state': true } ); // $ExpectError
 	random.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/array/randu/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/array/randu/docs/types/test.ts
@@ -98,7 +98,7 @@ import random = require( './index' );
 	random.factory( { 'name': null } ); // $ExpectError
 	random.factory( { 'name': [] } ); // $ExpectError
 	random.factory( { 'name': {} } ); // $ExpectError
-	random.factory( { 'name': true ); // $ExpectError
+	random.factory( { 'name': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -118,7 +118,7 @@ import random = require( './index' );
 	random.factory( { 'state': null } ); // $ExpectError
 	random.factory( { 'state': [] } ); // $ExpectError
 	random.factory( { 'state': {} } ); // $ExpectError
-	random.factory( { 'state': true ); // $ExpectError
+	random.factory( { 'state': true } ); // $ExpectError
 	random.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/arcsine/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/arcsine/docs/types/test.ts
@@ -151,14 +151,14 @@ import arcsine = require( './index' );
 	arcsine.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	arcsine.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	arcsine.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	arcsine.factory( 2, 2, { 'prng': true ); // $ExpectError
+	arcsine.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	arcsine.factory( { 'prng': 123 } ); // $ExpectError
 	arcsine.factory( { 'prng': 'abc' } ); // $ExpectError
 	arcsine.factory( { 'prng': null } ); // $ExpectError
 	arcsine.factory( { 'prng': [] } ); // $ExpectError
 	arcsine.factory( { 'prng': {} } ); // $ExpectError
-	arcsine.factory( { 'prng': true ); // $ExpectError
+	arcsine.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import arcsine = require( './index' );
 	arcsine.factory( 2, 2, { 'state': null } ); // $ExpectError
 	arcsine.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	arcsine.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	arcsine.factory( 2, 2, { 'state': true ); // $ExpectError
+	arcsine.factory( 2, 2, { 'state': true } ); // $ExpectError
 	arcsine.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	arcsine.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import arcsine = require( './index' );
 	arcsine.factory( { 'state': null } ); // $ExpectError
 	arcsine.factory( { 'state': [] } ); // $ExpectError
 	arcsine.factory( { 'state': {} } ); // $ExpectError
-	arcsine.factory( { 'state': true ); // $ExpectError
+	arcsine.factory( { 'state': true } ); // $ExpectError
 	arcsine.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/beta/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/beta/docs/types/test.ts
@@ -151,14 +151,14 @@ import beta = require( './index' );
 	beta.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	beta.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	beta.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	beta.factory( 2, 2, { 'prng': true ); // $ExpectError
+	beta.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	beta.factory( { 'prng': 123 } ); // $ExpectError
 	beta.factory( { 'prng': 'abc' } ); // $ExpectError
 	beta.factory( { 'prng': null } ); // $ExpectError
 	beta.factory( { 'prng': [] } ); // $ExpectError
 	beta.factory( { 'prng': {} } ); // $ExpectError
-	beta.factory( { 'prng': true ); // $ExpectError
+	beta.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import beta = require( './index' );
 	beta.factory( 2, 2, { 'state': null } ); // $ExpectError
 	beta.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	beta.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	beta.factory( 2, 2, { 'state': true ); // $ExpectError
+	beta.factory( 2, 2, { 'state': true } ); // $ExpectError
 	beta.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	beta.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import beta = require( './index' );
 	beta.factory( { 'state': null } ); // $ExpectError
 	beta.factory( { 'state': [] } ); // $ExpectError
 	beta.factory( { 'state': {} } ); // $ExpectError
-	beta.factory( { 'state': true ); // $ExpectError
+	beta.factory( { 'state': true } ); // $ExpectError
 	beta.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/betaprime/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/betaprime/docs/types/test.ts
@@ -151,14 +151,14 @@ import betaprime = require( './index' );
 	betaprime.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	betaprime.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	betaprime.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	betaprime.factory( 2, 2, { 'prng': true ); // $ExpectError
+	betaprime.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	betaprime.factory( { 'prng': 123 } ); // $ExpectError
 	betaprime.factory( { 'prng': 'abc' } ); // $ExpectError
 	betaprime.factory( { 'prng': null } ); // $ExpectError
 	betaprime.factory( { 'prng': [] } ); // $ExpectError
 	betaprime.factory( { 'prng': {} } ); // $ExpectError
-	betaprime.factory( { 'prng': true ); // $ExpectError
+	betaprime.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import betaprime = require( './index' );
 	betaprime.factory( 2, 2, { 'state': null } ); // $ExpectError
 	betaprime.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	betaprime.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	betaprime.factory( 2, 2, { 'state': true ); // $ExpectError
+	betaprime.factory( 2, 2, { 'state': true } ); // $ExpectError
 	betaprime.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	betaprime.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import betaprime = require( './index' );
 	betaprime.factory( { 'state': null } ); // $ExpectError
 	betaprime.factory( { 'state': [] } ); // $ExpectError
 	betaprime.factory( { 'state': {} } ); // $ExpectError
-	betaprime.factory( { 'state': true ); // $ExpectError
+	betaprime.factory( { 'state': true } ); // $ExpectError
 	betaprime.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/binomial/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/binomial/docs/types/test.ts
@@ -151,14 +151,14 @@ import binomial = require( './index' );
 	binomial.factory( 20, 0.3, { 'prng': null } ); // $ExpectError
 	binomial.factory( 20, 0.3, { 'prng': [] } ); // $ExpectError
 	binomial.factory( 20, 0.3, { 'prng': {} } ); // $ExpectError
-	binomial.factory( 20, 0.3, { 'prng': true ); // $ExpectError
+	binomial.factory( 20, 0.3, { 'prng': true } ); // $ExpectError
 
 	binomial.factory( { 'prng': 123 } ); // $ExpectError
 	binomial.factory( { 'prng': 'abc' } ); // $ExpectError
 	binomial.factory( { 'prng': null } ); // $ExpectError
 	binomial.factory( { 'prng': [] } ); // $ExpectError
 	binomial.factory( { 'prng': {} } ); // $ExpectError
-	binomial.factory( { 'prng': true ); // $ExpectError
+	binomial.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import binomial = require( './index' );
 	binomial.factory( 20, 0.3, { 'state': null } ); // $ExpectError
 	binomial.factory( 20, 0.3, { 'state': [] } ); // $ExpectError
 	binomial.factory( 20, 0.3, { 'state': {} } ); // $ExpectError
-	binomial.factory( 20, 0.3, { 'state': true ); // $ExpectError
+	binomial.factory( 20, 0.3, { 'state': true } ); // $ExpectError
 	binomial.factory( 20, 0.3, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	binomial.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import binomial = require( './index' );
 	binomial.factory( { 'state': null } ); // $ExpectError
 	binomial.factory( { 'state': [] } ); // $ExpectError
 	binomial.factory( { 'state': {} } ); // $ExpectError
-	binomial.factory( { 'state': true ); // $ExpectError
+	binomial.factory( { 'state': true } ); // $ExpectError
 	binomial.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/box-muller/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/box-muller/docs/types/test.ts
@@ -64,7 +64,7 @@ import randn = require( './index' );
 	randn.factory( { 'prng': null } ); // $ExpectError
 	randn.factory( { 'prng': [] } ); // $ExpectError
 	randn.factory( { 'prng': {} } ); // $ExpectError
-	randn.factory( { 'prng': true ); // $ExpectError
+	randn.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -84,7 +84,7 @@ import randn = require( './index' );
 	randn.factory( { 'state': null } ); // $ExpectError
 	randn.factory( { 'state': [] } ); // $ExpectError
 	randn.factory( { 'state': {} } ); // $ExpectError
-	randn.factory( { 'state': true ); // $ExpectError
+	randn.factory( { 'state': true } ); // $ExpectError
 	randn.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/cauchy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/cauchy/docs/types/test.ts
@@ -151,14 +151,14 @@ import cauchy = require( './index' );
 	cauchy.factory( -2, 2, { 'prng': null } ); // $ExpectError
 	cauchy.factory( -2, 2, { 'prng': [] } ); // $ExpectError
 	cauchy.factory( -2, 2, { 'prng': {} } ); // $ExpectError
-	cauchy.factory( -2, 2, { 'prng': true ); // $ExpectError
+	cauchy.factory( -2, 2, { 'prng': true } ); // $ExpectError
 
 	cauchy.factory( { 'prng': 123 } ); // $ExpectError
 	cauchy.factory( { 'prng': 'abc' } ); // $ExpectError
 	cauchy.factory( { 'prng': null } ); // $ExpectError
 	cauchy.factory( { 'prng': [] } ); // $ExpectError
 	cauchy.factory( { 'prng': {} } ); // $ExpectError
-	cauchy.factory( { 'prng': true ); // $ExpectError
+	cauchy.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import cauchy = require( './index' );
 	cauchy.factory( -2, 2, { 'state': null } ); // $ExpectError
 	cauchy.factory( -2, 2, { 'state': [] } ); // $ExpectError
 	cauchy.factory( -2, 2, { 'state': {} } ); // $ExpectError
-	cauchy.factory( -2, 2, { 'state': true ); // $ExpectError
+	cauchy.factory( -2, 2, { 'state': true } ); // $ExpectError
 	cauchy.factory( -2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	cauchy.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import cauchy = require( './index' );
 	cauchy.factory( { 'state': null } ); // $ExpectError
 	cauchy.factory( { 'state': [] } ); // $ExpectError
 	cauchy.factory( { 'state': {} } ); // $ExpectError
-	cauchy.factory( { 'state': true ); // $ExpectError
+	cauchy.factory( { 'state': true } ); // $ExpectError
 	cauchy.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/cosine/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/cosine/docs/types/test.ts
@@ -151,14 +151,14 @@ import cosine = require( './index' );
 	cosine.factory( -2, 2, { 'prng': null } ); // $ExpectError
 	cosine.factory( -2, 2, { 'prng': [] } ); // $ExpectError
 	cosine.factory( -2, 2, { 'prng': {} } ); // $ExpectError
-	cosine.factory( -2, 2, { 'prng': true ); // $ExpectError
+	cosine.factory( -2, 2, { 'prng': true } ); // $ExpectError
 
 	cosine.factory( { 'prng': 123 } ); // $ExpectError
 	cosine.factory( { 'prng': 'abc' } ); // $ExpectError
 	cosine.factory( { 'prng': null } ); // $ExpectError
 	cosine.factory( { 'prng': [] } ); // $ExpectError
 	cosine.factory( { 'prng': {} } ); // $ExpectError
-	cosine.factory( { 'prng': true ); // $ExpectError
+	cosine.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import cosine = require( './index' );
 	cosine.factory( -2, 2, { 'state': null } ); // $ExpectError
 	cosine.factory( -2, 2, { 'state': [] } ); // $ExpectError
 	cosine.factory( -2, 2, { 'state': {} } ); // $ExpectError
-	cosine.factory( -2, 2, { 'state': true ); // $ExpectError
+	cosine.factory( -2, 2, { 'state': true } ); // $ExpectError
 	cosine.factory( -2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	cosine.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import cosine = require( './index' );
 	cosine.factory( { 'state': null } ); // $ExpectError
 	cosine.factory( { 'state': [] } ); // $ExpectError
 	cosine.factory( { 'state': {} } ); // $ExpectError
-	cosine.factory( { 'state': true ); // $ExpectError
+	cosine.factory( { 'state': true } ); // $ExpectError
 	cosine.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/discrete-uniform/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/discrete-uniform/docs/types/test.ts
@@ -151,14 +151,14 @@ import discreteUniform = require( './index' );
 	discreteUniform.factory( 0, 4, { 'prng': null } ); // $ExpectError
 	discreteUniform.factory( 0, 4, { 'prng': [] } ); // $ExpectError
 	discreteUniform.factory( 0, 4, { 'prng': {} } ); // $ExpectError
-	discreteUniform.factory( 0, 4, { 'prng': true ); // $ExpectError
+	discreteUniform.factory( 0, 4, { 'prng': true } ); // $ExpectError
 
 	discreteUniform.factory( { 'prng': 123 } ); // $ExpectError
 	discreteUniform.factory( { 'prng': 'abc' } ); // $ExpectError
 	discreteUniform.factory( { 'prng': null } ); // $ExpectError
 	discreteUniform.factory( { 'prng': [] } ); // $ExpectError
 	discreteUniform.factory( { 'prng': {} } ); // $ExpectError
-	discreteUniform.factory( { 'prng': true ); // $ExpectError
+	discreteUniform.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import discreteUniform = require( './index' );
 	discreteUniform.factory( 0, 4, { 'state': null } ); // $ExpectError
 	discreteUniform.factory( 0, 4, { 'state': [] } ); // $ExpectError
 	discreteUniform.factory( 0, 4, { 'state': {} } ); // $ExpectError
-	discreteUniform.factory( 0, 4, { 'state': true ); // $ExpectError
+	discreteUniform.factory( 0, 4, { 'state': true } ); // $ExpectError
 	discreteUniform.factory( 0, 4, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	discreteUniform.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import discreteUniform = require( './index' );
 	discreteUniform.factory( { 'state': null } ); // $ExpectError
 	discreteUniform.factory( { 'state': [] } ); // $ExpectError
 	discreteUniform.factory( { 'state': {} } ); // $ExpectError
-	discreteUniform.factory( { 'state': true ); // $ExpectError
+	discreteUniform.factory( { 'state': true } ); // $ExpectError
 	discreteUniform.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/erlang/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/erlang/docs/types/test.ts
@@ -151,14 +151,14 @@ import erlang = require( './index' );
 	erlang.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	erlang.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	erlang.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	erlang.factory( 2, 2, { 'prng': true ); // $ExpectError
+	erlang.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	erlang.factory( { 'prng': 123 } ); // $ExpectError
 	erlang.factory( { 'prng': 'abc' } ); // $ExpectError
 	erlang.factory( { 'prng': null } ); // $ExpectError
 	erlang.factory( { 'prng': [] } ); // $ExpectError
 	erlang.factory( { 'prng': {} } ); // $ExpectError
-	erlang.factory( { 'prng': true ); // $ExpectError
+	erlang.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import erlang = require( './index' );
 	erlang.factory( 2, 2, { 'state': null } ); // $ExpectError
 	erlang.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	erlang.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	erlang.factory( 2, 2, { 'state': true ); // $ExpectError
+	erlang.factory( 2, 2, { 'state': true } ); // $ExpectError
 	erlang.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	erlang.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import erlang = require( './index' );
 	erlang.factory( { 'state': null } ); // $ExpectError
 	erlang.factory( { 'state': [] } ); // $ExpectError
 	erlang.factory( { 'state': {} } ); // $ExpectError
-	erlang.factory( { 'state': true ); // $ExpectError
+	erlang.factory( { 'state': true } ); // $ExpectError
 	erlang.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/f/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/f/docs/types/test.ts
@@ -151,14 +151,14 @@ import f = require( './index' );
 	f.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	f.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	f.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	f.factory( 2, 2, { 'prng': true ); // $ExpectError
+	f.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	f.factory( { 'prng': 123 } ); // $ExpectError
 	f.factory( { 'prng': 'abc' } ); // $ExpectError
 	f.factory( { 'prng': null } ); // $ExpectError
 	f.factory( { 'prng': [] } ); // $ExpectError
 	f.factory( { 'prng': {} } ); // $ExpectError
-	f.factory( { 'prng': true ); // $ExpectError
+	f.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import f = require( './index' );
 	f.factory( 2, 2, { 'state': null } ); // $ExpectError
 	f.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	f.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	f.factory( 2, 2, { 'state': true ); // $ExpectError
+	f.factory( 2, 2, { 'state': true } ); // $ExpectError
 	f.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	f.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import f = require( './index' );
 	f.factory( { 'state': null } ); // $ExpectError
 	f.factory( { 'state': [] } ); // $ExpectError
 	f.factory( { 'state': {} } ); // $ExpectError
-	f.factory( { 'state': true ); // $ExpectError
+	f.factory( { 'state': true } ); // $ExpectError
 	f.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/frechet/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/frechet/docs/types/test.ts
@@ -62,8 +62,8 @@ import frechet = require( './index' );
 // Attached to main export is a `factory` method which returns a function...
 {
 	frechet.factory( 2, 2, 0.7 ); // $ExpectType NullaryFunction
-	frechet.factory(); // $ExpectType BinaryFunction
-	frechet.factory( { 'copy': false } ); // $ExpectType BinaryFunction
+	frechet.factory(); // $ExpectType TernaryFunction
+	frechet.factory( { 'copy': false } ); // $ExpectType TernaryFunction
 }
 
 // The `factory` method returns a function which returns a number...
@@ -180,14 +180,14 @@ import frechet = require( './index' );
 	frechet.factory( 2, 2, 0.5, { 'prng': null } ); // $ExpectError
 	frechet.factory( 2, 2, 0.5, { 'prng': [] } ); // $ExpectError
 	frechet.factory( 2, 2, 0.5, { 'prng': {} } ); // $ExpectError
-	frechet.factory( 2, 2, 0.5, { 'prng': true ); // $ExpectError
+	frechet.factory( 2, 2, 0.5, { 'prng': true } ); // $ExpectError
 
 	frechet.factory( { 'prng': 123 } ); // $ExpectError
 	frechet.factory( { 'prng': 'abc' } ); // $ExpectError
 	frechet.factory( { 'prng': null } ); // $ExpectError
 	frechet.factory( { 'prng': [] } ); // $ExpectError
 	frechet.factory( { 'prng': {} } ); // $ExpectError
-	frechet.factory( { 'prng': true ); // $ExpectError
+	frechet.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -214,7 +214,7 @@ import frechet = require( './index' );
 	frechet.factory( 2, 2, 0.5, { 'state': null } ); // $ExpectError
 	frechet.factory( 2, 2, 0.5, { 'state': [] } ); // $ExpectError
 	frechet.factory( 2, 2, 0.5, { 'state': {} } ); // $ExpectError
-	frechet.factory( 2, 2, 0.5, { 'state': true ); // $ExpectError
+	frechet.factory( 2, 2, 0.5, { 'state': true } ); // $ExpectError
 	frechet.factory( 2, 2, 0.5, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	frechet.factory( { 'state': 123 } ); // $ExpectError
@@ -222,7 +222,7 @@ import frechet = require( './index' );
 	frechet.factory( { 'state': null } ); // $ExpectError
 	frechet.factory( { 'state': [] } ); // $ExpectError
 	frechet.factory( { 'state': {} } ); // $ExpectError
-	frechet.factory( { 'state': true ); // $ExpectError
+	frechet.factory( { 'state': true } ); // $ExpectError
 	frechet.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/gamma/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/gamma/docs/types/test.ts
@@ -151,14 +151,14 @@ import gamma = require( './index' );
 	gamma.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	gamma.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	gamma.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	gamma.factory( 2, 2, { 'prng': true ); // $ExpectError
+	gamma.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	gamma.factory( { 'prng': 123 } ); // $ExpectError
 	gamma.factory( { 'prng': 'abc' } ); // $ExpectError
 	gamma.factory( { 'prng': null } ); // $ExpectError
 	gamma.factory( { 'prng': [] } ); // $ExpectError
 	gamma.factory( { 'prng': {} } ); // $ExpectError
-	gamma.factory( { 'prng': true ); // $ExpectError
+	gamma.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import gamma = require( './index' );
 	gamma.factory( 2, 2, { 'state': null } ); // $ExpectError
 	gamma.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	gamma.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	gamma.factory( 2, 2, { 'state': true ); // $ExpectError
+	gamma.factory( 2, 2, { 'state': true } ); // $ExpectError
 	gamma.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	gamma.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import gamma = require( './index' );
 	gamma.factory( { 'state': null } ); // $ExpectError
 	gamma.factory( { 'state': [] } ); // $ExpectError
 	gamma.factory( { 'state': {} } ); // $ExpectError
-	gamma.factory( { 'state': true ); // $ExpectError
+	gamma.factory( { 'state': true } ); // $ExpectError
 	gamma.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/gumbel/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/gumbel/docs/types/test.ts
@@ -151,14 +151,14 @@ import gumbel = require( './index' );
 	gumbel.factory( -2, 2, { 'prng': null } ); // $ExpectError
 	gumbel.factory( -2, 2, { 'prng': [] } ); // $ExpectError
 	gumbel.factory( -2, 2, { 'prng': {} } ); // $ExpectError
-	gumbel.factory( -2, 2, { 'prng': true ); // $ExpectError
+	gumbel.factory( -2, 2, { 'prng': true } ); // $ExpectError
 
 	gumbel.factory( { 'prng': 123 } ); // $ExpectError
 	gumbel.factory( { 'prng': 'abc' } ); // $ExpectError
 	gumbel.factory( { 'prng': null } ); // $ExpectError
 	gumbel.factory( { 'prng': [] } ); // $ExpectError
 	gumbel.factory( { 'prng': {} } ); // $ExpectError
-	gumbel.factory( { 'prng': true ); // $ExpectError
+	gumbel.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import gumbel = require( './index' );
 	gumbel.factory( -2, 2, { 'state': null } ); // $ExpectError
 	gumbel.factory( -2, 2, { 'state': [] } ); // $ExpectError
 	gumbel.factory( -2, 2, { 'state': {} } ); // $ExpectError
-	gumbel.factory( -2, 2, { 'state': true ); // $ExpectError
+	gumbel.factory( -2, 2, { 'state': true } ); // $ExpectError
 	gumbel.factory( -2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	gumbel.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import gumbel = require( './index' );
 	gumbel.factory( { 'state': null } ); // $ExpectError
 	gumbel.factory( { 'state': [] } ); // $ExpectError
 	gumbel.factory( { 'state': {} } ); // $ExpectError
-	gumbel.factory( { 'state': true ); // $ExpectError
+	gumbel.factory( { 'state': true } ); // $ExpectError
 	gumbel.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/improved-ziggurat/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/improved-ziggurat/docs/types/test.ts
@@ -64,7 +64,7 @@ import randn = require( './index' );
 	randn.factory( { 'prng': null } ); // $ExpectError
 	randn.factory( { 'prng': [] } ); // $ExpectError
 	randn.factory( { 'prng': {} } ); // $ExpectError
-	randn.factory( { 'prng': true ); // $ExpectError
+	randn.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -84,7 +84,7 @@ import randn = require( './index' );
 	randn.factory( { 'state': null } ); // $ExpectError
 	randn.factory( { 'state': [] } ); // $ExpectError
 	randn.factory( { 'state': {} } ); // $ExpectError
-	randn.factory( { 'state': true ); // $ExpectError
+	randn.factory( { 'state': true } ); // $ExpectError
 	randn.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/invgamma/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/invgamma/docs/types/test.ts
@@ -151,14 +151,14 @@ import invgamma = require( './index' );
 	invgamma.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	invgamma.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	invgamma.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	invgamma.factory( 2, 2, { 'prng': true ); // $ExpectError
+	invgamma.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	invgamma.factory( { 'prng': 123 } ); // $ExpectError
 	invgamma.factory( { 'prng': 'abc' } ); // $ExpectError
 	invgamma.factory( { 'prng': null } ); // $ExpectError
 	invgamma.factory( { 'prng': [] } ); // $ExpectError
 	invgamma.factory( { 'prng': {} } ); // $ExpectError
-	invgamma.factory( { 'prng': true ); // $ExpectError
+	invgamma.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import invgamma = require( './index' );
 	invgamma.factory( 2, 2, { 'state': null } ); // $ExpectError
 	invgamma.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	invgamma.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	invgamma.factory( 2, 2, { 'state': true ); // $ExpectError
+	invgamma.factory( 2, 2, { 'state': true } ); // $ExpectError
 	invgamma.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	invgamma.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import invgamma = require( './index' );
 	invgamma.factory( { 'state': null } ); // $ExpectError
 	invgamma.factory( { 'state': [] } ); // $ExpectError
 	invgamma.factory( { 'state': {} } ); // $ExpectError
-	invgamma.factory( { 'state': true ); // $ExpectError
+	invgamma.factory( { 'state': true } ); // $ExpectError
 	invgamma.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/kumaraswamy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/kumaraswamy/docs/types/test.ts
@@ -151,14 +151,14 @@ import kumaraswamy = require( './index' );
 	kumaraswamy.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	kumaraswamy.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	kumaraswamy.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	kumaraswamy.factory( 2, 2, { 'prng': true ); // $ExpectError
+	kumaraswamy.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	kumaraswamy.factory( { 'prng': 123 } ); // $ExpectError
 	kumaraswamy.factory( { 'prng': 'abc' } ); // $ExpectError
 	kumaraswamy.factory( { 'prng': null } ); // $ExpectError
 	kumaraswamy.factory( { 'prng': [] } ); // $ExpectError
 	kumaraswamy.factory( { 'prng': {} } ); // $ExpectError
-	kumaraswamy.factory( { 'prng': true ); // $ExpectError
+	kumaraswamy.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import kumaraswamy = require( './index' );
 	kumaraswamy.factory( 2, 2, { 'state': null } ); // $ExpectError
 	kumaraswamy.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	kumaraswamy.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	kumaraswamy.factory( 2, 2, { 'state': true ); // $ExpectError
+	kumaraswamy.factory( 2, 2, { 'state': true } ); // $ExpectError
 	kumaraswamy.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	kumaraswamy.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import kumaraswamy = require( './index' );
 	kumaraswamy.factory( { 'state': null } ); // $ExpectError
 	kumaraswamy.factory( { 'state': [] } ); // $ExpectError
 	kumaraswamy.factory( { 'state': {} } ); // $ExpectError
-	kumaraswamy.factory( { 'state': true ); // $ExpectError
+	kumaraswamy.factory( { 'state': true } ); // $ExpectError
 	kumaraswamy.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/laplace/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/laplace/docs/types/test.ts
@@ -151,14 +151,14 @@ import laplace = require( './index' );
 	laplace.factory( -2, 2, { 'prng': null } ); // $ExpectError
 	laplace.factory( -2, 2, { 'prng': [] } ); // $ExpectError
 	laplace.factory( -2, 2, { 'prng': {} } ); // $ExpectError
-	laplace.factory( -2, 2, { 'prng': true ); // $ExpectError
+	laplace.factory( -2, 2, { 'prng': true } ); // $ExpectError
 
 	laplace.factory( { 'prng': 123 } ); // $ExpectError
 	laplace.factory( { 'prng': 'abc' } ); // $ExpectError
 	laplace.factory( { 'prng': null } ); // $ExpectError
 	laplace.factory( { 'prng': [] } ); // $ExpectError
 	laplace.factory( { 'prng': {} } ); // $ExpectError
-	laplace.factory( { 'prng': true ); // $ExpectError
+	laplace.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import laplace = require( './index' );
 	laplace.factory( -2, 2, { 'state': null } ); // $ExpectError
 	laplace.factory( -2, 2, { 'state': [] } ); // $ExpectError
 	laplace.factory( -2, 2, { 'state': {} } ); // $ExpectError
-	laplace.factory( -2, 2, { 'state': true ); // $ExpectError
+	laplace.factory( -2, 2, { 'state': true } ); // $ExpectError
 	laplace.factory( -2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	laplace.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import laplace = require( './index' );
 	laplace.factory( { 'state': null } ); // $ExpectError
 	laplace.factory( { 'state': [] } ); // $ExpectError
 	laplace.factory( { 'state': {} } ); // $ExpectError
-	laplace.factory( { 'state': true ); // $ExpectError
+	laplace.factory( { 'state': true } ); // $ExpectError
 	laplace.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/levy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/levy/docs/types/test.ts
@@ -151,14 +151,14 @@ import levy = require( './index' );
 	levy.factory( -2, 2, { 'prng': null } ); // $ExpectError
 	levy.factory( -2, 2, { 'prng': [] } ); // $ExpectError
 	levy.factory( -2, 2, { 'prng': {} } ); // $ExpectError
-	levy.factory( -2, 2, { 'prng': true ); // $ExpectError
+	levy.factory( -2, 2, { 'prng': true } ); // $ExpectError
 
 	levy.factory( { 'prng': 123 } ); // $ExpectError
 	levy.factory( { 'prng': 'abc' } ); // $ExpectError
 	levy.factory( { 'prng': null } ); // $ExpectError
 	levy.factory( { 'prng': [] } ); // $ExpectError
 	levy.factory( { 'prng': {} } ); // $ExpectError
-	levy.factory( { 'prng': true ); // $ExpectError
+	levy.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import levy = require( './index' );
 	levy.factory( -2, 2, { 'state': null } ); // $ExpectError
 	levy.factory( -2, 2, { 'state': [] } ); // $ExpectError
 	levy.factory( -2, 2, { 'state': {} } ); // $ExpectError
-	levy.factory( -2, 2, { 'state': true ); // $ExpectError
+	levy.factory( -2, 2, { 'state': true } ); // $ExpectError
 	levy.factory( -2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	levy.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import levy = require( './index' );
 	levy.factory( { 'state': null } ); // $ExpectError
 	levy.factory( { 'state': [] } ); // $ExpectError
 	levy.factory( { 'state': {} } ); // $ExpectError
-	levy.factory( { 'state': true ); // $ExpectError
+	levy.factory( { 'state': true } ); // $ExpectError
 	levy.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/logistic/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/logistic/docs/types/test.ts
@@ -151,14 +151,14 @@ import logistic = require( './index' );
 	logistic.factory( -2, 2, { 'prng': null } ); // $ExpectError
 	logistic.factory( -2, 2, { 'prng': [] } ); // $ExpectError
 	logistic.factory( -2, 2, { 'prng': {} } ); // $ExpectError
-	logistic.factory( -2, 2, { 'prng': true ); // $ExpectError
+	logistic.factory( -2, 2, { 'prng': true } ); // $ExpectError
 
 	logistic.factory( { 'prng': 123 } ); // $ExpectError
 	logistic.factory( { 'prng': 'abc' } ); // $ExpectError
 	logistic.factory( { 'prng': null } ); // $ExpectError
 	logistic.factory( { 'prng': [] } ); // $ExpectError
 	logistic.factory( { 'prng': {} } ); // $ExpectError
-	logistic.factory( { 'prng': true ); // $ExpectError
+	logistic.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import logistic = require( './index' );
 	logistic.factory( -2, 2, { 'state': null } ); // $ExpectError
 	logistic.factory( -2, 2, { 'state': [] } ); // $ExpectError
 	logistic.factory( -2, 2, { 'state': {} } ); // $ExpectError
-	logistic.factory( -2, 2, { 'state': true ); // $ExpectError
+	logistic.factory( -2, 2, { 'state': true } ); // $ExpectError
 	logistic.factory( -2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	logistic.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import logistic = require( './index' );
 	logistic.factory( { 'state': null } ); // $ExpectError
 	logistic.factory( { 'state': [] } ); // $ExpectError
 	logistic.factory( { 'state': {} } ); // $ExpectError
-	logistic.factory( { 'state': true ); // $ExpectError
+	logistic.factory( { 'state': true } ); // $ExpectError
 	logistic.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/lognormal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/lognormal/docs/types/test.ts
@@ -151,14 +151,14 @@ import lognormal = require( './index' );
 	lognormal.factory( -2, 2, { 'prng': null } ); // $ExpectError
 	lognormal.factory( -2, 2, { 'prng': [] } ); // $ExpectError
 	lognormal.factory( -2, 2, { 'prng': {} } ); // $ExpectError
-	lognormal.factory( -2, 2, { 'prng': true ); // $ExpectError
+	lognormal.factory( -2, 2, { 'prng': true } ); // $ExpectError
 
 	lognormal.factory( { 'prng': 123 } ); // $ExpectError
 	lognormal.factory( { 'prng': 'abc' } ); // $ExpectError
 	lognormal.factory( { 'prng': null } ); // $ExpectError
 	lognormal.factory( { 'prng': [] } ); // $ExpectError
 	lognormal.factory( { 'prng': {} } ); // $ExpectError
-	lognormal.factory( { 'prng': true ); // $ExpectError
+	lognormal.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import lognormal = require( './index' );
 	lognormal.factory( -2, 2, { 'state': null } ); // $ExpectError
 	lognormal.factory( -2, 2, { 'state': [] } ); // $ExpectError
 	lognormal.factory( -2, 2, { 'state': {} } ); // $ExpectError
-	lognormal.factory( -2, 2, { 'state': true ); // $ExpectError
+	lognormal.factory( -2, 2, { 'state': true } ); // $ExpectError
 	lognormal.factory( -2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	lognormal.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import lognormal = require( './index' );
 	lognormal.factory( { 'state': null } ); // $ExpectError
 	lognormal.factory( { 'state': [] } ); // $ExpectError
 	lognormal.factory( { 'state': {} } ); // $ExpectError
-	lognormal.factory( { 'state': true ); // $ExpectError
+	lognormal.factory( { 'state': true } ); // $ExpectError
 	lognormal.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/minstd-shuffle/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/minstd-shuffle/docs/types/test.ts
@@ -86,7 +86,7 @@ import minstd = require( './index' );
 	minstd.factory( { 'state': null } ); // $ExpectError
 	minstd.factory( { 'state': [] } ); // $ExpectError
 	minstd.factory( { 'state': {} } ); // $ExpectError
-	minstd.factory( { 'state': true ); // $ExpectError
+	minstd.factory( { 'state': true } ); // $ExpectError
 	minstd.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/mt19937/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/mt19937/docs/types/test.ts
@@ -74,7 +74,7 @@ import mt19937 = require( './index' );
 	mt19937.factory( { 'state': null } ); // $ExpectError
 	mt19937.factory( { 'state': [] } ); // $ExpectError
 	mt19937.factory( { 'state': {} } ); // $ExpectError
-	mt19937.factory( { 'state': true ); // $ExpectError
+	mt19937.factory( { 'state': true } ); // $ExpectError
 	mt19937.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/negative-binomial/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/negative-binomial/docs/types/test.ts
@@ -151,14 +151,14 @@ import negativeBinomial = require( './index' );
 	negativeBinomial.factory( 20, 0.3, { 'prng': null } ); // $ExpectError
 	negativeBinomial.factory( 20, 0.3, { 'prng': [] } ); // $ExpectError
 	negativeBinomial.factory( 20, 0.3, { 'prng': {} } ); // $ExpectError
-	negativeBinomial.factory( 20, 0.3, { 'prng': true ); // $ExpectError
+	negativeBinomial.factory( 20, 0.3, { 'prng': true } ); // $ExpectError
 
 	negativeBinomial.factory( { 'prng': 123 } ); // $ExpectError
 	negativeBinomial.factory( { 'prng': 'abc' } ); // $ExpectError
 	negativeBinomial.factory( { 'prng': null } ); // $ExpectError
 	negativeBinomial.factory( { 'prng': [] } ); // $ExpectError
 	negativeBinomial.factory( { 'prng': {} } ); // $ExpectError
-	negativeBinomial.factory( { 'prng': true ); // $ExpectError
+	negativeBinomial.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import negativeBinomial = require( './index' );
 	negativeBinomial.factory( 20, 0.3, { 'state': null } ); // $ExpectError
 	negativeBinomial.factory( 20, 0.3, { 'state': [] } ); // $ExpectError
 	negativeBinomial.factory( 20, 0.3, { 'state': {} } ); // $ExpectError
-	negativeBinomial.factory( 20, 0.3, { 'state': true ); // $ExpectError
+	negativeBinomial.factory( 20, 0.3, { 'state': true } ); // $ExpectError
 	negativeBinomial.factory( 20, 0.3, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	negativeBinomial.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import negativeBinomial = require( './index' );
 	negativeBinomial.factory( { 'state': null } ); // $ExpectError
 	negativeBinomial.factory( { 'state': [] } ); // $ExpectError
 	negativeBinomial.factory( { 'state': {} } ); // $ExpectError
-	negativeBinomial.factory( { 'state': true ); // $ExpectError
+	negativeBinomial.factory( { 'state': true } ); // $ExpectError
 	negativeBinomial.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/normal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/normal/docs/types/test.ts
@@ -151,14 +151,14 @@ import normal = require( './index' );
 	normal.factory( -2, 2, { 'prng': null } ); // $ExpectError
 	normal.factory( -2, 2, { 'prng': [] } ); // $ExpectError
 	normal.factory( -2, 2, { 'prng': {} } ); // $ExpectError
-	normal.factory( -2, 2, { 'prng': true ); // $ExpectError
+	normal.factory( -2, 2, { 'prng': true } ); // $ExpectError
 
 	normal.factory( { 'prng': 123 } ); // $ExpectError
 	normal.factory( { 'prng': 'abc' } ); // $ExpectError
 	normal.factory( { 'prng': null } ); // $ExpectError
 	normal.factory( { 'prng': [] } ); // $ExpectError
 	normal.factory( { 'prng': {} } ); // $ExpectError
-	normal.factory( { 'prng': true ); // $ExpectError
+	normal.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import normal = require( './index' );
 	normal.factory( -2, 2, { 'state': null } ); // $ExpectError
 	normal.factory( -2, 2, { 'state': [] } ); // $ExpectError
 	normal.factory( -2, 2, { 'state': {} } ); // $ExpectError
-	normal.factory( -2, 2, { 'state': true ); // $ExpectError
+	normal.factory( -2, 2, { 'state': true } ); // $ExpectError
 	normal.factory( -2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	normal.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import normal = require( './index' );
 	normal.factory( { 'state': null } ); // $ExpectError
 	normal.factory( { 'state': [] } ); // $ExpectError
 	normal.factory( { 'state': {} } ); // $ExpectError
-	normal.factory( { 'state': true ); // $ExpectError
+	normal.factory( { 'state': true } ); // $ExpectError
 	normal.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/pareto-type1/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/pareto-type1/docs/types/test.ts
@@ -151,14 +151,14 @@ import pareto1 = require( './index' );
 	pareto1.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	pareto1.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	pareto1.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	pareto1.factory( 2, 2, { 'prng': true ); // $ExpectError
+	pareto1.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	pareto1.factory( { 'prng': 123 } ); // $ExpectError
 	pareto1.factory( { 'prng': 'abc' } ); // $ExpectError
 	pareto1.factory( { 'prng': null } ); // $ExpectError
 	pareto1.factory( { 'prng': [] } ); // $ExpectError
 	pareto1.factory( { 'prng': {} } ); // $ExpectError
-	pareto1.factory( { 'prng': true ); // $ExpectError
+	pareto1.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import pareto1 = require( './index' );
 	pareto1.factory( 2, 2, { 'state': null } ); // $ExpectError
 	pareto1.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	pareto1.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	pareto1.factory( 2, 2, { 'state': true ); // $ExpectError
+	pareto1.factory( 2, 2, { 'state': true } ); // $ExpectError
 	pareto1.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	pareto1.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import pareto1 = require( './index' );
 	pareto1.factory( { 'state': null } ); // $ExpectError
 	pareto1.factory( { 'state': [] } ); // $ExpectError
 	pareto1.factory( { 'state': {} } ); // $ExpectError
-	pareto1.factory( { 'state': true ); // $ExpectError
+	pareto1.factory( { 'state': true } ); // $ExpectError
 	pareto1.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/randi/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/randi/docs/types/test.ts
@@ -64,7 +64,7 @@ import randi = require( './index' );
 	randi.factory( { 'name': null } ); // $ExpectError
 	randi.factory( { 'name': [] } ); // $ExpectError
 	randi.factory( { 'name': {} } ); // $ExpectError
-	randi.factory( { 'name': true ); // $ExpectError
+	randi.factory( { 'name': true } ); // $ExpectError
 	randi.factory( { 'name': ( x: number ): number => x } ); // $ExpectError
 }
 
@@ -85,7 +85,7 @@ import randi = require( './index' );
 	randi.factory( { 'state': null } ); // $ExpectError
 	randi.factory( { 'state': [] } ); // $ExpectError
 	randi.factory( { 'state': {} } ); // $ExpectError
-	randi.factory( { 'state': true ); // $ExpectError
+	randi.factory( { 'state': true } ); // $ExpectError
 	randi.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/randn/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/randn/docs/types/test.ts
@@ -64,7 +64,7 @@ import randn = require( './index' );
 	randn.factory( { 'name': null } ); // $ExpectError
 	randn.factory( { 'name': [] } ); // $ExpectError
 	randn.factory( { 'name': {} } ); // $ExpectError
-	randn.factory( { 'name': true ); // $ExpectError
+	randn.factory( { 'name': true } ); // $ExpectError
 	randn.factory( { 'name': ( x: number ): number => x } ); // $ExpectError
 }
 
@@ -75,7 +75,7 @@ import randn = require( './index' );
 	randn.factory( { 'prng': null } ); // $ExpectError
 	randn.factory( { 'prng': [] } ); // $ExpectError
 	randn.factory( { 'prng': {} } ); // $ExpectError
-	randn.factory( { 'prng': true ); // $ExpectError
+	randn.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -95,7 +95,7 @@ import randn = require( './index' );
 	randn.factory( { 'state': null } ); // $ExpectError
 	randn.factory( { 'state': [] } ); // $ExpectError
 	randn.factory( { 'state': {} } ); // $ExpectError
-	randn.factory( { 'state': true ); // $ExpectError
+	randn.factory( { 'state': true } ); // $ExpectError
 	randn.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/randu/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/randu/docs/types/test.ts
@@ -64,7 +64,7 @@ import randu = require( './index' );
 	randu.factory( { 'name': null } ); // $ExpectError
 	randu.factory( { 'name': [] } ); // $ExpectError
 	randu.factory( { 'name': {} } ); // $ExpectError
-	randu.factory( { 'name': true ); // $ExpectError
+	randu.factory( { 'name': true } ); // $ExpectError
 	randu.factory( { 'name': ( x: number ): number => x } ); // $ExpectError
 }
 
@@ -85,7 +85,7 @@ import randu = require( './index' );
 	randu.factory( { 'state': null } ); // $ExpectError
 	randu.factory( { 'state': [] } ); // $ExpectError
 	randu.factory( { 'state': {} } ); // $ExpectError
-	randu.factory( { 'state': true ); // $ExpectError
+	randu.factory( { 'state': true } ); // $ExpectError
 	randu.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/triangular/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/triangular/docs/types/test.ts
@@ -62,8 +62,8 @@ import triangular = require( './index' );
 // Attached to main export is a `factory` method which returns a function...
 {
 	triangular.factory( 2, 4, 2.7 ); // $ExpectType NullaryFunction
-	triangular.factory(); // $ExpectType BinaryFunction
-	triangular.factory( { 'copy': false } ); // $ExpectType BinaryFunction
+	triangular.factory(); // $ExpectType TernaryFunction
+	triangular.factory( { 'copy': false } ); // $ExpectType TernaryFunction
 }
 
 // The `factory` method returns a function which returns a number...
@@ -180,14 +180,14 @@ import triangular = require( './index' );
 	triangular.factory( 2, 4, 2.5, { 'prng': null } ); // $ExpectError
 	triangular.factory( 2, 4, 2.5, { 'prng': [] } ); // $ExpectError
 	triangular.factory( 2, 4, 2.5, { 'prng': {} } ); // $ExpectError
-	triangular.factory( 2, 4, 2.5, { 'prng': true ); // $ExpectError
+	triangular.factory( 2, 4, 2.5, { 'prng': true } ); // $ExpectError
 
 	triangular.factory( { 'prng': 123 } ); // $ExpectError
 	triangular.factory( { 'prng': 'abc' } ); // $ExpectError
 	triangular.factory( { 'prng': null } ); // $ExpectError
 	triangular.factory( { 'prng': [] } ); // $ExpectError
 	triangular.factory( { 'prng': {} } ); // $ExpectError
-	triangular.factory( { 'prng': true ); // $ExpectError
+	triangular.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -214,7 +214,7 @@ import triangular = require( './index' );
 	triangular.factory( 2, 4, 2.5, { 'state': null } ); // $ExpectError
 	triangular.factory( 2, 4, 2.5, { 'state': [] } ); // $ExpectError
 	triangular.factory( 2, 4, 2.5, { 'state': {} } ); // $ExpectError
-	triangular.factory( 2, 4, 2.5, { 'state': true ); // $ExpectError
+	triangular.factory( 2, 4, 2.5, { 'state': true } ); // $ExpectError
 	triangular.factory( 2, 4, 2.5, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	triangular.factory( { 'state': 123 } ); // $ExpectError
@@ -222,7 +222,7 @@ import triangular = require( './index' );
 	triangular.factory( { 'state': null } ); // $ExpectError
 	triangular.factory( { 'state': [] } ); // $ExpectError
 	triangular.factory( { 'state': {} } ); // $ExpectError
-	triangular.factory( { 'state': true ); // $ExpectError
+	triangular.factory( { 'state': true } ); // $ExpectError
 	triangular.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/uniform/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/uniform/docs/types/test.ts
@@ -151,14 +151,14 @@ import uniform = require( './index' );
 	uniform.factory( -2, 2, { 'prng': null } ); // $ExpectError
 	uniform.factory( -2, 2, { 'prng': [] } ); // $ExpectError
 	uniform.factory( -2, 2, { 'prng': {} } ); // $ExpectError
-	uniform.factory( -2, 2, { 'prng': true ); // $ExpectError
+	uniform.factory( -2, 2, { 'prng': true } ); // $ExpectError
 
 	uniform.factory( { 'prng': 123 } ); // $ExpectError
 	uniform.factory( { 'prng': 'abc' } ); // $ExpectError
 	uniform.factory( { 'prng': null } ); // $ExpectError
 	uniform.factory( { 'prng': [] } ); // $ExpectError
 	uniform.factory( { 'prng': {} } ); // $ExpectError
-	uniform.factory( { 'prng': true ); // $ExpectError
+	uniform.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import uniform = require( './index' );
 	uniform.factory( -2, 2, { 'state': null } ); // $ExpectError
 	uniform.factory( -2, 2, { 'state': [] } ); // $ExpectError
 	uniform.factory( -2, 2, { 'state': {} } ); // $ExpectError
-	uniform.factory( -2, 2, { 'state': true ); // $ExpectError
+	uniform.factory( -2, 2, { 'state': true } ); // $ExpectError
 	uniform.factory( -2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	uniform.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import uniform = require( './index' );
 	uniform.factory( { 'state': null } ); // $ExpectError
 	uniform.factory( { 'state': [] } ); // $ExpectError
 	uniform.factory( { 'state': {} } ); // $ExpectError
-	uniform.factory( { 'state': true ); // $ExpectError
+	uniform.factory( { 'state': true } ); // $ExpectError
 	uniform.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/weibull/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/weibull/docs/types/test.ts
@@ -151,14 +151,14 @@ import weibull = require( './index' );
 	weibull.factory( 2, 2, { 'prng': null } ); // $ExpectError
 	weibull.factory( 2, 2, { 'prng': [] } ); // $ExpectError
 	weibull.factory( 2, 2, { 'prng': {} } ); // $ExpectError
-	weibull.factory( 2, 2, { 'prng': true ); // $ExpectError
+	weibull.factory( 2, 2, { 'prng': true } ); // $ExpectError
 
 	weibull.factory( { 'prng': 123 } ); // $ExpectError
 	weibull.factory( { 'prng': 'abc' } ); // $ExpectError
 	weibull.factory( { 'prng': null } ); // $ExpectError
 	weibull.factory( { 'prng': [] } ); // $ExpectError
 	weibull.factory( { 'prng': {} } ); // $ExpectError
-	weibull.factory( { 'prng': true ); // $ExpectError
+	weibull.factory( { 'prng': true } ); // $ExpectError
 }
 
 // The compiler throws an error if the `factory` method is provided a `seed` option which is not a valid seed...
@@ -185,7 +185,7 @@ import weibull = require( './index' );
 	weibull.factory( 2, 2, { 'state': null } ); // $ExpectError
 	weibull.factory( 2, 2, { 'state': [] } ); // $ExpectError
 	weibull.factory( 2, 2, { 'state': {} } ); // $ExpectError
-	weibull.factory( 2, 2, { 'state': true ); // $ExpectError
+	weibull.factory( 2, 2, { 'state': true } ); // $ExpectError
 	weibull.factory( 2, 2, { 'state': ( x: number ): number => x } ); // $ExpectError
 
 	weibull.factory( { 'state': 123 } ); // $ExpectError
@@ -193,7 +193,7 @@ import weibull = require( './index' );
 	weibull.factory( { 'state': null } ); // $ExpectError
 	weibull.factory( { 'state': [] } ); // $ExpectError
 	weibull.factory( { 'state': {} } ); // $ExpectError
-	weibull.factory( { 'state': true ); // $ExpectError
+	weibull.factory( { 'state': true } ); // $ExpectError
 	weibull.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/iter/box-muller/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/iter/box-muller/docs/types/test.ts
@@ -66,7 +66,7 @@ import iterator = require( './index' );
 	iterator( { 'state': null } ); // $ExpectError
 	iterator( { 'state': [] } ); // $ExpectError
 	iterator( { 'state': {} } ); // $ExpectError
-	iterator( { 'state': true ); // $ExpectError
+	iterator( { 'state': true } ); // $ExpectError
 	iterator( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/iter/improved-ziggurat/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/iter/improved-ziggurat/docs/types/test.ts
@@ -66,7 +66,7 @@ import iterator = require( './index' );
 	iterator( { 'state': null } ); // $ExpectError
 	iterator( { 'state': [] } ); // $ExpectError
 	iterator( { 'state': {} } ); // $ExpectError
-	iterator( { 'state': true ); // $ExpectError
+	iterator( { 'state': true } ); // $ExpectError
 	iterator( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/iter/minstd-shuffle/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/iter/minstd-shuffle/docs/types/test.ts
@@ -66,7 +66,7 @@ import iterator = require( './index' );
 	iterator( { 'state': null } ); // $ExpectError
 	iterator( { 'state': [] } ); // $ExpectError
 	iterator( { 'state': {} } ); // $ExpectError
-	iterator( { 'state': true ); // $ExpectError
+	iterator( { 'state': true } ); // $ExpectError
 	iterator( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/iter/minstd/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/iter/minstd/docs/types/test.ts
@@ -66,7 +66,7 @@ import iterator = require( './index' );
 	iterator( { 'state': null } ); // $ExpectError
 	iterator( { 'state': [] } ); // $ExpectError
 	iterator( { 'state': {} } ); // $ExpectError
-	iterator( { 'state': true ); // $ExpectError
+	iterator( { 'state': true } ); // $ExpectError
 	iterator( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/iter/mt19937/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/iter/mt19937/docs/types/test.ts
@@ -66,7 +66,7 @@ import iterator = require( './index' );
 	iterator( { 'state': null } ); // $ExpectError
 	iterator( { 'state': [] } ); // $ExpectError
 	iterator( { 'state': {} } ); // $ExpectError
-	iterator( { 'state': true ); // $ExpectError
+	iterator( { 'state': true } ); // $ExpectError
 	iterator( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/iter/randn/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/iter/randn/docs/types/test.ts
@@ -79,7 +79,7 @@ import iterator = require( './index' );
 	iterator( { 'state': null } ); // $ExpectError
 	iterator( { 'state': [] } ); // $ExpectError
 	iterator( { 'state': {} } ); // $ExpectError
-	iterator( { 'state': true ); // $ExpectError
+	iterator( { 'state': true } ); // $ExpectError
 	iterator( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/utils/define-memoized-property/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/define-memoized-property/docs/types/test.ts
@@ -49,13 +49,13 @@ import defineMemoizedProperty = require( './index' );
 	defineMemoizedProperty( {}, 'foo', [] ); // $ExpectError
 	defineMemoizedProperty( {}, 'foo', {} ); // $ExpectError
 
-	defineMemoizedProperty( {}, 'foo', { 'configurable': true ); // $ExpectError
+	defineMemoizedProperty( {}, 'foo', { 'configurable': true } ); // $ExpectError
 	defineMemoizedProperty( {}, 'foo', { 'configurable': 'true', 'value': (): string => 'bar' } ); // $ExpectError
 
-	defineMemoizedProperty( {}, 'foo', { 'enumerable': true ); // $ExpectError
+	defineMemoizedProperty( {}, 'foo', { 'enumerable': true } ); // $ExpectError
 	defineMemoizedProperty( {}, 'foo', { 'enumerable': 'true', 'value': (): string => 'bar' } ); // $ExpectError
 
-	defineMemoizedProperty( {}, 'foo', { 'writable': true ); // $ExpectError
+	defineMemoizedProperty( {}, 'foo', { 'writable': true } ); // $ExpectError
 	defineMemoizedProperty( {}, 'foo', { 'writable': 'true', 'value': (): string => 'bar' } ); // $ExpectError
 }
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a syntax error present in 126 lines across 42 `docs/types/test.ts` files, where a `$ExpectError` test assertion opened an options object literal with `{` but omitted the closing `}` before the call's `)`, e.g. `factory( { 'state': true );` instead of `factory( { 'state': true } );`. The missing brace is a syntax error that prevents the affected test files from compiling. The closing `}` is inserted so the lines parse and still trigger the expected type error.
-   additionally corrects two pre-existing incorrect `$ExpectType` annotations in `random/base/frechet` and `random/base/triangular`. These were masked by the syntax error; once the files compile, the expect-type linter flags them. Both distributions take three parameters, so `factory()` returns a `TernaryFunction` (not `BinaryFunction`), matching the declaration files.

Affected namespaces: `random/base`, `random/array`, `random/iter`, and `utils/define-memoized-property`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Affected lines were found by scanning `docs/types/test.ts` files for inline statements (ending in `);`) where the count of `{` exceeds the count of `}`, isolating exactly the unclosed-object-literal case. All affected files pass `make eslint-ts-files` after the change.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored primarily by Claude Code: it scanned the codebase for the missing-brace pattern, applied the mechanical fixes, identified the two unmasked `$ExpectType` annotation bugs, and verified the result with the TypeScript test linter. Changes were reviewed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
