### PR TITLE
test: migrate `math/base/special/rad2deg` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/test/test.js
@@ -24,9 +24,8 @@ var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var rad2deg = require( './../lib' );
 
 
@@ -79,9 +78,6 @@ tape( 'the function converts an angle from radians to degrees', function test( t
 
 tape( 'the function converts an angle from radians to degrees (canonical values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
-	var er;
 	var x;
 	var r;
 	var i;
@@ -125,24 +121,11 @@ tape( 'the function converts an angle from radians to degrees (canonical values)
 	];
 	for ( i = 0; i < x.length; i++ ) {
 		r = rad2deg( x[i] );
-		er = expected[ i ];
-		if ( r === er ) {
-			t.strictEqual( r, er, 'x: '+x[i]+'. r: '+r+'. expected: '+er+'.' );
-		} else {
-			delta = abs( r - er );
-			tol = EPS * abs( er );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. r: '+r+'. expected: '+er+'. delta: '+delta+'. tol: '+ tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( r, expected[ i ], 1 ), true, 'returns expected value' );
+
 		// Negative `x`:
 		r = rad2deg( -x[i] );
-		er = -expected[ i ];
-		if ( r === er ) {
-			t.strictEqual( r, er, 'x: '+x[i]+'. r: '+r+'. expected: '+er+'.' );
-		} else {
-			delta = abs( r - er );
-			tol = EPS * abs( er );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. r: '+r+'. expected: '+er+'. delta: '+delta+'. tol: '+ tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( r, -expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/test/test.native.js
@@ -25,10 +25,9 @@ var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 
 
 // FIXTURES //
@@ -88,9 +87,6 @@ tape( 'the function converts an angle from radians to degrees', opts, function t
 
 tape( 'the function converts an angle from radians to degrees (canonical values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
-	var er;
 	var x;
 	var r;
 	var i;
@@ -134,24 +130,11 @@ tape( 'the function converts an angle from radians to degrees (canonical values)
 	];
 	for ( i = 0; i < x.length; i++ ) {
 		r = rad2deg( x[i] );
-		er = expected[ i ];
-		if ( r === er ) {
-			t.strictEqual( r, er, 'x: '+x[i]+'. r: '+r+'. expected: '+er+'.' );
-		} else {
-			delta = abs( r - er );
-			tol = EPS * abs( er );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. r: '+r+'. expected: '+er+'. delta: '+delta+'. tol: '+ tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( r, expected[ i ], 1 ), true, 'returns expected value' );
+
 		// Negative `x`:
 		r = rad2deg( -x[i] );
-		er = -expected[ i ];
-		if ( r === er ) {
-			t.strictEqual( r, er, 'x: '+x[i]+'. r: '+r+'. expected: '+er+'.' );
-		} else {
-			delta = abs( r - er );
-			tol = EPS * abs( er );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. r: '+r+'. expected: '+er+'. delta: '+delta+'. tol: '+ tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( r, -expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/rad2deg` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).
-   collapses the obsolete exact-equality short-circuit branches in the "(canonical values)" test block, as `isAlmostSameValue` covers exact equality.
-   removes the now-unused `EPS` and `abs` requires and the now-unused `delta`/`tol`/`er` variables.

The "(canonical values)" block requires a minimum ULP tolerance of `1` (ULP `0` fails 8 of 32 assertions). The native (C) implementation matches the JavaScript implementation at ULP `1` (verified by building the native add-on and running `test/test.native.js`; 2041 assertions passed, not skipped), so no compiler-divergence tolerance note is needed. The Julia fixture-based test block already uses exact `t.strictEqual` comparisons (max ULP `0`) and was left untouched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Minimum ULP values were independently re-verified by recomputing the maximum ULP difference over all fixture cases (16 positive + 16 negated canonical values, plus the 2003 Julia fixture cases).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, computed and verified the minimum required ULP tolerances, and ran the JavaScript and native test suites. A second, adversarial Claude Code agent independently re-verified the diff and recomputed the ULP values before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
