### PR TITLE
test: migrate `math/base/special/cbrt` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cbrt/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/test/test.native.js
@@ -27,8 +27,6 @@ var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -68,8 +66,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -78,21 +74,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]'
 	x = veryLargeNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -101,21 +89,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`',
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -124,21 +104,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`'
 	x = largeNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -147,21 +119,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', 
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -170,21 +134,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`',
 	x = mediumNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -193,21 +149,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', o
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -216,21 +164,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`'
 	x = smallNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -239,21 +179,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', 
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -262,21 +194,13 @@ tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', o
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1e-308]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -285,21 +209,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1
 	x = tinyNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-308]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -308,21 +224,13 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of subnormal `x`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -331,21 +239,13 @@ tape( 'the function evaluates the cubic root of subnormal `x`', opts, function t
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` (huge negative)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -355,21 +255,13 @@ tape( 'the function evaluates the cubic root of `x` (huge negative)', opts, func
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cubic root of `x` (huge positive)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -379,13 +271,7 @@ tape( 'the function evaluates the cubic root of `x` (huge positive)', opts, func
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = cbrt( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.native.js` of `math/base/special/cbrt` from relative-tolerance (EPS-based) assertions to exact equality assertions, completing the migration to ULP-based testing for this package. `test/test.js` was already migrated in #11839, which left the native test file behind.
-   computes the minimum required ULP tolerance for every fixture block by direct ULP-difference computation (via `@stdlib/number/float64/base/ulp-difference`) over all 14 Julia fixture files (7042 cases). The maximum ULP difference is `0` for every block, for both the JavaScript implementation and the native add-on, so plain `t.strictEqual( y, expected[ i ], 'returns expected value' )` is used rather than `isAlmostSameValue`, per maintainer guidance to avoid `isAlmostSameValue` where values are exactly equal.
-   removes the now-unused `EPS` and `abs` requires and the `delta`/`tol` variables, and collapses the obsolete exact-equality short-circuit branches.

The native results did not diverge from the JavaScript implementation (verified locally on arm64/clang), so no compiler-optimization tolerance notes were needed. All 7049 native assertions pass locally with the add-on built and loaded.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352
-   #11839

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The minimum ULP values were independently re-verified by a second pass which re-computed the maximum ULP difference per fixture block for both the JavaScript implementation and the compiled native add-on; all blocks are exactly `0` ULP.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, including the test migration and the ULP-minimality computation; an independent automated verification pass (also Claude Code) re-computed the minimum ULP values and reviewed the diff before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
