### PR TITLE
docs: fix typos in `assert/is-ndarray-descriptor`

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-ndarray-descriptor/README.md
+++ b/lib/node_modules/@stdlib/assert/is-ndarray-descriptor/README.md
@@ -32,7 +32,7 @@ var isndarrayDescriptor = require( '@stdlib/assert/is-ndarray-descriptor' );
 
 #### isndarrayDescriptor( value )
 
-Tests if a value is [ndarray][@stdlib/ndarray/ctor] descriptor.
+Tests if a value is an [ndarray][@stdlib/ndarray/ctor] descriptor.
 
 ```javascript
 var zeros = require( '@stdlib/ndarray/zeros' );
@@ -44,7 +44,7 @@ var bool = isndarrayDescriptor( zeros( [ 2, 2 ] ) );
 A value is an [ndarray][@stdlib/ndarray/ctor] descriptor if a value is an object with the following properties:
 
 -   **dtype**: an ndarray's underlying data type.
--   **data**: array-like object object pointing to an underlying data buffer.
+-   **data**: array-like object pointing to an underlying data buffer.
 -   **shape**: array-like object containing dimensions.
 -   **strides**: array-like object containing stride lengths.
 -   **offset**: number specifying the index offset.

--- a/lib/node_modules/@stdlib/assert/is-ndarray-descriptor/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-ndarray-descriptor/lib/main.js
@@ -51,7 +51,7 @@ function isndarrayDescriptor( v ) {
 		isObjectLike( v.strides ) &&
 		isNumber( v.offset ) &&
 		isString( v.order ) &&
-		hasProp( v, 'dtype' ) // note: intentionally a loose check, as ndarray dtypes can be strings, objects, or other
+		hasProp( v, 'dtype' ) // NOTE: intentionally a loose check, as ndarray dtypes can be strings, objects, or other
 	);
 }
 


### PR DESCRIPTION
Resolves stdlib-js/todo#2783.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a missing article in the `isndarrayDescriptor` description in the README ("Tests if a value is **an** ndarray descriptor")
-   removes a duplicated word in the `data` property description in the README ("array-like object ~~object~~ pointing to...")
-   fixes the casing of a `// NOTE:` annotation in `lib/main.js`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a multi-agent review of the package. All findings were independently verified against the package source, and the package test suite passes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
