### PR TITLE
build: source PR-triggered workflow scripts from trusted base repo

### DIFF
--- a/.github/workflows/lint_autofix.yml
+++ b/.github/workflows/lint_autofix.yml
@@ -95,6 +95,9 @@ jobs:
           # File path to checkout to:
           path: './'
 
+          # Avoid persisting the access token in the local Git configuration, where build/lint tooling running against the untrusted PR checkout could read it (the final push below uses an explicit authenticated remote URL):
+          persist-credentials: false
+
       # Install Node.js:
       - name: 'Install Node.js'
         # Pin action to full length commit SHA
@@ -133,14 +136,40 @@ jobs:
           files=$(echo "$files" | tr '\n' ' ' | sed 's/^ //;s/ $//')
           echo "files=${files}" >> $GITHUB_OUTPUT
 
+      # Checkout trusted workflow scripts from the base repository (so that we source helper script bodies from the base repository, never from the untrusted PR checkout). Performed after the build steps so that `make init`/`make install-node-modules` cannot remove the trusted checkout:
+      - name: 'Checkout trusted workflow scripts'
+        # Pin action to full length commit SHA
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Always use the base repository, never the PR's (potentially forked) repository:
+          repository: 'stdlib-js/stdlib'
+
+          # Pin to the base repository's default branch:
+          ref: 'develop'
+
+          # Checkout into a separate directory, outside the PR working tree:
+          path: './_trusted'
+
+          # Only fetch the workflow helper scripts:
+          sparse-checkout: |
+            .github/workflows/scripts
+          sparse-checkout-cone-mode: false
+
+          # Limit clone depth to the most recent commit:
+          fetch-depth: 1
+
+          # Avoid persisting any token in the local Git configuration:
+          persist-credentials: false
+        timeout-minutes: 10
+
       # Fix JavaScript lint errors:
       - name: 'Fix JavaScript lint errors'
         id: fix-lint-errors
         env:
           FILES: ${{ steps.changed-files.outputs.files }}
         run: |
-          files="$FILES"
-          FIX=1 . "$GITHUB_WORKSPACE/.github/workflows/scripts/common/lint_javascript_files" "$files" || true
+          # Source the trusted fixer script from the base repository (not the untrusted PR checkout):
+          FIX=1 . "$GITHUB_WORKSPACE/_trusted/.github/workflows/scripts/common/lint_javascript_files" "$FILES" || true
 
       # Add missing trailing newlines:
       - name: 'Add missing trailing newlines'
@@ -148,16 +177,19 @@ jobs:
         env:
           FILES: ${{ steps.changed-files.outputs.files }}
         run: |
-          files="$FILES"
-          . "$GITHUB_WORKSPACE/.github/workflows/scripts/lint_autofix/add_trailing_newlines" "$files"
+          # Source the trusted fixer script from the base repository (not the untrusted PR checkout):
+          . "$GITHUB_WORKSPACE/_trusted/.github/workflows/scripts/lint_autofix/add_trailing_newlines" "$FILES"
 
       # Remove related packages from README.md files:
       - name: 'Remove related packages from README.md files'
         env:
           FILES: ${{ steps.changed-files.outputs.files }}
         run: |
-          files="$FILES"
-          . "$GITHUB_WORKSPACE/.github/workflows/scripts/lint_autofix/remove_related_packages" "$files"
+          # Source the trusted fixer script from the base repository (not the untrusted PR checkout):
+          . "$GITHUB_WORKSPACE/_trusted/.github/workflows/scripts/lint_autofix/remove_related_packages" "$FILES"
+
+          # Remove the trusted checkout so that it is not included in the subsequent commit:
+          rm -rf "$GITHUB_WORKSPACE/_trusted"
 
       # Disable Git hooks:
       - name: 'Disable Git hooks'

--- a/.github/workflows/lint_autofix.yml
+++ b/.github/workflows/lint_autofix.yml
@@ -46,11 +46,98 @@ on:
 # Workflow jobs:
 jobs:
 
