### PR TITLE
docs: update TypeScript documentation and fix whitespace in `nlp/lda` declarations

### DIFF
--- a/lib/node_modules/@stdlib/nlp/lda/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/nlp/lda/docs/types/index.d.ts
@@ -28,7 +28,7 @@ interface Options {
 	alpha?: number;
 
 	/**
-	*  Dirichlet hyper-parameter for word vector phi (default: `0.1`).
+	* Dirichlet hyper-parameter for word vector phi (default: `0.1`).
 	*/
 	beta?: number;
 }
@@ -76,8 +76,9 @@ interface Model {
 * @param documents - document corpus
 * @param K - number of topics
 * @param options - options object
-* @param options.alpha - Dirichlet hyper-parameter of topic vector theta
-* @param options.beta - Dirichlet hyper-parameter for word vector phi
+* @param options.alpha - Dirichlet hyper-parameter of topic vector theta (default: 50/K)
+* @param options.beta - Dirichlet hyper-parameter for word vector phi (default: 0.1)
+* @throws first argument must be an array of strings
 * @throws second argument must be a positive integer
 * @throws must provide valid options
 * @returns model object


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request fixes TSDoc completeness and a whitespace inconsistency in the `@stdlib/nlp/lda` TypeScript declaration file (`docs/types/index.d.ts`). The changes are documentation-only and do not affect type-checking or runtime behavior:

-   Adds the missing `@throws first argument must be an array of strings` tag, which the implementation (`lib/main.js`) documents and throws at runtime but the declaration omitted.
-   Documents the `alpha`/`beta` defaults (`50/K` and `0.1`) on their `@param` lines, matching the `Options` interface, the implementation, and the file's own convention (e.g. the `getTerms` `no` param already states `(default: 10)`).
-   Removes a stray double space after the asterisk in the `Options.beta` description.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

The declaration issues were surfaced by a Claude Code TypeScript-declarations audit and verified against the implementation; the fixes were reviewed and applied with Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
