### PR TITLE
test: migrate `math/base/special/rcbrtf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rcbrtf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrtf/test/test.js
@@ -24,8 +24,6 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var rcbrtf = require( './../lib' );
 
@@ -58,8 +56,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[50,500]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -70,21 +66,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[20,50]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,21 +83,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[3,20]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -120,21 +100,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[0.8,3]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -145,21 +117,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[0.0,0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -170,21 +134,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[1e-30,1e-38]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -195,21 +151,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of subnormal `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -220,21 +168,13 @@ tape( 'the function evaluates the reciprocal cube root of subnormal `x`', functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` (huge positive)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -245,21 +185,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` (huge positive)', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` (huge negative)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -270,21 +202,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` (huge negative)', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-50,-500]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -295,21 +219,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-20,-50]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -320,21 +236,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-20,-3]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -345,21 +253,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-3,-0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -370,21 +270,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-0.8,0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -395,21 +287,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-1e-30,-1e-38]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -420,13 +304,7 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/rcbrtf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrtf/test/test.native.js
@@ -25,8 +25,6 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -67,8 +65,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[50,500]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -79,21 +75,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[20,50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -104,21 +92,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[3,20]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -129,21 +109,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[0.8,3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -154,21 +126,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[0.0,0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -179,21 +143,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[1e-30,1e-38]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -204,21 +160,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of subnormal `x`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -229,21 +177,13 @@ tape( 'the function evaluates the reciprocal cube root of subnormal `x`', opts, 
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` (huge positive)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -254,21 +194,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` (huge positive)', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` (huge negative)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -279,21 +211,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` (huge negative)', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-50,-500]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -304,21 +228,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-20,-50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -329,21 +245,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-20,-3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -354,21 +262,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-3,-0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -379,21 +279,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-0.8,0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -404,21 +296,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-1e-30,-1e-38]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -429,13 +313,7 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrtf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+', y: '+y+', expected: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/rcbrtf` from relative-tolerance (EPS-based) assertions to the testing approach described in #11352. The maximum ULP difference between actual and expected values (computed via direct ULP-difference comparison against the float32-coerced test fixtures, replicating the tests' `float64ToFloat32( expected[ i ] )` transformation) is `0` for every fixture block in **both** the JavaScript and native (C) implementations, so, per maintainer guidance, all tolerance-based branches were collapsed to plain `t.strictEqual( y, e, 'returns expected value' )` exact-equality assertions rather than `isAlmostSameValue` with a `0` ULP tolerance.
-   removes the now-unused `delta`/`tol` variables and the now-unused `EPS` (`@stdlib/constants/float32/eps`) and `abs` requires from both test files.

The native implementation does not diverge from the JavaScript implementation (all native assertions pass with exact equality), so no enlarged native tolerances (and no accompanying compiler-optimization NOTE comments) were needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Minimum ULP values were verified by an independent recomputation over all fixture files (15 blocks, JS implementation): max ULP difference is `0` everywhere, so exact equality is the tightest possible assertion.
-   Both the JavaScript and native test suites were run via the official test harness and passed (48052/48052 assertions, no skips).
-   Pre-existing quirks were intentionally left untouched to keep the diff minimal: the `[-50,-500]` test description has an unclosed backtick, and the `[1e-30,1e-38]`/`[-1e-30,-1e-38]` interval bounds in the descriptions are reversed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated test migration workflow for #11352, including computation of the minimum required ULP values, and was adversarially verified by a second Claude Code agent which independently recomputed the ULP values from the test fixtures.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
