### PR TITLE
test: migrate `math/base/special/fmodf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fmodf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/fmodf/test/test.js
@@ -23,8 +23,6 @@
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
-var absf = require( '@stdlib/math/base/special/absf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var fmodf = require( './../lib' );
 
 
@@ -49,8 +47,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the modulus function (subnormal results)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -63,17 +59,13 @@ tape( 'the function evaluates the modulus function (subnormal results)', functio
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (small `x`, large `y`)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -86,17 +78,13 @@ tape( 'the function evaluates the modulus function (small `x`, large `y`)', func
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (large `x`, small `y`)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -109,17 +97,13 @@ tape( 'the function evaluates the modulus function (large `x`, small `y`)', func
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (small `x`, small `y`)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -132,17 +116,13 @@ tape( 'the function evaluates the modulus function (small `x`, small `y`)', func
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (positive `x`, negative `y`)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -155,17 +135,13 @@ tape( 'the function evaluates the modulus function (positive `x`, negative `y`)'
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (negative `x`, positive `y`)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -178,17 +154,13 @@ tape( 'the function evaluates the modulus function (negative `x`, positive `y`)'
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (negative `x`, negative `y`)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -201,9 +173,7 @@ tape( 'the function evaluates the modulus function (negative `x`, negative `y`)'
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/fmodf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fmodf/test/test.native.js
@@ -24,8 +24,6 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
-var absf = require( '@stdlib/math/base/special/absf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,8 +56,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the modulus function (subnormal results)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -72,17 +68,13 @@ tape( 'the function evaluates the modulus function (subnormal results)', opts, f
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (small `x`, large `y`)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -95,17 +87,13 @@ tape( 'the function evaluates the modulus function (small `x`, large `y`)', opts
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (large `x`, small `y`)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -118,17 +106,13 @@ tape( 'the function evaluates the modulus function (large `x`, small `y`)', opts
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (small `x`, small `y`)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -141,17 +125,13 @@ tape( 'the function evaluates the modulus function (small `x`, small `y`)', opts
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (positive `x`, negative `y`)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -164,17 +144,13 @@ tape( 'the function evaluates the modulus function (positive `x`, negative `y`)'
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (negative `x`, positive `y`)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -187,17 +163,13 @@ tape( 'the function evaluates the modulus function (negative `x`, positive `y`)'
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the modulus function (negative `x`, negative `y`)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var v;
 	var x;
 	var y;
@@ -210,9 +182,7 @@ tape( 'the function evaluates the modulus function (negative `x`, negative `y`)'
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		v = fmodf( float64ToFloat32( x[ i ] ), float64ToFloat32( y[ i ] ) );
-		delta = absf( v - e );
-		tol = EPS * absf( e );
-		t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. v: '+v+'. E: '+e+'. Δ: '+delta+'. tol: '+tol );
+		t.strictEqual( v, e, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `@stdlib/math/base/special/fmodf` from relative-tolerance (EPS-based) assertions to exact-equality assertions, per the migration guidelines in #11352.
-   Independent ULP-difference computation (via `@stdlib/number/float32/base/ulp-difference`, with single-precision coercion of inputs and expected values exactly as performed in the tests) over all 7 fixture blocks (20004 cases) measured a maximum ULP difference of `0` for every block. As `fmod` is exact per IEEE 754, every assertion was therefore converted to a plain `t.strictEqual( v, e, 'returns expected value' )` rather than `isAlmostSameValue`, following maintainer guidance that `isAlmostSameValue` should not be used where values are exactly equal.
-   removes the now-unused `EPS` (`@stdlib/constants/float32/eps`) and `absf` requires and the `delta`/`tol` variables.
-   Native (C) tests were built and run (not skipped) and pass with identical exact-equality assertions: no JS/C divergence was observed, so no tolerance `NOTE` annotations were necessary.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code: an automated agent performed the test migration and computed the minimum required ULP values, and an independent adversarial verification agent recomputed the ULP values over all fixtures and reviewed the diff before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
