### PR TITLE
docs: fix descriptions in `ndarray/base/nulls-like`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/nulls-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/nulls-like/docs/types/index.d.ts
@@ -23,10 +23,10 @@
 import { genericndarray } from '@stdlib/types/ndarray';
 
 /**
-* Creates a null-filled array having the same shape and data type as a provided input ndarray.
+* Creates a null-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
-* @returns null-filled array
+* @returns null-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );


### PR DESCRIPTION
Resolves stdlib-js/todo#2775.

## Description

> What is the purpose of this pull request?

This pull request:

-   updates the TSDoc summary and `@returns` description in `docs/types/index.d.ts` to read "null-filled ndarray" instead of "null-filled array", matching the wording used consistently throughout the rest of the package (`lib/main.js`, `lib/index.js`, README, REPL docs, and `package.json`)

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This is a comment-only change; no type signatures were modified, so `docs/types/test.ts` required no updates.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a multi-agent review of the package. All findings were independently verified against the package source, and the package test suite passes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
