### PR TITLE
docs: fix examples and benchmark names in `ndarray/base/nans-like`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/README.md
@@ -46,9 +46,9 @@ Creates a NaN-filled ndarray having the same shape and [data type][@stdlib/ndarr
 
 ```javascript
 var getShape = require( '@stdlib/ndarray/shape' );
-var ones = require( '@stdlib/ndarray/ones' );
+var ones = require( '@stdlib/ndarray/base/ones' );
 
-var x = ones( [ 2, 2 ] );
+var x = ones( 'float64', [ 2, 2 ], 'row-major' );
 // returns <ndarray>[ [ 1.0, 1.0 ], [ 1.0, 1.0 ] ]
 
 var y = nansLike( x );
@@ -83,7 +83,7 @@ var sh = getShape( y );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var ones = require( '@stdlib/ndarray/ones' );
+var ones = require( '@stdlib/ndarray/base/ones' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var nansLike = require( '@stdlib/ndarray/base/nans-like' );
 
@@ -101,9 +101,7 @@ var x;
 var y;
 var i;
 for ( i = 0; i < dt.length; i++ ) {
-    x = ones( [ 2, 2 ], {
-        'dtype': dt[ i ]
-    });
+    x = ones( dt[ i ], [ 2, 2 ], 'row-major' );
     y = nansLike( x );
     console.log( ndarray2array( y ) );
 }

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.js
@@ -30,7 +30,7 @@ var nansLike = require( './../lib' );
 
 // MAIN //
 
-bench( format( '%s:dtype=float64', pkg ), function benchmark( b ) {
+bench( format( '%s::base:dtype=float64', pkg ), function benchmark( b ) {
 	var x;
 	var y;
 	var i;
@@ -52,7 +52,7 @@ bench( format( '%s:dtype=float64', pkg ), function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:dtype=float32', pkg ), function benchmark( b ) {
+bench( format( '%s::base:dtype=float32', pkg ), function benchmark( b ) {
 	var x;
 	var y;
 	var i;
@@ -74,7 +74,7 @@ bench( format( '%s:dtype=float32', pkg ), function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:dtype=complex128', pkg ), function benchmark( b ) {
+bench( format( '%s::base:dtype=complex128', pkg ), function benchmark( b ) {
 	var x;
 	var y;
 	var i;
@@ -96,7 +96,7 @@ bench( format( '%s:dtype=complex128', pkg ), function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:dtype=complex64', pkg ), function benchmark( b ) {
+bench( format( '%s::base:dtype=complex64', pkg ), function benchmark( b ) {
 	var x;
 	var y;
 	var i;
@@ -118,7 +118,7 @@ bench( format( '%s:dtype=complex64', pkg ), function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:dtype=generic', pkg ), function benchmark( b ) {
+bench( format( '%s::base:dtype=generic', pkg ), function benchmark( b ) {
 	var x;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.complex128.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.complex128.js
@@ -89,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:dtype=complex128,size=%d', pkg, len ), f );
+		bench( format( '%s::base:dtype=complex128,size=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.complex64.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.complex64.js
@@ -89,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:dtype=complex64,size=%d', pkg, len ), f );
+		bench( format( '%s::base:dtype=complex64,size=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.float32.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.float32.js
@@ -89,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:dtype=float32,size=%d', pkg, len ), f );
+		bench( format( '%s::base:dtype=float32,size=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.float64.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.float64.js
@@ -89,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:dtype=float64,size=%d', pkg, len ), f );
+		bench( format( '%s::base:dtype=float64,size=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.generic.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/benchmark/benchmark.size.generic.js
@@ -89,7 +89,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:dtype=generic,size=%d', pkg, len ), f );
+		bench( format( '%s::base:dtype=generic,size=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/repl.txt
@@ -20,7 +20,7 @@
 
     Examples
     --------
-    > var x = {{alias:@stdlib/ndarray/zeros}}( [ 2, 2 ] )
+    > var x = {{alias:@stdlib/ndarray/base/zeros}}( 'float64', [ 2, 2 ], 'row-major' )
     <ndarray>[ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ]
     > var y = {{alias}}( x )
     <ndarray>[ [ NaN, NaN ], [ NaN, NaN ] ]

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/examples/index.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var ones = require( '@stdlib/ndarray/ones' );
+var ones = require( '@stdlib/ndarray/base/ones' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var nansLike = require( './../lib' );
 
@@ -36,9 +36,7 @@ var x;
 var y;
 var i;
 for ( i = 0; i < dt.length; i++ ) {
-	x = ones( [ 2, 2 ], {
-		'dtype': dt[ i ]
-	});
+	x = ones( dt[ i ], [ 2, 2 ], 'row-major' );
 	y = nansLike( x );
 	console.log( ndarray2array( y ) );
 }

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/index.js
@@ -26,12 +26,10 @@
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
 * var getDType = require( '@stdlib/ndarray/dtype' );
-* var ones = require( '@stdlib/ndarray/ones' );
+* var ones = require( '@stdlib/ndarray/base/ones' );
 * var nansLike = require( '@stdlib/ndarray/base/nans-like' );
 *
-* var x = ones( [ 2, 2 ], {
-*     'dtype': 'float32'
-* });
+* var x = ones( 'float32', [ 2, 2 ], 'row-major' );
 * // returns <ndarray>[ [ 1.0, 1.0 ], [ 1.0, 1.0 ] ]
 *
 * var y = nansLike( x );

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/lib/main.js
@@ -38,11 +38,9 @@ var CNAN = require( '@stdlib/constants/complex128/nan' );
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
 * var getDType = require( '@stdlib/ndarray/dtype' );
-* var ones = require( '@stdlib/ndarray/ones' );
+* var ones = require( '@stdlib/ndarray/base/ones' );
 *
-* var x = ones( [ 2, 2 ], {
-*     'dtype': 'float32'
-* });
+* var x = ones( 'float32', [ 2, 2 ], 'row-major' );
 * // returns <ndarray>[ [ 1.0, 1.0 ], [ 1.0, 1.0 ] ]
 *
 * var y = nansLike( x );


### PR DESCRIPTION
Resolves stdlib-js/todo#2772.

## Description

> What is the purpose of this pull request?

This pull request:

-   updates the examples in `lib/main.js`, `lib/index.js`, `README.md`, `docs/repl.txt`, and `examples/index.js` to use the base API (`@stdlib/ndarray/base/ones` with positional `dtype`/`shape`/`order` arguments) instead of the high-level options-object API (`@stdlib/ndarray/ones`), matching sibling base packages (`ndarray/base/ones-like`, `ndarray/base/zeros-like`, `ndarray/base/empty-like`)
-   adds the missing `::base:` segment to the benchmark name format strings in `benchmark/benchmark.js` and the five `benchmark/benchmark.size.<dtype>.js` files, matching sibling base packages

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The original example shapes (`[ 2, 2 ]`) and dtypes were preserved. `docs/types/index.d.ts` and `docs/types/test.ts` already used the base API and required no changes. The package test suite passes (73/73) and `examples/index.js` runs correctly.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a multi-agent review of the package. All findings were independently verified against sibling base packages, and the package test suite passes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
