### PR TITLE
refactor: align callback helper type names in `iter/for-each`

### DIFF
--- a/lib/node_modules/@stdlib/iter/for-each/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/for-each/docs/types/index.d.ts
@@ -30,7 +30,7 @@ type Iterator = Iter | IterableIterator;
 *
 * @returns callback result
 */
-type Nullary = () => any;
+type nullaryCallback = () => any;
 
 /**
 * Callback function invoked for each iterated value.
@@ -38,16 +38,7 @@ type Nullary = () => any;
 * @param value - iterated value
 * @returns callback result
 */
-type Unary = ( value: any ) => any;
-
-/**
-* Callback function invoked for each iterated value.
-*
-* @param value - iterated value
-* @param i - iteration index
-* @returns callback result
-*/
-type Binary = ( value: any, i: number ) => any;
+type unaryCallback = ( value: any ) => any;
 
 /**
 * Callback function invoked for each iterated value.
@@ -56,7 +47,16 @@ type Binary = ( value: any, i: number ) => any;
 * @param i - iteration index
 * @returns callback result
 */
-type Callback = Nullary | Unary | Binary;
+type binaryCallback = ( value: any, i: number ) => any;
+
+/**
+* Callback function invoked for each iterated value.
+*
+* @param value - iterated value
+* @param i - iteration index
+* @returns callback result
+*/
+type Callback = nullaryCallback | unaryCallback | binaryCallback;
 
 /**
 * Returns an iterator which invokes a function for each iterated value before returning the iterated value.

--- a/lib/node_modules/@stdlib/iter/for-each/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/iter/for-each/docs/types/test.ts
@@ -46,9 +46,8 @@ function iterator() {
 *
 * @param v - iterated value
 * @param i - iteration index
-* @returns callback result
 */
-function fcn( v: any, i: number ) {
+function fcn( v: any, i: number ): any {
 	if ( v !== v || i !== i ) {
 		throw new Error( 'something went wrong' );
 	}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Renames the internal callback helper type aliases in `iter/for-each` from `Nullary`/`Unary`/`Binary` to `nullaryCallback`/`unaryCallback`/`binaryCallback`, matching the naming convention used by every other member of the `iter` `*-each` family (`until-each`, `while-each`, `do-until-each`, `do-while-each`). `for-each` was the lone outlier.

These are non-exported helper types unioned into the `Callback` type used in the function signature, so there is no public API change and no `$ExpectType` impact. The fixture `fcn` in `test.ts` is also brought in line with the family (drops a stale `@returns` tag for a function that does not return, matching `do-while-each`).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by a TypeScript-declarations audit of the `iter` namespace. Documentation-only fixes from the same audit are submitted in a separate PR.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

The naming inconsistency was surfaced by an AI-assisted audit (Claude Code) of the `iter` namespace declarations, and the rename was drafted with Claude Code and verified against the sibling family.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
