### PR TITLE
test: migrate `math/base/special/cflipsign` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cflipsign/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsign/test/test.js
@@ -24,8 +24,6 @@ var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
@@ -48,13 +46,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function evaluates the flipsign function', function test( t ) {
-	var delta;
 	var ans;
 	var ere;
 	var eim;
 	var are;
 	var aim;
-	var tol;
 	var re;
 	var im;
 	var y;
@@ -72,18 +68,8 @@ tape( 'the function evaluates the flipsign function', function test( t ) {
 		ans = cflipsign( z, y[ i ] );
 		are = real( ans );
 		aim = imag( ans );
-		if ( are === ere[ i ] && aim === eim[ i ] ) {
-			t.strictEqual( are, ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
-			t.strictEqual( aim, eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
-		} else {
-			delta = abs( are - ere[ i ] );
-			tol = EPS * abs( ere[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual re: '+are+'. Expected re: '+ere[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-
-			delta = abs( aim - eim[ i ] );
-			tol = EPS * abs( eim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual im: '+aim+'. Expected im: '+eim[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( are, ere[ i ], 'returns expected value' );
+		t.strictEqual( aim, eim[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cflipsign/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsign/test/test.native.js
@@ -25,8 +25,6 @@ var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
@@ -57,13 +55,11 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function evaluates the flipsign function', opts, function test( t ) {
-	var delta;
 	var ans;
 	var ere;
 	var eim;
 	var are;
 	var aim;
-	var tol;
 	var re;
 	var im;
 	var y;
@@ -81,18 +77,8 @@ tape( 'the function evaluates the flipsign function', opts, function test( t ) {
 		ans = cflipsign( z, y[ i ] );
 		are = real( ans );
 		aim = imag( ans );
-		if ( are === ere[ i ] && aim === eim[ i ] ) {
-			t.strictEqual( are, ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
-			t.strictEqual( aim, eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
-		} else {
-			delta = abs( are - ere[ i ] );
-			tol = EPS * abs( ere[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual re: '+are+'. Expected re: '+ere[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-
-			delta = abs( aim - eim[ i ] );
-			tol = EPS * abs( eim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual im: '+aim+'. Expected im: '+eim[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( are, ere[ i ], 'returns expected value' );
+		t.strictEqual( aim, eim[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `@stdlib/math/base/special/cflipsign` from relative-tolerance (EPS-based) assertions to ULP-based testing per #11352. Direct ULP-difference computation over all 2003 fixture cases (real and imaginary components, via `@stdlib/number/float64/base/ulp-difference`) yields a maximum ULP difference of `0` — `cflipsign` is exact sign negation — so, per maintainer guidance, the tolerance blocks are collapsed to plain `t.strictEqual( ..., 'returns expected value' )` assertions rather than `isAlmostSameValue`.
-   removes the now-unused `EPS` and `abs` requires and the now-unused `delta`/`tol` variable declarations.
-   drops the obsolete exact-equality short-circuit branches, which are subsumed by the exact assertions.

The native (C) results are bit-identical to the JavaScript results across all fixture cases (native test suite run with zero skips), so no JS-vs-C tolerance divergence exists and no `NOTE` comment is needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The minimum ULP value (`0`) was independently re-verified by recomputing the ULP difference for every fixture case against the unchanged implementation.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, which performed the test migration, computed the minimum ULP values over the test fixtures, and ran the JavaScript and native test suites; a second adversarial Claude Code agent independently re-verified the diff and the ULP computation.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
