### PR TITLE
test: migrate `math/base/special/hypotf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/hypotf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/test/test.js
@@ -24,12 +24,11 @@ var tape = require( 'tape' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var sqrtf = require( '@stdlib/math/base/special/sqrtf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var hypotf = require( './../lib' );
 
 
@@ -123,12 +122,11 @@ tape( 'the function returns `+0` if both arguments are `+-0`', function test( t 
 
 tape( 'the function computes the hypotenuse', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var h;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	x = data.x;
 	y = data.y;
@@ -136,13 +134,8 @@ tape( 'the function computes the hypotenuse', function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		h = hypotf( x[ i ], y[ i ] );
-		if ( h === expected[ i ] ) {
-			t.ok( true, 'x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'.' );
-		} else {
-			delta = absf( h - expected[ i ] );
-			tol = 2.0 * EPS * absf( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		e = float64ToFloat32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( h, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/test/test.native.js
@@ -25,12 +25,11 @@ var tape = require( 'tape' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var sqrtf = require( '@stdlib/math/base/special/sqrtf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -132,12 +131,11 @@ tape( 'the function returns `+0` if both arguments are `+-0`', opts, function te
 
 tape( 'the function computes the hypotenuse', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var h;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	x = data.x;
 	y = data.y;
@@ -145,20 +143,13 @@ tape( 'the function computes the hypotenuse', opts, function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		h = hypotf( x[ i ], y[ i ] );
-		if ( h === expected[ i ] ) {
-			t.ok( true, 'x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'.' );
-		} else {
-			delta = absf( h - expected[ i ] );
-			tol = 2.0 * EPS * absf( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		e = float64ToFloat32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( h, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hypotenuse (canonical inputs)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var h;
 
 	h = hypotf( 3.0, 4.0 );
@@ -169,9 +160,7 @@ tape( 'the function computes the hypotenuse (canonical inputs)', opts, function 
 
 	// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 	h = hypotf( 5.0, 12.0 );
-	delta = absf( h - 13.0 );
-	tol = EPS * absf( 13.0 );
-	t.strictEqual( delta <= tol, true, 'within tolerance. h: '+h+'. Expected: 13.0. Delta: '+delta+'. Tol: '+tol+'.' );
+	t.strictEqual( isAlmostSameValue( h, 13.0, 1 ), true, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/hypotf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures: JS fixture block max `2` ULP, native fixture block max `2` ULP, native canonical-inputs block max `1` ULP).
-   as `hypotf` is single-precision, uses the `float32` variant of `is-almost-same-value` and coerces fixture expected values via the file's existing `float64ToFloat32` require, following the merged precedent in `math/base/special/acothf` (ed81430366d) and `math/base/special/atanhf` (7f68fc4aa25); all 2003 fixture expected values are exactly representable in single precision, so the coercion is a semantic no-op.
-   preserves the native-vs-JS divergence handling for canonical inputs: the native implementation returns `12.999999046325684` (1 ULP below `13.0`) for `hypotf( 5.0, 12.0 )` due to compiler optimizations, while the JavaScript implementation is exact; the pre-existing `NOTE` comment (see 69e1068fd9b) is retained, the JavaScript test keeps a plain `t.strictEqual`, and the native assertion uses `isAlmostSameValue( h, 13.0, 1 )`.
-   removes the now-unused `EPS` and `absf` requires and `delta`/`tol` variables.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

All ULP values were independently recomputed (including the native results, via a locally built add-on) and confirmed to be the minimum integer values for which all test cases pass. Both the JavaScript and native test suites pass (2031 assertions each, native tests run against a real add-on build, no skips).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code: the test migration was performed by an automated agent and independently verified by a second adversarial agent (which recomputed all minimum ULP values from the fixtures), with human supervision.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
