### PR TITLE
test: migrate `math/base/special/rcbrt` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rcbrt/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrt/test/test.js
@@ -24,8 +24,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var rcbrt = require( './../lib' );
 
 
@@ -57,8 +55,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[50,500]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -67,21 +63,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[20,50]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -90,21 +78,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[3,20]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -113,21 +93,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[0.8,3]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -136,21 +108,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[0.0,0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -159,21 +123,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[1e-300,1e-308]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -182,21 +138,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of subnormal `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -205,21 +153,13 @@ tape( 'the function evaluates the reciprocal cube root of subnormal `x`', functi
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` (huge positive)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -228,21 +168,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` (huge positive)', 
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` (huge negative)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -252,21 +184,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` (huge negative)', 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-50,-500]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -275,21 +199,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = veryLargeNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-20,-50]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -298,21 +214,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = largeNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-20,-3]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -321,21 +229,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = mediumNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-3,-0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -344,21 +244,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = smallNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-0.8,0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -367,21 +259,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-1e-300,-1e-308]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -390,13 +274,7 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = tinyNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/rcbrt/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrt/test/test.native.js
@@ -25,8 +25,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -66,8 +64,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[50,500]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -76,21 +72,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[20,50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -99,21 +87,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[3,20]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -122,21 +102,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[0.8,3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -145,21 +117,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[0.0,0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -168,21 +132,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[1e-300,1e-308]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -191,21 +147,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of subnormal `x`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -214,21 +162,13 @@ tape( 'the function evaluates the reciprocal cube root of subnormal `x`', opts, 
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` (huge positive)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -237,21 +177,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` (huge positive)', 
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` (huge negative)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -261,21 +193,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` (huge negative)', 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-50,-500]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -284,21 +208,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = veryLargeNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-20,-50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -307,21 +223,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = largeNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-20,-3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -330,21 +238,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = mediumNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-3,-0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -353,21 +253,13 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = smallNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[-1e-300,-1e-308]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -376,13 +268,7 @@ tape( 'the function evaluates the reciprocal cube root of `x` on the interval `[
 	x = tinyNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = rcbrt( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/rcbrt` from relative-tolerance (EPS-based) assertions to the ULP-based testing convention of #11352.
-   computes the minimum required ULP value per fixture block via direct ULP-difference computation (`@stdlib/number/float64/base/ulp-difference`) over all test fixtures. Every fixture block (8 positive blocks × 5003 cases, 6 negative blocks × 503 cases) has a maximum ULP difference of `0`: both the JavaScript and native (C) results are bit-identical to the Julia reference fixtures. Accordingly, per the migration convention, all migrated assertions use plain `t.strictEqual( y, expected[ i ], 'returns expected value' );` rather than `isAlmostSameValue`, and the now-unused `EPS` and `abs` requires and `delta`/`tol` variables were removed.
-   collapses the obsolete exact-equality `if`/`else` short-circuit branches into the single exact assertion.

Native results did not diverge from the JavaScript results (all native assertions pass with exact equality), so no native-specific larger tolerances (and no accompanying `NOTE` comments) were needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

Since all fixture values match exactly, this migration removes tolerance testing for this package entirely (exact equality) rather than introducing `isAlmostSameValue`. Flagging for maintainer awareness in case looser tolerances are preferred for cross-platform native builds.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Minimum ULP values were independently re-verified by a second pass which recomputed the maximum ULP difference per fixture block; all blocks confirmed at `0`. JavaScript tests pass via the official harness (`make test`), and the native add-on was built and all native test assertions pass locally.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated migration of `math/base/special` test suites to ULP-based testing (issue #11352), including automated minimum-ULP discovery and an independent adversarial verification pass; the changes were reviewed before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
