### PR TITLE
feat: add `uint64/base/to-words`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2026 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
@@ -1,0 +1,120 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2018 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# toWords
+
+> Split a [64-bit unsigned integer][uint64] into a higher order word and a lower order word.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var toWords = require( '@stdlib/number/uint64/base/to-words' );
+```
+
+#### toWords( a )
+
+Splits a [64-bit unsigned integer][uint64] into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer).
+
+```javascript
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+
+var a = new Uint64( 4294967296 );
+var w = toWords( a );
+// returns [ 1, 0 ]
+
+var high = w[ 0 ];
+// returns 1
+
+var low = w[ 1 ];
+// returns 0
+```
+
+By default, the function returns an `array` containing two elements: a higher order word and a lower order word. The lower order word contains the less significant bits, while the higher order word contains the more significant bits.
+
+#### toWords.assign( a, out, stride, offset )
+
+Splits a [64-bit unsigned integer][uint64] into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer) and assigns results to a provided output array.
+
+```javascript
+var Uint32Array = require( '@stdlib/array/uint32' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+
+var out = new Uint32Array( 2 );
+
+var a = new Uint64( 4294967296 );
+var w = toWords.assign( a, out, 1, 0 );
+// returns <Uint32Array>[ 1, 0 ]
+
+var bool = ( w === out );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+```javascript
+var toWords = require( '@stdlib/number/uint64/base/to-words' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+
+var a = new Uint64( 4294967296 );
+var w = toWords( a );
+// returns [ 1, 0 ]
+
+a = new Uint64( 10000000000 );
+w = toWords( a );
+// returns [ 2, 1410065408 ]
+
+a = new Uint64.of( 12, 34 );
+w = toWords( a );
+// returns [ 12, 34 ]
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[uint64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/uint64/ctor
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
@@ -77,8 +77,8 @@ var bool = ( w === out );
 ## Examples
 
 ```javascript
-var toWords = require( '@stdlib/number/uint64/base/to-words' );
 var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var toWords = require( '@stdlib/number/uint64/base/to-words' );
 
 var a = new Uint64( 4294967296 );
 var w = toWords( a );

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # toWords
 
-> Split a [64-bit unsigned integer][uint64] into a higher order word and a lower order word.
+> Split a [64-bit unsigned integer][@stdlib/number/uint64/ctor] into a higher order word and a lower order word.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var toWords = require( '@stdlib/number/uint64/base/to-words' );
 
 #### toWords( a )
 
-Splits a [64-bit unsigned integer][uint64] into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer).
+Splits a [64-bit unsigned integer][@stdlib/number/uint64/ctor] into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer).
 
 ```javascript
 var Uint64 = require( '@stdlib/number/uint64/ctor' );
@@ -52,7 +52,7 @@ By default, the function returns an `array` containing two elements: a higher or
 
 #### toWords.assign( a, out, stride, offset )
 
-Splits a [64-bit unsigned integer][uint64] into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer) and assigns results to a provided output array.
+Splits a [64-bit unsigned integer][@stdlib/number/uint64/ctor] into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer) and assigns results to a provided output array.
 
 ```javascript
 var Uint32Array = require( '@stdlib/array/uint32' );
@@ -109,7 +109,7 @@ w = toWords( a );
 
 <section class="links">
 
