### PR TITLE
test: migrate `math/base/special/cosm1` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cosm1/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cosm1/test/test.js
@@ -23,12 +23,11 @@
 var tape = require( 'tape' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var cos = require( '@stdlib/math/base/special/cos' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PI = require( '@stdlib/constants/float64/pi' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var cosm1 = require( './../lib' );
 
 
@@ -70,8 +69,6 @@ tape( 'the function computes the cosine minus one more accurately inside the int
 
 tape( 'the function computes `cos(x) - 1.0` outside the interval [-π/4,π/4]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -81,9 +78,7 @@ tape( 'the function computes `cos(x) - 1.0` outside the interval [-π/4,π/4]', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = cosm1( x[i] );
 		expected = cos( x[i] ) - 1;
-		delta = abs( y - expected );
-		tol = EPS * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( y, expected, 1 ), true, 'returns expected value' );
 	}
 
 	x = linspace( -4.0*PI, NPIO4, 100 );
@@ -91,9 +86,7 @@ tape( 'the function computes `cos(x) - 1.0` outside the interval [-π/4,π/4]', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = cosm1( x[i] );
 		expected = cos( x[i] ) - 1.0;
-		delta = abs( y - expected );
-		tol = EPS * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( y, expected, 1 ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/cosm1/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cosm1/test/test.native.js
@@ -24,12 +24,11 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var cos = require( '@stdlib/math/base/special/cos' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PI = require( '@stdlib/constants/float64/pi' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -75,8 +74,6 @@ tape( 'the function computes the cosine minus one more accurately inside the int
 
 tape( 'the function computes `cos(x) - 1.0` outside the interval [-π/4,π/4]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -86,9 +83,7 @@ tape( 'the function computes `cos(x) - 1.0` outside the interval [-π/4,π/4]', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = cosm1( x[i] );
 		expected = cos( x[i] ) - 1;
-		delta = abs( y - expected );
-		tol = EPS * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( y, expected, 1 ), true, 'returns expected value' );
 	}
 
 	x = linspace( -4.0*PI, NPIO4, 100 );
@@ -96,9 +91,7 @@ tape( 'the function computes `cos(x) - 1.0` outside the interval [-π/4,π/4]', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = cosm1( x[i] );
 		expected = cos( x[i] ) - 1.0;
-		delta = abs( y - expected );
-		tol = EPS * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( y, expected, 1 ), true, 'returns expected value' );
 	}
 
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/cosm1` from relative-tolerance (EPS-based) assertions to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   uses the minimum required ULP value (`1`) for the migrated test block in both files, verified by direct ULP-difference computation over the test inputs (a ULP value of `0` fails for 2 of the 200 cases).
-   removes the now-unused `abs` and `EPS` requires and the obsolete `delta`/`tol` variables.
-   leaves the fixtures-based exact-equality test block and the NaN/infinity special-value tests untouched.

The native (C) implementation results match the JavaScript implementation on the tested inputs (maximum ULP difference of `1` for both), so no divergent tolerance or NOTE annotation was needed for the native test file.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, computed and verified the minimum required ULP values, and was independently verified by a second adversarial Claude Code review pass.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
