### PR TITLE
test: migrate `math/base/special/boxcox1pinv` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/boxcox1pinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox1pinv/test/test.js
@@ -23,8 +23,8 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var boxcox1pinv = require( './../lib' );
 
 
@@ -94,8 +94,6 @@ tape( 'the function returns `NaN` if `x` is positive and `lambda` is negative (f
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -106,21 +104,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = mediumPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -131,21 +121,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = mediumNegative.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for positive small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -156,21 +138,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = smallPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for negative small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -181,21 +155,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = smallNegative.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for very small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -206,21 +172,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = verySmall.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( b, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -231,21 +189,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = tiny.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( b, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation when `lambda` is zero', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -256,13 +206,7 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = lambdaZero.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/boxcox1pinv/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox1pinv/test/test.native.js
@@ -24,8 +24,8 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -103,8 +103,6 @@ tape( 'the function returns `NaN` if `x` is positive and `lambda` is negative (f
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for positive medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -115,21 +113,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = mediumPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for negative medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -140,21 +130,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = mediumNegative.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for positive small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -165,21 +147,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = smallPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for negative small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -190,21 +164,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = smallNegative.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for very small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -215,21 +181,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = verySmall.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( b, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for tiny numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -240,21 +198,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = tiny.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( b, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation when `lambda` is zero', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -265,13 +215,7 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = lambdaZero.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1pinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/boxcox1pinv` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`
-   uses the minimum required ULP values for each test block, verified by direct ULP-difference computation over the test fixtures (`medium_positive`: 4, `medium_negative`: 2, `small_positive`: 4, `small_negative`: 4, `lambda_zero`: 1)
-   replaces tolerance assertions with plain `t.strictEqual` for the `very_small` and `tiny` fixture sets, as all fixture values match exactly (0 ULP)
-   removes the now-unused `abs` require and the `delta`/`tol` variables (the `EPS` require is retained, as it is still used by the `NaN` guard tests)

The native test suite was built and run locally and passed at ULP values identical to the JavaScript implementation, so no divergence `NOTE` annotations were needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code: it performed the test migration, computed the minimum ULP values over the test fixtures, and was adversarially verified by an independent Claude Code agent which recomputed all ULP values before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
