### PR TITLE
test: migrate `math/base/special/ahaversinf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ahaversinf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ahaversinf/test/test.js
@@ -23,7 +23,8 @@
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var randu = require( '@stdlib/random/base/randu' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var ahaversinf = require( './../lib' );
 
@@ -44,10 +45,9 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse half-value versed sine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	x = data.x;
@@ -55,23 +55,17 @@ tape( 'the function computes the inverse half-value versed sine', function test(
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahaversinf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = 2.1 * EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse half-value versed sine (small positive numbers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	x = smallPositive.x;
@@ -79,13 +73,8 @@ tape( 'the function computes the inverse half-value versed sine (small positive 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahaversinf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ahaversinf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ahaversinf/test/test.native.js
@@ -24,7 +24,8 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var randu = require( '@stdlib/random/base/randu' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -53,10 +54,9 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse half-value versed sine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	x = data.x;
@@ -64,23 +64,17 @@ tape( 'the function computes the inverse half-value versed sine', opts, function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahaversinf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = 2.1 * EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse half-value versed sine (small positive numbers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	x = smallPositive.x;
@@ -88,13 +82,8 @@ tape( 'the function computes the inverse half-value versed sine (small positive 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahaversinf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/ahaversinf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, following the pattern established in `math/base/special/acothf` and `math/base/special/atanhf`), with expected values coerced to single precision via `@stdlib/number/float64/base/to-float32`.
-   uses the minimum required ULP values, verified by direct ULP-difference computation over the test fixtures using `@stdlib/number/float32/base/ulp-difference`:
    -   `data` fixtures: maximum ULP difference of `2` (32 cases exceed ULP `1`, so `2` is minimal).
    -   `small_positive` fixtures: exact after single-precision coercion (maximum ULP difference of `0`), so plain `t.strictEqual( y, e, 'returns expected value' )` is used instead of `isAlmostSameValue`.
-   removes the now-unused `@stdlib/math/base/special/absf` require and the `delta`/`tol` variables; the `@stdlib/constants/float32/eps` require is retained, as it is still used by the out-of-domain (`NaN`) range tests.

Native (C) results are bit-identical to the JavaScript implementation on the test machine (arm64/clang): the same ULP values apply to both files, and no compiler-divergence `NOTE` annotation is needed. The native test suite was built and run successfully (all assertions passing), and the full JavaScript test harness passed as well.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The minimum ULP values were independently re-verified by an adversarial review pass which recomputed the maximum ULP difference per fixture block directly against the unchanged implementation.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated migration of `math/base/special` test suites to ULP-based testing (issue #11352), including independent recomputation of the minimum ULP tolerances, and was reviewed by a separate adversarial verification pass before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
