### PR TITLE
test: migrate `math/base/special/avercos` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/avercos/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/avercos/test/test.js
@@ -23,8 +23,8 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var avercos = require( './../lib' );
 
 
@@ -44,8 +44,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse versed cosine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -54,22 +52,14 @@ tape( 'the function computes the inverse versed cosine', function test( t ) {
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = avercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 15.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = avercos( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 21 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse versed cosine (small negative numbers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -78,14 +68,8 @@ tape( 'the function computes the inverse versed cosine (small negative numbers)'
 	expected = smallNegative.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = avercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = avercos( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/avercos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/avercos/test/test.native.js
@@ -24,8 +24,8 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -53,8 +53,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse versed cosine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -63,22 +61,14 @@ tape( 'the function computes the inverse versed cosine', opts, function test( t 
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = avercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 350.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = avercos( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 21 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse versed cosine (small negative numbers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -87,14 +77,8 @@ tape( 'the function computes the inverse versed cosine (small negative numbers)'
 	expected = smallNegative.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = avercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = avercos( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/avercos` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`.
-   uses the minimum required ULP values, verified by direct ULP-difference computation over the test fixtures: `data.json` requires a maximum of `21` ULPs (a value of `20` fails), and `small_negative.json` matches exactly (`0` ULPs), so the latter test block uses plain `t.strictEqual( y, expected[ i ], 'returns expected value' )` assertions.
-   applies the same ULP values to the native test file, as the native add-on results are bit-identical to the JavaScript implementation on the tested fixtures (max ULP differences of `21` and `0`, respectively), so no compiler-divergence note was needed despite the previous native tolerance (`350.0 * EPS`) being larger than the JavaScript tolerance (`15.0 * EPS`).
-   retains the `EPS` require in both files, as it is still used by the NaN-domain tests, and removes the now-unused `abs` require and `delta`/`tol` variables.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Both the JavaScript and native test suites were run locally and pass (24009 assertions each). The minimum ULP values were independently recomputed via `@stdlib/number/float64/base/ulp-difference` over all fixture cases and confirmed minimal.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, including the test migration and the minimum-ULP discovery; the changes were verified by an independent automated review pass and by running the full JavaScript and native test suites locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
