### PR TITLE
test: migrate `math/base/special/haversin` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/haversin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/haversin/test/test.js
@@ -22,10 +22,8 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var haversin = require( './../lib' );
 
 
@@ -49,8 +47,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the half-value versed sine (for -256*pi < x < 0 )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -60,13 +56,7 @@ tape( 'the function computes the half-value versed sine (for -256*pi < x < 0 )',
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -74,8 +64,6 @@ tape( 'the function computes the half-value versed sine (for -256*pi < x < 0 )',
 
 tape( 'the function computes the half-value versed sine (for 0 < x < 256*pi )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -85,13 +73,7 @@ tape( 'the function computes the half-value versed sine (for 0 < x < 256*pi )', 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -99,8 +81,6 @@ tape( 'the function computes the half-value versed sine (for 0 < x < 256*pi )', 
 
 tape( 'the function computes the half-value versed sine (for -2**60 (pi/2) < x < -2**20 (pi/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -110,13 +90,7 @@ tape( 'the function computes the half-value versed sine (for -2**60 (pi/2) < x <
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -124,8 +98,6 @@ tape( 'the function computes the half-value versed sine (for -2**60 (pi/2) < x <
 
 tape( 'the function computes the half-value versed sine (for 2**20 (pi/2) < x < 2**60 (pi/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -135,13 +107,7 @@ tape( 'the function computes the half-value versed sine (for 2**20 (pi/2) < x < 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -149,8 +115,6 @@ tape( 'the function computes the half-value versed sine (for 2**20 (pi/2) < x < 
 
 tape( 'the function computes the half-value versed sine (for x <= -2**60 (PI/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -160,13 +124,7 @@ tape( 'the function computes the half-value versed sine (for x <= -2**60 (PI/2) 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -174,8 +132,6 @@ tape( 'the function computes the half-value versed sine (for x <= -2**60 (PI/2) 
 
 tape( 'the function computes the half-value versed sine (for x >= 2**60 (PI/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -185,13 +141,7 @@ tape( 'the function computes the half-value versed sine (for x >= 2**60 (PI/2) )
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/haversin/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/haversin/test/test.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the half-value versed sine (for -256*pi < x < 0 )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -69,13 +66,9 @@ tape( 'the function computes the half-value versed sine (for -256*pi < x < 0 )',
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -83,8 +76,6 @@ tape( 'the function computes the half-value versed sine (for -256*pi < x < 0 )',
 
 tape( 'the function computes the half-value versed sine (for 0 < x < 256*pi )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -94,13 +85,9 @@ tape( 'the function computes the half-value versed sine (for 0 < x < 256*pi )', 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -108,8 +95,6 @@ tape( 'the function computes the half-value versed sine (for 0 < x < 256*pi )', 
 
 tape( 'the function computes the half-value versed sine (for -2**60 (pi/2) < x < -2**20 (pi/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -119,13 +104,9 @@ tape( 'the function computes the half-value versed sine (for -2**60 (pi/2) < x <
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -133,8 +114,6 @@ tape( 'the function computes the half-value versed sine (for -2**60 (pi/2) < x <
 
 tape( 'the function computes the half-value versed sine (for 2**20 (pi/2) < x < 2**60 (pi/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -144,13 +123,9 @@ tape( 'the function computes the half-value versed sine (for 2**20 (pi/2) < x < 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -158,8 +133,6 @@ tape( 'the function computes the half-value versed sine (for 2**20 (pi/2) < x < 
 
 tape( 'the function computes the half-value versed sine (for x <= -2**60 (PI/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -169,13 +142,9 @@ tape( 'the function computes the half-value versed sine (for x <= -2**60 (PI/2) 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -183,8 +152,6 @@ tape( 'the function computes the half-value versed sine (for x <= -2**60 (PI/2) 
 
 tape( 'the function computes the half-value versed sine (for x >= 2**60 (PI/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -194,13 +161,9 @@ tape( 'the function computes the half-value versed sine (for x >= 2**60 (PI/2) )
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = haversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/haversin` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).
-   JavaScript tests: all 24,000 fixture cases (6 blocks × 4,000) match the Julia fixtures bit-for-bit (max ULP difference of 0, verified via a scratch script using `@stdlib/number/float64/base/ulp-difference`). Accordingly, every JS test block uses plain `t.strictEqual( y, expected[ i ], 'returns expected value' )`, and `test.js` no longer requires `isAlmostSameValue` (the `abs`/`EPS` requires and `delta`/`tol` logic were removed, and the exact-equality short-circuit branches were collapsed).
-   native tests: the maximum observed ULP difference is exactly 2 in every block on darwin/arm64 (clang); the previous tolerance was `1.7 * EPS`. A ULP threshold of 1 fails with 32 failures (minimality verified by a decrement spot-check, then restored). All six native test blocks use `isAlmostSameValue( ..., 2 )` with the canonical compiler-optimization NOTE comment.
-   the native tolerance (2 ULP) diverges from the JavaScript tolerance (0 ULP; bit-for-bit equality), which is expected for this double-precision package due to compiler optimizations affecting the native implementation.

Test results: `make test` passed (24,005/24,005 assertions). Native tests passed (24,005/24,005 assertions) when run directly via `NODE_PATH=.../lib/node_modules node test/test.native.js` (darwin/arm64, clang).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves a part of #11352.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Implementation and environment notes:

-   Minimum ULP values were verified by computing ULP differences directly over the test fixtures: JS max ULP is 0 in all six blocks (hence exact equality assertions), and native max ULP is exactly 2 in every block (a threshold of 1 produces 32 failures).
-   The native addon was built directly with npm's bundled `node-gyp` because `make install-node-addons` crashed in the repository's `node-gyp` due to a broken `cacache` module in the local `node_modules` ("Cannot read properties of undefined (reading 'content')"); the addon built successfully.
-   Native tests were run directly via `node test/test.native.js` (with `NODE_PATH` set), as the local checkout has no `make test-native` target.
-   `make lint-javascript-files` reports 10 pre-existing `no-restricted-syntax` "FunctionExpression" errors; identical errors occur on the unmodified `HEAD` file (verified via `git stash`), i.e., they are environmental false positives. The pre-commit hook's own ESLint pass succeeded.
-   The work was performed in a sparse-checkout worktree (excluding unrelated `datasets`, `stats`, `blas`, and `ml` namespaces due to local disk constraints; none are needed by `haversin`). The worktree and scratch verification script have since been cleaned up.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated ULP-migration workflow. The test migrations were generated by Claude Code, and the minimum ULP thresholds were determined and adversarially verified by Claude Code via direct ULP-difference computation over the test fixtures and by running the full test suites (JavaScript and native).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
