### PR TITLE
docs: add links

### DIFF
--- a/lib/node_modules/@stdlib/number/float16/base/mul/README.md
+++ b/lib/node_modules/@stdlib/number/float16/base/mul/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # mul
 
-> Multiply two half-precision floating-point numbers.
+> Multiply two [half-precision floating-point numbers][ieee754].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -107,6 +107,8 @@ logEachMap( '%d x %d = %d', x, y, mul );
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
+
+[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
 
 </section>
 

--- a/lib/node_modules/@stdlib/number/float16/base/sub/README.md
+++ b/lib/node_modules/@stdlib/number/float16/base/sub/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # sub
 
-> Subtract two half-precision floating-point numbers.
+> Subtract two [half-precision floating-point numbers][ieee754].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -109,6 +109,8 @@ logEachMap( 'x: %f, y: %f => %f', x, y, sub );
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
+
+[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
 
 </section>
 


### PR DESCRIPTION
## Description

This pull request:

-   Wraps the phrase "half-precision floating-point numbers" in the README introductions of `@stdlib/number/float16/base/mul` and `@stdlib/number/float16/base/sub` in a markdown reference link to the IEEE 754 Wikipedia article, and adds the corresponding `[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985` definition inside each package's `<section class="links">` block.

### Namespace summary

-   Namespace audited: `@stdlib/number/float16/base/` (12 non-autogenerated member packages).
-   Features extracted: file tree, `package.json` / `manifest.json` shape, README section list, test/benchmark/example file naming, plus per-package public signature, return kind, validation prologue, error construction, JSDoc shape, and dependencies (read from `lib/main.js` and `lib/index.js` for all 12 members; no `lib/validate.js` exists in any).
-   Features with a clear ≥75% majority: README `[ieee754]` link definition (9/12 = 75%); intro paragraph wrapping "half-precision floating-point number(s)" in a markdown ref link (10/12 = 83%); universal file set (`README.md`, `lib/index.js`, `lib/main.js`, `package.json`, `test/test.js`, `benchmark/benchmark.js`, `examples/index.js`, `docs/types/index.d.ts`, `docs/types/test.ts`, `docs/repl.txt`); 18 universal `package.json` keys.
-   Features excluded for no clear majority: `gypfile` / `manifest.json` / `binding.gyp` / `src/*` / `lib/native.js` / `test/test.native.js` / README "C APIs" sections (all 7/12, tracking the native-vs-pure-JS split — intentional per package); `__stdlib__.scaffold` metadata key (2/12, package-generator owned); `{uinteger16}` vs `{unsigned16}` JSDoc type (2/2 within the namespace — stdlib-wide normalization would belong in a separate run); single bench block vs `::inline` second block (11/1, removing the extra benchmark would be a regression); README "Notes" section (1/12, legitimately package-specific in `ulp-difference`).

### `@stdlib/number/float16/base/mul`

The README's one-line intro carried the plain-text phrase "half-precision floating-point numbers", and `<section class="links">` was empty. Nine of twelve siblings (75%) define `[ieee754]: …/IEEE_754-1985` in their links section, and ten (83%) wrap that phrase as a markdown reference link in the intro. Conformed `mul`'s intro and links section to the majority; no other change.

### `@stdlib/number/float16/base/sub`

Same pattern as `mul`: plain-text intro phrase, empty `<section class="links">`. Conformed both to the namespace majority (`[half-precision floating-point numbers][ieee754]` in the intro plus the link definition in the links section). Identical mechanical fix.

### Validation

-   Structural feature extraction over all 12 member packages.
-   Semantic feature extraction by direct reading of `lib/main.js` and `lib/index.js` per package.
-   Three independent agent reviews (semantic, cross-reference, structural) returned `confirmed-drift` for both `mul` and `sub`.
-   Deliberately excluded: `ulp-difference` (intro phrasing — "half-precision floating-point **values**" — is structurally different and uses a different link target by design); the `{uinteger16}` vs `{unsigned16}` JSDoc type drift (no within-namespace majority); the `__stdlib__.scaffold` metadata (generator-owned). No outlier whose tests or examples depend on the current README text was found.

## Related Issues

No.

## Questions

No.

## Other

PR #12821 is open against the same namespace but touches `from-word/lib/native.js` and `signbit/lib/native.js` — no file or content overlap with this PR.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated cross-package drift detection routine running under Claude Code. The routine enumerated the `@stdlib/number/float16/base` namespace, extracted structural and semantic features from each member package, identified the IEEE 754 link convention as a ≥75% majority pattern, flagged `mul` and `sub` as the two outliers carrying neither the intro link nor the link definition, and applied the mechanical fix to both. Three independent agent reviews (semantic, cross-reference, structural) confirmed the drift before any edit was applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017T1ySBT5nmyyhucY9wEG3B)_