### PR TITLE
test: migrate `math/base/special/riemann-zeta` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/test/test.js
@@ -22,12 +22,11 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var zeta = require( './../lib' );
 
 
@@ -52,8 +51,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function evaluates the Riemann zeta function', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 	var i;
@@ -62,9 +59,7 @@ tape( 'the function evaluates the Riemann zeta function', function test( t ) {
 	expected = data.expected;
 	for ( i = 0; i < s.length; i++ ) {
 		v = zeta( s[i] );
-		delta = abs( v - expected[i] );
-		tol = 34.0 * EPS * abs( expected[i] );
-		t.ok( delta <= tol, 'within tolerance. s: '+s[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 46 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -118,8 +113,6 @@ tape( 'the function returns `0` for all even negative integers', function test( 
 
 tape( 'the function handles negative values which are larger in magnitude than the maximum factorial', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -128,30 +121,20 @@ tape( 'the function handles negative values which are larger in magnitude than t
 
 	s = -170.7;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = 53.0 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 20 ), true, 'returns expected value' );
 
 	// Wolfram: zeta( -171.1 )
 	expected = 1.762429756041972327545919944532107376580768035147432e172;
 
 	s = -171.1;
 	v = zeta( s );
-	delta = abs( v - expected );
-
-	// Note: FF seems to return less precise results (https://travis-ci.org/math-io/riemann-zeta/jobs/115748766). For Node/Chrome, 286.0*eps.
-	tol = 355.0 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 404 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function handles negative integer values which are larger in magnitude than twice the index of the maximum Bernoulli number', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -162,10 +145,7 @@ tape( 'the function handles negative integer values which are larger in magnitud
 
 	s = -259;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = 352.0 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 223 ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -197,8 +177,6 @@ tape( 'if provided `-1` (special value), the function returns `-1/12`', function
 
 tape( 'if provided `-13` (special value), the function returns `-1/12`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -206,17 +184,12 @@ tape( 'if provided `-13` (special value), the function returns `-1/12`', functio
 
 	s = -13.0;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `4` (special value), the function returns `~1.0823`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -225,17 +198,12 @@ tape( 'if provided `4` (special value), the function returns `~1.0823`', functio
 
 	s = 4.0;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `3` (special value), the function returns `~1.202`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -244,17 +212,12 @@ tape( 'if provided `3` (special value), the function returns `~1.202`', function
 
 	s = 3.0;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `2` (special value), the function returns `~1.645`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -263,17 +226,12 @@ tape( 'if provided `2` (special value), the function returns `~1.645`', function
 
 	s = 2.0;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `3/2` (special value), the function returns `~2.612`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -282,17 +240,12 @@ tape( 'if provided `3/2` (special value), the function returns `~2.612`', functi
 
 	s = 1.5;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `1/2` (special value), the function returns `~-1.46`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -301,9 +254,6 @@ tape( 'if provided `1/2` (special value), the function returns `~-1.46`', functi
 
 	s = 0.5;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/test/test.native.js
@@ -23,12 +23,11 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -61,8 +60,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) 
 
 tape( 'the function evaluates the Riemann zeta function', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 	var i;
@@ -71,9 +68,7 @@ tape( 'the function evaluates the Riemann zeta function', opts, function test( t
 	expected = data.expected;
 	for ( i = 0; i < s.length; i++ ) {
 		v = zeta( s[i] );
-		delta = abs( v - expected[i] );
-		tol = 34.0 * EPS * abs( expected[i] );
-		t.ok( delta <= tol, 'within tolerance. s: '+s[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 46 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -127,8 +122,6 @@ tape( 'the function returns `0` for all even negative integers', opts, function 
 
 tape( 'the function handles negative values which are larger in magnitude than the maximum factorial', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -137,30 +130,20 @@ tape( 'the function handles negative values which are larger in magnitude than t
 
 	s = -170.7;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = 53.0 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 20 ), true, 'returns expected value' );
 
 	// Wolfram: zeta( -171.1 )
 	expected = 1.762429756041972327545919944532107376580768035147432e172;
 
 	s = -171.1;
 	v = zeta( s );
-	delta = abs( v - expected );
-
-	// Note: FF seems to return less precise results (https://travis-ci.org/math-io/riemann-zeta/jobs/115748766). For Node/Chrome, 286.0*eps.
-	tol = 355.0 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 404 ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function handles negative integer values which are larger in magnitude than twice the index of the maximum Bernoulli number', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -171,12 +154,9 @@ tape( 'the function handles negative integer values which are larger in magnitud
 
 	s = -259;
 	v = zeta( s );
-	delta = abs( v - expected );
 
 	// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-	tol = 656.0 * EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 1022 ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -208,8 +188,6 @@ tape( 'if provided `-1` (special value), the function returns `-1/12`', opts, fu
 
 tape( 'if provided `-13` (special value), the function returns `-1/12`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -217,17 +195,12 @@ tape( 'if provided `-13` (special value), the function returns `-1/12`', opts, f
 
 	s = -13.0;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `4` (special value), the function returns `~1.0823`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -236,17 +209,12 @@ tape( 'if provided `4` (special value), the function returns `~1.0823`', opts, f
 
 	s = 4.0;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `3` (special value), the function returns `~1.202`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -255,17 +223,12 @@ tape( 'if provided `3` (special value), the function returns `~1.202`', opts, fu
 
 	s = 3.0;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `2` (special value), the function returns `~1.645`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -274,17 +237,12 @@ tape( 'if provided `2` (special value), the function returns `~1.645`', opts, fu
 
 	s = 2.0;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `3/2` (special value), the function returns `~2.612`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -293,17 +251,12 @@ tape( 'if provided `3/2` (special value), the function returns `~2.612`', opts, 
 
 	s = 1.5;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `1/2` (special value), the function returns `~-1.46`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var s;
 	var v;
 
@@ -312,9 +265,6 @@ tape( 'if provided `1/2` (special value), the function returns `~-1.46`', opts, 
 
 	s = 0.5;
 	v = zeta( s );
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. s: '+s+'. v: '+v+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/riemann-zeta` from relative-tolerance (EPS-based) assertions to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures and special values).
-   replaces tolerance assertions with plain `t.strictEqual` checks for the `zeta( 4 )`, `zeta( 3 )`, and `zeta( 2 )` special-value tests, where computed and expected values match exactly (minimum ULP of `0`).
-   uses a larger tolerance for the native implementation than for the JavaScript implementation for `zeta( -259 )` (1022 ULP vs 223 ULP), as the native (C) result diverges due to compiler optimizations; the canonical NOTE comment explaining this divergence (already present in the original file above the old `656.0 * EPS` tolerance) is retained directly above the new assertion. All other native ULP values match the JavaScript values.
-   removes an obsolete comment ("Note: FF seems to return less precise results ... For Node/Chrome, 286.0*eps.") in both files, as it exclusively documented the removed EPS-based tolerance line.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Each ULP value is the minimum integer for which all cases in the respective test block pass: decrementing any value causes test failures.
-   `test/test.polynomial_series.js` (tests for the internal `polynomial_series.js` helper) still uses the EPS relative-tolerance pattern and was deliberately left untouched, as the migration is scoped to `test.js` and `test.native.js` (consistent with merged precedent); it is a candidate for a follow-up.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, computed and verified the minimum ULP values, and ran the JavaScript and native test suites; an independent AI verification pass recomputed the minimum ULP values before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