+  # Define a job for determining whether the pull request is eligible for automatic fixes...
+  check:
+
+    # Define a display name:
+    name: 'Check autofix eligibility'
+
+    # Define the type of virtual host machine:
+    runs-on: ubuntu-latest
+
+    # Define the job outputs:
+    outputs:
+      # Boolean (serialized as a string) indicating whether it is safe to run autofix against the pull request:
+      safe: ${{ steps.guard.outputs.safe }}
+
+    # Define the sequence of job steps...
+    steps:
+
+      # Checkout trusted workflow scripts from the base repository (this job never checks out the untrusted PR, so the guard below always runs trusted code):
+      - name: 'Checkout trusted workflow scripts'
+        # Pin action to full length commit SHA
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Always use the base repository, never the PR's (potentially forked) repository:
+          repository: 'stdlib-js/stdlib'
+
+          # Pin to the base repository's default branch:
+          ref: 'develop'
+
+          # Only fetch the workflow helper scripts:
+          sparse-checkout: |
+            .github/workflows/scripts
+          sparse-checkout-cone-mode: false
+
+          # Limit clone depth to the most recent commit:
+          fetch-depth: 1
+
+          # Avoid persisting any token in the local Git configuration:
+          persist-credentials: false
+        timeout-minutes: 10
+
+      # Get list of changed files:
+      - name: 'Get list of changed files'
+        id: changed-files
+        run: |
+          page=1
+          files=""
+          while true; do
+              changed_files=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.STDLIB_BOT_GITHUB_TOKEN
+                  }}" "https://api.github.com/repos/stdlib-js/stdlib/pulls/${{ inputs.pull_request_number }}/files?page=$page&per_page=100" | jq -r '.[] | .filename')
+              if [ -z "$changed_files" ]; then
+                  break
+              fi
+              files="$files $changed_files"
+              page=$((page+1))
+          done
+          files=$(echo "$files" | tr '\n' ' ' | sed 's/^ //;s/ $//')
+          echo "files=${files}" >> $GITHUB_OUTPUT
+
+      # Determine whether the changed files are safe to automatically fix:
+      - name: 'Check whether changed files are safe to autofix'
+        id: guard
+        env:
+          FILES: ${{ steps.changed-files.outputs.files }}
+        run: |
+          # The autofix job checks out the pull request's (potentially forked) code and runs the
+          # repository's build and lint tooling against it (`make install-node-modules`, `make init`,
+          # ESLint, node-gyp, etc.). If the pull request modifies any file that can influence how that
+          # tooling executes, an outside contributor could achieve arbitrary code execution in the
+          # privileged autofix job. As a defense-in-depth guard, refuse to autofix when the pull request
+          # touches build-, dependency-, or lint-configuration-sensitive paths; such pull requests
+          # require manual review.
+          if sensitive=$("$GITHUB_WORKSPACE/.github/workflows/scripts/common/contains_sensitive_paths" $FILES); then
+            echo "::warning::Skipping autofix: pull request modifies build-/config-sensitive file(s): $(echo "$sensitive" | tr '\n' ' ')"
+            echo "safe=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Autofix skipped";
+              echo "";
+              echo "This pull request modifies build-, dependency-, or lint-configuration files, so automatic lint fixing was skipped to avoid executing untrusted tooling in a privileged context. Please apply any lint fixes manually.";
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "safe=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Define a job for automatically fixing lint errors:
   autofix:
 
     # Define a display name:
     name: 'Fix lint errors'
