### PR TITLE
test: migrate `math/base/special/acsc` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acsc/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acsc/test/test.js
@@ -23,8 +23,6 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var acsc = require( './../lib' );
 
 
@@ -44,8 +42,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the arccosecant (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -55,21 +51,13 @@ tape( 'the function computes the arccosecant (negative values)', function test( 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acsc( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosecant (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -79,13 +67,7 @@ tape( 'the function computes the arccosecant (positive values)', function test( 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acsc( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acsc/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acsc/test/test.native.js
@@ -24,8 +24,6 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -53,8 +51,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the arccosecant (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -64,21 +60,13 @@ tape( 'the function computes the arccosecant (negative values)', opts, function 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acsc( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosecant (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -88,13 +76,7 @@ tape( 'the function computes the arccosecant (positive values)', opts, function 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acsc( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/acsc` from relative-tolerance (EPS-based) assertions to ULP-difference-based testing per #11352, using the minimum required ULP values as verified by direct ULP-difference computation over the test fixtures.
-   In this case, all fixture cases (2003 negative + 2003 positive) are **bit-exact** (max ULP difference = 0, verified via `@stdlib/number/float64/base/ulp-difference` and a direct `===` check over every case) for **both** the JavaScript and native implementations, as `acsc(x) = asin(1/x)` exactly reproduces the Julia-generated fixtures. Accordingly, both fixture-driven test blocks in both files use plain `t.strictEqual( y, expected[ i ], 'returns expected value' );` rather than introducing `@stdlib/assert/is-almost-same-value` for exactly-equal values.
-   removes the now-unused `EPS` and `abs` requires and the `delta`/`tol` variables, and collapses the previous exact-equality `if`/`else` branches.
-   No divergence between the JavaScript and C implementations was observed, so no native-vs-JS tolerance divergence note was needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Both test files were run against the built native add-on: 6009/6009 assertions passing in each file.
-   Linting with the repository's tests ESLint configuration (`ESLINT_CONF=etc/eslint/.eslintrc.tests.js`) is clean for both files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which computed and verified the ULP differences over the test fixtures, updated the test files, and ran the JavaScript and native test suites. The changes were reviewed by me before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
