### PR TITLE
fix: type `dtype` parameter as `DataType` in ndarray-base siblings

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-ndarray-like-with-data-type/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-ndarray-like-with-data-type/docs/types/index.d.ts
@@ -18,6 +18,10 @@
 
 // TypeScript Version: 4.1
 
+/// <reference types="@stdlib/types"/>
+
+import { DataType } from '@stdlib/types/ndarray';
+
 /**
 * Tests if a value is an ndarray-like object having a specified data type.
 *
@@ -36,7 +40,7 @@
 * bool = isndarrayLikeWithDataType( [], 'generic' );
 * // returns false
 */
-declare function isndarrayLikeWithDataType( v: any, dtype: any ): boolean;
+declare function isndarrayLikeWithDataType( v: any, dtype: DataType ): boolean;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/base/dtype-alignment/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/dtype-alignment/docs/types/index.d.ts
@@ -18,6 +18,10 @@
 
 // TypeScript Version: 4.1
 
+/// <reference types="@stdlib/types"/>
+
+import { DataType } from '@stdlib/types/ndarray';
+
 /**
 * Interface describing an object mapping data type strings to alignments (in bytes).
 */
@@ -39,7 +43,7 @@ interface Table {
 * out = dtypeAlignment( 'generic' );
 * // returns null
 */
-declare function dtypeAlignment( dtype: any ): number | null;
+declare function dtypeAlignment( dtype: DataType ): number | null;
 
 /**
 * Returns an object mapping data type strings to alignments.


### PR DESCRIPTION
## Description

Propagating the `dtype: any` → `dtype: DataType` fix from `f1e20349` ("fix: type `dtype` parameter as `DataType`") to two sibling declarations whose runtime accepts only `DataType`-typed inputs as exercised by the existing JSDoc examples and type tests.

- `f1e20349` ([`fix: type \`dtype\` parameter as \`DataType\``](https://github.com/stdlib-js/stdlib/commit/f1e20349616f31f14b87e403e690d9ba13550e68))
  - `@stdlib/assert/is-ndarray-like-with-data-type`
  - `@stdlib/ndarray/base/dtype-alignment`

## Related Issues

None.

## Questions

No.

## Other

Five additional `dtype: any` sites under `ndarray/base/{buffer-ctors,bytes-per-element,dtype-char,dtype2c,dtype-desc}` were inspected and excluded: their runtime accepts `Function` (struct constructors), numeric enum constants via `dtype-resolve-str`, or arbitrary objects with a `byteLength` property — inputs that `DataType` does not cover. Those sites would need a broader `DataType | number` or `DataType | Function` typing and fall outside this commit's mechanical pattern.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of a fix merged to `develop` over the prior 24 hours. The candidate sites were located via a `dtype:\s*any` search across `lib/node_modules/@stdlib/**/docs/types/index.d.ts`, then independently validated by two opus reviewer agents that read each candidate file in full; only the sites where both passes returned `confirmed` advanced. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
