### PR TITLE
test: migrate `math/base/special/logit` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/logit/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/logit/test/test.js
@@ -24,8 +24,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var logit = require( './../lib' );
 
 
@@ -72,8 +71,6 @@ tape( 'the function returns `+Infinity` when provided `1`', function test( t ) {
 
 tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -82,21 +79,13 @@ tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', fun
 	x = small.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -105,21 +94,13 @@ tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', 
 	x = medium.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -128,13 +109,7 @@ tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', fun
 	x = large.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/logit/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/logit/test/test.native.js
@@ -25,8 +25,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -81,8 +80,6 @@ tape( 'the function returns `+Infinity` when provided `1`', opts, function test(
 
 tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -91,21 +88,13 @@ tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', opt
 	x = small.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -114,21 +103,13 @@ tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', 
 	x = medium.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -137,13 +118,7 @@ tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', opt
 	x = large.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/logit` from relative-tolerance (EPS-based) assertions to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.
-   uses the minimum required ULP values, verified by direct ULP-difference computation over the test fixtures: all three fixture blocks (`small`, `medium`, `large`; 500 cases each) have a computed maximum ULP difference of exactly `1` (29/38/29 cases sit at exactly 1 ULP, so a tolerance of `0` would fail).
-   collapses the now-obsolete exact-equality short-circuit branches, as `isAlmostSameValue` covers exact equality.
-   removes the now-unused `EPS` and `abs` requires and the `delta`/`tol` variable declarations.

The native (C) addon tests were run as well (not skipped) and pass with the same ULP values as the JavaScript implementation, so no JS-vs-C tolerance divergence annotations are needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, computed and verified the minimum required ULP tolerances against the test fixtures, and ran the JavaScript and native test suites. An independent adversarial verification pass (also Claude Code) recomputed the ULP values and reviewed the diff before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
