### PR TITLE
test: migrate `math/base/special/acosf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acosf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosf/test/test.js
@@ -24,8 +24,8 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var PI = require( '@stdlib/constants/float32/pi' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var acosf = require( './../lib' );
@@ -48,8 +48,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the arccosine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -61,21 +59,13 @@ tape( 'the function computes the arccosine', function test( t ) {
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 115.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 163 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosine (small negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -87,21 +77,13 @@ tape( 'the function computes the arccosine (small negative values)', function te
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosine (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -113,13 +95,7 @@ tape( 'the function computes the arccosine (small positive values)', function te
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosf/test/test.native.js
@@ -25,8 +25,8 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var PI = require( '@stdlib/constants/float32/pi' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -57,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the arccosine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -70,21 +68,13 @@ tape( 'the function computes the arccosine', opts, function test( t ) {
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 115.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 163 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosine (small negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -96,21 +86,13 @@ tape( 'the function computes the arccosine (small negative values)', opts, funct
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosine (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -122,13 +104,7 @@ tape( 'the function computes the arccosine (small positive values)', opts, funct
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/acosf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, following the merged precedent in `math/base/special/acothf` and `math/base/special/atanhf`), using the minimum required ULP values as verified by direct ULP-difference computation over the test fixtures (`@stdlib/number/float32/base/ulp-difference`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Minimum ULP values per test block (expected values coerced to single precision via the file's existing `float64ToFloat32` before comparison):
    -   `data.json` ("the function computes the arccosine"): `163` (worst case `x = 0.999000999000999`, near the ill-conditioned `x -> 1` boundary; minimality verified: `162` fails, `163` passes). Consistent with the previous `115 * EPS` relative tolerance, which permitted up to roughly `230` float32 ULPs.
    -   `small_negative.json` and `small_positive.json`: exact (max ULP `0`), so plain `t.strictEqual( y, e, 'returns expected value' )` is used per maintainer guidance.
-   The native (C) implementation was built and tested; its maximum ULP differences are identical to the JavaScript implementation (`163`/`0`/`0`), so no divergence `NOTE` annotation is needed.
-   The `EPS` require is retained in both test files as it is still used for the uniform bounds in the out-of-domain (`NaN`) tests; the now-unused `abs` require was removed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated test migration for #11352: the test assertion changes were generated by one agent, and the minimum ULP values were independently recomputed and the diff adversarially reviewed by a second agent before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
