### PR TITLE
test: migrate `math/base/special/hacoversin` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/hacoversin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/hacoversin/test/test.js
@@ -24,8 +24,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var hacoversin = require( './../lib' );
 
 
@@ -49,8 +47,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the half-value coversed sine (for -256*pi < x < 0)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -60,21 +56,13 @@ tape( 'the function computes the half-value coversed sine (for -256*pi < x < 0)'
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for 0 < x < 256*pi)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -84,21 +72,13 @@ tape( 'the function computes the half-value coversed sine (for 0 < x < 256*pi)',
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for -2**60 (pi/2) < x < -2**20 (pi/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -108,21 +88,13 @@ tape( 'the function computes the half-value coversed sine (for -2**60 (pi/2) < x
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for 2**20 (pi/2) < x < 2**60 (pi/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -132,21 +104,13 @@ tape( 'the function computes the half-value coversed sine (for 2**20 (pi/2) < x 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for x <= -2**60 (PI/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -156,21 +120,13 @@ tape( 'the function computes the half-value coversed sine (for x <= -2**60 (PI/2
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for x >= 2**60 (PI/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -180,13 +136,7 @@ tape( 'the function computes the half-value coversed sine (for x >= 2**60 (PI/2)
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/hacoversin/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/hacoversin/test/test.native.js
@@ -25,8 +25,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the half-value coversed sine (for -256*pi < x < 0)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -69,21 +66,15 @@ tape( 'the function computes the half-value coversed sine (for -256*pi < x < 0)'
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for 0 < x < 256*pi)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -93,21 +84,15 @@ tape( 'the function computes the half-value coversed sine (for 0 < x < 256*pi)',
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 4.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for -2**60 (pi/2) < x < -2**20 (pi/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -117,21 +102,15 @@ tape( 'the function computes the half-value coversed sine (for -2**60 (pi/2) < x
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 4.6 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for 2**20 (pi/2) < x < 2**60 (pi/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -141,21 +120,15 @@ tape( 'the function computes the half-value coversed sine (for 2**20 (pi/2) < x 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for x <= -2**60 (PI/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -165,21 +138,15 @@ tape( 'the function computes the half-value coversed sine (for x <= -2**60 (PI/2
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.3 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the half-value coversed sine (for x >= 2**60 (PI/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -189,13 +156,9 @@ tape( 'the function computes the half-value coversed sine (for x >= 2**60 (PI/2)
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = hacoversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 3.6 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/hacoversin` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).
-   for the JavaScript implementation, all six fixture blocks match the Julia reference values exactly (max ULP difference of `0`), so plain `t.strictEqual` assertions are used and `is-almost-same-value` is not required in `test/test.js`.
-   for the native (C) implementation, results diverge from the Julia reference values in every block (minimum required ULP values of `2`/`4`/`8`/`2`/`4`/`4`), so each native assertion uses `isAlmostSameValue` with the standard note regarding compiler-optimization-induced divergence (see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205).
-   removes the now-unused `EPS` and `abs` requires, the `delta`/`tol` variables, and the obsolete exact-equality short-circuit branches.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

All ULP values were verified to be minimal by independently recomputing the maximum ULP difference per fixture block (for both the JavaScript implementation and a locally compiled native add-on). The full test suite (`make test`) passes for both `test/test.js` and `test/test.native.js` with the native add-on loaded (not skipped).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which performed the test migration, computed the minimum ULP values from the test fixtures, and verified the results; the changes were independently re-verified by a second automated pass before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