+
+    # Only run when the changed files have been determined to be safe to automatically fix:
+    needs: check
+    if: needs.check.outputs.safe == 'true'
 
     # Define the type of virtual host machine:
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts/common/contains_sensitive_paths
+++ b/.github/workflows/scripts/common/contains_sensitive_paths
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to determine whether a list of file paths includes any path which can influence how the repository's build or lint tooling executes.
+#
+# When automatically fixing lint errors on a pull request, a workflow checks out the pull request's (potentially forked) code and runs the repository's build and lint tooling against it (e.g., `make install-node-modules`, `make init`, ESLint, and node-gyp). If a pull request modifies a file which can change how that tooling executes (e.g., a Makefile, a dependency manifest, a native add-on build descriptor, or a linter configuration file), an outside contributor could achieve arbitrary code execution in a privileged context. This script provides a defense-in-depth guard for refusing to operate on such pull requests.
+#
+# Usage: contains_sensitive_paths file1 [file2 file3 ...]
+#
+# Arguments:
+#
+#   file1       File path.
+#   file2       File path.
+#   file3       File path.
+#
+# Returns:
+#
+#   Exits with code `0` if one or more provided paths are sensitive, printing each matching path to `stdout`; otherwise, exits with a non-zero code.
+#
+# NOTE: the set of sensitive paths is a denylist and is not guaranteed to be exhaustive; it complements, but does not replace, the longer-term goal of never executing untrusted code in pull-request-triggered workflows.
+
+# Exit status (`1` => no sensitive paths found):
+status=1
+
+# Iterate over the provided file paths...
+for file in "$@"; do
+	case "$file" in
+		# Build tooling (Makefiles, `make` recipes, and helper tool packages which `make` executes):
+		Makefile|*/Makefile|*.mk|tools/*|lib/node_modules/@stdlib/_tools/*)
+			echo "${file}"
+			status=0
+			;;
+
+		# Dependency manifests and registry configuration (read and/or executed during `npm install`):
+		package.json|*/package.json|package-lock.json|*/package-lock.json|npm-shrinkwrap.json|*/npm-shrinkwrap.json|.npmrc|*/.npmrc)
+			echo "${file}"
+			status=0
+			;;
+
+		# Native add-on build descriptors (evaluated and run by node-gyp):
+		*.gyp|*.gypi)
+			echo "${file}"
+			status=0
+			;;
+
+		# Lint and formatting tool configuration (executed by the respective linters):
+		etc/*|.eslintrc*|*/.eslintrc*|.remarkrc*|*/.remarkrc*)
+			echo "${file}"
+			status=0
+			;;
+	esac
+done
+
+exit "${status}"

--- a/.github/workflows/scripts/common/test_contains_sensitive_paths
+++ b/.github/workflows/scripts/common/test_contains_sensitive_paths
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# @license Apache-2.0
+#
+# Copyright (c) 2026 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests for the `contains_sensitive_paths` script.
+#
+# Usage: test_contains_sensitive_paths
+#
+# Exits with code `0` if all assertions pass; otherwise, exits with a non-zero code.
+
+# Resolve the path to the script under test (relative to the directory of this script):
+script="$(dirname -- "$0")/contains_sensitive_paths"
+
+# Counter tracking the number of failed assertions:
+failures=0
+
+# Asserts that a given set of file paths is flagged as sensitive (script exits `0`)...
+assert_sensitive() {
+	if "${script}" "$@" > /dev/null; then
+		echo "ok - sensitive: $*"
+	else
+		echo "not ok - expected sensitive, but was allowed: $*"
+		failures=$((failures+1))
+	fi
+}
+
+# Asserts that a given set of file paths is *not* flagged as sensitive (script exits non-zero)...
+assert_safe() {
+	if "${script}" "$@" > /dev/null; then
+		echo "not ok - expected safe, but was flagged: $*"
+		failures=$((failures+1))
+	else
+		echo "ok - safe: $*"
+	fi
+}
+
+# Sensitive paths (must be flagged):
+assert_sensitive "Makefile"
+assert_sensitive "lib/node_modules/@stdlib/math/base/special/abs/Makefile"
+assert_sensitive "tools/make/lib/lint/javascript/eslint.mk"
+assert_sensitive "tools/make/common.mk"
+assert_sensitive "lib/node_modules/@stdlib/_tools/scripts/print_npm_install_deps"
+assert_sensitive "package.json"
+assert_sensitive "lib/node_modules/@stdlib/math/base/special/abs/package.json"
+assert_sensitive "package-lock.json"
+assert_sensitive ".npmrc"
+assert_sensitive "lib/node_modules/@stdlib/math/base/special/abs/binding.gyp"
+assert_sensitive "lib/node_modules/@stdlib/math/base/special/abs/include.gypi"
+assert_sensitive "etc/eslint/.eslintrc.js"
+assert_sensitive "lib/node_modules/@stdlib/math/base/special/abs/.eslintrc.js"
+assert_sensitive ".remarkrc.js"
+
+# A safe set with a single sensitive path mixed in (must still be flagged):
+assert_sensitive "lib/node_modules/@stdlib/math/base/special/abs/lib/main.js" "package.json"
+
+# Safe paths (must not be flagged):
+assert_safe "lib/node_modules/@stdlib/math/base/special/abs/lib/main.js"
+assert_safe "lib/node_modules/@stdlib/math/base/special/abs/test/test.js"
+assert_safe "lib/node_modules/@stdlib/math/base/special/abs/README.md"
+assert_safe "lib/node_modules/@stdlib/math/base/special/abs/docs/types/index.d.ts"
+assert_safe "lib/node_modules/@stdlib/math/base/special/abs/examples/index.js"
+assert_safe "lib/node_modules/@stdlib/math/base/special/abs/benchmark/benchmark.js"
+
+# An empty argument list is safe:
+assert_safe
+
+if [ "${failures}" -gt 0 ]; then
+	echo "FAILED: ${failures} assertion(s) failed."
+	exit 1
+fi
+echo "PASS"

