### PR TITLE
refactor: replace `isMatrixTranspose` with `resolveTrans` in `*gemv` packages

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/cgemv/lib/cgemv.native.js
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/lib/cgemv.native.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
-var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operation' );
 var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string' );
 var max = require( '@stdlib/math/base/special/fast/max' );
 var resolveOrder = require( '@stdlib/blas/base/layout-resolve-enum' );
@@ -37,7 +36,7 @@ var addon = require( './../src/addon.node' );
 * Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y` or `y = α*A^H*x + β*y`, where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
 *
 * @param {string} order - storage layout
-* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {(integer|string)} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
 * @param {NonNegativeInteger} M - number of rows in the matrix `A`
 * @param {NonNegativeInteger} N - number of columns in the matrix `A`
 * @param {number} alpha - scalar constant
@@ -75,11 +74,13 @@ function cgemv( order, trans, M, N, alpha, A, LDA, x, strideX, beta, y, strideY 
 	var viewX;
 	var viewY;
 	var vala;
+	var t;
 
 	if ( !isLayout( order ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a valid order. Value: `%s`.', order ) );
 	}
-	if ( !isMatrixTranspose( trans ) ) {
+	t = resolveTrans( trans );
+	if ( t === null ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be a valid transpose operation. Value: `%s`.', trans ) );
 	}
 	if ( M < 0 ) {
@@ -109,7 +110,7 @@ function cgemv( order, trans, M, N, alpha, A, LDA, x, strideX, beta, y, strideY 
 	viewA = reinterpret( A, 0 );
 	viewX = reinterpret( x, 0 );
 	viewY = reinterpret( y, 0 );
-	addon( resolveOrder( order ), resolveTrans( trans ), M, N, alpha, viewA, LDA, viewX, strideX, beta, viewY, strideY ); // eslint-disable-line max-len
+	addon( resolveOrder( order ), t, M, N, alpha, viewA, LDA, viewX, strideX, beta, viewY, strideY ); // eslint-disable-line max-len
 	return y;
 }
 

--- a/lib/node_modules/@stdlib/blas/base/cgemv/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/cgemv/lib/ndarray.native.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operation' );
 var resolveTrans = require( '@stdlib/blas/base/transpose-operation-resolve-enum' );
 var format = require( '@stdlib/string/format' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -32,7 +31,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y` or `y = α*A^H*x + β*y`, where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
 *
-* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {(integer|string)} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
 * @param {NonNegativeInteger} M - number of rows in the matrix `A`
 * @param {NonNegativeInteger} N - number of columns in the matrix `A`
 * @param {Complex64} alpha - scalar constant
@@ -71,8 +70,10 @@ function cgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, 
 	var viewA;
 	var viewX;
 	var viewY;
+	var t;
 
