### PR TITLE
test: migrate `math/base/special/cabs2f` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cabs2f/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cabs2f/test/test.js
@@ -22,8 +22,8 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var cabs2f = require( './../lib' );
 
@@ -43,11 +43,10 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the squared absolute value of a complex number', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var y;
+	var e;
 	var i;
 
 	re = data.re;
@@ -56,13 +55,8 @@ tape( 'the function computes the squared absolute value of a complex number', fu
 
 	for ( i = 0; i < re.length; i++ ) {
 		y = cabs2f( new Complex64( re[ i ], im[ i ] ) );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 're: '+re[i]+'. im: '+im[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[i]+'. im: '+im[i]+' y: '+y+'. Expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cabs2f/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cabs2f/test/test.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -52,11 +51,10 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the squared absolute value of a complex number', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var y;
+	var e;
 	var i;
 
 	re = data.re;
@@ -65,13 +63,8 @@ tape( 'the function computes the squared absolute value of a complex number', op
 
 	for ( i = 0; i < re.length; i++ ) {
 		y = cabs2f( new Complex64( re[ i ], im[ i ] ) );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 're: '+re[i]+'. im: '+im[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[i]+'. im: '+im[i]+' y: '+y+'. Expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( y, e, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` for `math/base/special/cabs2f` from relative-tolerance (EPS-based) assertions to ULP-difference assertions, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).
-   uses `@stdlib/number/float32/base/assert/is-almost-same-value` together with `f32 = require( '@stdlib/number/float64/base/to-float32' )` and `e = f32( expected[ i ] )`, following the established convention for single-precision packages (e.g., `atanhf`, `acothf`).
-   JavaScript tests: `isAlmostSameValue( y, e, 1 )`. The JS implementation returns the unrounded double `(re*re) + (im*im)` on float32 components (it does not round through float64-to-float32), so the result is not bitwise equal to `f32( expected[ i ] )` as a double for most fixture cases (only 3 of 2003), while the single-precision ULP difference is 0 for all cases. The minimum integer ULP value for which all cases pass is therefore 1 (0 degenerates to SameValue and fails 2000 cases).
-   native tests: the C implementation returns a genuine `float`, and `y` equals `f32( expected[ i ] )` exactly for all 2003 fixture cases, so a plain `t.strictEqual( y, e, 'returns expected value' )` is used (ULP 0). Note that this is a reversed JS-vs-C situation (JS looser than native), caused by the JS implementation not emulating single-precision arithmetic; no `NOTE` comment about compiler optimizations is needed since the native tolerance does not exceed the JavaScript tolerance.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Native exactness was measured on darwin/arm64 (clang). If compiler optimizations (e.g., fp contraction) on CI introduce divergence in `(re*re) + (im*im)`, the native assertion may need to be bumped to `isAlmostSameValue( y, e, 1 )` with the canonical compiler-optimizations `NOTE`.
-   The JavaScript implementation could in principle be aligned with the float32-emulation convention used by sibling packages (e.g., `hypotf`, `cabsf`); this was intentionally left unchanged here, as this PR is test-only.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated migration of test suites to ULP-based testing (issue #11352), including independent verification of the minimum ULP values by a separate adversarial review agent. The changes were run against the official test harness locally before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
