### PR TITLE
test: migrate `math/base/special/ldexpf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ldexpf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ldexpf/test/test.js
@@ -25,10 +25,9 @@ var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var ldexpf = require( './../lib' );
 
 
@@ -50,10 +49,8 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function multiplies a number by an integer power of two (small values)', function test( t ) {
 	var expected;
-	var delta;
 	var frac;
 	var exp;
-	var tol;
 	var v;
 	var i;
 	var e;
@@ -64,23 +61,15 @@ tape( 'the function multiplies a number by an integer power of two (small values
 	for ( i = 0; i < frac.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = ldexpf( frac[i], exp[i] );
-		if ( v === e ) {
-			t.strictEqual( v, e, 'frac: '+frac[i]+'; exp: '+exp[i]+'; expected: '+e );
-		} else {
-			delta = absf( v - e );
-			tol = 1.2 * EPS * absf( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. frac: '+frac[i]+'; exp: '+exp[i]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function multiplies a number by an integer power of two (medium values)', function test( t ) {
 	var expected;
-	var delta;
 	var frac;
 	var exp;
-	var tol;
 	var v;
 	var i;
 	var e;
@@ -91,23 +80,15 @@ tape( 'the function multiplies a number by an integer power of two (medium value
 	for ( i = 0; i < frac.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = ldexpf( frac[i], exp[i] );
-		if ( v === e ) {
-			t.strictEqual( v, e, 'frac: '+frac[i]+'; exp: '+exp[i]+'; expected: '+e );
-		} else {
-			delta = absf( v - e );
-			tol = EPS * absf( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. frac: '+frac[i]+'; exp: '+exp[i]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function multiplies a number by an integer power of two (large values)', function test( t ) {
 	var expected;
-	var delta;
 	var frac;
 	var exp;
-	var tol;
 	var v;
 	var i;
 	var e;
@@ -118,23 +99,15 @@ tape( 'the function multiplies a number by an integer power of two (large values
 	for ( i = 0; i < frac.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = ldexpf( frac[i], exp[i] );
-		if ( v === e ) {
-			t.strictEqual( v, e, 'frac: '+frac[i]+'; exp: '+exp[i]+'; expected: '+e );
-		} else {
-			delta = absf( v - e );
-			tol = 1.0 * EPS * absf( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. frac: '+frac[i]+'; exp: '+exp[i]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function multiplies a number by an integer power of two (subnormals)', function test( t ) {
 	var expected;
-	var delta;
 	var frac;
 	var exp;
-	var tol;
 	var v;
 	var i;
 	var e;
@@ -145,13 +118,7 @@ tape( 'the function multiplies a number by an integer power of two (subnormals)'
 	for ( i = 0; i < frac.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = ldexpf( frac[i], exp[i] );
-		if ( v === e ) {
-			t.strictEqual( v, e, 'frac: '+frac[i]+'; exp: '+exp[i]+'; expected: '+e );
-		} else {
-			delta = absf( v - e );
-			tol = 15.0 * EPS * absf( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. frac: '+frac[i]+'; exp: '+exp[i]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ldexpf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ldexpf/test/test.native.js
@@ -26,10 +26,9 @@ var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -59,10 +58,8 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function multiplies a number by an integer power of two (small values)', opts, function test( t ) {
 	var expected;
-	var delta;
 	var frac;
 	var exp;
-	var tol;
 	var v;
 	var i;
 	var e;
@@ -73,23 +70,15 @@ tape( 'the function multiplies a number by an integer power of two (small values
 	for ( i = 0; i < frac.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = ldexpf( frac[i], exp[i] );
-		if ( v === e ) {
-			t.strictEqual( v, e, 'frac: '+frac[i]+'; exp: '+exp[i]+'; expected: '+e );
-		} else {
-			delta = absf( v - e );
-			tol = 1.2 * EPS * absf( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. frac: '+frac[i]+'; exp: '+exp[i]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function multiplies a number by an integer power of two (medium values)', opts, function test( t ) {
 	var expected;
-	var delta;
 	var frac;
 	var exp;
-	var tol;
 	var v;
 	var i;
 	var e;
@@ -100,23 +89,15 @@ tape( 'the function multiplies a number by an integer power of two (medium value
 	for ( i = 0; i < frac.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = ldexpf( frac[i], exp[i] );
-		if ( v === e ) {
-			t.strictEqual( v, e, 'frac: '+frac[i]+'; exp: '+exp[i]+'; expected: '+e );
-		} else {
-			delta = absf( v - e );
-			tol = EPS * absf( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. frac: '+frac[i]+'; exp: '+exp[i]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function multiplies a number by an integer power of two (large values)', opts, function test( t ) {
 	var expected;
-	var delta;
 	var frac;
 	var exp;
-	var tol;
 	var v;
 	var i;
 	var e;
@@ -127,23 +108,15 @@ tape( 'the function multiplies a number by an integer power of two (large values
 	for ( i = 0; i < frac.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = ldexpf( frac[i], exp[i] );
-		if ( v === e ) {
-			t.strictEqual( v, e, 'frac: '+frac[i]+'; exp: '+exp[i]+'; expected: '+e );
-		} else {
-			delta = absf( v - e );
-			tol = 1.0 * EPS * absf( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. frac: '+frac[i]+'; exp: '+exp[i]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function multiplies a number by an integer power of two (subnormals)', opts, function test( t ) {
 	var expected;
-	var delta;
 	var frac;
 	var exp;
-	var tol;
 	var v;
 	var i;
 	var e;
@@ -154,13 +127,7 @@ tape( 'the function multiplies a number by an integer power of two (subnormals)'
 	for ( i = 0; i < frac.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = ldexpf( frac[i], exp[i] );
-		if ( v === e ) {
-			t.strictEqual( v, e, 'frac: '+frac[i]+'; exp: '+exp[i]+'; expected: '+e );
-		} else {
-			delta = absf( v - e );
-			tol = 15.0 * EPS * absf( e );
-			t.strictEqual( delta <= tol, true, 'within tolerance. frac: '+frac[i]+'; exp: '+exp[i]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( v, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/ldexpf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions.
-   uses `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, following the precedent of `math/base/special/acothf` and `math/base/special/atanhf`) with the minimum required ULP values, verified by direct ULP-difference computation (via `@stdlib/number/float32/base/ulp-difference`) over all 1007 cases in each test fixture.
-   uses plain `t.strictEqual( v, e, 'returns expected value' );` for the small, medium, and large value test blocks, as all fixture values match exactly (maximum ULP difference of 0).
-   uses `isAlmostSameValue( v, e, 1 )` for the subnormal test block, where the minimum required ULP value is 1 (166 of 1007 cases differ from the expected values by exactly 1 ULP).
-   removes the now-unused `EPS` and `absf` requires and the `delta`/`tol` variables, and collapses the obsolete exact-equality short-circuit branches.

Native (C) results are bit-identical to the JavaScript results (same ULP values for every test block), so no divergence note is required.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Minimum ULP values were verified independently by recomputing the maximum ULP difference per fixture block: small/medium/large blocks are exact (max ULP 0), and the subnormal block requires ULP 1 (ULP 0 fails 166 cases in both the JavaScript and native test runs).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, computed and verified the minimum ULP values against the test fixtures, and ran the JavaScript and native test suites. A second, independent Claude Code agent adversarially verified the diff and recomputed the ULP values before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