--- a/.github/workflows/update_pr_copyright_years.yml
+++ b/.github/workflows/update_pr_copyright_years.yml
@@ -95,6 +95,35 @@ jobs:
           # File path to checkout to:
           path: './'
 
+          # Avoid persisting the access token in the local Git configuration, where scripts running against the untrusted PR checkout could read it:
+          persist-credentials: false
+
+      # Checkout trusted workflow scripts from the base repository (so that we never execute helper scripts from the untrusted PR checkout):
+      - name: 'Checkout trusted workflow scripts'
+        # Pin action to full length commit SHA
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Always use the base repository, never the PR's (potentially forked) repository:
+          repository: 'stdlib-js/stdlib'
+
+          # Pin to the base repository's default branch:
+          ref: 'develop'
+
+          # Checkout into a separate directory, outside the PR working tree:
+          path: './_trusted'
+
+          # Only fetch the workflow helper scripts:
+          sparse-checkout: |
+            .github/workflows/scripts
+          sparse-checkout-cone-mode: false
+
+          # Limit clone depth to the most recent commit:
+          fetch-depth: 1
+
+          # Avoid persisting any token in the local Git configuration:
+          persist-credentials: false
+        timeout-minutes: 10
+
       # Get list of added files:
       - name: 'Get list of added files'
         id: added-files
@@ -119,8 +148,11 @@ jobs:
         env:
           FILES: ${{ steps.added-files.outputs.files }}
         run: |
-          files="$FILES"
-          . "$GITHUB_WORKSPACE/.github/workflows/scripts/update_pr_copyright_years/run" "$files"
+          # Run the trusted copyright-years script from the base repository (not the untrusted PR checkout):
+          . "$GITHUB_WORKSPACE/_trusted/.github/workflows/scripts/update_pr_copyright_years/run" "$FILES"
+
+          # Remove the trusted checkout so that it is not included in the subsequent commit:
+          rm -rf "$GITHUB_WORKSPACE/_trusted"
 
       # Disable Git hooks:
       - name: 'Disable Git hooks'


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request hardens the `lint_autofix` and `update_pr_copyright_years` reusable workflows against **pwn-request** attacks. Both are invoked (via `label_commands` / `slash_commands`, when a maintainer applies the `bot: Lint Autofix` / requests copyright updates) against the **head branch of a pull request** — which, for an outside contributor, is an attacker-controlled fork.

### 1. Never execute helper scripts from the untrusted checkout

Previously both workflows checked out the fork with the write-scoped `STDLIB_BOT_GITHUB_TOKEN` and then **sourced helper scripts directly from the fork checkout** (`$GITHUB_WORKSPACE/.github/workflows/scripts/...`). A malicious PR could replace those scripts with arbitrary code that runs in the privileged job (which also imports the GPG signing key and pushes with the bot token).

