### PR TITLE
test: migrate `math/base/special/atanf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/atanf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/atanf/test/test.js
@@ -22,14 +22,13 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var HALF_PI = require( '@stdlib/constants/float32/half-pi' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var atanf = require( './../lib' );
 
 
@@ -60,8 +59,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the arctangent on the interval `[ -1e-38, -1e-30] `', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -73,21 +70,13 @@ tape( 'the function computes the arctangent on the interval `[ -1e-38, -1e-30] `
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 1e-30, 1e-38 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -99,21 +88,13 @@ tape( 'the function computes the arctangent on the interval `[ 1e-30, 1e-38 ]`',
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -0.8, 0.8 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -125,21 +106,13 @@ tape( 'the function computes the arctangent on the interval `[ -0.8, 0.8 ]`', fu
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.8 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -1.0, -0.8 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -151,21 +124,13 @@ tape( 'the function computes the arctangent on the interval `[ -1.0, -0.8 ]`', f
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 0.8, 1.0 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -177,21 +142,13 @@ tape( 'the function computes the arctangent on the interval `[ 0.8, 1.0 ]`', fun
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -3.0, -1.0 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -203,21 +160,13 @@ tape( 'the function computes the arctangent on the interval `[ -3.0, -1.0 ]`', f
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 1.0, 3.0 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -229,21 +178,13 @@ tape( 'the function computes the arctangent on the interval `[ 1.0, 3.0 ]`', fun
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 3.0, 100.0 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -255,21 +196,13 @@ tape( 'the function computes the arctangent on the interval `[ 3.0, 100.0 ]`', f
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -100.0, -3.0 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -281,21 +214,13 @@ tape( 'the function computes the arctangent on the interval `[ -100.0, -3.0 ]`',
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 100.0, 1000.0 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -307,21 +232,13 @@ tape( 'the function computes the arctangent on the interval `[ 100.0, 1000.0 ]`'
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -1000.0, -100.0 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -333,21 +250,13 @@ tape( 'the function computes the arctangent on the interval `[ -1000.0, -100.0 ]
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -1e20, -1e28 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -359,21 +268,13 @@ tape( 'the function computes the arctangent on the interval `[ -1e20, -1e28 ]`',
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 1e30, 1e38 ]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -385,13 +286,7 @@ tape( 'the function computes the arctangent on the interval `[ 1e30, 1e38 ]`', f
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/atanf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/atanf/test/test.native.js
@@ -23,14 +23,13 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var HALF_PI = require( '@stdlib/constants/float32/half-pi' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -69,8 +68,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the arctangent on the interval `[ -1e-38, -1e-30] `', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -82,21 +79,13 @@ tape( 'the function computes the arctangent on the interval `[ -1e-38, -1e-30] `
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 1e-30, 1e-38 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -108,21 +97,13 @@ tape( 'the function computes the arctangent on the interval `[ 1e-30, 1e-38 ]`',
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -0.8, 0.8 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -134,21 +115,13 @@ tape( 'the function computes the arctangent on the interval `[ -0.8, 0.8 ]`', op
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.8 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -1.0, -0.8 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -160,21 +133,13 @@ tape( 'the function computes the arctangent on the interval `[ -1.0, -0.8 ]`', o
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 0.8, 1.0 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -186,21 +151,13 @@ tape( 'the function computes the arctangent on the interval `[ 0.8, 1.0 ]`', opt
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -3.0, -1.0 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -212,21 +169,13 @@ tape( 'the function computes the arctangent on the interval `[ -3.0, -1.0 ]`', o
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 1.0, 3.0 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -238,21 +187,13 @@ tape( 'the function computes the arctangent on the interval `[ 1.0, 3.0 ]`', opt
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 3.0, 100.0 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -264,21 +205,13 @@ tape( 'the function computes the arctangent on the interval `[ 3.0, 100.0 ]`', o
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -100.0, -3.0 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -290,21 +223,13 @@ tape( 'the function computes the arctangent on the interval `[ -100.0, -3.0 ]`',
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 100.0, 1000.0 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -316,21 +241,13 @@ tape( 'the function computes the arctangent on the interval `[ 100.0, 1000.0 ]`'
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -1000.0, -100.0 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -342,21 +259,13 @@ tape( 'the function computes the arctangent on the interval `[ -1000.0, -100.0 ]
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ -1e20, -1e28 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -368,21 +277,13 @@ tape( 'the function computes the arctangent on the interval `[ -1e20, -1e28 ]`',
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent on the interval `[ 1e30, 1e38 ]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -394,13 +295,7 @@ tape( 'the function computes the arctangent on the interval `[ 1e30, 1e38 ]`', o
 	for ( i = 0; i < x.length; i++ ) {
 		y = atanf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/atanf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, following the precedent of `math/base/special/acothf` and `math/base/special/atanhf`)
-   uses the minimum required ULP values per test block, verified by direct ULP-difference computation over the test fixtures via `@stdlib/number/float32/base/ulp-difference`: the `tiny_negative`, `tiny_positive`, `huge_negative`, and `huge_positive` blocks match exactly (ULP 0) and therefore use plain `t.strictEqual`, the `[ -0.8, 0.8 ]` block requires 3 ULPs (the original test used a widened `1.8 * EPS` tolerance there), and all remaining blocks require 1 ULP
-   applies the same ULP values to the native test file; the native (C) results do not diverge from the JavaScript results, so no compiler-optimization tolerance note is needed

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Minimality of the ULP values was verified by recomputing the maximum ULP difference per fixture block and by confirming that reducing the `[ -0.8, 0.8 ]` block from 3 to 2 ULPs fails in both the JavaScript and native test suites. The full JavaScript and native test suites pass with these values (6514/6514 assertions each).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, including the test migration, minimum-ULP discovery, and an independent adversarial verification pass that recomputed the per-block ULP values from the fixtures.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
