### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/ctor/package.json
@@ -68,6 +68,7 @@
     "properties",
     "props",
     "univariate",
+    "counts",
     "discrete"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/mgf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/mgf/package.json
@@ -62,6 +62,7 @@
     "generating functions",
     "moments",
     "discrete",
+    "counts",
     "poisson",
     "univariate"
   ]


### PR DESCRIPTION
## Description

Align `package.json` keyword arrays in two outlier packages of the `@stdlib/stats/base/dists/poisson` namespace with the within-namespace majority pattern. The `counts` keyword is carried by 12 of 14 sibling packages (85.7%); only `ctor` and `mgf` lack it. Both packages describe operations on a Poisson-distributed count-valued random variable, so the omission is unintentional metadata drift.

### Namespace summary

- **Target:** `@stdlib/stats/base/dists/poisson`
- **Members analyzed:** 14 (`cdf`, `ctor`, `entropy`, `kurtosis`, `logpmf`, `mean`, `median`, `mgf`, `mode`, `pmf`, `quantile`, `skewness`, `stdev`, `variance`); no autogenerated members.
- **Features analyzed:** file tree, `package.json` top-level keys / `directories` / `keywords`, README `##`/`###` heading sequence, `manifest.json` shape, `test/`/`benchmark/`/`examples/`/`lib/` filenames, `lib/main.js` public signature, return kind, validation prologue, error construction, JSDoc shape, and `require()` dependency set.
- **Features with clear majority (≥75%):** `package.json` top-level key set (18 keys, 14/14); `directories` keys `benchmark`/`doc`/`example`/`lib`/`test` (14/14); README sections `## Usage` and `## Examples` (14/14); nine namespace-wide keywords (`stdlib`, `stdmath`, `statistics`, `stats`, `distribution`, `dist`, `discrete`, `poisson`, `univariate` — each 14/14); `counts` keyword (12/14 = 85.7%); `returnKind: value` (14/14); JSDoc `@example` present (14/14); `test/test.js`, `examples/index.js`, `lib/index.js`, `docs/repl.txt`, `docs/types/index.d.ts` (14/14).
- **Features without clear majority (excluded from drift detection):** native-bindings file group (`manifest.json`, `binding.gyp`, `include.gypi`, `src/**`, `lib/native.js`, `benchmark/c/**`, `examples/c/**`, `test/test.native.js`) at 11/14 = 78.6% — above threshold but the missing packages (`ctor` / `entropy` / `quantile`) have well-known intentional or in-progress reasons (see below); public signature shape (split between `(lambda)` summary stats, `(x, lambda)` mass-function family, `(t, lambda)` MGF, `(p, lambda)` quantile, `(lambda?)` constructor — no shape ≥75%); validation `lambda` predicate (8 use `lambda < 0`, 3 use `lambda <= 0`, 1 delegates — semantically motivated, not drift); error construction (only `ctor` throws — `format`; the rest return `NaN`).

### `stats/base/dists/poisson/mgf`

Adds `counts` keyword to `package.json`, bringing `mgf` into conformance with 12 of 14 siblings in the Poisson namespace (85.7% carry the keyword; only `mgf` and `ctor` lack it). The keyword is inserted between `discrete` and `poisson`, matching the ordering convention established by `pmf`, `logpmf`, and `quantile`. Semantically justified: the MGF characterizes the distribution of a count-valued random variable. Metadata-only change; no source, tests, or behavior affected.

### `stats/base/dists/poisson/ctor`

Adds `counts` to the `keywords` array in `package.json`, bringing `@stdlib/stats/base/dists/poisson/ctor` into conformance with 12 of its 14 namespace siblings (85.7%). The keyword is inserted between `univariate` and `discrete`, matching the ordering convention established by `mean`, `variance`, `mode`, and other summary-statistic packages in the namespace. No source, tests, or behavior are affected; this is a metadata-only change.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

### Validation

Checked:

- Structural feature extraction across all 14 members (file tree, `package.json` shape, `keywords`, `directories`, `manifest.json` shape, README headings, `test/`/`benchmark/`/`examples/`/`lib/` filenames).
- Semantic feature extraction across all 14 members by reading each `lib/main.js` and `lib/index.js` directly (public signature, validation prologue, error construction, JSDoc shape, dependency set).
- Three-agent drift validation on the `counts`-keyword candidate corrections:
  - opus semantic-review confirmed both `mgf` and `ctor` describe operations on the same count-valued Poisson random variable as the 12 conformers; the absence is unintentional drift, not an intentional semantic deviation.
  - opus cross-reference verified no test, example, type-declaration, or sibling-package documentation reads or asserts on the keyword array contents. Keywords are consumed only as a search-index free-text blob, so the addition breaks no documented API contract.
  - sonnet structural-review confirmed canonical insertion positions consistent with sibling convention (between `discrete` and `poisson` for `mgf`; between `univariate` and `discrete` for `ctor`).
- Cross-run dedup: no open or recently merged PR proposes `counts` keyword additions to either package. Open PR [#10874](https://github.com/stdlib-js/stdlib/pull/10874) adds a C implementation for `poisson/entropy` (orthogonal); doc-propagation PR [#12677](https://github.com/stdlib-js/stdlib/pull/12677) only touches `poisson/mgf/lib/factory.js` wording (orthogonal). Sibling-namespace drift PR [#11902](https://github.com/stdlib-js/stdlib/pull/11902) targets `stats/base/dists/binomial` and is the precedent for the analogous `successes`/`independent trials`/`exponential family` keyword adds.

Deliberately excluded:

- Native-bindings file group on `ctor`/`entropy`/`quantile` (11/14 = 78.6%). `ctor` is a pure JS class with no numerical kernel to compile; `entropy` has an open native-implementation PR ([#10874](https://github.com/stdlib-js/stdlib/pull/10874)) in flight; `quantile` lacks a C implementation today. Treated as intentional / WIP rather than mechanical drift.
- `## C APIs` README section on `ctor`/`entropy`/`quantile` (12/14 = 85.7%). Same reason as above — the section only exists where a native implementation is present.
- `ctor` README structure (`## Usage` → `## poisson` → `### Writable Properties` / `### Computed Properties` / `### Methods` → `## Examples`) deviates from the canonical `## Usage` → `## Examples` ordering. Marked **intentional deviation**: a class constructor's documentation surface legitimately requires intermediate property/method subsections, matching the precedent set by every other distribution `ctor` in `stats/base/dists/*`.
- `test/fixtures/julia/REQUIRE` and `test/fixtures/julia/runner.jl` absent on `ctor` only (13/14 = 92.9%). Marked **intentional deviation**: the constructor has no numerical formula to compare against a Julia reference.
- `stdev/lib/main.js` empty validation prologue: delegates to `sqrt( variance( lambda ) )` — `variance` already performs validation, and `sqrt(NaN) === NaN` preserves observable behavior. Same idiom used by `binomial/stdev`, `pareto-type1/stdev`, `lognormal/stdev`. Intentional.
- `mgf`/`kurtosis`/`skewness` use `lambda <= 0` instead of the more common `lambda < 0` validation. Reflects a real semantic difference (the latter functions diverge at `lambda = 0`); changing it would alter observable behavior. Out of scope for mechanical drift.
- Public signature shapes vary by function family (`(lambda)` for summary statistics; `(x, lambda)` for the mass-function family; `(t, lambda)` for MGF; `(p, lambda)` for quantile; `(lambda?)` for the constructor) — no shape reaches 75%, so excluded from drift detection.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: structural and semantic features were extracted from every member of `stats/base/dists/poisson`, majority patterns were computed at the 75% conformance threshold, and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed each correction was high-signal mechanical drift before any file was edited. All edits are pure `package.json` `keywords` string insertions; no source, behavior, test, doc, or generator output is touched.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTDk7njsoJZcJCmcRNwFoi)_