-   Set `persist-credentials: false` on the PR checkout, so the write-scoped token is no longer written into `.git/config` where code running against the untrusted tree could read it. The final push uses an explicit authenticated remote URL and does not rely on persisted credentials.
-   Add a separate, sparse checkout of the **base** repository (`stdlib-js/stdlib`@`develop`, `persist-credentials: false`) into `./_trusted`, and source all helper scripts from there instead of from the PR checkout. The trusted checkout is removed before the commit step so it is not included in the resulting commit.

### 2. Skip `lint_autofix` entirely when a PR touches build/lint-sensitive files

Unlike `update_pr_copyright_years` (which runs a self-contained `sed` script and is fully addressed by §1), `lint_autofix` runs the repository's build and lint tooling against the PR's code — `make install-node-modules`, `make init`, ESLint, and node-gyp. If the PR modifies a file that influences how that tooling executes, an outside contributor can still achieve code execution even with §1 in place.

To guard this, a lightweight **`check` job** now runs before `autofix` and gates it (`needs` + `if`):

-   It checks out only the base repository's helper scripts (sparse, trusted) — it never checks out the PR — so the guard always runs trusted code.
-   It passes the PR's changed-file list to a new `common/contains_sensitive_paths` script, which flags paths that can affect build/lint execution: Makefiles and `tools/`/`_tools/` helpers, dependency manifests (`package.json`, lockfiles, `.npmrc`), native add-on descriptors (`*.gyp`/`*.gypi`), and linter configuration (`etc/`, `.eslintrc*`, `.remarkrc*`).
-   When any changed path is sensitive, `autofix` is skipped (with a job-summary note) and the PR is left for manual review. The gate **fails closed** if eligibility cannot be determined.
-   A `common/test_contains_sensitive_paths` test covers the sensitive and safe cases; both scripts are shellcheck-clean.

### Scope / residual risk

-   `update_pr_copyright_years` is **fully addressed** (no build step).
-   `lint_autofix` is now **substantially narrowed**: the build/lint tooling only runs for PRs whose changed files are all "safe leaves" (package source, tests, docs, examples, benchmarks). The remaining residual is denylist *completeness* — this is a defense-in-depth control, not a proof. The longer-term goal remains to never execute untrusted tooling in this workflow (e.g., build tooling from the base repo).
-   The denylist is intentionally conservative and currently flags **every** `package.json` to cover ESLint's `eslintConfig` resolution. ESLint here runs in classic eslintrc mode **without `--no-eslintrc`**, so it cascades into in-tree `.eslintrc.*` / `package.json#eslintConfig` — a pre-existing exposure across the lint workflows. A follow-up PR will add `--no-eslintrc` (and pin plugin resolution) in `tools/make/lib/lint/javascript/eslint.mk`; once merged, the per-package `package.json` entry can be relaxed so autofix keeps running on new-package PRs.

This is part of a series of fixes from a security audit of our GitHub Actions workflows and `make` tooling.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

-   These workflows have not been exercised end-to-end from this branch (they are `workflow_call` reusable workflows triggered by bot labels). Before merge, it would be worth confirming a real `bot: Lint Autofix` run on (a) a "safe" PR — that the `check` job passes and autofix proceeds — and (b) a PR touching e.g. `package.json` — that `check` sets `safe=false` and `autofix` is skipped. Also worth confirming the sparse `_trusted` checkout resolves and `persist-credentials: false` does not disturb the final push.
-   Sanity-check the `contains_sensitive_paths` denylist for any exec-influencing path category I may have missed.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

References:

-   [GitHub Security Lab — "Keeping your GitHub Actions and workflows secure: Preventing pwn requests"](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

The underlying security audit and these fixes were produced with Claude Code (a multi-agent audit identified the pwn-request vectors; the remediation, the changed-file guard, and its test were applied and reviewed with AI assistance). All changes were reviewed by the author prior to submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
