### PR TITLE
test: migrate `math/base/special/ahavercosf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ahavercosf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ahavercosf/test/test.js
@@ -23,7 +23,8 @@
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var randu = require( '@stdlib/random/base/randu' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var ahavercosf = require( './../lib' );
 
@@ -44,10 +45,9 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse half-value versed cosine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	x = data.x;
@@ -55,23 +55,17 @@ tape( 'the function computes the inverse half-value versed cosine', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahavercosf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = 1.21 * EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse half-value versed cosine (small positive numbers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	x = smallPositive.x;
@@ -79,13 +73,8 @@ tape( 'the function computes the inverse half-value versed cosine (small positiv
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahavercosf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ahavercosf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ahavercosf/test/test.native.js
@@ -24,7 +24,8 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var randu = require( '@stdlib/random/base/randu' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -53,10 +54,9 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse half-value versed cosine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	x = data.x;
@@ -64,23 +64,17 @@ tape( 'the function computes the inverse half-value versed cosine', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahavercosf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = 1.21 * EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse half-value versed cosine (small positive numbers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	x = smallPositive.x;
@@ -88,13 +82,8 @@ tape( 'the function computes the inverse half-value versed cosine (small positiv
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahavercosf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/ahavercosf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions.
-   as this is a single-precision package, follows the established `f32` precedent (e.g., `acothf`, `atanhf`): assertions use `isAlmostSameValue` from `@stdlib/number/float32/base/assert/is-almost-same-value`, with expected fixture values coerced to single precision via `@stdlib/number/float64/base/to-float32` before comparison.
-   uses the minimum required ULP values, verified by direct ULP-difference computation (`@stdlib/number/float32/base/ulp-difference`) over all test fixtures: `data.json` requires a maximum of 1 ULP (64 of 2003 cases differ by exactly 1 ULP), and `small_positive.json` matches exactly (0 ULP), so the latter block uses plain `t.strictEqual` assertions.
-   removes the now-unused `absf` require and `delta`/`tol` variables; the `EPS` require is retained, as it is still used by the out-of-domain `NaN` tests.
-   native (C) results are identical to the JavaScript results (maximum ULP differences of 1 and 0, respectively), so no tolerance divergence note is needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated migration of test suites to ULP-based testing (issue #11352), including independent adversarial verification of the minimum ULP values by a second agent.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
