### PR TITLE
build: remove Node.js v12 and v14 from `macos_test` matrix

### DIFF
--- a/.github/workflows/macos_test.yml
+++ b/.github/workflows/macos_test.yml
@@ -86,8 +86,7 @@ jobs:
 
         # Define the list of Node.js versions:
         # NODE_VERSION: ['16', '14', '12', '10', '8', '6', '4', '0.12', '0.10']
-        # Note: v12 and v14 are excluded because macOS-latest runners use Apple Silicon (arm64)
-        # and neither Node.js v12 nor v14 ship arm64/darwin binaries.
+        # Note: versions earlier than v16 are excluded because macOS-latest runners use Apple Silicon (arm64), and versions earlier than v16 do not ship arm64/darwin binaries.
         NODE_VERSION: ['16']
 
         # Define the list of operating systems:

--- a/.github/workflows/macos_test.yml
+++ b/.github/workflows/macos_test.yml
@@ -86,7 +86,9 @@ jobs:
 
         # Define the list of Node.js versions:
         # NODE_VERSION: ['16', '14', '12', '10', '8', '6', '4', '0.12', '0.10']
-        NODE_VERSION: ['16', '14', '12']
+        # Note: v12 and v14 are excluded because macOS-latest runners use Apple Silicon (arm64)
+        # and neither Node.js v12 nor v14 ship arm64/darwin binaries.
+        NODE_VERSION: ['16']
 
         # Define the list of operating systems:
         OS: ['macOS-latest']
@@ -99,11 +101,11 @@ jobs:
           - NODE_VERSION: '16'
             NPM_VERSION: '>2.7.0 <10.0.0'
 
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0 <10.0.0'
+          # - NODE_VERSION: '14'
+          #   NPM_VERSION: '>2.7.0 <10.0.0'
 
-          - NODE_VERSION: '12'
-            NPM_VERSION: '>2.7.0 <9.0.0'
+          # - NODE_VERSION: '12'
+          #   NPM_VERSION: '>2.7.0 <9.0.0'
 
           # - NODE_VERSION: '10'
           #   NPM_VERSION: '>2.7.0 <7.0.0'


### PR DESCRIPTION
Resolves #{{TODO: add issue number}}.

## Description

> What is the purpose of this pull request?

This pull request:

-   Removes Node.js v12 and v14 from the `NODE_VERSION` matrix in `.github/workflows/macos_test.yml` and comments out their corresponding `include` entries.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/27270019032

**Symptom:** The `Node.js v14` and `Node.js v12` jobs in `macos_test` fail every nightly run at the "Install Node.js" step with `Unable to find Node version '14' for platform darwin and architecture arm64.`

**Root cause:** `macOS-latest` GitHub Actions runners now provision Apple Silicon (arm64) machines. Node.js v12 and v14 predate Apple Silicon and ship no `darwin/arm64` binaries. `actions/setup-node` cannot resolve those versions on the current runner image, causing a hard failure before any tests run. This has failed on every nightly run for the past 20+ days across multiple `develop` SHAs, confirming it is a persistent environment regression, not a code regression.

**Fix:** Remove `'14'` and `'12'` from `NODE_VERSION: ['16', '14', '12']`, leaving only `'16'`. Node.js v16 has official `darwin/arm64` binaries (since April 2021) and resolves correctly on Apple Silicon. The same versions continue to be tested in `linux_test.yml` (ubuntu-latest, x64), preserving v12/v14 code-path coverage on Linux.

**Validation:** YAML syntax verified (strict `yaml.safe_load`). Three independent reviewers examined correctness, regression scope, and style:
- **Reviewer A (correctness):** Approved. Fix eliminates the v12/v14 jobs entirely; no residual failure path. v16 resolves correctly on arm64. No dangling active references to the removed versions.
- **Reviewer B (regression scope):** Approved. No other workflow references the removed matrix legs' artifacts or outputs. `linux_test.yml` retains v12/v14 coverage on Linux. `package.json` engine declarations unaffected.
- **Reviewer C (style):** Approved. Commented-out entries match the `# - NODE_VERSION` / `#   NPM_VERSION` pattern already used for v10/v8/v6/v4/v0.12/v0.10. Commit type `build:` is correct for a workflow YAML change.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{{TODO: add related issue number}}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Reviewer note (non-blocking):** The sibling workflows `macos_test_cov.yml` and `macos_benchmark.yml` contain the same `NODE_VERSION: ['16', '14', '12']` matrix declaration and will fail for the identical arm64 reason. They are not addressed here to keep each fix scoped to a single cluster.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code. The CI failure was identified by enumerating 24-hour GitHub Actions runs, confirmed as persistent via 20+ days of identical failures across distinct SHAs, and root-caused by examining the `actions/setup-node` error output. The fix was validated by three independent agent reviews (correctness, regression scope, style).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018jNV8eGma6x4JAeTUBJjHm)_