### PR TITLE
test: migrate `math/base/special/versin` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/versin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/versin/test/test.js
@@ -22,10 +22,8 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var versin = require( './../lib' );
 
 
@@ -49,8 +47,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the versed sine (for -256*pi < x < 0 )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -60,13 +56,7 @@ tape( 'the function computes the versed sine (for -256*pi < x < 0 )', function t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -74,8 +64,6 @@ tape( 'the function computes the versed sine (for -256*pi < x < 0 )', function t
 
 tape( 'the function computes the versed sine (for 0 < x < 256*pi )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -85,13 +73,7 @@ tape( 'the function computes the versed sine (for 0 < x < 256*pi )', function te
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -99,8 +81,6 @@ tape( 'the function computes the versed sine (for 0 < x < 256*pi )', function te
 
 tape( 'the function computes the versed sine (for -2**60 (pi/2) < x < -2**20 (pi/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -110,13 +90,7 @@ tape( 'the function computes the versed sine (for -2**60 (pi/2) < x < -2**20 (pi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -124,8 +98,6 @@ tape( 'the function computes the versed sine (for -2**60 (pi/2) < x < -2**20 (pi
 
 tape( 'the function computes the versed sine (for 2**20 (pi/2) < x < 2**60 (pi/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -135,13 +107,7 @@ tape( 'the function computes the versed sine (for 2**20 (pi/2) < x < 2**60 (pi/2
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -149,8 +115,6 @@ tape( 'the function computes the versed sine (for 2**20 (pi/2) < x < 2**60 (pi/2
 
 tape( 'the function computes the versed sine (for x <= -2**60 (PI/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -160,13 +124,7 @@ tape( 'the function computes the versed sine (for x <= -2**60 (PI/2) )', functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -174,8 +132,6 @@ tape( 'the function computes the versed sine (for x <= -2**60 (PI/2) )', functio
 
 tape( 'the function computes the versed sine (for x >= 2**60 (PI/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -185,13 +141,7 @@ tape( 'the function computes the versed sine (for x >= 2**60 (PI/2) )', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/versin/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/versin/test/test.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the versed sine (for -256*pi < x < 0 )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -69,13 +66,9 @@ tape( 'the function computes the versed sine (for -256*pi < x < 0 )', opts, func
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -83,8 +76,6 @@ tape( 'the function computes the versed sine (for -256*pi < x < 0 )', opts, func
 
 tape( 'the function computes the versed sine (for 0 < x < 256*pi )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -94,13 +85,9 @@ tape( 'the function computes the versed sine (for 0 < x < 256*pi )', opts, funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -108,8 +95,6 @@ tape( 'the function computes the versed sine (for 0 < x < 256*pi )', opts, funct
 
 tape( 'the function computes the versed sine (for -2**60 (pi/2) < x < -2**20 (pi/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -119,13 +104,9 @@ tape( 'the function computes the versed sine (for -2**60 (pi/2) < x < -2**20 (pi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -133,8 +114,6 @@ tape( 'the function computes the versed sine (for -2**60 (pi/2) < x < -2**20 (pi
 
 tape( 'the function computes the versed sine (for 2**20 (pi/2) < x < 2**60 (pi/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -144,13 +123,9 @@ tape( 'the function computes the versed sine (for 2**20 (pi/2) < x < 2**60 (pi/2
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -158,8 +133,6 @@ tape( 'the function computes the versed sine (for 2**20 (pi/2) < x < 2**60 (pi/2
 
 tape( 'the function computes the versed sine (for x <= -2**60 (PI/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -169,13 +142,9 @@ tape( 'the function computes the versed sine (for x <= -2**60 (PI/2) )', opts, f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -183,8 +152,6 @@ tape( 'the function computes the versed sine (for x <= -2**60 (PI/2) )', opts, f
 
 tape( 'the function computes the versed sine (for x >= 2**60 (PI/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -194,13 +161,9 @@ tape( 'the function computes the versed sine (for x >= 2**60 (PI/2) )', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = versin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/versin` from relative-tolerance (EPS-based) assertions to ULP-difference based assertions using `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).
-   for the JavaScript implementation, the computed results match the Julia fixture values exactly (maximum ULP difference of `0` across all six fixture sets), so the assertions use plain `t.strictEqual( y, expected[ i ], 'returns expected value' )` rather than `isAlmostSameValue`.
-   for the native (C) implementation, a maximum ULP difference of `2` is required in all six fixture-based test blocks (consistent with the previous `1.7 * EPS` native tolerance); a ULP value of `1` fails 32 cases. Since the native tolerance exceeds the JavaScript tolerance, the canonical `NOTE` comment explaining compiler-optimization-induced divergence has been added above each native assertion.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Native tests were run against the actual compiled addon (24005 assertions, 0 skips), and the official test harness (`make test`) passed for both files.
-   The reported minimum ULP values for the JavaScript tests were independently re-verified by recomputing the maximum ULP difference over every fixture case.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which performed the test migration, determined the minimum required ULP values, and ran the test suites; a second Claude Code agent adversarially verified the diff and independently recomputed the ULP values before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
