### PR TITLE
test: migrate `math/base/special/log10` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log10/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log10/test/test.js
@@ -24,8 +24,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var log10 = require( './../lib' );
 
@@ -51,8 +49,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the common logarithm of `x` (very large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -61,21 +57,13 @@ tape( 'the function evaluates the common logarithm of `x` (very large positive v
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -84,21 +72,13 @@ tape( 'the function evaluates the common logarithm of `x` (large positive values
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -107,21 +87,13 @@ tape( 'the function evaluates the common logarithm of `x` (medium positive value
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -130,21 +102,13 @@ tape( 'the function evaluates the common logarithm of `x` (small positive values
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (smaller values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -153,21 +117,13 @@ tape( 'the function evaluates the common logarithm of `x` (smaller values)', fun
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (tiny positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -176,21 +132,13 @@ tape( 'the function evaluates the common logarithm of `x` (tiny positive values)
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (subnormal values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -199,13 +147,7 @@ tape( 'the function evaluates the common logarithm of `x` (subnormal values)', f
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/log10/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log10/test/test.native.js
@@ -26,8 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 
 
@@ -60,8 +59,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the common logarithm of `x` (very large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -70,21 +67,13 @@ tape( 'the function evaluates the common logarithm of `x` (very large positive v
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -93,21 +82,13 @@ tape( 'the function evaluates the common logarithm of `x` (large positive values
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -116,21 +97,13 @@ tape( 'the function evaluates the common logarithm of `x` (medium positive value
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -139,21 +112,15 @@ tape( 'the function evaluates the common logarithm of `x` (small positive values
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (smaller values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -162,21 +129,15 @@ tape( 'the function evaluates the common logarithm of `x` (smaller values)', opt
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (tiny positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -185,21 +146,13 @@ tape( 'the function evaluates the common logarithm of `x` (tiny positive values)
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the common logarithm of `x` (subnormal values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -208,13 +161,7 @@ tape( 'the function evaluates the common logarithm of `x` (subnormal values)', o
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = log10( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `@stdlib/math/base/special/log10` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures)
-   uses plain `t.strictEqual( y, expected[ i ], 'returns expected value' )` for all seven JavaScript fixture blocks and for five of the seven native fixture blocks, as the computed results match the Julia fixtures exactly (maximum ULP difference of `0` across all cases)
-   uses `isAlmostSameValue( y, expected[ i ], 1 )` for the `small positive values` and `smaller values` blocks in `test/test.native.js`, as the native (C) implementation diverges from the fixtures by at most 1 ULP on arm64 macOS (clang) due to compiler optimizations; the canonical `NOTE` comment referencing https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205 is included above those assertions
-   removes the now-unused `EPS` and `abs` requires and the `delta`/`tol` variables from both test files

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Minimality of the ULP values was verified: for the JavaScript implementation, an independent recomputation over all 3500 fixture cases confirmed a maximum ULP difference of `0` for every block; for the native implementation, plain `strictEqual` (ULP `0`) failed only in the two blocks now using a tolerance of 1 ULP.
-   Both test files were run successfully (JavaScript via the official test harness; native against a locally built addon).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, computed and verified the minimum required ULP values, and ran the test suites. A second, independent Claude Code agent adversarially reviewed the diff and recomputed the ULP values before this PR was opened.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