-[uint64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/uint64/ctor
+[@stdlib/number/uint64/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/uint64/ctor
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
@@ -48,7 +48,7 @@ var low = w[ 1 ];
 // returns 0
 ```
 
-By default, the function returns an `array` containing two elements: a higher order word and a lower order word. The lower order word contains the less significant bits, while the higher order word contains the more significant bits.
+The function returns an `array` containing two elements: a higher order word and a lower order word. The lower order word contains the less significant bits, while the higher order word contains the more significant bits.
 
 #### toWords.assign( a, out, stride, offset )
 

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
@@ -48,7 +48,7 @@ var low = w[ 1 ];
 // returns 0
 ```
 
-The function returns an `array` containing two elements: a higher order word and a lower order word. The lower order word contains the less significant bits, while the higher order word contains the more significant bits.
+The function returns an array containing two elements: a higher order word and a lower order word. The lower order word contains the less significant bits, while the higher order word contains the more significant bits.
 
 #### toWords.assign( a, out, stride, offset )
 

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/benchmark/benchmark.js
@@ -23,29 +23,37 @@
 var bench = require( '@stdlib/bench' );
 var Uint32Array = require( '@stdlib/array/uint32' );
 var isArray = require( '@stdlib/assert/is-array' );
-var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
 var Uint64 = require( '@stdlib/number/uint64/ctor' );
-var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var toWords = require( './../lib' );
+
+
+// VARIABLES //
+
+var rand = discreteUniform.factory( 0, MAX_SAFE_INTEGER );
 
 
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
 	var values;
+	var N;
 	var a;
-	var w;
 	var i;
+	var w;
 
-	values = discreteUniform( 100, 0, UINT32_MAX, {
-		'dtype': 'uint32'
-	});
+	N = 100;
+	values = [];
+	for ( i = 0; i < N; i++ ) {
+		values.push( new Uint64( rand() ) );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		a = Uint64.of( values[ i % values.length ], values[ (i+1) % values.length ] ); // eslint-disable-line max-len
+		a = values[ i % N ];
 		w = toWords( a );
 		if ( typeof w !== 'object' ) {
 			b.fail( 'should return an array' );
@@ -62,19 +70,22 @@ bench( pkg, function benchmark( b ) {
 bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var values;
 	var out;
+	var N;
 	var a;
-	var w;
 	var i;
+	var w;
 
-	values = discreteUniform( 100, 0, UINT32_MAX, {
-		'dtype': 'uint32'
-	});
+	N = 100;
+	values = [];
+	for ( i = 0; i < N; i++ ) {
+		values.push( new Uint64( rand() ) );
+	}
 
 	out = new Uint32Array( 2 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		a = Uint64.of( values[ i % values.length ], values[ (i+1) % values.length ] ); // eslint-disable-line max-len
+		a = values[ i % N ];
 		w = toWords.assign( a, out, 1, 0 );
 		if ( typeof w !== 'object' ) {
 			b.fail( 'should return an array' );

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/benchmark/benchmark.js
@@ -1,0 +1,89 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var isArray = require( '@stdlib/assert/is-array' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var toWords = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var a;
+	var w;
+	var i;
+
+	values = discreteUniform( 100, 0, UINT32_MAX, {
+		'dtype': 'uint32'
+	});
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		a = Uint64.of( values[ i % values.length ], values[ (i+1) % values.length ] ); // eslint-disable-line max-len
+		w = toWords( a );
+		if ( typeof w !== 'object' ) {
+			b.fail( 'should return an array' );
+		}
+	}
+	b.toc();
+	if ( !isArray( w ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
+	var values;
+	var out;
+	var a;
+	var w;
+	var i;
+
+	values = discreteUniform( 100, 0, UINT32_MAX, {
+		'dtype': 'uint32'
+	});
+
+	out = new Uint32Array( 2 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		a = Uint64.of( values[ i % values.length ], values[ (i+1) % values.length ] ); // eslint-disable-line max-len
+		w = toWords.assign( a, out, 1, 0 );
+		if ( typeof w !== 'object' ) {
+			b.fail( 'should return an array' );
+		}
+	}
+	b.toc();
+	if ( w !== out ) {
+		b.fail( 'should return the output array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/repl.txt
@@ -1,0 +1,64 @@
+
+{{alias}}( a )
+    Splits a 64-bit unsigned integer into a higher order word (32-bit unsigned
+    integer) and a lower order word (32-bit unsigned integer).
+
+    The function returns an array with two elements: a higher order word and a
+    lower order word, respectively. The lower order word contains the less
+    significant bits, while the higher order word contains the more significant
+    bits.
+
+    Parameters
+    ----------
+    a: Uint64
+        64-bit unsigned integer.
+
+    Returns
+    -------
+    out: Array<uinteger>
+        Higher and lower order words.
+
+    Examples
+    --------
+    > var a = new {{alias:@stdlib/number/uint64/ctor}}( 10000000000 )
+    <Uint64>[ 10000000000n ]
+    > var w = {{alias}}( a )
+    [ 2, 1410065408 ]
+
+
+{{alias}}.assign( a, out, stride, offset )
+    Splits a 64-bit unsigned integer into a higher order word (32-bit unsigned
+    integer) and a lower order word (32-bit unsigned integer) and assigns
+    results to a provided output array.
+
+    Parameters
+    ----------
+    a: Uint64
+        64-bit unsigned integer.
+
+    out: Array|TypedArray|Object
+        Output array.
+
+    stride: integer
+        Output array stride.
+
+    offset: integer
+        Output array index offset.
+
+    Returns
+    -------
+    out: Array|TypedArray|Object
+        Higher and lower order words.
+
+    Examples
+    --------
+    > var a = new {{alias:@stdlib/number/uint64/ctor}}( 10000000000 )
+    <Uint64>[ 10000000000n ]
+    > var out = new {{alias:@stdlib/array/uint32}}( 2 );
+    > var w = {{alias}}.assign( a, out, 1, 0 )
+    <Uint32Array>[ 2, 1410065408 ]
+    > var bool = ( w === out )
+    true
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/index.d.ts
@@ -28,7 +28,7 @@ import { Uint64 } from '@stdlib/types/number';
 */
 interface ToWords {
 	/**
-	* Splits a 64-bit unsigned integer into a higher order word (unsigned 32-bit integer) and a lower order word (unsigned 32-bit integer).
+	* Splits a 64-bit unsigned integer into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer).
 	*
 	* @param a - input value
 	* @returns output array
@@ -43,7 +43,7 @@ interface ToWords {
 	( a: Uint64 ): [ number, number ];
 
 	/**
-	* Splits a 64-bit unsigned integer into a higher order word (unsigned 32-bit integer) and a lower order word (unsigned 32-bit integer) and assigns results to a provided output array.
+	* Splits a 64-bit unsigned integer into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer) and assigns results to a provided output array.
 	*
 	* @param a - input value
 	* @param out - output array
@@ -68,7 +68,7 @@ interface ToWords {
 }
 
 /**
-* Splits a 64-bit unsigned integer into a higher order word (unsigned 32-bit integer) and a lower order word (unsigned 32-bit integer).
+* Splits a 64-bit unsigned integer into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer).
 *
 * @param a - input value
 * @returns output array

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/index.d.ts
@@ -40,7 +40,7 @@ interface ToWords {
 	* var w = toWords( a );
 	* // returns [ 1, 0 ]
 	*/
-	( a: Uint64 ): Array<number>;
+	( a: Uint64 ): [ number, number ];
 
 	/**
 	* Splits a 64-bit unsigned integer into a higher order word (unsigned 32-bit integer) and a lower order word (unsigned 32-bit integer) and assigns results to a provided output array.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/index.d.ts
@@ -1,0 +1,101 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Collection, NumericArray } from '@stdlib/types/array';
+import { Uint64 } from '@stdlib/types/number';
+
+/**
+* Interface describing `toWords`.
+*/
+interface ToWords {
+	/**
+	* Splits a 64-bit unsigned integer into a higher order word (unsigned 32-bit integer) and a lower order word (unsigned 32-bit integer).
+	*
+	* @param a - input value
+	* @returns output array
+	*
+	* @example
+	* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+	*
+	* var a = new Uint64( 4294967296 );
+	* var w = toWords( a );
+	* // returns [ 1, 0 ]
+	*/
+	( a: Uint64 ): Array<number>;
+
+	/**
+	* Splits a 64-bit unsigned integer into a higher order word (unsigned 32-bit integer) and a lower order word (unsigned 32-bit integer) and assigns results to a provided output array.
+	*
+	* @param a - input value
+	* @param out - output array
+	* @param stride - stride length
+	* @param offset - starting index
+	* @returns output array
+	*
+	* @example
+	* var Uint32Array = require( '@stdlib/array/uint32' );
+	* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+	*
+	* var out = new Uint32Array( 2 );
+	*
+	* var a = new Uint64( 4294967296 );
+	* var w = toWords.assign( a, out, 1, 0 );
+	* // returns <Uint32Array>[ 1, 0 ]
+	*
+	* var bool = ( w === out );
+	* // returns true
+	*/
+	assign<T extends NumericArray | Collection<number>>( a: Uint64, out: T, stride: number, offset: number ): T;
+}
+
+/**
+* Splits a 64-bit unsigned integer into a higher order word (unsigned 32-bit integer) and a lower order word (unsigned 32-bit integer).
+*
+* @param a - input value
+* @returns output array
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 4294967296 );
+* var w = toWords( a );
+* // returns [ 1, 0 ]
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var out = new Uint32Array( 2 );
+*
+* var a = new Uint64( 4294967296 );
+* var w = toWords.assign( a, out, 1, 0 );
+* // returns <Uint32Array>[ 1, 0 ]
+*
+* var bool = ( w === out );
+* // returns true
+*/
+declare var toWords: ToWords;
+
+
+// EXPORTS //
+
+export = toWords;

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/test.ts
@@ -1,0 +1,120 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2021 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Uint64 = require( '@stdlib/number/uint64/ctor' );
+import toWords = require( './index' );
+
+
+// TESTS //
+
+// The function returns an array...
+{
+	const a = new Uint64( 5 );
+	toWords( a ); // $ExpectType number[]
+}
+
+// The compiler throws an error if the function is provided an argument that is not a 64-bit unsigned integer...
+{
+	toWords( '5' ); // $ExpectError
+	toWords( true ); // $ExpectError
+	toWords( false ); // $ExpectError
+	toWords( null ); // $ExpectError
+	toWords( {} ); // $ExpectError
+	toWords( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const a = new Uint64( 5 );
+
+	toWords(); // $ExpectError
+	toWords( a, a ); // $ExpectError
+}
+
+// Attached to the main export is an `assign` method which returns an array-like object containing numbers...
+{
+	const a = new Uint64( 5 );
+
+	toWords.assign( a, [ 0, 0 ], 1, 0 ); // $ExpectType number[]
+	toWords.assign( a, new Uint32Array( 2 ), 1, 0 ); // $ExpectType Uint32Array
+	toWords.assign( a, new Float64Array( 2 ), 1, 0 ); // $ExpectType Float64Array
+}
+
+// The compiler throws an error if the `assign` method is provided a first argument which is not a 64-bit unsigned integer...
+{
+	const out = [ 0.0, 0.0 ];
+
+	toWords.assign( true, out, 1, 0 ); // $ExpectError
+	toWords.assign( false, out, 1, 0 ); // $ExpectError
+	toWords.assign( '5', out, 1, 0 ); // $ExpectError
+	toWords.assign( null, out, 1, 0 ); // $ExpectError
+	toWords.assign( [], out, 1, 0 ); // $ExpectError
+	toWords.assign( {}, out, 1, 0 ); // $ExpectError
+	toWords.assign( ( x: number ): number => x, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a second argument which is not an array-like object...
+{
+	const a = new Uint64( 5 );
+
+	toWords.assign( a, 1, 1, 0 ); // $ExpectError
+	toWords.assign( a, true, 1, 0 ); // $ExpectError
+	toWords.assign( a, false, 1, 0 ); // $ExpectError
+	toWords.assign( a, null, 1, 0 ); // $ExpectError
+	toWords.assign( a, {}, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a third argument which is not a number...
+{
+	const out = [ 0.0, 0.0 ];
+	const a = new Uint64( 5 );
+
+	toWords.assign( a, out, '5', 0 ); // $ExpectError
+	toWords.assign( a, out, true, 0 ); // $ExpectError
+	toWords.assign( a, out, false, 0 ); // $ExpectError
+	toWords.assign( a, out, null, 0 ); // $ExpectError
+	toWords.assign( a, out, [], 0 ); // $ExpectError
+	toWords.assign( a, out, {}, 0 ); // $ExpectError
+	toWords.assign( a, out, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...
+{
+	const out = [ 0.0, 0.0 ];
+	const a = new Uint64( 5 );
+
+	toWords.assign( a, out, 1, '5' ); // $ExpectError
+	toWords.assign( a, out, 1, true ); // $ExpectError
+	toWords.assign( a, out, 1, false ); // $ExpectError
+	toWords.assign( a, out, 1, null ); // $ExpectError
+	toWords.assign( a, out, 1, [] ); // $ExpectError
+	toWords.assign( a, out, 1, {} ); // $ExpectError
+	toWords.assign( a, out, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided an unsupported number of arguments...
+{
+	const out = [ 0.0, 0.0 ];
+	const a = new Uint64( 5 );
+
+	toWords.assign(); // $ExpectError
+	toWords.assign( a ); // $ExpectError
+	toWords.assign( a, out ); // $ExpectError
+	toWords.assign( a, out, 1 ); // $ExpectError
+	toWords.assign( a, out, 1, 0, 1 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/docs/types/test.ts
@@ -25,7 +25,7 @@ import toWords = require( './index' );
 // The function returns an array...
 {
 	const a = new Uint64( 5 );
-	toWords( a ); // $ExpectType number[]
+	toWords( a ); // $ExpectType [number, number]
 }
 
 // The compiler throws an error if the function is provided an argument that is not a 64-bit unsigned integer...

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/examples/index.js
@@ -23,12 +23,15 @@ var toWords = require( './../lib' );
 
 var a = new Uint64( 4294967296 );
 var w = toWords( a );
-// returns [ 1, 0 ]
+console.log( w );
+// => [ 1, 0 ]
 
 a = new Uint64( 10000000000 );
 w = toWords( a );
-// returns [ 2, 1410065408 ]
+console.log( w );
+// => [ 2, 1410065408 ]
 
 a = new Uint64.of( 12, 34 );
-w = toWords( a ); // eslint-disable-line no-unused-vars
-// returns [ 12, 34 ]
+w = toWords( a );
+console.log( w );
+// => [ 12, 34 ]

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/examples/index.js
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var toWords = require( './../lib' );
+
+var a = new Uint64( 4294967296 );
+var w = toWords( a );
+// returns [ 1, 0 ]
+
+a = new Uint64( 10000000000 );
+w = toWords( a );
+// returns [ 2, 1410065408 ]
+
+a = new Uint64.of( 12, 34 );
+w = toWords( a ); // eslint-disable-line no-unused-vars
+// returns [ 12, 34 ]

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/assign.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/assign.js
@@ -23,7 +23,6 @@
 /**
 * Splits a 64-bit unsigned integer into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer).
 *
-* @private
 * @param {Uint64} a - input value
 * @param {Collection} out - output array
 * @param {integer} stride - output array stride

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/assign.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Splits a 64-bit unsigned integer into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer).
+*
+* @private
+* @param {Uint64} a - input value
+* @param {Collection} out - output array
+* @param {integer} stride - output array stride
+* @param {NonNegativeInteger} offset - output array index offset
+* @returns {Collection} output array
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var out = new Uint32Array( 2 );
+*
+* var a = new Uint64( 4294967296 );
+* var w = toWords( a, out, 1, 0 );
+* // returns <Uint32Array>[ 1, 0 ]
+*
+* var bool = ( w === out );
+* // returns true
+*/
+function toWords( a, out, stride, offset ) {
+	out[ offset ] = a.hi;
+	out[ offset + stride ] = a.lo;
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = toWords;

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/index.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Split a 64-bit unsigned integer into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer).
+*
+* @module @stdlib/number/uint64/base/to-words
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+* var toWords = require( '@stdlib/number/uint64/base/to-words' );
+*
+* var a = new Uint64( 4294967296 );
+* var w = toWords( a );
+* // returns [ 1, 0 ]
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+* var toWords = require( '@stdlib/number/uint64/base/to-words' );
+*
+* var out = new Uint32Array( 2 );
+*
+* var a = new Uint64( 4294967296 );
+* var w = toWords.assign( a, out, 1, 0 );
+* // returns <Uint32Array>[ 1, 0 ]
+*
+* var bool = ( w === out );
+* // returns true
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var main = require( './main.js' );
+var assign = require( './assign.js' );
+
+
+// MAIN //
+
+setReadOnly( main, 'assign', assign );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/lib/main.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var fcn = require( './assign.js' );
+
+
+// MAIN //
+
+/**
+* Splits a 64-bit unsigned integer into a higher order word (32-bit unsigned integer) and a lower order word (32-bit unsigned integer).
+*
+* @param {Uint64} a - input value
+* @returns {Array<number>} output array
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 4294967296 );
+* var w = toWords( a );
+* // returns [ 1, 0 ]
+*/
+function toWords( a ) {
+	return fcn( a, [ 0>>>0, 0>>>0 ], 1, 0 );
+}
+
+
+// EXPORTS //
+
+module.exports = toWords;

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@stdlib/number/uint64/base/to-words",
+  "version": "0.0.0",
+  "description": "Split a 64-bit unsigned integer into a higher order word and a lower order word.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "base",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "types",
+    "type",
+    "uint64",
+    "unsigned",
+    "64-bit",
+    "integer",
+    "int",
+    "words",
+    "split",
+    "high",
+    "low"
+  ]
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.assign.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.assign.js
@@ -1,0 +1,215 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasBigIntSupport = require( '@stdlib/assert/has-bigint-support' );
+var BigInt = require( '@stdlib/bigint/ctor' );
+var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var isInteger = require( '@stdlib/math/base/assert/is-integer' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var toWords = require( './../lib/assign.js' );
+
+
+// VARIABLES //
+
+var HAS_BIGINT = hasBigIntSupport();
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof toWords, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a two-element numeric array containing integers', function test( t ) {
+	var out;
+	var a;
+	var w;
+
+	out = [ 0, 0 ];
+	a = new Uint64( 4294967296 );
+	w = toWords( a, out, 1, 0 );
+
+	t.strictEqual( w, out, 'returns expected value' );
+	t.strictEqual( isInteger( w[0] ), true, 'returns expected value' );
+	t.strictEqual( isInteger( w[1] ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function splits a 64-bit unsigned integer into a higher order word and a lower order word', function test( t ) {
+	var values;
+	var out;
+	var u;
+	var v;
+	var w;
+	var i;
+
+	values = [
+		0,
+		1,
+		2,
+		3,
+		4,
+		5,
+		10,
+		99,
+		100,
+		999,
+		1000,
+		999999,
+		1000000,
+		999999999,
+		1000000000,
+		UINT32_MAX,
+		UINT32_MAX + 1,
+		9007199254740881, // Largest prime under 2^53
+		MAX_SAFE_INTEGER - 1,
+		MAX_SAFE_INTEGER
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		v = new Uint64( values[i] );
+		out = [ 0, 0 ];
+
+		w = toWords( v, out, 1, 0 );
+		t.strictEqual( w, out, 'returns expected value' );
+
+		u = new Uint64.from( w );
+		t.strictEqual( u.toString(), v.toString(), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function splits a 64-bit unsigned integer into a higher order word and a lower order word (larger than max safe integer)', function test( t ) {
+	var values;
+	var out;
+	var u;
+	var v;
+	var w;
+	var i;
+
+	if ( !HAS_BIGINT ) {
+		t.end();
+		return;
+	}
+
+	values = [
+		'9007199254740992', // MAX_SAFE_INTEGER + 1
+		'9999999999999999',
+		'10000000000000000',
+		'99999999999999999',
+		'100000000000000000',
+		'999999999999999999',
+		'1000000000000000000',
+		'9223372036854775783', // Largest prime under 2^63
+		'9999999999999999999',
+		'10000000000000000000',
+		'18446744073709551557', // Largest prime under 2^64
+		'18446744073709551615' // 2^64 - 1
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		// TODO: Use uint64/parse instead of BigInt
+		v = new Uint64( BigInt( values[i] ) );
+		out = [ 0, 0 ];
+
+		w = toWords( v, out, 1, 0 );
+		t.strictEqual( w, out, 'returns expected value' );
+
+		u = new Uint64.from( w );
+		t.strictEqual( u.toString(), v.toString(), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function supports providing an output object (array)', function test( t ) {
+	var out;
+	var a;
+	var w;
+
+	out = [ 0, 0 ];
+	a = new Uint64( 4294967296 );
+	w = toWords( a, out, 1, 0 );
+
+	t.strictEqual( w, out, 'returns expected value' );
+	t.strictEqual( w[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( w[ 1 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing an output object (typed array)', function test( t ) {
+	var out;
+	var a;
+	var w;
+
+	out = new Uint32Array( 2 );
+	a = new Uint64( 4294967296 );
+	w = toWords( a, out, 1, 0 );
+
+	t.strictEqual( w, out, 'returns expected value' );
+	t.strictEqual( w[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( w[ 1 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a stride', function test( t ) {
+	var out;
+	var val;
+	var a;
+
+	out = new Uint32Array( 4 );
+	a = new Uint64( 4294967298 );
+	val = toWords( a, out, 2, 0 );
+
+	t.strictEqual( val, out, 'returns expected value' );
+	t.strictEqual( val[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( val[ 1 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 2 ], 2, 'returns expected value' );
+	t.strictEqual( val[ 3 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an offset', function test( t ) {
+	var out;
+	var val;
+	var a;
+
+	out = new Uint32Array( 4 );
+	a = new Uint64( 4294967298 );
+	val = toWords( a, out, 2, 1 );
+
+	t.strictEqual( val, out, 'returns expected value' );
+	t.strictEqual( val[ 0 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 1 ], 1, 'returns expected value' );
+	t.strictEqual( val[ 2 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 3 ], 2, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var toWords = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof toWords, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is an `assign` method', function test( t ) {
+	t.strictEqual( hasOwnProp( toWords, 'assign' ), true, 'has property' );
+	t.strictEqual( typeof toWords.assign, 'function', 'has method' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.main.js
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isInteger = require( '@stdlib/math/base/assert/is-integer' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var toWords = require( './../lib/main.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof toWords, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a two-element numeric array containing integers', function test( t ) {
+	var a;
+	var w;
+
+	a = new Uint64( 4294967296 );
+	w = toWords( a );
+
+	t.strictEqual( isInteger( w[0] ), true, 'returns expected value' );
+	t.strictEqual( isInteger( w[1] ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function splits a 64-bit unsigned integer into a higher order word and a lower order word', function test( t ) {
+	var a;
+	var w;
+
+	a = new Uint64( 4294967296 );
+	w = toWords( a );
+
+	t.strictEqual( w[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( w[ 1 ], 0, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a package to extract the high and low 32-bit words of an `Uint64` instance.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- This package unblocks #12508.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
