### PR TITLE
test: migrate `math/base/special/log2` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log2/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log2/test/test.js
@@ -24,8 +24,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var log2 = require( './../lib' );
 
@@ -51,8 +49,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the binary logarithm of `x` (very large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -61,21 +57,13 @@ tape( 'the function evaluates the binary logarithm of `x` (very large positive v
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -84,21 +72,13 @@ tape( 'the function evaluates the binary logarithm of `x` (large positive values
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -107,21 +87,13 @@ tape( 'the function evaluates the binary logarithm of `x` (medium positive value
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -130,21 +102,13 @@ tape( 'the function evaluates the binary logarithm of `x` (small positive values
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (smaller positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -153,21 +117,13 @@ tape( 'the function evaluates the binary logarithm of `x` (smaller positive valu
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (tiny positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -176,21 +132,13 @@ tape( 'the function evaluates the binary logarithm of `x` (tiny positive values)
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (subnormal values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -199,13 +147,7 @@ tape( 'the function evaluates the binary logarithm of `x` (subnormal values)', f
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/log2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log2/test/test.native.js
@@ -25,8 +25,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -60,8 +58,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the binary logarithm of `x` (very large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -70,21 +66,13 @@ tape( 'the function evaluates the binary logarithm of `x` (very large positive v
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -93,21 +81,13 @@ tape( 'the function evaluates the binary logarithm of `x` (large positive values
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -116,21 +96,13 @@ tape( 'the function evaluates the binary logarithm of `x` (medium positive value
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -139,21 +111,13 @@ tape( 'the function evaluates the binary logarithm of `x` (small positive values
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (smaller positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -162,21 +126,13 @@ tape( 'the function evaluates the binary logarithm of `x` (smaller positive valu
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (tiny positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -185,21 +141,13 @@ tape( 'the function evaluates the binary logarithm of `x` (tiny positive values)
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the binary logarithm of `x` (subnormal values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -208,13 +156,7 @@ tape( 'the function evaluates the binary logarithm of `x` (subnormal values)', o
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log2( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/log2` from relative-tolerance (EPS-based) assertions to the ULP-based testing convention.
-   Direct ULP-difference computation (via `@stdlib/number/float64/base/ulp-difference`) over all seven Julia fixture sets (500–503 cases each) yields a maximum ULP difference of `0` for every test block, i.e., the JavaScript implementation matches the Julia reference values exactly. Accordingly, per maintainer guidance, the assertions use plain `t.strictEqual( y, expected[ i ], 'returns expected value' );` rather than `isAlmostSameValue`, and the now-unused `EPS` and `abs` requires and `delta`/`tol` variables were removed.
-   The native implementation produces bit-identical results to the JavaScript implementation on the test platform (all native test blocks also pass with exact equality), so no native-vs-JavaScript tolerance divergence comments were needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code: one agent performed the test migration and minimum-ULP discovery, and a second adversarial agent independently recomputed the ULP values from the fixtures and verified the diff before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
