### PR TITLE
test: migrate `math/base/special/besselj0` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/besselj0/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/test/test.js
@@ -25,8 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var j0 = require( './../lib' );
 
 
@@ -55,8 +54,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (very large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -65,21 +62,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 800.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 968 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -88,21 +77,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1450.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1944 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -111,21 +92,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 500.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 631 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -134,21 +107,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 130.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 192 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (small negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -157,21 +122,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = smallNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 130.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 192 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates Bessel function of the first kind of zero order (J_0) (smaller values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -180,21 +137,13 @@ tape( 'the function evaluates Bessel function of the first kind of zero order (J
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.5 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (tiny positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -203,21 +152,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (subnormal values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -226,21 +167,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (huge positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -249,21 +182,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 900.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1200 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order zero (J_0) (positive values over a wide range of magnitudes)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -272,21 +197,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order zer
 	x = positiveGamut.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 16.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 27 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order zero (J_0) (negative values over a wide range of magnitudes)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -295,13 +212,7 @@ tape( 'the function evaluates the Bessel function of the first kind of order zer
 	x = negativeGamut.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 16.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 27 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/besselj0/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/test/test.native.js
@@ -26,8 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -64,8 +63,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (very large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -74,21 +71,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 800.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 968 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -97,21 +86,15 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1450.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1968 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -120,21 +103,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 500.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 631 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -143,23 +118,15 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
 
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2774#discussion_r1712904184
-			tol = 131.4 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 194 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (small negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -168,23 +135,15 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = smallNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
 
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2774#discussion_r1712904184
-			tol = 131.4 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 194 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates Bessel function of the first kind of zero order (J_0) (smaller values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -193,21 +152,13 @@ tape( 'the function evaluates Bessel function of the first kind of zero order (J
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.5 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (tiny positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -216,21 +167,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (subnormal values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -239,21 +182,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of zero order (J_0) (huge positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -262,21 +197,13 @@ tape( 'the function evaluates the Bessel function of the first kind of zero orde
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 900.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1200 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order zero (J_0) (positive values over a wide range of magnitudes)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -285,21 +212,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order zer
 	x = positiveGamut.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 16.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 27 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order zero (J_0) (negative values over a wide range of magnitudes)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -308,13 +227,7 @@ tape( 'the function evaluates the Bessel function of the first kind of order zer
 	x = negativeGamut.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j0( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 16.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 27 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/besselj0` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`
-   uses the minimum required ULP value for each test block, verified by direct ULP-difference computation (`@stdlib/number/float64/base/ulp-difference`) over the test fixtures
-   removes the now-unused `EPS` and `abs` requires and the obsolete `delta`/`tol` variables and exact-equality short-circuit branches

The native (C) implementation diverges from the JavaScript implementation on three test blocks (large positive: `1968` vs `1944`; small positive/negative: `194` vs `192`), so those native assertions carry larger ULP tolerances along with the standard explanatory `NOTE` comment (see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205). The small positive/negative native blocks previously carried a similar note for their larger EPS-based tolerances.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

All ULP values in `test/test.js` were independently recomputed against the fixtures and confirmed to be the minimum integer values for which all cases pass. Native values were verified against a locally built addon; on the local toolchain, the native "medium positive" block is tighter than the JavaScript implementation (max `203` vs `631`), but the JavaScript value was retained per existing convention, since native results vary across compilers/platforms. JavaScript and native test suites both pass.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which performed the test migration, computed and verified the minimum ULP tolerances against the fixtures, and ran the JavaScript and native test suites. An independent Claude Code verification pass recomputed all ULP values and reviewed the diff before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
