### PR TITLE
test: migrate `math/base/special/kernel-tanf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/kernel-tanf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-tanf/test/test.js
@@ -23,13 +23,12 @@
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var rempio2f = require( '@stdlib/math/base/special/rempio2f' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var kernelTanf = require( './../lib' );
 
 
@@ -99,8 +98,6 @@ tape( 'the function evaluates the tangent for input values inside of `[-pi/4, pi
 tape( 'the function can be used to compute the tangent for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2f` (positive)', function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -115,13 +112,7 @@ tape( 'the function can be used to compute the tangent for input values outside 
 		expected[ i ] = f32( expected[ i ] );
 		n = rempio2f( x, y );
 		out = kernelTanf( y[ 0 ], 1 - ( (n&1)<<1 ) );
-		if ( out === expected[ i ] ) {
-			t.strictEqual( out, expected[ i ], 'returns expected value' );
-		} else {
-			delta = absf( out - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x+'. out: '+out+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -129,8 +120,6 @@ tape( 'the function can be used to compute the tangent for input values outside 
 tape( 'the function can be used to compute the tangent for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2f` (negative)', function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -145,13 +134,7 @@ tape( 'the function can be used to compute the tangent for input values outside 
 		expected[ i ] = f32( expected[ i ] );
 		n = rempio2f( x, y );
 		out = kernelTanf( y[ 0 ], 1 - ( (n&1)<<1 ) );
-		if ( out === expected[ i ] ) {
-			t.strictEqual( out, expected[ i ], 'returns expected value' );
-		} else {
-			delta = absf( out - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x+'. out: '+out+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/kernel-tanf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-tanf/test/test.native.js
@@ -24,13 +24,12 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var rempio2f = require( '@stdlib/math/base/special/rempio2f' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -108,8 +107,6 @@ tape( 'the function evaluates the tangent for input values inside of `[-pi/4, pi
 tape( 'the function can be used to compute the tangent for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2f` (positive)', opts, function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -124,13 +121,7 @@ tape( 'the function can be used to compute the tangent for input values outside 
 		expected[ i ] = f32( expected[ i ] );
 		n = rempio2f( x, y );
 		out = kernelTanf( y[ 0 ], 1 - ( (n&1)<<1 ) );
-		if ( out === expected[ i ] ) {
-			t.strictEqual( out, expected[ i ], 'returns expected value' );
-		} else {
-			delta = absf( out - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x+'. out: '+out+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -138,8 +129,6 @@ tape( 'the function can be used to compute the tangent for input values outside 
 tape( 'the function can be used to compute the tangent for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2f` (negative)', opts, function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -154,13 +143,7 @@ tape( 'the function can be used to compute the tangent for input values outside 
 		expected[ i ] = f32( expected[ i ] );
 		n = rempio2f( x, y );
 		out = kernelTanf( y[ 0 ], 1 - ( (n&1)<<1 ) );
-		if ( out === expected[ i ] ) {
-			t.strictEqual( out, expected[ i ], 'returns expected value' );
-		} else {
-			delta = absf( out - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x+'. out: '+out+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/kernel-tanf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, following the precedent of `math/base/special/acothf` and `math/base/special/atanhf`).
-   uses the minimum required ULP values, verified by direct ULP-difference computation over the test fixtures using `@stdlib/number/float32/base/ulp-difference`: the `large_positive` and `large_negative` blocks each have a maximum ULP difference of `1` (140/1000 cases at exactly `1` ULP, so `0` would fail), in both the JavaScript and native implementations.
-   leaves the `small_range` block untouched, as all fixture values match exactly (maximum ULP difference of `0`) and the block already uses plain `t.strictEqual` assertions.
-   removes the now-unused `absf` and `EPS` requires and the obsolete exact-equality short-circuit branches, which are subsumed by `isAlmostSameValue`.

Native (C) results were bit-identical to the JavaScript results over all fixtures (same maximum ULP difference of `1`), so no divergence `NOTE` comment was required, and the JavaScript and native test files use identical ULP values.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

All 3008 JavaScript assertions pass via `make test`, and all 3008 native assertions pass with the addon built and loaded (tests not skipped). Minimum ULP values were independently re-verified by a second agent via direct ULP-difference computation over the fixtures.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of an automated test migration for #11352, including discovery of the minimum required ULP values, with an independent adversarial verification pass (also by Claude Code) recomputing the ULP minimums before the PR was opened.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
