### PR TITLE
test: migrate `math/base/special/pow` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/pow/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/pow/test/test.native.js
@@ -33,6 +33,7 @@ var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -221,8 +222,6 @@ tape( 'the function evaluates the exponential function (`x ~ 1`, `y` large)', op
 tape( 'the function evaluates the exponential function (`x ~ 1`, `y` huge)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -232,14 +231,9 @@ tape( 'the function evaluates the exponential function (`x ~ 1`, `y` huge)', opt
 	expected = baseNearUnityHuge.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = pow( x[i], y[i] );
-		if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
-		} else {
-			// NOTE: the results may differ slightly from the reference and JavaScript implementations due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			delta = abs( actual - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. pow('+x[i]+','+y[i]+'). Expected: '+expected[i]+'. Actual: '+actual+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -420,8 +414,6 @@ tape( 'the function evaluates the exponential function (near underflow)', opts, 
 tape( 'the function evaluates the exponential function (small `x`, large `y`)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -433,13 +425,9 @@ tape( 'the function evaluates the exponential function (small `x`, large `y`)', 
 		actual = pow( x[i], y[i] );
 		if ( expected[i] === 5.0e-324 ) {
 			t.strictEqual( actual === expected[i] || actual === 0.0, true, 'pow('+x[i]+','+y[i]+') returns 5e-324 or 0' );
-		} else if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
 		} else {
-			// NOTE: the results may differ slightly from the reference and JavaScript implementations due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			delta = abs( actual - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. pow('+x[i]+','+y[i]+'). Expected: '+expected[i]+'. Actual: '+actual+'. Delta: '+delta+'. Tol: '+tol+'.' );
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -465,8 +453,6 @@ tape( 'the function evaluates the exponential function (large `x`, small `y`)', 
 tape( 'the function evaluates the exponential function (small `x`, small `y`)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -476,14 +462,9 @@ tape( 'the function evaluates the exponential function (small `x`, small `y`)', 
 	expected = smallSmall.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = pow( x[i], y[i] );
-		if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
-		} else {
-			// NOTE: the results may differ slightly from the reference and JavaScript implementations due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			delta = abs( actual - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. pow('+x[i]+','+y[i]+'). Expected: '+expected[i]+'. Actual: '+actual+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -491,8 +472,6 @@ tape( 'the function evaluates the exponential function (small `x`, small `y`)', 
 tape( 'the function evaluates the exponential function (decimal `x`, decimal `y`)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -502,14 +481,9 @@ tape( 'the function evaluates the exponential function (decimal `x`, decimal `y`
 	expected = decimalDecimal.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = pow( x[i], y[i] );
-		if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
-		} else {
-			// NOTE: the results may differ slightly from the reference and JavaScript implementations due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			delta = abs( actual - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. pow('+x[i]+','+y[i]+'). Expected: '+expected[i]+'. Actual: '+actual+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -517,8 +491,6 @@ tape( 'the function evaluates the exponential function (decimal `x`, decimal `y`
 tape( 'the function evaluates the exponential function (decimal `x`, integer `y`)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -528,14 +500,9 @@ tape( 'the function evaluates the exponential function (decimal `x`, integer `y`
 	expected = decimalInteger.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = pow( x[i], y[i] );
-		if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
-		} else {
-			// NOTE: the results may differ slightly from the reference and JavaScript implementations due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			delta = abs( actual - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. pow('+x[i]+','+y[i]+'). Expected: '+expected[i]+'. Actual: '+actual+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -543,8 +510,6 @@ tape( 'the function evaluates the exponential function (decimal `x`, integer `y`
 tape( 'the function evaluates the exponential function (integer `x`, decimal `y`)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -554,14 +519,9 @@ tape( 'the function evaluates the exponential function (integer `x`, decimal `y`
 	expected = integerDecimal.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = pow( x[i], y[i] );
-		if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
-		} else {
-			// NOTE: the results may differ slightly from the reference and JavaScript implementations due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			delta = abs( actual - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. pow('+x[i]+','+y[i]+'). Expected: '+expected[i]+'. Actual: '+actual+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -569,8 +529,6 @@ tape( 'the function evaluates the exponential function (integer `x`, decimal `y`
 tape( 'the function evaluates the exponential function (integer `x`, integer `y`)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -580,14 +538,9 @@ tape( 'the function evaluates the exponential function (integer `x`, integer `y`
 	expected = integerInteger.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = pow( x[i], y[i] );
-		if ( actual === expected[i] ) {
-			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
-		} else {
-			// NOTE: the results may differ slightly from the reference and JavaScript implementations due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			delta = abs( actual - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. pow('+x[i]+','+y[i]+'). Expected: '+expected[i]+'. Actual: '+actual+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.native.js` for `math/base/special/pow` from relative-tolerance (`EPS`-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).
-   leaves `test/test.js` unchanged, as the JavaScript test file contains no relative-tolerance assertions: every fixture block already asserts exact equality via `t.strictEqual`, and a direct ULP-difference computation over all seven fixture sets confirms a maximum ULP difference of `0` for the JavaScript implementation.
-   collapses the obsolete exact-equality short-circuit branches (`if ( actual === expected[i] ) { ... } else { ...tolerance... }`) in the native test file into single `isAlmostSameValue` assertions, as `isAlmostSameValue` covers exact equality.
-   uses a maximum ULP difference of `1` for all seven migrated native test blocks, which is larger than the JavaScript counterpart (exact, `0` ULP) due to compiler optimizations which may result in result divergence; accordingly, the canonical `NOTE` comment (see #2298 and commit 69e1068fd9b) is added above each migrated assertion.
-   preserves the special-case handling for the `5.0e-324` (smallest subnormal) underflow branch in the small `x`, large `y` test block.
-   retains the `EPS` and `abs` requires, as both are still used elsewhere in the native test file.

ULP minimality was verified by confirming that a maximum ULP difference of `0` produces native test failures, while `1` passes all assertions (73605+ assertions across all test files via `make test`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The native ULP values were measured on darwin arm64 (clang). CI should confirm the tolerances hold across other platforms and compilers.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, including the test migration and the minimum-ULP computation; an independent automated verification pass recomputed the ULP values against the fixtures before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
