### PR TITLE
docs: order `float16` before `float32` in data type lists

### DIFF
--- a/lib/node_modules/@stdlib/array/ctors/README.md
+++ b/lib/node_modules/@stdlib/array/ctors/README.md
@@ -51,9 +51,9 @@ var ctor = ctors( 'float64' );
 
 The function returns constructors for the following data types:
 
+-   `float16`: half-precision floating-point numbers.
 -   `float32`: single-precision floating-point numbers.
 -   `float64`: double-precision floating-point numbers.
--   `float16`: half-precision floating-point numbers.
 -   `complex64`: single-precision complex floating-point numbers.
 -   `complex128`: double-precision complex floating-point numbers.
 -   `bool`: boolean values.

--- a/lib/node_modules/@stdlib/array/ctors/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/ctors/docs/repl.txt
@@ -4,9 +4,9 @@
 
     The function returns constructors for the following data types:
 
+    - float16: half-precision floating-point numbers.
     - float32: single-precision floating-point numbers.
     - float64: double-precision floating-point numbers.
-    - float16: half-precision floating-point numbers.
     - complex64: single-precision complex floating-point numbers.
     - complex128: double-precision complex floating-point numbers.
     - bool: boolean values.

--- a/lib/node_modules/@stdlib/array/typed-ctors/README.md
+++ b/lib/node_modules/@stdlib/array/typed-ctors/README.md
@@ -51,9 +51,9 @@ var ctor = ctors( 'float64' );
 
 The function returns constructors for the following data types:
 
+-   `float16`: half-precision floating-point numbers.
 -   `float32`: single-precision floating-point numbers.
 -   `float64`: double-precision floating-point numbers.
--   `float16`: half-precision floating-point numbers.
 -   `complex64`: single-precision complex floating-point numbers.
 -   `complex128`: double-precision complex floating-point numbers.
 -   `bool`: boolean values.

--- a/lib/node_modules/@stdlib/array/typed-ctors/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/typed-ctors/docs/repl.txt
@@ -4,9 +4,9 @@
 
     The function returns constructors for the following data types:
 
+    - float16: half-precision floating-point numbers.
     - float32: single-precision floating-point numbers.
     - float64: double-precision floating-point numbers.
-    - float16: half-precision floating-point numbers.
     - complex64: single-precision complex floating-point numbers.
     - complex128: double-precision complex floating-point numbers.
     - bool: boolean values.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-06-08 20:42:35 UTC (`c0a017ba7`) and 2026-06-08 21:13:58 UTC (`a2a20a2a6`).

This pull request:

-   `544e175e` inserted `float16` after `float32` and `float64` in the float subgroup of `lib/node_modules/@stdlib/array/ctors/README.md` and `lib/node_modules/@stdlib/array/ctors/docs/repl.txt`; reorder to `float16, float32, float64` to match the ascending-precision convention used throughout (cf. `@stdlib/array/dtypes`).
-   In `12ccf2e3`, `float16` was appended after `float64` in the float subgroup of `lib/node_modules/@stdlib/array/typed-ctors/README.md` and `docs/repl.txt`, breaking the ascending-precision order (`float16, float32, float64`) used across sibling packages like `@stdlib/array/dtypes`; reorder accordingly.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Window scanned: 15 first-parent commits to `develop` (8× float16 dtype additions in `@stdlib/array/*`, plus assorted `docs:`/`chore:`/`fix:` polish). Four parallel reviewers were run: two for stdlib code-style compliance and two for runtime/logic bugs. Only findings corroborated by re-reading the diff against the established convention were carried through; subjective concerns, single-agent claims that could not be independently re-verified, and the pre-existing 4-space indent on `"bool"` in `array/promotion-rules/lib/promotion_rules.json` (predates the window) were deliberately excluded.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as a follow-up review pass over commits merged to `develop` in the last 24 hours. The reviewer routine ran four parallel sub-agents (two style, two bug) over the union diff; only corroborated, re-verifiable, in-window findings were carried through. All proposed edits were applied as exact in-place reorderings without expanding scope.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5Ytn9hxHB9Yrj3e2JdVSy)_