### PR TITLE
test: migrate `math/base/special/sqrtf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sqrtf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtf/test/test.js
@@ -26,8 +26,7 @@ var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var sqrtf = require( './../lib' );
 
 
@@ -53,184 +52,136 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[50,500]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = veryLargePositive.expected;
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[20,50]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = largePositive.expected;
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[3,20]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = mediumPositive.expected;
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[0.8,3]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = smallPositive.expected;
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates principal square root of `x` on the interval `[0.0,0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = smaller.expected;
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[1e-30,1e-38]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = tinyPositive.expected;
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of subnormal `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = subnormal.expected;
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` (huge positive)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = hugePositive.expected;
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sqrtf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtf/test/test.native.js
@@ -27,8 +27,7 @@ var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -62,184 +61,136 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[50,500]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = veryLargePositive.expected;
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[20,50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = largePositive.expected;
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[3,20]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = mediumPositive.expected;
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[0.8,3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = smallPositive.expected;
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates principal square root of `x` on the interval `[0.0,0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = smaller.expected;
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` on the interval `[1e-30,1e-38]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = tinyPositive.expected;
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of subnormal `x`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = subnormal.expected;
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root of `x` (huge positive)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	expected = hugePositive.expected;
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
-		y = sqrtf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		y = sqrtf( x[ i ] );
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/sqrtf` from relative-tolerance (EPS-based) assertions to ULP-based testing per #11352.
-   As `sqrtf` is a single-precision package, expected fixture values are coerced via `f32 = require( '@stdlib/number/float64/base/to-float32' )`, following the precedent established for `math/base/special/acothf` (ed81430366d) and `math/base/special/atanhf` (7f68fc4aa25).
-   The maximum float32 ULP difference, computed directly via `@stdlib/number/float32/base/ulp-difference` over all eight fixture blocks (5003/5003 cases each), is `0` for every block (and independently re-verified): `sqrtf` is correctly rounded, and the Julia fixtures round-trip exactly to single precision. Accordingly, all migrated assertions use plain `t.strictEqual( y, e, 'returns expected value' )` rather than `isAlmostSameValue`, as values are exactly equal.
-   Native (C) results do not diverge from the JavaScript implementation (libm `sqrtf` is also correctly rounded): all 40034 native assertions pass with identical ULP `0`, so no divergence `NOTE` comments are needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The `f32` coercion of expected values is load-bearing: only 1 of 40024 raw double fixture values is strictly equal to the float32 result, so the exact-equality assertions are non-trivial.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which performed the test migration, computed the minimum required ULP values directly from the test fixtures, and adversarially verified the result (including independent recomputation of the ULP values).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
