### PR TITLE
docs: add missing tag and fix description

### DIFF
--- a/lib/node_modules/@stdlib/number/float16/base/from-word/lib/native.js
+++ b/lib/node_modules/@stdlib/number/float16/base/from-word/lib/native.js
@@ -28,6 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Creates a half-precision floating-point number from an unsigned integer corresponding to an IEEE 754 binary representation.
 *
+* @private
 * @param {uinteger16} word - unsigned integer
 * @returns {number} half-precision floating-point number
 *

--- a/lib/node_modules/@stdlib/number/float16/base/signbit/lib/native.js
+++ b/lib/node_modules/@stdlib/number/float16/base/signbit/lib/native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {number} x - input value
-* @returns {boolean} - boolean indicating if sign bit is on or off
+* @returns {boolean} boolean indicating if sign bit is on or off
 *
 * @example
 * var toFloat16 = require( '@stdlib/number/float64/base/to-float16' );


### PR DESCRIPTION
Resolves none.

## Description

Two small JSDoc corrections to native variants in `number/float16/base`, identified by comparing each `lib/native.js` against its siblings within the namespace. Both deviations match a 6-of-7 (86%) majority pattern across the C-addon subset.

### `number/float16/base/from-word`

Adds the missing `@private` JSDoc tag to the wrapped function in `lib/native.js`. Six of seven (86%) sibling `lib/native.js` files mark the wrapped function `@private` — `exponent`, `signbit`, `significand`, `to-float32`, `to-float64`, `to-word`. `from-word` was the lone outlier.

### `number/float16/base/signbit`

Removes a stray leading hyphen from the `@returns` tag in `lib/native.js`. The corrected form (`@returns {boolean} boolean indicating if sign bit is on or off`) matches the package's own `lib/main.js` and 6 of 7 (86%) sibling `lib/native.js` files. The leading-hyphen prefix is reserved for `@param` tags by stdlib JSDoc convention.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code, which compared structural and semantic features across the 12 packages in `number/float16/base` to identify clear majority patterns and surface outliers. Each correction was verified against the package's siblings and its own `lib/main.js` before being applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01XXFbsxVGmNDEHkjyjqiZmP)_