### PR TITLE
test: migrate `math/base/special/expm1` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/expm1/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/expm1/test/test.js
@@ -24,13 +24,12 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var expm1 = require( './../lib' );
 
 
@@ -55,9 +54,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function agrees with `exp(x) - 1` for most `x`', function test( t ) {
 	var expected;
-	var delta;
 	var val;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -66,17 +63,13 @@ tape( 'the function agrees with `exp(x) - 1` for most `x`', function test( t ) {
 		val = x[ i ];
 		y = expm1( val );
 		expected = exp( val ) - 1.0;
-		delta = abs( y - expected );
-		tol = 1e-12 * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. x: '+x+'. y: '+y+'. Δ: '+delta+'. E: '+ expected[i]+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( y, expected, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -86,17 +79,13 @@ tape( 'the function accurately computes `exp(x) - 1` for negative medium numbers
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for negative medium numbers (tested against the Boost C++ library)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -106,17 +95,13 @@ tape( 'the function accurately computes `exp(x) - 1` for negative medium numbers
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -126,17 +111,13 @@ tape( 'the function accurately computes `exp(x) - 1` for positive medium numbers
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for positive medium numbers (tested against the Boost C++ library)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -146,17 +127,13 @@ tape( 'the function accurately computes `exp(x) - 1` for positive medium numbers
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for negative small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -166,17 +143,13 @@ tape( 'the function accurately computes `exp(x) - 1` for negative small numbers'
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for positive small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -186,17 +159,13 @@ tape( 'the function accurately computes `exp(x) - 1` for positive small numbers'
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for very small `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -206,9 +175,7 @@ tape( 'the function accurately computes `exp(x) - 1` for very small `x`', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/expm1/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/expm1/test/test.native.js
@@ -25,14 +25,13 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 
 
 // FIXTURES //
@@ -64,9 +63,7 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function agrees with `exp(x) - 1` for most `x`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var val;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -75,17 +72,13 @@ tape( 'the function agrees with `exp(x) - 1` for most `x`', opts, function test(
 		val = x[ i ];
 		y = expm1( val );
 		expected = exp( val ) - 1.0;
-		delta = abs( y - expected );
-		tol = 1e-12 * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. x: '+x+'. y: '+y+'. Δ: '+delta+'. E: '+ expected[i]+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( y, expected, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for negative medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -95,17 +88,13 @@ tape( 'the function accurately computes `exp(x) - 1` for negative medium numbers
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for negative medium numbers (tested against the Boost C++ library)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -115,17 +104,13 @@ tape( 'the function accurately computes `exp(x) - 1` for negative medium numbers
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for positive medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -135,17 +120,15 @@ tape( 'the function accurately computes `exp(x) - 1` for positive medium numbers
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for positive medium numbers (tested against the Boost C++ library)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -155,17 +138,13 @@ tape( 'the function accurately computes `exp(x) - 1` for positive medium numbers
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for negative small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -175,17 +154,15 @@ tape( 'the function accurately computes `exp(x) - 1` for negative small numbers'
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for positive small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -195,17 +172,15 @@ tape( 'the function accurately computes `exp(x) - 1` for positive small numbers'
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `exp(x) - 1` for very small `x`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -215,9 +190,7 @@ tape( 'the function accurately computes `exp(x) - 1` for very small `x`', opts, 
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+v+'. E: '+ expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/expm1` from relative-tolerance (`EPS`-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).
-   uses plain `t.strictEqual( v, expected[ i ], 'returns expected value' )` for all seven fixture-based test blocks in `test/test.js` (and four in `test/test.native.js`), as the JavaScript implementation matches the Julia and Boost C++ fixtures exactly (max ULP difference of `0` across all fixture cases).
-   uses `isAlmostSameValue` with a maximum ULP difference of `2` for the runtime-computed block comparing `expm1(x)` against `exp(x) - 1.0` over `incrspace( -10.0, 50.0, 0.5 )` in both test files (a ULP value of `1` fails exactly one case).
-   uses `isAlmostSameValue` with a maximum ULP difference of `1` for three fixture-based blocks in `test/test.native.js` (`julia/medium_positive`, `julia/small_negative`, and `julia/small_positive`), as the native (C) implementation diverges from exact equality on those fixtures due to compiler optimizations (verified by building the add-on and running the native tests; clang on macOS arm64). Each such assertion carries the canonical `NOTE` comment per https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Both the JavaScript and native test suites were run locally and pass. The minimum ULP values were additionally verified by an independent script which recomputes the ULP difference for every fixture case against the JavaScript implementation.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, determined the minimum ULP values, and verified the results via an independent ULP-difference recomputation over the test fixtures. The changes were additionally reviewed by a separate adversarial verification agent before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
