### PR TITLE
test(@stdlib/dstructs/named-typed-tuple): guard de-DE locale assertion

### DIFF
--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_locale_string.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_locale_string.js
@@ -100,6 +100,13 @@ tape( 'the method serializes a tuple as a locale-specific string (specified loca
 	var Point;
 	var p;
 
+	// Skip when the runtime lacks full ICU data for `de-DE` (e.g., small-icu builds):
+	if ( (123456.789).toLocaleString( 'de-DE' ) !== '123.456,789' ) {
+		t.pass( 'environment does not support `de-DE` locale formatting' );
+		t.end();
+		return;
+	}
+
 	Point = namedtypedtuple( [ 'price', 'quantity' ] );
 	p = new Point( [ 123456.789, 9876 ] );
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds a probe guard in the `de-DE` locale test for `@stdlib/dstructs/named-typed-tuple` to skip the assertion on runtimes that lack full ICU data

Node.js v12, v14, and v16 ship with `small-icu` by default. On these builds, `toLocaleString('de-DE')` silently falls back to the default locale, producing English-formatted output instead of German. The test hardcoded the `de-DE` expected value without guarding for this, causing scheduled CI failures on those Node.js versions.

The fix probes `(123456.789).toLocaleString('de-DE')` before the assertion. If the result does not equal `'123.456,789'`, the test calls `t.pass`, `t.end`, and returns early. On full-ICU runtimes the guard is false and the assertion runs unchanged.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Failing run**: https://github.com/stdlib-js/stdlib/actions/runs/27199463894

The `linux_test` scheduled job was failing on Node.js v12, v14, and v16 (ubuntu-latest) with:

```
expected: 'tuple(price=123.456,789, quantity=9.876)'
actual:   'tuple(price=123,456.789, quantity=9,876)'
```

The probe was verified on Node.js v22 with full ICU: `(123456.789).toLocaleString('de-DE')` returns `'123.456,789'`. The `t.pass` + `t.end` + `return` skip-guard pattern matches stdlib convention (`'environment does not support ...'`).

Three independent reviewers (correctness, regression scope, style) approved with no blocking findings.

Two other CI failure clusters observed in the same triage run are tracked under existing PRs (#12527, #12448) and are out of scope here.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI failure investigation routine. The root cause (Node.js small-icu builds lacking `de-DE` locale data) and the fix (ICU probe guard) were identified and validated by the AI agent. A human should confirm the guard pattern is acceptable before merging.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkSFBWxtssSuhcRAyciX9b)_