### PR TITLE
test: migrate `math/base/special/ahaversin` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ahaversin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ahaversin/test/test.js
@@ -23,8 +23,8 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var ahaversin = require( './../lib' );
 
 
@@ -44,8 +44,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse half-value versed sine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -54,22 +52,14 @@ tape( 'the function computes the inverse half-value versed sine', function test(
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = ahaversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = ahaversin( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse half-value versed sine (small positive numbers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -78,14 +68,8 @@ tape( 'the function computes the inverse half-value versed sine (small positive 
 	expected = smallPositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = ahaversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = ahaversin( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ahaversin/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ahaversin/test/test.native.js
@@ -24,8 +24,8 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -53,8 +53,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse half-value versed sine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -63,22 +61,14 @@ tape( 'the function computes the inverse half-value versed sine', opts, function
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = ahaversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = ahaversin( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse half-value versed sine (small positive numbers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -87,14 +77,8 @@ tape( 'the function computes the inverse half-value versed sine (small positive 
 	expected = smallPositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = ahaversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = ahaversin( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/ahaversin` from relative-tolerance (`EPS`-based) assertions to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   uses the minimum required ULP values, verified by direct ULP-difference computation over the test fixtures: the `data.json` block requires a maximum ULP difference of `1` (270 of 2003 cases differ by exactly 1 ULP, so a tolerance of `0` fails), and the `small_positive.json` block matches exactly (max ULP difference of `0`), so plain `t.strictEqual` assertions are used there.
-   removes the now-unused `abs` require and the obsolete `delta`/`tol` variables. The `EPS` require is retained, as it is still used by the out-of-domain `NaN` tests.

Native results match the JavaScript implementation exactly (max ULP differences of `1` and `0`, respectively), so no JS-vs-C tolerance divergence note is needed. All native tests pass with no skips.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, computed the minimum required ULP tolerances from the fixtures, and verified the results via an independent adversarial review pass. All changes were validated by running the full JavaScript and native test suites locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
