### PR TITLE
test: migrate `math/base/special/kernel-tan` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/kernel-tan/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-tan/test/test.native.js
@@ -24,8 +24,7 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var rempio2 = require( '@stdlib/math/base/special/rempio2' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -77,8 +76,6 @@ tape( 'the function returns `NaN` if provided `NaN` for `x` or `y`', opts, funct
 tape( 'the function evaluates the tangent for input values inside of `[-pi/4, pi/4]`', opts, function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var out;
 	var x;
 	var i;
@@ -88,15 +85,9 @@ tape( 'the function evaluates the tangent for input values inside of `[-pi/4, pi
 	for ( i = 0; i < values.length; i++ ) {
 		x = values[ i ];
 		out = kernelTan( x, 0.0, 1 );
-		if ( out === expected[ i ] ) {
-			t.strictEqual( out, expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( out - expected[ i ] );
 
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x+'. out: '+out+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -104,8 +95,6 @@ tape( 'the function evaluates the tangent for input values inside of `[-pi/4, pi
 tape( 'the function can be used to compute the tangent for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2` (positive)', opts, function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -119,15 +108,9 @@ tape( 'the function can be used to compute the tangent for input values outside 
 		x = values[ i ];
 		n = rempio2( x, y );
 		out = kernelTan( y[ 0 ], y[ 1 ], 1 - ( (n&1)<<1 ) );
-		if ( out === expected[ i ] ) {
-			t.strictEqual( out, expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( out - expected[ i ] );
 
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x+'. out: '+out+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -135,8 +118,6 @@ tape( 'the function can be used to compute the tangent for input values outside 
 tape( 'the function can be used to compute the tangent for input values outside of `[-pi/4, pi/4]` after argument reduction via `rempio2` (negative)', opts, function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var out;
 	var x;
 	var y;
@@ -150,15 +131,9 @@ tape( 'the function can be used to compute the tangent for input values outside 
 		x = values[ i ];
 		n = rempio2( x, y );
 		out = kernelTan( y[ 0 ], y[ 1 ], 1 - ( (n&1)<<1 ) );
-		if ( out === expected[ i ] ) {
-			t.strictEqual( out, expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( out - expected[ i ] );
 
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x+'. out: '+out+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( out, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.native.js` for `math/base/special/kernel-tan` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP value (`1`) for each of the three fixture-driven test blocks. The minimum ULP values were determined by direct ULP-difference computation (via `@stdlib/number/float64/base/ulp-difference`) over all fixture cases against the built native addon and independently re-verified.
-   leaves `test/test.js` unchanged: the JavaScript test file already used exact `t.strictEqual( out, expected[ i ], ... )` assertions, and the measured maximum ULP difference for the JavaScript implementation is `0` across all fixture cases, so exact equality assertions are retained per maintainer guidance.
-   since the native (C) results diverge from the JavaScript results (native maximum ULP difference of `1` versus `0` for JavaScript), the canonical `NOTE` comment regarding compiler optimizations (see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205) is retained above each migrated assertion, as in the pre-migration code.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Minimality was verified: with a ULP tolerance of `0`, native assertions fail; with `1`, all 3008 tests pass via the official test harness (`make test`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which performed the test migration, computed the minimum ULP tolerances against the test fixtures, and verified the results; an independent automated verification pass re-computed the ULP values before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
