### PR TITLE
chore: fix example and remove blank line

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmsumabs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmsumabs/docs/types/index.d.ts
@@ -41,8 +41,6 @@ type accumulator = ( x?: number ) => number | null;
 * @returns accumulator function
 *
 * @example
-* var nanmsumabs = require( '@stdlib/stats/incr/nanmsumabs' );
-*
 * var accumulator = incrnanmsumabs( 3 );
 *
 * var v = accumulator();

--- a/lib/node_modules/@stdlib/stats/incr/nanmsumabs/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmsumabs/docs/types/test.ts
@@ -18,6 +18,7 @@
 
 import incrnanmsumabs = require( './index' );
 
+
 // TESTS //
 
 // The function returns an accumulator function...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Follow-up fixes for commits merged to `develop` between `2026-06-09 10:07 -0700` and `2026-06-10 01:13 -0700` (27 commits reviewed).

Fixes by package:

**`stats/incr/nanmsumabs`** (from `50463ad3`)

-   Fix broken TSDoc `@example` in `stats/incr/nanmsumabs/docs/types/index.d.ts` where `require` bound to `nanmsumabs` but the example then called undeclared `incrnanmsumabs`; drop the stray `require` line to match siblings `nanmse` and `nanrmse`. [`50463ad3`]
-   Fix single blank line between import and `// TESTS //` comment in `stats/incr/nanmsumabs/docs/types/test.ts`; two blank lines are required per convention (cf. `mse`, `rmse`, `msumabs`, `nanmse`, `nanrmse`). [`50463ad3`]

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation audit.** Each fix was cross-confirmed against sibling packages in the same namespace before applying. Edits were limited to the diff window of the originating commit; no surrounding code was reformatted.

Audit covered:

-   stdlib JS style-guide compliance against established sibling packages
-   Diff-only bug scan and a separate logic/security scan over the union diff

Deliberately excluded:

-   Workflow `${{ ... }}` interpolations remaining in `run:` shells of `57a83de40a`. Each remaining interpolation is bound to a GitHub-validated input type (`boolean`, `choice`, or `number`), so no shell-injection risk remains; the hardening commit correctly targeted only free-form string inputs.
-   Pre-existing `subd2ind` import alias typo in `ndarray/sub2ind/docs/types/test.ts`. Outside the diff window of `098451fcfd`.
-   Stylistic `randu()-0.5` operator spacing in new accumulator benchmarks. Matches the existing stats/incr benchmark convention across `mse`, `rmse`, `msumabs`, etc.
-   Wording of the "Notes" section in `time/quarter-of-year`. Borderline interpretation; not a clear-cut error.

**Dropped after PR opened:**

-   Realigning the Complex128 ndarray REPL output in `blas/ext/base/ndarray/zaxpby/docs/repl.txt` to use decimal notation and a space after the comma. The decimal form pushed the line to 94 characters, violating the REPL `line-length` rule (80-char cap). Reverted rather than expand scope into adjacent input-data lines.
-   `stats/incr/nanmse/README.md` `<img src>` swap from the source-package CDN URL to a local `./docs/img/...` path. Dropped at maintainer request (Planeshifter review on `73875e8f`).

A local report with the full validated-issue list, dropped findings, and originating commit window lives at `~/drift-reports/commit-review-2026-06-10.md`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code running an automated commit-review routine over `develop`. The routine summarized the 24-hour commit window, fanned out parallel reviewer subagents (style compliance against reference packages, diff-only bug scan, logic/security scan), de-duplicated and verified findings against sibling packages, and applied only the high-signal fixes listed above. Each fix was re-read post-edit; PR-body bullets were drafted by per-issue refinement subagents.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md