### PR TITLE
test: migrate `math/base/special/acoversin` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acoversin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acoversin/test/test.js
@@ -23,8 +23,8 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var acoversin = require( './../lib' );
 
 
@@ -44,8 +44,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse coversed sine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -54,22 +52,14 @@ tape( 'the function computes the inverse coversed sine', function test( t ) {
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = acoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 350.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = acoversin( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 356 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse coversed sine (small positive numbers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -78,14 +68,8 @@ tape( 'the function computes the inverse coversed sine (small positive numbers)'
 	expected = smallPositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = acoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = acoversin( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acoversin/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acoversin/test/test.native.js
@@ -26,7 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 
 
 // FIXTURES //
@@ -53,8 +53,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse coversed sine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -63,22 +61,14 @@ tape( 'the function computes the inverse coversed sine', opts, function test( t 
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = acoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 350.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = acoversin( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 356 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse coversed sine (small positive numbers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -87,14 +77,8 @@ tape( 'the function computes the inverse coversed sine (small positive numbers)'
 	expected = smallPositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = acoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = acoversin( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/acoversin` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values as verified by direct ULP-difference computation over the test fixtures:
    -   `data` fixture block: `maxULP = 356` (original tolerance was `350 * EPS` relative; `355` fails exactly one case, so `356` is the minimum)
    -   `small positive numbers` fixture block: exact match (`maxULP = 0`), so plain `t.strictEqual` is used per maintainer guidance

Native results are bit-identical to the JavaScript implementation (max ULP 356/0 measured by calling the compiled addon directly), so no divergence `NOTE` comment was needed and both files use identical tolerances. The `EPS` require is retained in both files, as it is still used by the out-of-domain `NaN` tests; the now-unused `abs` require was removed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Minimum ULP values were independently verified by recomputing the maximum ULP difference over all fixture cases for both the JavaScript and native implementations.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, including the test migration and the scripts used to determine and independently verify the minimum ULP tolerances. The changes were adversarially reviewed by a second automated agent before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
