### PR TITLE
test: migrate `math/base/special/deg2radf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/deg2radf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/deg2radf/test/test.js
@@ -23,9 +23,7 @@
 var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var deg2radf = require( './../lib' );
 
 
@@ -62,8 +60,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function converts an angle from degrees to radians', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -73,13 +69,7 @@ tape( 'the function converts an angle from degrees to radians', function test( t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = deg2radf( x[i] );
-		delta = absf( y - expected[i] );
-		tol = EPS * absf( expected[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[i], 'returns '+expected[i]+' when provided '+x[i] );
-		} else {
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite of `math/base/special/deg2radf` from relative-tolerance (EPS-based) assertions to exact assertions, per the ULP-based testing migration tracked in #11352.
-   in `test/test.js`, direct ULP-difference computation (via `@stdlib/number/float32/base/ulp-difference`) over all 2003 fixture cases showed a maximum ULP difference of `0` (every fixture expected value is exactly single-precision representable, and `deg2radf( x )` returns the expected value bit-for-bit). Accordingly, the exact-equality short-circuit and relative-tolerance branch collapse to a plain `t.strictEqual( y, expected[ i ], 'returns expected value' );` assertion, and the now-unused `EPS` and `absf` requires and `delta`/`tol` variables are removed.
-   leaves `test/test.native.js` unmodified, as it already uses exact `strictEqual` assertions for the fixture block (no relative-tolerance assertions to migrate). The native add-on was built locally and all assertions pass with exact equality, confirming the JavaScript and C implementations agree bit-for-bit (no JS-vs-native divergence; no enlarged native tolerances needed).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The minimum ULP value (`0`) was verified twice: once during migration and once by an independent adversarial verification pass which recomputed the maximum ULP difference over the test fixtures.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated migration of `math/base/special` test suites to ULP-based testing (#11352), including minimum-ULP discovery and an independent adversarial verification pass; changes were reviewed by a human before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
