### PR TITLE
test: migrate `math/base/special/sincos` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincos/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincos/test/test.assign.js
@@ -24,8 +24,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var Float64Array = require( '@stdlib/array/float64' );
 var sincos = require( './../lib/assign.js' );
 
@@ -50,9 +48,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the sine and cosine (for -256*pi < x < 0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -66,29 +62,15 @@ tape( 'the function computes the sine and cosine (for -256*pi < x < 0)', functio
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 0 < x < 256*pi)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -102,29 +84,15 @@ tape( 'the function computes the sine and cosine (for 0 < x < 256*pi)', function
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for -2**60 (pi/2) < x < -2**20 (pi/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -138,29 +106,15 @@ tape( 'the function computes the sine and cosine (for -2**60 (pi/2) < x < -2**20
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 2**20 (pi/2) < x < 2**60 (pi/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -174,29 +128,15 @@ tape( 'the function computes the sine and cosine (for 2**20 (pi/2) < x < 2**60 (
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x <= -2**60 (PI/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -210,29 +150,15 @@ tape( 'the function computes the sine and cosine (for x <= -2**60 (PI/2))', func
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x >= 2**60 (PI/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -246,20 +172,8 @@ tape( 'the function computes the sine and cosine (for x >= 2**60 (PI/2))', funct
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sincos/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincos/test/test.main.js
@@ -24,8 +24,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var sincos = require( './../lib/main.js' );
 
 
@@ -49,9 +47,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the sine and cosine (for -256*pi < x < 0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -62,29 +58,15 @@ tape( 'the function computes the sine and cosine (for -256*pi < x < 0)', functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 0 < x < 256*pi)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,29 +77,15 @@ tape( 'the function computes the sine and cosine (for 0 < x < 256*pi)', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for -2**60 (pi/2) < x < -2**20 (pi/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -128,29 +96,15 @@ tape( 'the function computes the sine and cosine (for -2**60 (pi/2) < x < -2**20
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 2**20 (pi/2) < x < 2**60 (pi/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -161,29 +115,15 @@ tape( 'the function computes the sine and cosine (for 2**20 (pi/2) < x < 2**60 (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x <= -2**60 (PI/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -194,29 +134,15 @@ tape( 'the function computes the sine and cosine (for x <= -2**60 (PI/2))', func
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x >= 2**60 (PI/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -227,20 +153,8 @@ tape( 'the function computes the sine and cosine (for x >= 2**60 (PI/2))', funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y[ 0 ], sine[ i ], 'returns expected value' );
+		t.strictEqual( y[ 1 ], cosine[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sincos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincos/test/test.native.js
@@ -25,8 +25,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,9 +57,7 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the sine and cosine (for -256*pi < x < 0)', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -71,29 +68,19 @@ tape( 'the function computes the sine and cosine (for -256*pi < x < 0)', opts, f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 0 < x < 256*pi)', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -104,29 +91,19 @@ tape( 'the function computes the sine and cosine (for 0 < x < 256*pi)', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for -2**60 (pi/2) < x < -2**20 (pi/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -137,29 +114,19 @@ tape( 'the function computes the sine and cosine (for -2**60 (pi/2) < x < -2**20
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 2**20 (pi/2) < x < 2**60 (pi/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -170,29 +137,19 @@ tape( 'the function computes the sine and cosine (for 2**20 (pi/2) < x < 2**60 (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x <= -2**60 (PI/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -203,29 +160,19 @@ tape( 'the function computes the sine and cosine (for x <= -2**60 (PI/2))', opts
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x >= 2**60 (PI/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -236,20 +183,12 @@ tape( 'the function computes the sine and cosine (for x >= 2**60 (PI/2))', opts,
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincos( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/sincos` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).
-   note: this package's `test/test.js` is a thin wrapper (export and `assign`-property checks only) and contains no tolerance assertions; the relative-tolerance tests live in `test/test.main.js`, `test/test.assign.js`, and `test/test.native.js`, all three of which are migrated here.
-   for the JavaScript implementation (both the main and `assign` paths), the maximum ULP difference is `0` for every fixture (medium/large/huge ranges, negative and positive; sine and cosine components measured separately), so all JavaScript assertions use plain `t.strictEqual` per current maintainer guidance.
-   for the native (C) implementation, the maximum ULP difference is `1` for both sine and cosine in all six test blocks (compiler-optimization divergence); minimality was verified (a tolerance of `0` produces failures), and the canonical `NOTE` comment referencing https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205 is included above each diverging assertion.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Native tests were run against the real compiled addon (not skipped); the full test suite (`make test`) passed (72024/72024 assertions).
-   ULP minimality for the JavaScript blocks was independently re-verified by recomputing the maximum ULP difference over all 24000 fixture cases.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which performed the test migration, computed and verified the minimum ULP values against the fixtures, and was independently cross-checked by a second automated verification pass.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