-	if ( !isMatrixTranspose( trans ) ) {
+	t = resolveTrans( trans );
+	if ( t === null ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a valid transpose operation. Value: `%s`.', trans ) );
 	}
 	if ( M < 0 ) {
@@ -94,7 +95,7 @@ function cgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, 
 	viewA = reinterpret( A, 0 );
 	viewX = reinterpret( x, 0 );
 	viewY = reinterpret( y, 0 );
-	addon.ndarray( resolveTrans( trans ), M, N, alpha, viewA, strideA1, strideA2, offsetA, viewX, strideX, offsetX, beta, viewY, strideY, offsetY ); // eslint-disable-line max-len
+	addon.ndarray( t, M, N, alpha, viewA, strideA1, strideA2, offsetA, viewX, strideX, offsetX, beta, viewY, strideY, offsetY ); // eslint-disable-line max-len
 	return y;
 }
 

--- a/lib/node_modules/@stdlib/blas/base/dgemv/lib/dgemv.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/lib/dgemv.native.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
-var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operation' );
 var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string' );
 var max = require( '@stdlib/math/base/special/fast/max' );
 var resolveOrder = require( '@stdlib/blas/base/layout-resolve-enum' );
@@ -36,7 +35,7 @@ var addon = require( './../src/addon.node' );
 * Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y`, where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
 *
 * @param {string} order - storage layout
-* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {(integer|string)} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
 * @param {NonNegativeInteger} M - number of rows in the matrix `A`
 * @param {NonNegativeInteger} N - number of columns in the matrix `A`
 * @param {number} alpha - scalar constant
@@ -68,10 +67,13 @@ var addon = require( './../src/addon.node' );
 */
 function dgemv( order, trans, M, N, alpha, A, LDA, x, strideX, beta, y, strideY ) { // eslint-disable-line max-params, max-len
 	var vala;
+	var t;
+
 	if ( !isLayout( order ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a valid order. Value: `%s`.', order ) );
 	}
-	if ( !isMatrixTranspose( trans ) ) {
+	t = resolveTrans( trans );
+	if ( t === null ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be a valid transpose operation. Value: `%s`.', trans ) );
 	}
 	if ( M < 0 ) {
@@ -98,7 +100,7 @@ function dgemv( order, trans, M, N, alpha, A, LDA, x, strideX, beta, y, strideY 
 	if ( M === 0 || N === 0 || ( alpha === 0.0 && beta === 1.0 ) ) {
 		return y;
 	}
-	addon( resolveOrder( order ), resolveTrans( trans ), M, N, alpha, A, LDA, x, strideX, beta, y, strideY ); // eslint-disable-line max-len
+	addon( resolveOrder( order ), t, M, N, alpha, A, LDA, x, strideX, beta, y, strideY ); // eslint-disable-line max-len
 	return y;
 }
 

--- a/lib/node_modules/@stdlib/blas/base/dgemv/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/lib/ndarray.native.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operation' );
 var resolveTrans = require( '@stdlib/blas/base/transpose-operation-resolve-enum' );
 var format = require( '@stdlib/string/format' );
 var addon = require( './../src/addon.node' );
@@ -31,7 +30,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y`, where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
 *
-* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {(integer|string)} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
 * @param {NonNegativeInteger} M - number of rows in the matrix `A`
 * @param {NonNegativeInteger} N - number of columns in the matrix `A`
 * @param {number} alpha - scalar constant
@@ -64,7 +63,10 @@ var addon = require( './../src/addon.node' );
 * // y => <Float64Array>[ 7.0, 16.0 ]
 */
 function dgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, offsetX, beta, y, strideY, offsetY ) { // eslint-disable-line max-params, max-len
-	if ( !isMatrixTranspose( trans ) ) {
+	var t;
+
+	t = resolveTrans( trans );
+	if ( t === null ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a valid transpose operation. Value: `%s`.', trans ) );
 	}
 	if ( M < 0 ) {
@@ -83,7 +85,7 @@ function dgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, 
 	if ( M === 0 || N === 0 || ( alpha === 0.0 && beta === 1.0 ) ) {
 		return y;
 	}
-	addon.ndarray( resolveTrans( trans ), M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, offsetX, beta, y, strideY, offsetY ); // eslint-disable-line max-len
+	addon.ndarray( t, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, offsetX, beta, y, strideY, offsetY ); // eslint-disable-line max-len
 	return y;
 }
 

--- a/lib/node_modules/@stdlib/blas/base/sgemv/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/lib/ndarray.native.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operation' );
 var resolveTrans = require( '@stdlib/blas/base/transpose-operation-resolve-enum' );
 var format = require( '@stdlib/string/format' );
 var addon = require( './../src/addon.node' );
@@ -31,7 +30,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y`, where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
 *
-* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {(integer|string)} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
 * @param {NonNegativeInteger} M - number of rows in the matrix `A`
 * @param {NonNegativeInteger} N - number of columns in the matrix `A`
 * @param {number} alpha - scalar constant
@@ -64,7 +63,10 @@ var addon = require( './../src/addon.node' );
 * // y => <Float32Array>[ 7.0, 16.0 ]
 */
 function sgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, offsetX, beta, y, strideY, offsetY ) { // eslint-disable-line max-params, max-len
-	if ( !isMatrixTranspose( trans ) ) {
+	var t;
+
+	t = resolveTrans( trans );
+	if ( t === null ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a valid transpose operation. Value: `%s`.', trans ) );
 	}
 	if ( M < 0 ) {
@@ -83,7 +85,7 @@ function sgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, 
 	if ( M === 0 || N === 0 || ( alpha === 0.0 && beta === 1.0 ) ) {
 		return y;
 	}
-	addon.ndarray( resolveTrans( trans ), M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, offsetX, beta, y, strideY, offsetY ); // eslint-disable-line max-len
+	addon.ndarray( t, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, offsetX, beta, y, strideY, offsetY ); // eslint-disable-line max-len
 	return y;
 }
 

--- a/lib/node_modules/@stdlib/blas/base/sgemv/lib/sgemv.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sgemv/lib/sgemv.native.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
-var isMatrixTranspose = require( '@stdlib/blas/base/assert/is-transpose-operation' );
 var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string' );
 var max = require( '@stdlib/math/base/special/fast/max' );
 var resolveOrder = require( '@stdlib/blas/base/layout-resolve-enum' );
@@ -36,7 +35,7 @@ var addon = require( './../src/addon.node' );
 * Performs one of the matrix-vector operations `y = α*A*x + β*y` or `y = α*A^T*x + β*y`, where `α` and `β` are scalars, `x` and `y` are vectors, and `A` is an `M` by `N` matrix.
 *
 * @param {string} order - storage layout
-* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {(integer|string)} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
 * @param {NonNegativeInteger} M - number of rows in the matrix `A`
 * @param {NonNegativeInteger} N - number of columns in the matrix `A`
 * @param {number} alpha - scalar constant
@@ -68,10 +67,13 @@ var addon = require( './../src/addon.node' );
 */
 function sgemv( order, trans, M, N, alpha, A, LDA, x, strideX, beta, y, strideY ) { // eslint-disable-line max-params, max-len
 	var vala;
+	var t;
+
 	if ( !isLayout( order ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a valid order. Value: `%s`.', order ) );
 	}
-	if ( !isMatrixTranspose( trans ) ) {
+	t = resolveTrans( trans );
+	if ( t === null ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be a valid transpose operation. Value: `%s`.', trans ) );
 	}
 	if ( M < 0 ) {
@@ -98,7 +100,7 @@ function sgemv( order, trans, M, N, alpha, A, LDA, x, strideX, beta, y, strideY 
 	if ( M === 0 || N === 0 || ( alpha === 0.0 && beta === 1.0 ) ) {
 		return y;
 	}
-	addon( resolveOrder( order ), resolveTrans( trans ), M, N, alpha, A, LDA, x, strideX, beta, y, strideY ); // eslint-disable-line max-len
+	addon( resolveOrder( order ), t, M, N, alpha, A, LDA, x, strideX, beta, y, strideY ); // eslint-disable-line max-len
 	return y;
 }
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: na
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #{{TODO: add issue number}}.

## Description

refactor: replace `isMatrixTranspose` with `resolveTrans` in native `*gemv`

This pull request:

 This PR fixes an API inconsistency between the JavaScript and native implementations of `cgemv`, `dgemv`, and `sgemv` (including their `ndarray` variants).

Previously, the native wrappers validated the trans argument using `isMatrixTranspose`, which only accepts string values. As a result, valid integer enums would work in the JavaScript implementations but fail with a TypeError when using the native add-ons.

This PR removes the redundant validation and relies on `resolveTrans` for both validation and conversion. Since `resolveTrans` supports both strings and integer enums, the native and JavaScript implementations now behave consistently.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{{TODO: add related issue number}}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
