### PR TITLE
test: migrate `math/base/special/vercos` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/vercos/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/vercos/test/test.js
@@ -22,10 +22,8 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var vercos = require( './../lib' );
 
 
@@ -49,8 +47,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the versed cosine (for -256*pi < x < 0 )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -60,13 +56,7 @@ tape( 'the function computes the versed cosine (for -256*pi < x < 0 )', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -74,8 +64,6 @@ tape( 'the function computes the versed cosine (for -256*pi < x < 0 )', function
 
 tape( 'the function computes the versed cosine (for 0 < x < 256*pi )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -85,13 +73,7 @@ tape( 'the function computes the versed cosine (for 0 < x < 256*pi )', function 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -99,8 +81,6 @@ tape( 'the function computes the versed cosine (for 0 < x < 256*pi )', function 
 
 tape( 'the function computes the versed cosine (for -2**60 (pi/2) < x < -2**20 (pi/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -110,13 +90,7 @@ tape( 'the function computes the versed cosine (for -2**60 (pi/2) < x < -2**20 (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -124,8 +98,6 @@ tape( 'the function computes the versed cosine (for -2**60 (pi/2) < x < -2**20 (
 
 tape( 'the function computes the versed cosine (for 2**20 (pi/2) < x < 2**60 (pi/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -135,13 +107,7 @@ tape( 'the function computes the versed cosine (for 2**20 (pi/2) < x < 2**60 (pi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -149,8 +115,6 @@ tape( 'the function computes the versed cosine (for 2**20 (pi/2) < x < 2**60 (pi
 
 tape( 'the function computes the versed cosine (for x <= -2**60 (PI/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -160,13 +124,7 @@ tape( 'the function computes the versed cosine (for x <= -2**60 (PI/2) )', funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -174,8 +132,6 @@ tape( 'the function computes the versed cosine (for x <= -2**60 (PI/2) )', funct
 
 tape( 'the function computes the versed cosine (for x >= 2**60 (PI/2) )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -185,13 +141,7 @@ tape( 'the function computes the versed cosine (for x >= 2**60 (PI/2) )', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/vercos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/vercos/test/test.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the versed cosine (for -256*pi < x < 0 )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -69,13 +66,9 @@ tape( 'the function computes the versed cosine (for -256*pi < x < 0 )', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -83,8 +76,6 @@ tape( 'the function computes the versed cosine (for -256*pi < x < 0 )', opts, fu
 
 tape( 'the function computes the versed cosine (for 0 < x < 256*pi )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -94,13 +85,9 @@ tape( 'the function computes the versed cosine (for 0 < x < 256*pi )', opts, fun
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -108,8 +95,6 @@ tape( 'the function computes the versed cosine (for 0 < x < 256*pi )', opts, fun
 
 tape( 'the function computes the versed cosine (for -2**60 (pi/2) < x < -2**20 (pi/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -119,13 +104,9 @@ tape( 'the function computes the versed cosine (for -2**60 (pi/2) < x < -2**20 (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 6.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 8 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -133,8 +114,6 @@ tape( 'the function computes the versed cosine (for -2**60 (pi/2) < x < -2**20 (
 
 tape( 'the function computes the versed cosine (for 2**20 (pi/2) < x < 2**60 (pi/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -144,13 +123,9 @@ tape( 'the function computes the versed cosine (for 2**20 (pi/2) < x < 2**60 (pi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 6.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 8 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -158,8 +133,6 @@ tape( 'the function computes the versed cosine (for 2**20 (pi/2) < x < 2**60 (pi
 
 tape( 'the function computes the versed cosine (for x <= -2**60 (PI/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -169,13 +142,9 @@ tape( 'the function computes the versed cosine (for x <= -2**60 (PI/2) )', opts,
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.6 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -183,8 +152,6 @@ tape( 'the function computes the versed cosine (for x <= -2**60 (PI/2) )', opts,
 
 tape( 'the function computes the versed cosine (for x >= 2**60 (PI/2) )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -194,13 +161,9 @@ tape( 'the function computes the versed cosine (for x >= 2**60 (PI/2) )', opts, 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = vercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.6 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `@stdlib/math/base/special/vercos` from relative-tolerance (EPS-based) assertions to ULP-difference assertions.
-   for the JavaScript implementation, the computed results match the Julia reference fixtures exactly (maximum ULP difference of `0` across all six fixture blocks), so the tolerance-based assertions were collapsed to plain `t.strictEqual( y, expected[ i ], 'returns expected value' )` assertions, and `@stdlib/assert/is-almost-same-value` is not needed in `test/test.js`.
-   for the native (C) implementation, results diverge from the JavaScript implementation due to compiler optimizations (observed with Apple clang on arm64): medium fixtures require a maximum ULP of `2`, large fixtures `8`, and huge fixtures `2`. All six native test blocks therefore use `isAlmostSameValue` with the canonical note explaining the larger tolerance relative to the JavaScript implementation.
-   ULP values are the minimum required values, verified by direct ULP-difference computation over the test fixtures (lowering any native value by one causes test failures; the JavaScript values of `0` were independently recomputed).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   `make test` passes for both files (24005/24005 assertions), including the native addon tests.
-   Native ULP values were determined locally on macOS (Apple clang, arm64); CI may surface different compiler behavior, hence the draft status.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, computed and adversarially verified the minimum ULP values against the fixtures, and was independently re-verified by a second automated review pass before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
