### PR TITLE
bench: use base zeros in ndarray/ones-like benchmarks

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -35,9 +35,7 @@ bench( format( '%s:dtype=float64', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'float64'
-	});
+	x = zeros( 'float64', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -59,9 +57,7 @@ bench( format( '%s:dtype=float32', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'float32'
-	});
+	x = zeros( 'float32', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -83,9 +79,7 @@ bench( format( '%s:dtype=complex128', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'complex128'
-	});
+	x = zeros( 'complex128', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -107,9 +101,7 @@ bench( format( '%s:dtype=complex64', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'complex64'
-	});
+	x = zeros( 'complex64', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -131,9 +123,7 @@ bench( format( '%s:dtype=int32', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'int32'
-	});
+	x = zeros( 'int32', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -155,9 +145,7 @@ bench( format( '%s:dtype=uint32', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'uint32'
-	});
+	x = zeros( 'uint32', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -179,9 +167,7 @@ bench( format( '%s:dtype=int16', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'int16'
-	});
+	x = zeros( 'int16', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -203,9 +189,7 @@ bench( format( '%s:dtype=uint16', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'uint16'
-	});
+	x = zeros( 'uint16', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -227,9 +211,7 @@ bench( format( '%s:dtype=int8', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'int8'
-	});
+	x = zeros( 'int8', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -251,9 +233,7 @@ bench( format( '%s:dtype=uint8', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'uint8'
-	});
+	x = zeros( 'uint8', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -275,9 +255,7 @@ bench( format( '%s:dtype=uint8c', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'uint8c'
-	});
+	x = zeros( 'uint8c', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -299,9 +277,7 @@ bench( format( '%s:dtype=generic', pkg ), function benchmark( b ) {
 	var y;
 	var i;
 
-	x = zeros( [ 0 ], {
-		'dtype': 'generic'
-	});
+	x = zeros( 'generic', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.complex128.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.complex128.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'complex128'
-	});
+	var x = zeros( 'complex128', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.complex64.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.complex64.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'complex64'
-	});
+	var x = zeros( 'complex64', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.float32.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.float32.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'float32'
-	});
+	var x = zeros( 'float32', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.float64.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.float64.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'float64'
-	});
+	var x = zeros( 'float64', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.generic.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.generic.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'generic'
-	});
+	var x = zeros( 'generic', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.int16.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.int16.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'int16'
-	});
+	var x = zeros( 'int16', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.int32.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.int32.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'int32'
-	});
+	var x = zeros( 'int32', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.int8.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.int8.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'int8'
-	});
+	var x = zeros( 'int8', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.uint16.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.uint16.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'uint16'
-	});
+	var x = zeros( 'uint16', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.uint32.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.uint32.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'uint32'
-	});
+	var x = zeros( 'uint32', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.uint8.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.uint8.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'uint8'
-	});
+	var x = zeros( 'uint8', [ len ], 'row-major' );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.uint8c.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/benchmark/benchmark.size.uint8c.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var zeros = require( '@stdlib/ndarray/base/zeros' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var onesLike = require( './../lib' );
@@ -39,9 +39,7 @@ var onesLike = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = zeros( [ len ], {
-		'dtype': 'uint8c'
-	});
+	var x = zeros( 'uint8c', [ len ], 'row-major' );
 	return benchmark;
 
 	/**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   updates all benchmark files (`benchmark/benchmark.js` and the twelve `benchmark/benchmark.size.<dtype>.js` files) to use `@stdlib/ndarray/base/zeros` with positional `dtype`/`shape`/`order` arguments for creating setup arrays, instead of the high-level options-object API (`@stdlib/ndarray/zeros`), matching sibling packages (`ndarray/zeros-like`, `ndarray/empty-like`)

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The package test suite passes (270/270) after the change.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a multi-agent review of the package. All findings were independently verified against sibling packages, and the package test suite passes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
