### PR TITLE
docs: fix and align TSDoc comments in `iter` declarations

### DIFF
--- a/lib/node_modules/@stdlib/iter/cusome-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/cusome-by/docs/types/index.d.ts
@@ -62,7 +62,7 @@ type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U>;
 * Returns an iterator which cumulatively tests whether at least `n` iterated values pass a test implemented by a predicate function.
 *
 * @param iterator - source iterator
-* @param n - minimum number of truthy elements
+* @param n - minimum number of successful values
 * @param predicate - predicate function
 * @param thisArg - execution context
 * @returns iterator

--- a/lib/node_modules/@stdlib/iter/cusome/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/cusome/docs/types/index.d.ts
@@ -55,7 +55,8 @@ type Iterator = Iter | IterableIterator;
 * v = it.next().value;
 * // returns true
 *
-* // ..
+* var bool = it.next().done;
+* // returns true
 */
 declare function iterCuSome( iterator: Iterator, n: number ): Iterator;
 

--- a/lib/node_modules/@stdlib/iter/datespace/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/datespace/docs/types/index.d.ts
@@ -81,7 +81,7 @@ declare function iterDatespace( start: number | string | Date, stop: number | st
 * @param start - starting date as either a `Date` object, JavaScript timestamp, or a date string (inclusive)
 * @param stop - stopping date as either a `Date` object, JavaScript timestamp, or a date string (inclusive)
 * @param options - function options
-* @param options.round - specifies how sub-millisecond times should be rounded: 'floor', 'ceil', or 'round' (default: 'floor' )
+* @param options.round - specifies how sub-millisecond times should be rounded: 'floor', 'ceil', or 'round' (default: 'floor')
 * @throws a numeric `start` argument must be a nonnegative integer
 * @throws a numeric `stop` argument must be a nonnegative integer
 * @throws unable to parse date string

--- a/lib/node_modules/@stdlib/iter/dedupe-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/dedupe-by/docs/types/index.d.ts
@@ -86,8 +86,9 @@ type Quinary = ( curr: any, sprev: any, dprev: any, index: number, acc: any ) =>
 * Indicates whether an iterated value is a "duplicate".
 *
 * @param curr - current source iterated value
-* @param prev - previous iterated value
-* @param index - iteration index (zero-based)
+* @param sprev - previous source iterated value
+* @param dprev - previous downstream iterated value
+* @param index - source iteration index (zero-based)
 * @param acc - previous resolved value
 * @returns resolved value
 */

--- a/lib/node_modules/@stdlib/iter/do-until-each/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/do-until-each/docs/types/index.d.ts
@@ -132,7 +132,7 @@ type Predicate = nullaryPredicate | unaryPredicate | binaryPredicate;
 * // returns 2
 *
 * r = it.next().value;
-* // undefined
+* // returns undefined
 *
 * // ...
 */

--- a/lib/node_modules/@stdlib/iter/do-while-each/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/do-while-each/docs/types/index.d.ts
@@ -93,7 +93,7 @@ type Predicate = nullaryPredicate | unaryPredicate | binaryPredicate;
 
 /**
 * Returns an iterator which invokes a function for each iterated value **before** returning the iterated value until either a predicate function returns `false` or the iterator has iterated over all values.
-* The condition is evaluated *after* executing the provided function; thus, fcn` *always* executes at least once.
+* The condition is evaluated *after* executing the provided function; thus, `fcn` *always* executes at least once.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/iter/fill/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/fill/docs/types/index.d.ts
@@ -35,7 +35,7 @@ type Iterator = Iter | IterableIterator;
 *
 * @param iterator - input iterator
 * @param value - static (fill) value
-* @param begin - start iteration index (inclusive)
+* @param begin - start iteration index (inclusive; default: 0)
 * @param end - end iteration index (non-inclusive)
 * @returns iterator
 *

--- a/lib/node_modules/@stdlib/iter/pipeline-thunk/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/pipeline-thunk/docs/types/index.d.ts
@@ -26,11 +26,11 @@ import { Iterator as Iter, IterableIterator } from '@stdlib/types/iter';
 type Iterator = Iter | IterableIterator;
 
 /**
-* Iterator function
+* Iterator function.
 *
 * @param iterator - input iterator
 * @param args - function arguments
-* @returns hash value
+* @returns iterator function result
 */
 type IteratorFunction = ( iterator: Iterator, ...args: Array<any> ) => any;
 

--- a/lib/node_modules/@stdlib/iter/replicate-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/replicate-by/docs/types/index.d.ts
@@ -70,7 +70,7 @@ type Ternary = ( value: any, index: number, n: number ) => number;
 type Callback = Nullary | Unary | Binary | Ternary;
 
 /**
-* Returns an iterator which invokes a function for each iterated value.
+* Returns an iterator which replicates each iterated value according to a provided function.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/iter/strided/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/strided/docs/types/index.d.ts
@@ -35,7 +35,7 @@ type Iterator = Iter | IterableIterator;
 * @param iterator - input iterator
 * @param stride - stride
 * @param offset - offset
-* @param eager - boolean indicating whether to eagerly advance an input iterator when provided a non-zero `offset`
+* @param eager - boolean indicating whether to eagerly advance an input iterator when provided a non-zero `offset` (default: false)
 * @returns iterator
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request fixes documentation-only (TSDoc) defects and inconsistencies in the TypeScript declaration files of `iter` packages, surfaced by an audit of the namespace. No runtime behavior or emitted types change. Changes:

-   `do-while-each`: fix a malformed inline-code span (`` thus, fcn` `` → `` thus, `fcn` ``) in the summary.
-   `replicate-by`: replace a stale, copy-pasted summary ("invokes a function for each iterated value") with the correct "replicates each iterated value according to a provided function".
-   `pipeline-thunk`: fix `IteratorFunction` `@returns hash value` → `@returns iterator function result` (copy-paste from an unrelated function) and add the missing terminating period to its summary.
-   `cusome-by`: fix `@param n` from "minimum number of truthy elements" (the non-predicate `cusome` wording) to "minimum number of successful values" (`n` counts predicate-passing values, matching `some-by`).
-   `dedupe-by`: fix the `Callback` union doc block which named a nonexistent `prev` param and omitted the real `sprev`/`dprev` (now mirrors the maximal-arity `Quinary` member).
-   `strided`: document `(default: false)` for the optional `eager` param, matching the sibling `strided-by` and the implementation.
-   `fill`: document `@param begin` `(default: 0)`, matching the sibling `slice` and the implementation.
-   `datespace`: remove a stray space in `(default: 'floor' )` to match the first overload.
-   `cusome`: complete a truncated `@example` (`// ..`) with the family's closing `done` assertion (matching `cuany`/`cuevery`/`cunone`).
-   `do-until-each`: add the `returns` keyword to an `@example` annotation (`// undefined` → `// returns undefined`) for consistency with every other annotation in the block.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

One change aligns an outlier with its sibling family rather than fixing an outright error: the `cusome` example completion (replacing a `// ..` placeholder with the family's closing `done` assertion). Happy to drop it if reviewers consider it out of scope for a docs-fix PR.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

These changes were identified via a systematic audit of the `iter` namespace's TypeScript declarations and then re-checked against the broader namespace conventions. Two candidate findings were intentionally dropped after that re-check: removing the `Predicate` union `@param` tags in `any-by` (all `-by` siblings carry them, so removal would create an outlier) and adding index-argument `@throws` to `to-array-view` (only `to-array-view-right` documents these; `fill`/`slice`/`strided` omit them, so the sibling is the anomaly). The companion `refactor:` changes (helper-type renames and `any`/`unknown` alignment) are submitted as separate PRs.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

The TSDoc inconsistencies were surfaced by an AI-assisted audit (Claude Code) of the `iter` namespace declarations, and the fixes were drafted with Claude Code. Each finding was verified against the actual declaration files, implementations, and sibling-package conventions before applying; several candidate findings were discarded as false positives or convention violations.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
