### PR TITLE
refactor: align callback and predicate value types in `iter/do-until-each`

### DIFF
--- a/lib/node_modules/@stdlib/iter/do-until-each/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/do-until-each/docs/types/index.d.ts
@@ -30,7 +30,7 @@ type Iterator = Iter | IterableIterator;
 *
 * @returns callback result
 */
-type nullaryCallback = () => unknown;
+type nullaryCallback = () => any;
 
 /**
 * Callback function invoked for each iterated value.
@@ -38,7 +38,7 @@ type nullaryCallback = () => unknown;
 * @param value - iterated value
 * @returns callback result
 */
-type unaryCallback = ( value: unknown ) => unknown;
+type unaryCallback = ( value: any ) => any;
 
 /**
 * Callback function invoked for each iterated value.
@@ -47,7 +47,7 @@ type unaryCallback = ( value: unknown ) => unknown;
 * @param i - iteration index
 * @returns callback result
 */
-type binaryCallback = ( value: unknown, i: number ) => unknown;
+type binaryCallback = ( value: any, i: number ) => any;
 
 /**
 * Callback function invoked for each iterated value.
@@ -71,7 +71,7 @@ type nullaryPredicate = () => boolean;
 * @param value - iterated value
 * @returns a boolean indicating whether to continue iterating or not
 */
-type unaryPredicate = ( value: unknown ) => boolean;
+type unaryPredicate = ( value: any ) => boolean;
 
 /**
 * Predicate function invoked for each iterated value.
@@ -80,7 +80,7 @@ type unaryPredicate = ( value: unknown ) => boolean;
 * @param i - iteration index
 * @returns a boolean indicating whether to continue iterating or not
 */
-type binaryPredicate = ( value: unknown, i: number ) => boolean;
+type binaryPredicate = ( value: any, i: number ) => boolean;
 
 /**
 * Predicate function invoked for each iterated value.
@@ -136,7 +136,7 @@ type Predicate = nullaryPredicate | unaryPredicate | binaryPredicate;
 *
 * // ...
 */
-declare function iterDoUntilEach( iterator: Iterator, predicate: Predicate, fcn: Callback, thisArg?: unknown ): Iterator;
+declare function iterDoUntilEach( iterator: Iterator, predicate: Predicate, fcn: Callback, thisArg?: any ): Iterator;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Changes the callback/predicate value types and `thisArg` in `iter/do-until-each` from `unknown` to `any`, aligning it with the rest of the `iter` `*-each` family (`until-each`, `while-each`, `do-while-each`), all of which use `any`. `do-until-each` was the lone outlier.

Specifically, `nullaryCallback`/`unaryCallback`/`binaryCallback` value and return types, `unaryPredicate`/`binaryPredicate` value types, and the `thisArg?` parameter on `iterDoUntilEach` are changed from `unknown` to `any`.

Since this only loosens (input) parameter types and the returned `Iterator` type is unchanged, there is no `$ExpectType` impact: the existing `test.ts` assertions (`$ExpectType Iterator` and the `$ExpectError` cases) continue to hold, so no test updates are required.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

The divergence could alternatively be resolved by upgrading the three siblings to `unknown` (the stricter, more modern choice). This PR instead matches the established family convention (`any`) by changing the single outlier; happy to flip the direction if reviewers prefer `unknown` across the family.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by a TypeScript-declarations audit of the `iter` namespace. Documentation-only fixes from the same audit are submitted in a separate PR.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

The inconsistency was surfaced by an AI-assisted audit (Claude Code) of the `iter` namespace declarations, and the change was drafted with Claude Code and verified against the sibling family and the package's type tests.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
