### PR TITLE
test: migrate `math/base/special/dirichlet-eta` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/dirichlet-eta/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/dirichlet-eta/test/test.js
@@ -22,11 +22,10 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var LN2 = require( '@stdlib/constants/float64/ln-two' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var eta = require( './../lib' );
 
 
@@ -51,8 +50,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function evaluates the Dirichlet eta function', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 	var i;
@@ -61,12 +58,10 @@ tape( 'the function evaluates the Dirichlet eta function', function test( t ) {
 	expected = data.expected;
 	for ( i = 0; i < s.length; i++ ) {
 		v = eta( s[i] );
-		delta = abs( v - expected[i] );
 
 		// R: 1.1e5*eps => 2.4424906541753444e-11 => http://finzi.psych.upenn.edu/library/pracma/html/eta.html states that accuracy is 13 digits
 		// Julia: 68.0*eps => 1.509903313490213e-14
-		tol = 68.0 * EPS * abs( expected[i] );
-		t.ok( delta <= tol, 'within tolerance. s: '+s[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 130 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -91,8 +86,6 @@ tape( 'if provided `-1`, the function returns `0.25` (Abel sum)', function test(
 
 tape( 'if provided `2`, the function returns `π²/12`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -102,17 +95,12 @@ tape( 'if provided `2`, the function returns `π²/12`', function test( t ) {
 	s = 2.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `4`, the function returns `7π**4/720`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -121,17 +109,12 @@ tape( 'if provided `4`, the function returns `7π**4/720`', function test( t ) {
 	s = 4.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `6`, the function returns `31π**6/30240`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -140,17 +123,12 @@ tape( 'if provided `6`, the function returns `31π**6/30240`', function test( t 
 	s = 6.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = 2.0 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 3 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `8`, the function returns `127π**8/1209600`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -159,17 +137,12 @@ tape( 'if provided `8`, the function returns `127π**8/1209600`', function test(
 	s = 8.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = 2.05 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 4 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `10`, the function returns `73π**10/6842880`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -178,17 +151,12 @@ tape( 'if provided `10`, the function returns `73π**10/6842880`', function test
 	s = 10.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = 1.55 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 3 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `12`, the function returns `1414477π**12/1307674368000`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -197,9 +165,6 @@ tape( 'if provided `12`, the function returns `1414477π**12/1307674368000`', fu
 	s = 12.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = 2.05 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 4 ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/dirichlet-eta/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/dirichlet-eta/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var LN2 = require( '@stdlib/constants/float64/ln-two' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -60,8 +59,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) 
 
 tape( 'the function evaluates the Dirichlet eta function', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 	var i;
@@ -70,12 +67,10 @@ tape( 'the function evaluates the Dirichlet eta function', opts, function test( 
 	expected = data.expected;
 	for ( i = 0; i < s.length; i++ ) {
 		v = eta( s[i] );
-		delta = abs( v - expected[i] );
 
 		// R: 1.1e5*eps => 2.4424906541753444e-11 => http://finzi.psych.upenn.edu/library/pracma/html/eta.html states that accuracy is 13 digits
 		// Julia: 68.0*eps => 1.509903313490213e-14
-		tol = 68.0 * EPS * abs( expected[i] );
-		t.ok( delta <= tol, 'within tolerance. s: '+s[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 130 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -100,8 +95,6 @@ tape( 'if provided `-1`, the function returns `0.25` (Abel sum)', opts, function
 
 tape( 'if provided `2`, the function returns `π²/12`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -111,17 +104,12 @@ tape( 'if provided `2`, the function returns `π²/12`', opts, function test( t 
 	s = 2.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `4`, the function returns `7π**4/720`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -130,17 +118,12 @@ tape( 'if provided `4`, the function returns `7π**4/720`', opts, function test(
 	s = 4.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `6`, the function returns `31π**6/30240`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -149,17 +132,12 @@ tape( 'if provided `6`, the function returns `31π**6/30240`', opts, function te
 	s = 6.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = 2.0 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 3 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `8`, the function returns `127π**8/1209600`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -168,17 +146,12 @@ tape( 'if provided `8`, the function returns `127π**8/1209600`', opts, function
 	s = 8.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = 2.05 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 4 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `10`, the function returns `73π**10/6842880`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -187,17 +160,12 @@ tape( 'if provided `10`, the function returns `73π**10/6842880`', opts, functio
 	s = 10.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = 1.55 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 3 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `12`, the function returns `1414477π**12/1307674368000`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -206,9 +174,6 @@ tape( 'if provided `12`, the function returns `1414477π**12/1307674368000`', op
 	s = 12.0;
 	v = eta( s );
 
-	delta = abs( v - expected );
-	tol = 2.05 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 4 ), true, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `@stdlib/math/base/special/dirichlet-eta` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves a part of #11352.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Minimum ULPs were computed with a scratch script using `@stdlib/number/float64/base/ulp-difference` over the Julia fixtures and the exact scalar expected-value expressions.
-   The fixtures block needs `130` ULP (the old tolerance was `68 * EPS` relative; ULP-based and relative-EPS tolerances can differ by up to 2x depending on mantissa position, so `130 ≈ 2 * 68` is consistent, not an anomaly). Minimality was spot-checked: `129` fails exactly one assertion, while `130` passes.
-   The `s = 2` block is bit-exact (ULP difference of `0`), so it uses plain `t.strictEqual`.
-   The native test file passes at the **same** ULP values as the JavaScript tests (3015/3015 assertions passing), so there is no native-vs-JS tolerance divergence and no `NOTE` comments were needed. (Local note: the repo-pinned `node-gyp@9.4.1` is incompatible with Node v24, so the addon was built with `node-gyp@11` for local verification.)
-   The R/Julia tolerance provenance comments in the fixtures block were preserved verbatim, consistent with previously merged migrations.
-   `make lint-javascript-files` reports 12 pre-existing `no-restricted-syntax` (`FunctionExpression`) errors on both the pristine and migrated files (an environment/ESLint-config quirk of that target); the pre-commit hook's ESLint pass on the same files succeeded, so no new lint issues were introduced.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which migrated the test assertions, computed and verified the minimum ULP tolerances, and ran the JavaScript and native test suites. The changes were reviewed by myself before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
