### PR TITLE
test: migrate `math/base/special/erfinv` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/erfinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/test/test.js
@@ -26,8 +26,7 @@ var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var erfinv = require( './../lib' );
 
 
@@ -102,8 +101,6 @@ tape( 'if provided a value which is either less than `-1` or greater than `1`, t
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[-0.5,0.5]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -112,21 +109,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x1.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[-0.5,-0.75]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -135,21 +124,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x2.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[0.5,0.75]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -158,21 +139,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x3.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[0.75,0.9998]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -181,21 +154,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x4.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 14.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[0.9998,0.9999..8]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -204,21 +169,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x5.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 9.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[0.9999..8,1]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -230,13 +187,7 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 		if ( expected[ i ] === null ) {
 			expected[ i ] = PINF;
 		}
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/test/test.native.js
@@ -28,8 +28,7 @@ var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 
 
 // FIXTURES //
@@ -111,8 +110,6 @@ tape( 'if provided a value which is either less than `-1` or greater than `1`, t
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[-0.5,0.5]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -121,21 +118,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x1.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[-0.5,-0.75]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -144,21 +133,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x2.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[0.5,0.75]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -167,21 +148,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x3.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[0.75,0.9998]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -190,21 +163,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x4.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 14.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[0.9998,0.9999..8]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -213,21 +178,13 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 	x = x5.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 9.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[0.9999..8,1]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -239,13 +196,7 @@ tape( 'the function evaluates the inverse error function for `x` on the interval
 		if ( expected[ i ] === null ) {
 			expected[ i ] = PINF;
 		}
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/erfinv` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`.
-   uses the minimum required ULP values per test block (5, 3, 3, 20, 11, 1), verified by direct ULP-difference computation over the test fixtures (each block passes at the chosen value and fails at one ULP lower).
-   removes the now-unused `EPS` and `abs` requires and the obsolete `delta`/`tol` variables, and collapses the exact-equality short-circuit branches, which `isAlmostSameValue` covers.
-   keeps the native test file at the same ULP values as the JavaScript test file: measured native maximum ULP differences (4, 3, 3, 20, 11, 0) did not exceed the JavaScript values, so no larger native tolerances (and no divergence `NOTE` comments) were needed. Native tests passed un-skipped against a locally built addon (5513/5513 assertions).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, computed and verified the minimum ULP values against the fixtures, and was adversarially reviewed by a second Claude Code agent.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
