### PR TITLE
test: migrate `math/base/special/cabs2` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cabs2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cabs2/test/test.native.js
@@ -23,8 +23,6 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -52,8 +50,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the squared absolute value of a complex number', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var y;
@@ -65,13 +61,7 @@ tape( 'the function computes the squared absolute value of a complex number', op
 
 	for ( i = 0; i < re.length; i++ ) {
 		y = cabs2( new Complex128( re[ i ], im[ i ] ) );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 're: '+re[i]+'. im: '+im[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[i]+'. im: '+im[i]+' y: '+y+'. Expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.native.js` of `@stdlib/math/base/special/cabs2` from relative-tolerance (EPS-based) assertions to exact assertions. `test/test.js` was already migrated to ULP-based testing on `develop` and is left untouched.
-   the maximum ULP difference over all 2003 Julia fixture cases is `0` for both the JavaScript and native implementations (verified by direct ULP-difference computation over the test fixtures; `cabs2` computes `re*re + im*im`, which is bit-exact versus Julia's `abs2`), so, per maintainer guidance, the assertions use plain `t.strictEqual( y, expected[ i ], 'returns expected value' )` rather than `isAlmostSameValue`.
-   removes the now-unused `EPS` and `abs` requires and the `delta`/`tol` variable declarations, and collapses the obsolete exact-equality short-circuit branch.
-   the native and JavaScript results do not diverge, so no compiler-optimization tolerance note is required.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The native addon was built and the native tests ran (not skipped): 2008/2008 assertions pass. The official harness (`make test TESTS_FILTER=".*/math/base/special/cabs2/.*"`) also passes (2008/2008).
-   The already-migrated `test/test.js` on `develop` uses `isAlmostSameValue` with a `maxULP` of `1`, although `0` ULP suffices; it was deliberately left unchanged to keep this PR scoped to the native test file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated test migration for issue #11352, including independent recomputation of the minimum required ULP values over the test fixtures, and was adversarially verified by a second Claude Code agent before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
