### PR TITLE
test: migrate `math/base/special/acovercosf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acovercosf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acovercosf/test/test.js
@@ -23,9 +23,9 @@
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var randu = require( '@stdlib/random/base/randu' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var acovercosf = require( './../lib' );
 
 
@@ -45,8 +45,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse coversed cosine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -58,21 +56,13 @@ tape( 'the function computes the inverse coversed cosine', function test( t ) {
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		y = acovercosf( x[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = 230.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 234 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse coversed cosine (small positive numbers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -84,13 +74,7 @@ tape( 'the function computes the inverse coversed cosine (small positive numbers
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		y = acovercosf( x[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acovercosf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acovercosf/test/test.native.js
@@ -24,9 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var randu = require( '@stdlib/random/base/randu' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -54,8 +54,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse coversed cosine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -67,21 +65,13 @@ tape( 'the function computes the inverse coversed cosine', opts, function test( 
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		y = acovercosf( x[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = 230.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 234 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse coversed cosine (small positive numbers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -93,13 +83,7 @@ tape( 'the function computes the inverse coversed cosine (small positive numbers
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		y = acovercosf( x[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/acovercosf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, following the merged precedent in `math/base/special/acothf` and `math/base/special/atanhf`).
-   uses the minimum required ULP values, verified by direct ULP-difference computation over the test fixtures: for the `data.json` block, the minimum ULP is `234` (a tolerance of `233` fails for two fixture cases; this is consistent with the pre-existing `230.0 * EPS` relative tolerance and inherent to the `asinf( x - 1.0 )` cancellation near the domain edges, not a regression). For the `small_positive.json` block, all computed values match the fixtures exactly, so plain `t.strictEqual( y, e, 'returns expected value' )` is used instead of `isAlmostSameValue`.
-   removes the now-unused `absf` require and the `delta`/`tol` variables, and collapses the obsolete exact-equality short-circuit branches (covered by `isAlmostSameValue`). The `EPS` require is retained, as it is still used by the domain (`NaN`) tests.
-   native (C) results are bit-identical to the JavaScript implementation for these fixtures (max ULP `234` / `0`), so no native-vs-JavaScript tolerance divergence note is needed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated migration of test suites to ULP-based testing (issue #11352). The minimum ULP values were verified by an independent adversarial verification agent which recomputed the ULP differences over the test fixtures, and the changes were reviewed by a human before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
