### PR TITLE
docs: update parameter type and add keyword

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/README.md
@@ -222,7 +222,7 @@ The function accepts the following arguments:
 double stdlib_strided_dcorrelation( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const double *Y, const CBLAS_INT strideY );
 ```
 
-#### stdlib_strided_dcorrelation_ndarray( N, \*X, strideX, offsetX, \*Y, strideY, offsetY )
+#### stdlib_strided_dcorrelation_ndarray( N, \*X, sx, ox, \*Y, sy, oy )
 
 Computes the [correlation distance][correlation-distance] between two double-precision floating-point strided arrays using alternative indexing semantics.
 

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/README.md
@@ -222,7 +222,7 @@ The function accepts the following arguments:
 double stdlib_strided_dcorrelation( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const double *Y, const CBLAS_INT strideY );
 ```
 
-#### stdlib_strided_dcorrelation_ndarray( N, \*X, sx, ox, \*Y, sy, oy )
+#### stdlib_strided_dcorrelation_ndarray( N, \*X, strideX, offsetX, \*Y, strideY, offsetY )
 
 Computes the [correlation distance][correlation-distance] between two double-precision floating-point strided arrays using alternative indexing semantics.
 

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/dcorrelation.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/dcorrelation.js
@@ -29,7 +29,7 @@ var ndarray = require( './ndarray.js' );
 /**
 * Computes the correlation distance between two double-precision floating-point strided arrays.
 *
-* @param {PositiveInteger} N - number of indexed elements
+* @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float64Array} x - first input array
 * @param {integer} strideX - stride length of `x`
 * @param {Float64Array} y - second input array

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/dcorrelation.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/dcorrelation.native.js
@@ -28,7 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Computes the correlation distance between two double-precision floating-point strided arrays.
 *
-* @param {PositiveInteger} N - number of indexed elements
+* @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float64Array} x - first input array
 * @param {integer} strideX - stride length of `x`
 * @param {Float64Array} y - second input array

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/ndarray.js
@@ -28,7 +28,7 @@ var dpcorr = require( '@stdlib/stats/strided/dpcorr' ).ndarray;
 /**
 * Computes the correlation distance between two double-precision floating-point strided arrays using alternative indexing semantics.
 *
-* @param {PositiveInteger} N - number of indexed elements
+* @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float64Array} x - first input array
 * @param {integer} strideX - stride length of `x`
 * @param {NonNegativeInteger} offsetX - starting index of `x`

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/ndarray.native.js
@@ -28,7 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Computes the correlation distance between two double-precision floating-point strided arrays using alternative indexing semantics.
 *
-* @param {PositiveInteger} N - number of indexed elements
+* @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float64Array} x - first input array
 * @param {integer} strideX - stride length of `x`
 * @param {NonNegativeInteger} offsetX - starting index of `x`

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/package.json
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/package.json
@@ -62,6 +62,7 @@
     "dcorrelation",
     "correlation",
     "distance",
+    "metric",
     "strided",
     "strided array",
     "typed",


### PR DESCRIPTION
## Description

This pull request aligns `@stdlib/stats/strided/distances/dcorrelation` with the seven sibling packages in the namespace.

### Namespace summary

-   **Target:** `@stdlib/stats/strided/distances`
-   **Members analyzed:** 8 (`dchebyshev`, `dcityblock`, `dcorrelation`, `dcosine-distance`, `dcosine-similarity`, `deuclidean`, `dminkowski`, `dsquared-euclidean`)
-   **Features extracted:** complete file tree, `package.json` shape (top-level keys, `scripts`, `directories`, `keywords`), `manifest.json` shape, README heading sequence, `test/` `benchmark/` `examples/` file-name patterns, semantic features (public signature, JSDoc shape, dependency set, error construction, validation prologue, return kind) from `lib/main.js`, the per-package wrapper, and `lib/ndarray.js`.
-   **Features with clear majority (≥75% = 6/8):** identical 33-file structure (100%); `package.json` top-level key set (100%); `directories` keys (100%); empty `scripts` (100%); `manifest.json` keys `confs`/`fields`/`options` (100%); 14 universal keywords at 100% (`array`, `distance`, `double`, `float64`, `float64array`, `math`, `mathematics`, `statistics`, `stats`, `stdlib`, `stdmath`, `strided`, `strided array`, `typed`); README H2 set (`Usage`, `Notes`, `Examples`, `C APIs`, 100%); H3 set (`Usage`, `Examples`, 100%); `metric` keyword at 7/8 = 87.5%; `@param {NonNegativeInteger} N` JSDoc in the lib wrappers and `ndarray.js` at 7/8 = 87.5%; full `strideX, offsetX, strideY, offsetY` parameter names in the README C-API `ndarray` H4 heading at 7/8 = 87.5% (corrected then reverted — see *Dropped fixes* below).
-   **Features without clear majority (excluded from drift detection):** REPL phrasing `Stride length of`/`for`; TypeScript declaration phrasing (the canonical TS form `` `x` stride length `` differs by *word order* from the JS `stride length of `x`` form, so a simple `of → for` substitution would not produce the sibling pattern); description verb `Compute the …` at 100% (unchanged — PR #12310's `Compute → Calculate` standardization across the parent `stats/strided` namespace explicitly excluded the `distances` sub-namespace, and within this sub-namespace the verb is consistent); metric-specific keywords (e.g. `cosine`, `euclidean` — package-specific, no majority).

### `@stdlib/stats/strided/distances/dcorrelation`

`dcorrelation` lagged the other seven `stats/strided/distances` packages on its JSDoc and package metadata. Its `@param {PositiveInteger} N` JSDoc across `lib/dcorrelation.js`, `lib/dcorrelation.native.js`, `lib/ndarray.js`, and `lib/ndarray.native.js` contradicts the tested `N <= 0 → NaN` contract — 7/8 siblings annotate `NonNegativeInteger`, and tests at `test/test.dcorrelation.js:64-78` and `test/test.ndarray.js:64-78` already exercise the `N=0` and `N<0` paths. The `package.json` keywords array was missing `metric`, the only universally-present semantic tag across the seven sibling distance packages (`dchebyshev`, `dcityblock`, `dcosine-distance`, `dcosine-similarity`, `deuclidean`, `dminkowski`, `dsquared-euclidean` all carry it).

### Validation

Three independent validation agents reviewed each candidate fix before any edit was applied:

1.  **Semantic-review (Opus):** read `dcorrelation/lib/dcorrelation.js`, `lib/ndarray.js`, both `.native.js` counterparts, both test suites, and the same files for `deuclidean` and `dcosine-distance` for comparison. Verdict: `confirmed-drift` on the JSDoc N-type retype; the function explicitly handles `N <= 0` by returning `NaN`, exactly matching siblings, so the `PositiveInteger` annotation has no semantic basis.
2.  **Cross-reference (Opus):** searched for downstream consumers of the literal pre-fix strings across the wider `lib/node_modules/@stdlib/` tree. Verdict: `safe-to-fix` on the keyword addition (no tooling treats `"metric"` as a semantically meaningful discovery index), the README heading correction (no test, benchmark, or example references `sx, ox, sy, oy`), and the JSDoc retype (no runtime check, test, or `.d.ts` consumes the JSDoc type tag). Verdict: `needs-human` on a broader REPL/TS wording cleanup — the candidate conflated `lib/ndarray.js`'s universal `stride length of` form (which is *not* drifted) with `docs/repl.txt`'s drifted `Stride length of` form and with `docs/types/index.d.ts`'s entirely different `` `x` stride length `` word order; that bucket was dropped.
3.  **Structural-review (Sonnet):** confirmed that `"metric"` semantically applies to a correlation-distance package — the correlation distance `d_c = 1 - r(X, Y)` is a valid pseudometric (non-negative, symmetric, triangle inequality), and the sibling pattern applies the keyword uniformly across the group regardless of strict-metric vs pseudometric distinction (`dcosine-similarity`, which is not itself a metric, also carries the keyword).

### Dropped fixes (after agent validation passed)

-   **README `## C APIs` `ndarray` H4 heading:** initially replaced abbreviated `sx, ox, sy, oy` placeholders with the full `strideX, offsetX, strideY, offsetY` form (matching all 7 siblings) in commit `4415b3397`. CI's `Run changed examples` job flagged the resulting 91-character heading against `remark-lint`'s `maximum-heading-length: 80` rule. Every sibling heading in the namespace exceeds the same limit (89-97 characters), but the rule only runs on PR-touched READMEs; the violation has accumulated silently. Reverted in commit `a000843e6`. The README's argument list (lines 241-245) and the literal C signature in the same file (line 248) already use the full parameter names, so readers see the correct names; only the heading retains the abbreviation. The namespace-wide heading-length issue is a separate concern.

### Other deliberately excluded

-   REPL phrasing cleanup (`Stride length of` → `Stride length for` in `docs/repl.txt`) and the TypeScript declaration rewording (`stride length of `x`` → `` `x` stride length ``, `starting index of `x`` → `starting index for `x`` in `docs/types/index.d.ts`) — agent #2 flagged the candidate as ambiguous; the underlying drift is real but the fix requires file-by-file disambiguation rather than a single substitution. Logged for a future targeted pass.
-   Removal of the self-referential `"dcorrelation"` keyword (1/8 occurrence; siblings exclude the d-prefixed package name) — outside the validated scope and would need a separate `chore:`-level run.
-   `dcorrelation/src/main.c` `@param` C-comment phrasing — real drift, but outside the agent-validated scope of this run.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

-   Final diff: 5 lines across 5 files (one `package.json` keyword insertion, four JSDoc `@param N` retypes).
-   No tests, examples, benchmarks, REPL fixtures, TypeScript declarations, or REPL docs were modified.
-   Full local report (member list, feature distributions, per-agent verdicts, dropped findings, future-run notes) saved at `~/drift-reports/drift-stats-strided-distances-2026-06-09.md` outside the repo working tree.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package API drift detection routine on the randomly-selected `@stdlib/stats/strided/distances` namespace. Structural features (file tree, `package.json` shape, README headings, etc.) were extracted across all eight members; semantic features (JSDoc shape, public signature, dependency set, validation prologue, return kind) were read directly from each member's `lib/main.js`, per-package wrapper, and `lib/ndarray.js`. Three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) reviewed each candidate fix before any file was edited. A human should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md