### PR TITLE
test: migrate `math/base/special/erfcx` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/erfcx/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfcx/test/test.js
@@ -22,9 +22,8 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var erfcx = require( './../lib' );
 
 
@@ -96,8 +95,6 @@ tape( 'the function returns `( 1 / sqrt(pi) ) / x` if `x` is larger than `5e7`',
 
 tape( 'the function computes the scaled complementary error function for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -106,21 +103,13 @@ tape( 'the function computes the scaled complementary error function for positiv
 	x = mediumPositive.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for positive small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -129,21 +118,13 @@ tape( 'the function computes the scaled complementary error function for positiv
 	x = smallPositive.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for negative small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -152,21 +133,13 @@ tape( 'the function computes the scaled complementary error function for negativ
 	x = smallNegative.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -175,21 +148,13 @@ tape( 'the function computes the scaled complementary error function for negativ
 	x = mediumNegative.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for positive large numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -198,21 +163,13 @@ tape( 'the function computes the scaled complementary error function for positiv
 	x = largePositive.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -221,13 +178,7 @@ tape( 'the function computes the scaled complementary error function for tiny nu
 	x = tiny.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/erfcx/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfcx/test/test.native.js
@@ -23,9 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -101,8 +100,6 @@ tape( 'the function returns `( 1 / sqrt(pi) ) / x` if `x` is larger than `5e7`',
 
 tape( 'the function computes the scaled complementary error function for positive medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -111,21 +108,15 @@ tape( 'the function computes the scaled complementary error function for positiv
 	x = mediumPositive.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for positive small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -134,21 +125,15 @@ tape( 'the function computes the scaled complementary error function for positiv
 	x = smallPositive.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for negative small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -157,21 +142,13 @@ tape( 'the function computes the scaled complementary error function for negativ
 	x = smallNegative.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for negative medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -180,21 +157,13 @@ tape( 'the function computes the scaled complementary error function for negativ
 	x = mediumNegative.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for positive large numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -203,21 +172,15 @@ tape( 'the function computes the scaled complementary error function for positiv
 	x = largePositive.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the scaled complementary error function for tiny numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -226,13 +189,7 @@ tape( 'the function computes the scaled complementary error function for tiny nu
 	x = tiny.x;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = erfcx( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'returns '+y+' when provided '+x[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - y );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+y+' when provided '+x[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `@stdlib/math/base/special/erfcx` from relative-tolerance (`EPS`-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).
-   uses plain `t.strictEqual` for test blocks in which all computed values exactly match the fixture values (positive medium, positive small, positive large, and tiny numbers in `test/test.js`; tiny numbers in `test/test.native.js`).
-   uses larger tolerances (ULP of `1` instead of exact equality) for the positive medium, positive small, and positive large number blocks in `test/test.native.js`, as the native implementation diverges from the JavaScript implementation on these blocks due to compiler optimizations; the canonical `NOTE` comment referencing https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205 is included above each such assertion.
-   removes the now-unused `EPS` and `abs` requires and the `delta`/`tol` variables.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Minimum ULP values were determined by computing the exact ULP difference (via `@stdlib/number/float64/base/ulp-difference`) between computed and expected values over all fixture cases for each test block and independently re-verified.
-   JavaScript test suite passes (`make test`), and the native test suite passes with the addon built and loaded (9867/9867 assertions).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which migrated the test assertions, computed the minimum ULP tolerances from the test fixtures, and verified the results; a second, adversarial Claude Code agent independently recomputed the ULP values and reviewed the diff before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
