### PR TITLE
test: migrate `math/base/special/ceilb` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ceilb/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceilb/test/test.js
@@ -24,15 +24,14 @@ var tape = require( 'tape' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var ceil = require( '@stdlib/math/base/special/ceil' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var ceilb = require( './../lib' );
 
 
@@ -235,8 +234,6 @@ tape( 'if `b^n` is too large and `x < 0`, the function returns `-0` (sign preser
 
 tape( 'the function supports rounding very small numbers (including subnormals)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;
@@ -270,13 +267,7 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = ceilb( x, n[i], 10 );
-		if ( v === expected[i] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
-		} else {
-			delta = abs( v - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ceilb/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceilb/test/test.native.js
@@ -25,15 +25,14 @@ var tape = require( 'tape' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var ceil = require( '@stdlib/math/base/special/ceil' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -201,8 +200,6 @@ tape( 'if `b^n` is too large and `x < 0`, the function returns `-0` (sign preser
 
 tape( 'the function supports rounding very small numbers (including subnormals)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;
@@ -236,13 +233,7 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = ceilb( x, n[i], 10 );
-		if ( v === expected[i] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
-		} else {
-			delta = abs( v - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/ceilb` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over all test cases: max ULP difference is `1`, with 4 of 17 cases at 1 ULP and the remainder exact; ULP `0` fails those 4 cases)
-   collapses the obsolete exact-equality short-circuit branches, as `isAlmostSameValue` covers exact equality
-   removes the now-unused `EPS` and `abs` requires and `delta`/`tol` variable declarations

Native (C) addon results were verified to be identical to the JavaScript implementation at ULP `1`, so no native-vs-JavaScript tolerance divergence note is needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which migrated the test assertions, computed the minimum required ULP values from the test cases, and verified the results against both the JavaScript and native implementations; an independent AI verification pass recomputed the ULP values before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
