### PR TITLE
docs: add notes section to `time/quarter-of-year`

### DIFF
--- a/lib/node_modules/@stdlib/time/quarter-of-year/README.md
+++ b/lib/node_modules/@stdlib/time/quarter-of-year/README.md
@@ -66,6 +66,16 @@ q = quarterOfYear( 'apr' );
 
 <!-- /.usage -->
 
+<section class="notes">
+
+## Notes
+
+-   The function's return value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
+
+</section>
+
+<!-- /.notes -->
+
 <section class="examples">
 
 ## Examples


### PR DESCRIPTION
## Description

This pull request adds the `## Notes` section present in 17 of 19 sibling `@stdlib/time/*` packages (~89% conformance) to the `quarter-of-year` README. The boilerplate text matches the disclaimer added to `iso-weeks-in-year` (#12313), `day-of-quarter`, and `day-of-year` (#12369). `quarterOfYear()` accepts a `Date` argument and uses `Date.prototype.getMonth()` (local time), so the daylight-savings / timezone disclaimer is semantically applicable, matching sibling `day-of-quarter`.

### Namespace summary

- Members analyzed: 19 (`@stdlib/time/*` direct children with `package.json`)
- Structural features with clear majority (≥75%): `file_tree` (set), `pkg_json.top_keys`, `readme_sections` (set and sequence), `test_files`, `examples_files`
- Semantic features with clear majority: `errorConstruction` (uniformly `format`), `@example` presence, JSDoc tag families (matched to per-function semantics)
- Features excluded for no clear majority: `benchmark/benchmark.js` presence (2/19), `pkg_json.scripts_keys`, `pkg_json.stdlib_keys`

### `quarter-of-year`

Sole outlier with confirmed, mechanically fixable drift. The README jumped from `## Usage` directly to `## Examples`, skipping the `## Notes` section present in 17 of 19 siblings (89.5% conformance). The Notes content is identical verbatim across all conformant siblings; the disclaimer applies semantically because `quarterOfYear` reads the month via `Date.prototype.getMonth()` in local time.

### Validation

- Structural extraction: file trees, `package.json` shapes, README section sets and sequences, test/benchmark/example filenames across all 19 members.
- Semantic extraction: error-construction style, JSDoc tag families, dependencies via `require()`, public-function shapes — scanned directly across all 19 `lib/main.js` files.
- Three-agent validation on the surviving outlier (cross-reference and structural review) — both returned `confirmed-drift`. Semantic-review skipped (purely structural feature).
- Deliberately excluded: `base` (meta sub-namespace), `tic`/`toc` lacking CLI infrastructure (no shell use case; CLI not present in ≥90% of stdlib outside this namespace), and `benchmark/benchmark.js` adds across 17 packages (below 75% majority threshold).
- Generator-owned files (`docs/repl.txt`, `docs/types/index.d.ts`) intentionally not touched, despite some prior maintainer PRs (#12313) editing them; this PR plays conservative on generator-owned scope.

## Related Issues

No.

## Questions

No.

## Other

Recent precedent for this exact correction on adjacent siblings: #12313 (`iso-weeks-in-year`) and #12369 (`day-of-quarter`, `day-of-year`). Both added the verbatim Notes block in the same README position.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a cross-package API drift detection routine: structural and semantic features extracted across all 19 direct children of `@stdlib/time/`, majority pattern identified per feature (75% threshold), single high-signal outlier (`quarter-of-year` missing `## Notes`) confirmed via multi-agent validation, and the verbatim sibling boilerplate applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_014Q7oBSmAMebMhFbDoyK86a)_