### PR TITLE
fix: pass `sigma` to `skewness` in `stats/base/dists/rayleigh/ctor`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/ctor/lib/main.js
@@ -268,7 +268,7 @@ setReadOnlyAccessor( Rayleigh.prototype, 'mode', function get() {
 * // returns ~0.631
 */
 setReadOnlyAccessor( Rayleigh.prototype, 'skewness', function get() {
-	return skewness( this.k, this.sigma );
+	return skewness( this.sigma );
 });
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes the Rayleigh constructor's `skewness` accessor so it calls `skewness( this.sigma )` instead of `skewness( this.k, this.sigma )`.

### `stats/base/dists/rayleigh/ctor`

The `skewness` accessor at `ctor/lib/main.js:271` invoked `skewness( this.k, this.sigma )`, but a Rayleigh instance has no `k` property and the standalone `@stdlib/stats/base/dists/rayleigh/skewness` is a single-argument function. The accessor returned the correct Rayleigh skewness constant only because `this.k` evaluated to `undefined`, fell through both `isnan` and `< 0.0` guards inside `skewness`, and JS arity dropped the trailing `this.sigma`. The other seven scalar moment accessors on `Rayleigh.prototype` (`entropy`, `kurtosis`, `mean`, `median`, `mode`, `stdev`, `variance`) all use the `fn( this.sigma )` pattern — a 7/8 = 87.5% majority. Aligning `skewness` with that pattern removes the latent invocation bug while preserving the observed value (the Rayleigh skewness is parameter-independent for any valid `sigma`, and the constructor already validates `sigma` as positive on construction and assignment). The existing test at `ctor/test/test.js:211` asserts `rayleigh.skewness === skewness( 0.5 )` (single-argument), which the corrected accessor satisfies; no other test, type declaration, REPL doc, README section, or example references a `k` property.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by a cross-package API drift audit of the `stats/base/dists/rayleigh` namespace (15 members). The accessor-call drift was the only finding that advanced through pre-validation gates and the three-agent semantic / cross-reference / structural review. Other observed deviations were deliberately not changed: the `ctor` package's absence of native bindings (no math-function analog), `mgf`'s missing `test/fixtures/julia/` (the Rayleigh MGF has no R or Julia reference implementation, per the existing `TODO` in `mgf/test/test.js`), and `entropy`'s `PositiveNumber` / `sigma <= 0.0` validation (entropy diverges at `sigma = 0`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A cross-package API drift audit of `stats/base/dists/rayleigh` was run by Claude Code: structural and semantic features were extracted per member, the majority pattern was computed per feature, and outliers were triaged through three independent review agents before the single advancing correction was applied. Tests and the example were re-run against the fixed accessor before commit; the change was reviewed by myself before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01QN95HUKdhbLZMzYrx6Dgob)_