### PR TITLE
test: migrate `math/base/special/asecdf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/asecdf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asecdf/test/test.js
@@ -23,9 +23,9 @@
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var asecdf = require( './../lib' );
 
 
@@ -45,8 +45,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the arcsecant in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -57,21 +55,13 @@ tape( 'the function computes the arcsecant in degrees (negative values)', functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecdf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsecant in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -82,13 +72,7 @@ tape( 'the function computes the arcsecant in degrees (positive values)', functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecdf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asecdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asecdf/test/test.native.js
@@ -24,9 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -54,8 +54,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the arcsecant in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -66,21 +64,13 @@ tape( 'the function computes the arcsecant in degrees (negative values)', opts, 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecdf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsecant in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -91,13 +81,7 @@ tape( 'the function computes the arcsecant in degrees (positive values)', opts, 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecdf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/asecdf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, following the precedent of `acothf` and `atanhf`, as `asecdf` is a single-precision function).
-   uses the minimum required ULP value (`1`) for both the negative and positive fixture test blocks, verified by direct ULP-difference computation (`@stdlib/number/float32/base/ulp-difference`) over all test fixtures for both the JavaScript implementation and the compiled native addon. The JavaScript and C implementations do not diverge (max ULP difference is `1` for both), so no compiler-optimization tolerance note is needed.
-   removes the now-unused `abs` require and `delta`/`tol` variables, and collapses the obsolete exact-equality short-circuit branches. The `EPS` require is retained, as it is still used by the `uniform()` domain-guard `NaN` tests.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

ULP minimality was independently verified by recomputing the maximum ULP difference over both fixture sets for both the JavaScript implementation and the built native addon: max ULP is `1` in all four cases, and a ULP value of `0` fails 462 of 6009 assertions, confirming `1` is the minimum. Both test files pass with 6009/6009 assertions.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code (test migration and minimum-ULP determination), with the result adversarially verified by a second automated agent which independently recomputed the minimum ULP values for both the JavaScript and native implementations.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
