### PR TITLE
docs: replace "array" with "ndarray" in various type declarations

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/docs/types/index.d.ts
@@ -1935,7 +1935,7 @@ interface Namespace {
 	* @param dtype - underlying data type
 	* @param shape - array shape
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-	* @returns `false`-filled array
+	* @returns `false`-filled ndarray
 	*
 	* @example
 	* var getDType = require( '@stdlib/ndarray/dtype' );
@@ -3082,12 +3082,12 @@ interface Namespace {
 	minmaxViewBufferIndex: typeof minmaxViewBufferIndex;
 
 	/**
-	* Creates a NaN-filled array having a specified shape and data type.
+	* Creates a NaN-filled ndarray having a specified shape and data type.
 	*
 	* @param dtype - underlying data type
 	* @param shape - array shape
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-	* @returns NaN-filled array
+	* @returns NaN-filled ndarray
 	*
 	* @example
 	* var getDType = require( '@stdlib/ndarray/dtype' );
@@ -3101,10 +3101,10 @@ interface Namespace {
 	nans: typeof nans;
 
 	/**
-	* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+	* Creates a NaN-filled ndarray having the same shape and data type as a provided input ndarray.
 	*
 	* @param x - input array
-	* @returns NaN-filled array
+	* @returns NaN-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -3501,12 +3501,12 @@ interface Namespace {
 	nullaryBlockSize: typeof nullaryBlockSize;
 
 	/**
-	* Creates a null-filled array having a specified shape and data type.
+	* Creates a null-filled ndarray having a specified shape and data type.
 	*
 	* @param dtype - underlying data type
 	* @param shape - array shape
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-	* @returns null-filled array
+	* @returns null-filled ndarray
 	*
 	* @example
 	* var getDType = require( '@stdlib/ndarray/dtype' );
@@ -3520,10 +3520,10 @@ interface Namespace {
 	nulls: typeof nulls;
 
 	/**
-	* Creates a null-filled array having the same shape and data type as a provided input ndarray.
+	* Creates a null-filled ndarray having the same shape and data type as a provided input ndarray.
 	*
 	* @param x - input array
-	* @returns null-filled array
+	* @returns null-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -3594,12 +3594,12 @@ interface Namespace {
 	offset: typeof offset;
 
 	/**
-	* Creates a ones-filled array having a specified shape and data type.
+	* Creates a ones-filled ndarray having a specified shape and data type.
 	*
 	* @param dtype - underlying data type
 	* @param shape - array shape
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-	* @returns ones-filled array
+	* @returns ones-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -3617,10 +3617,10 @@ interface Namespace {
 	ones: typeof ones;
 
 	/**
-	* Creates a ones-filled array having the same shape and data type as a provided input ndarray.
+	* Creates a ones-filled ndarray having the same shape and data type as a provided input ndarray.
 	*
 	* @param x - input array
-	* @returns ones-filled array
+	* @returns ones-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -5590,7 +5590,7 @@ interface Namespace {
 	* @param dtype - underlying data type
 	* @param shape - array shape
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-	* @returns `true`-filled array
+	* @returns `true`-filled ndarray
 	*
 	* @example
 	* var getDType = require( '@stdlib/ndarray/dtype' );
@@ -6272,12 +6272,12 @@ interface Namespace {
 	wrapIndex: typeof wrapIndex;
 
 	/**
-	* Creates a zero-filled array having a specified shape and data type.
+	* Creates a zero-filled ndarray having a specified shape and data type.
 	*
 	* @param dtype - underlying data type
 	* @param shape - array shape
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-	* @returns zero-filled array
+	* @returns zero-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -6295,10 +6295,10 @@ interface Namespace {
 	zeros: typeof zeros;
 
 	/**
-	* Creates a zero-filled array having the same shape and data type as a provided input ndarray.
+	* Creates a zero-filled ndarray having the same shape and data type as a provided input ndarray.
 	*
 	* @param x - input array
-	* @returns zero-filled array
+	* @returns zero-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/base/falses/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/falses/docs/types/index.d.ts
@@ -28,7 +28,7 @@ import { Shape, Order, boolndarray, genericndarray, BooleanDataType, GenericData
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns `false`-filled array
+* @returns `false`-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );
@@ -47,7 +47,7 @@ declare function falses( dtype: BooleanDataType, shape: Shape, order: Order ): b
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns `false`-filled array
+* @returns `false`-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );

--- a/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/nans-like/docs/types/index.d.ts
@@ -23,10 +23,10 @@
 import { realcomplexndarray, genericndarray } from '@stdlib/types/ndarray';
 
 /**
-* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+* Creates a NaN-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/base/nans/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/nans/docs/types/index.d.ts
@@ -23,12 +23,12 @@
 import { Shape, Order, typedndarray, genericndarray, float64ndarray, float32ndarray, complex128ndarray, complex64ndarray, FloatingPointAndGenericDataType, GenericDataType, Float64DataType, Float32DataType, Complex128DataType, Complex64DataType } from '@stdlib/types/ndarray';
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );
@@ -42,12 +42,12 @@ import { Shape, Order, typedndarray, genericndarray, float64ndarray, float32ndar
 declare function nans( dtype: Float64DataType, shape: Shape, order: Order ): float64ndarray;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );
@@ -61,12 +61,12 @@ declare function nans( dtype: Float64DataType, shape: Shape, order: Order ): flo
 declare function nans( dtype: Float32DataType, shape: Shape, order: Order ): float32ndarray;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );
@@ -80,12 +80,12 @@ declare function nans( dtype: Float32DataType, shape: Shape, order: Order ): flo
 declare function nans( dtype: Complex128DataType, shape: Shape, order: Order ): complex128ndarray;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );
@@ -99,12 +99,12 @@ declare function nans( dtype: Complex128DataType, shape: Shape, order: Order ): 
 declare function nans( dtype: Complex64DataType, shape: Shape, order: Order ): complex64ndarray;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );
@@ -118,12 +118,12 @@ declare function nans( dtype: Complex64DataType, shape: Shape, order: Order ): c
 declare function nans( dtype: GenericDataType, shape: Shape, order: Order ): genericndarray<number>;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );

--- a/lib/node_modules/@stdlib/ndarray/base/nulls/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/nulls/docs/types/index.d.ts
@@ -23,12 +23,12 @@
 import { Shape, Order, genericndarray, GenericDataType } from '@stdlib/types/ndarray';
 
 /**
-* Creates a null-filled array having a specified shape and data type.
+* Creates a null-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns null-filled array
+* @returns null-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );

--- a/lib/node_modules/@stdlib/ndarray/base/ones-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/ones-like/docs/types/index.d.ts
@@ -24,10 +24,10 @@ import { ComplexLike } from '@stdlib/types/complex';
 import { typedndarray } from '@stdlib/types/ndarray';
 
 /**
-* Creates a ones-filled array having the same shape and data type as a provided input ndarray.
+* Creates a ones-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/base/ones/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/ones/docs/types/index.d.ts
@@ -23,12 +23,12 @@
 import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray, NumericAndGenericDataType, Float64DataType, Float32DataType, Complex128DataType, Complex64DataType, Int32DataType, Int16DataType, Int8DataType, Uint32DataType, Uint16DataType, Uint8DataType, Uint8cDataType, GenericDataType } from '@stdlib/types/ndarray';
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -46,12 +46,12 @@ import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarra
 declare function ones( dtype: Float64DataType, shape: Shape, order: Order ): float64ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -69,12 +69,12 @@ declare function ones( dtype: Float64DataType, shape: Shape, order: Order ): flo
 declare function ones( dtype: Float32DataType, shape: Shape, order: Order ): float32ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -92,12 +92,12 @@ declare function ones( dtype: Float32DataType, shape: Shape, order: Order ): flo
 declare function ones( dtype: Complex128DataType, shape: Shape, order: Order ): complex128ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -115,12 +115,12 @@ declare function ones( dtype: Complex128DataType, shape: Shape, order: Order ): 
 declare function ones( dtype: Complex64DataType, shape: Shape, order: Order ): complex64ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -138,12 +138,12 @@ declare function ones( dtype: Complex64DataType, shape: Shape, order: Order ): c
 declare function ones( dtype: Int32DataType, shape: Shape, order: Order ): int32ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -161,12 +161,12 @@ declare function ones( dtype: Int32DataType, shape: Shape, order: Order ): int32
 declare function ones( dtype: Int16DataType, shape: Shape, order: Order ): int16ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -184,12 +184,12 @@ declare function ones( dtype: Int16DataType, shape: Shape, order: Order ): int16
 declare function ones( dtype: Int8DataType, shape: Shape, order: Order ): int8ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -207,12 +207,12 @@ declare function ones( dtype: Int8DataType, shape: Shape, order: Order ): int8nd
 declare function ones( dtype: Uint32DataType, shape: Shape, order: Order ): uint32ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -230,12 +230,12 @@ declare function ones( dtype: Uint32DataType, shape: Shape, order: Order ): uint
 declare function ones( dtype: Uint16DataType, shape: Shape, order: Order ): uint16ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -253,12 +253,12 @@ declare function ones( dtype: Uint16DataType, shape: Shape, order: Order ): uint
 declare function ones( dtype: Uint8DataType, shape: Shape, order: Order ): uint8ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -276,12 +276,12 @@ declare function ones( dtype: Uint8DataType, shape: Shape, order: Order ): uint8
 declare function ones( dtype: Uint8cDataType, shape: Shape, order: Order ): uint8cndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -299,12 +299,12 @@ declare function ones( dtype: Uint8cDataType, shape: Shape, order: Order ): uint
 declare function ones( dtype: GenericDataType, shape: Shape, order: Order ): genericndarray<number>;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/base/trues/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/trues/docs/types/index.d.ts
@@ -28,7 +28,7 @@ import { Shape, Order, boolndarray, genericndarray, BooleanDataType, GenericData
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns `true`-filled array
+* @returns `true`-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );
@@ -47,7 +47,7 @@ declare function trues( dtype: BooleanDataType, shape: Shape, order: Order ): bo
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns `true`-filled array
+* @returns `true`-filled ndarray
 *
 * @example
 * var getDType = require( '@stdlib/ndarray/dtype' );

--- a/lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/index.d.ts
@@ -24,10 +24,10 @@ import { ComplexLike } from '@stdlib/types/complex';
 import { typedndarray } from '@stdlib/types/ndarray';
 
 /**
-* Creates a zero-filled array having the same shape and data type as a provided input ndarray.
+* Creates a zero-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
@@ -23,12 +23,12 @@
 import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray, NumericAndGenericDataType, Float64DataType, Float32DataType, Complex128DataType, Complex64DataType, Int32DataType, Int16DataType, Int8DataType, Uint32DataType, Uint16DataType, Uint8DataType, Uint8cDataType, GenericDataType } from '@stdlib/types/ndarray';
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -46,12 +46,12 @@ import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarra
 declare function zeros( dtype: Float64DataType, shape: Shape, order: Order ): float64ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -69,12 +69,12 @@ declare function zeros( dtype: Float64DataType, shape: Shape, order: Order ): fl
 declare function zeros( dtype: Float32DataType, shape: Shape, order: Order ): float32ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -92,12 +92,12 @@ declare function zeros( dtype: Float32DataType, shape: Shape, order: Order ): fl
 declare function zeros( dtype: Complex128DataType, shape: Shape, order: Order ): complex128ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -115,12 +115,12 @@ declare function zeros( dtype: Complex128DataType, shape: Shape, order: Order ):
 declare function zeros( dtype: Complex64DataType, shape: Shape, order: Order ): complex64ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -138,12 +138,12 @@ declare function zeros( dtype: Complex64DataType, shape: Shape, order: Order ): 
 declare function zeros( dtype: Int32DataType, shape: Shape, order: Order ): int32ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -161,12 +161,12 @@ declare function zeros( dtype: Int32DataType, shape: Shape, order: Order ): int3
 declare function zeros( dtype: Int16DataType, shape: Shape, order: Order ): int16ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -184,12 +184,12 @@ declare function zeros( dtype: Int16DataType, shape: Shape, order: Order ): int1
 declare function zeros( dtype: Int8DataType, shape: Shape, order: Order ): int8ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -207,12 +207,12 @@ declare function zeros( dtype: Int8DataType, shape: Shape, order: Order ): int8n
 declare function zeros( dtype: Uint32DataType, shape: Shape, order: Order ): uint32ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -230,12 +230,12 @@ declare function zeros( dtype: Uint32DataType, shape: Shape, order: Order ): uin
 declare function zeros( dtype: Uint16DataType, shape: Shape, order: Order ): uint16ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -253,12 +253,12 @@ declare function zeros( dtype: Uint16DataType, shape: Shape, order: Order ): uin
 declare function zeros( dtype: Uint8DataType, shape: Shape, order: Order ): uint8ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -276,12 +276,12 @@ declare function zeros( dtype: Uint8DataType, shape: Shape, order: Order ): uint
 declare function zeros( dtype: Uint8cDataType, shape: Shape, order: Order ): uint8cndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -299,12 +299,12 @@ declare function zeros( dtype: Uint8cDataType, shape: Shape, order: Order ): uin
 declare function zeros( dtype: GenericDataType, shape: Shape, order: Order ): genericndarray<number>;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param dtype - underlying data type
 * @param shape - array shape
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/docs/types/index.d.ts
@@ -2504,7 +2504,7 @@ interface Namespace {
 	mostlySafeCasts: typeof mostlySafeCasts;
 
 	/**
-	* Creates a NaN-filled array having a specified shape and data type.
+	* Creates a NaN-filled ndarray having a specified shape and data type.
 	*
 	* @param shape - array shape
 	* @param options - options
@@ -2513,7 +2513,7 @@ interface Namespace {
 	* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 	* @param options.readonly - boolean indicating whether an array should be read-only
-	* @returns NaN-filled array
+	* @returns NaN-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -2531,7 +2531,7 @@ interface Namespace {
 	nans: typeof nans;
 
 	/**
-	* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+	* Creates a NaN-filled ndarray having the same shape and data type as a provided input ndarray.
 	*
 	* @param x - input array
 	* @param options - options
@@ -2541,7 +2541,7 @@ interface Namespace {
 	* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 	* @param options.readonly - boolean indicating whether an array should be read-only
-	* @returns NaN-filled array
+	* @returns NaN-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -2687,7 +2687,7 @@ interface Namespace {
 	offset: typeof offset;
 
 	/**
-	* Creates a ones-filled array having a specified shape and data type.
+	* Creates a ones-filled ndarray having a specified shape and data type.
 	*
 	* @param shape - array shape
 	* @param options - options
@@ -2696,7 +2696,7 @@ interface Namespace {
 	* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 	* @param options.readonly - boolean indicating whether an array should be read-only
-	* @returns ones-filled array
+	* @returns ones-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -2714,7 +2714,7 @@ interface Namespace {
 	ones: typeof ones;
 
 	/**
-	* Creates a ones-filled array having the same shape and data type as a provided input ndarray.
+	* Creates a ones-filled ndarray having the same shape and data type as a provided input ndarray.
 	*
 	* @param x - input array
 	* @param options - options
@@ -2724,7 +2724,7 @@ interface Namespace {
 	* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 	* @param options.readonly - boolean indicating whether an array should be read-only
-	* @returns ones-filled array
+	* @returns ones-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -4313,7 +4313,7 @@ interface Namespace {
 	ndarrayWith: typeof ndarrayWith;
 
 	/**
-	* Creates a zero-filled array having a specified shape and data type.
+	* Creates a zero-filled ndarray having a specified shape and data type.
 	*
 	* @param shape - array shape
 	* @param options - options
@@ -4322,7 +4322,7 @@ interface Namespace {
 	* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 	* @param options.readonly - boolean indicating whether an array should be read-only
-	* @returns zero-filled array
+	* @returns zero-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );
@@ -4340,7 +4340,7 @@ interface Namespace {
 	zeros: typeof zeros;
 
 	/**
-	* Creates a zero-filled array having the same shape and data type as a provided input ndarray.
+	* Creates a zero-filled ndarray having the same shape and data type as a provided input ndarray.
 	*
 	* @param x - input array
 	* @param options - options
@@ -4350,7 +4350,7 @@ interface Namespace {
 	* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 	* @param options.readonly - boolean indicating whether an array should be read-only
-	* @returns zero-filled array
+	* @returns zero-filled ndarray
 	*
 	* @example
 	* var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/nans-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/docs/types/index.d.ts
@@ -148,7 +148,7 @@ interface OptionsWithDType extends Options {
 }
 
 /**
-* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+* Creates a NaN-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
 * @param options - options
@@ -157,7 +157,7 @@ interface OptionsWithDType extends Options {
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -187,7 +187,7 @@ interface OptionsWithDType extends Options {
 declare function nansLike<T extends genericndarray<any> | typedndarray<number | ComplexLike>>( x: T, options?: Options ): T;
 
 /**
-* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+* Creates a NaN-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
 * @param options - options
@@ -196,7 +196,7 @@ declare function nansLike<T extends genericndarray<any> | typedndarray<number | 
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -236,7 +236,7 @@ declare function nansLike( x: genericndarray<any>, options?: Options ): genericn
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -278,7 +278,7 @@ declare function nansLike( x: ndarray, options: Float64Options ): float64ndarray
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -320,7 +320,7 @@ declare function nansLike( x: ndarray, options: Float32Options ): float32ndarray
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -362,7 +362,7 @@ declare function nansLike( x: ndarray, options: Complex128Options ): complex128n
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -404,7 +404,7 @@ declare function nansLike( x: ndarray, options: Complex64Options ): complex64nda
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -436,7 +436,7 @@ declare function nansLike( x: ndarray, options: Complex64Options ): complex64nda
 declare function nansLike( x: ndarray, options: GenericOptions ): genericndarray<number>;
 
 /**
-* Creates a NaN-filled array having the same shape and data type as a provided input ndarray.
+* Creates a NaN-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
 * @param options - options
@@ -446,7 +446,7 @@ declare function nansLike( x: ndarray, options: GenericOptions ): genericndarray
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/nans/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/nans/docs/types/index.d.ts
@@ -136,7 +136,7 @@ interface OptionsWithDType extends Options {
 }
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -145,7 +145,7 @@ interface OptionsWithDType extends Options {
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -165,7 +165,7 @@ interface OptionsWithDType extends Options {
 declare function nans( shape: Shape | number, options: Float64Options ): float64ndarray;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -174,7 +174,7 @@ declare function nans( shape: Shape | number, options: Float64Options ): float64
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -194,7 +194,7 @@ declare function nans( shape: Shape | number, options: Float64Options ): float64
 declare function nans( shape: Shape | number, options: Float32Options ): float32ndarray;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -203,7 +203,7 @@ declare function nans( shape: Shape | number, options: Float32Options ): float32
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -223,7 +223,7 @@ declare function nans( shape: Shape | number, options: Float32Options ): float32
 declare function nans( shape: Shape | number, options: Complex128Options ): complex128ndarray;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -232,7 +232,7 @@ declare function nans( shape: Shape | number, options: Complex128Options ): comp
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -252,7 +252,7 @@ declare function nans( shape: Shape | number, options: Complex128Options ): comp
 declare function nans( shape: Shape | number, options: Complex64Options ): complex64ndarray;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -261,7 +261,7 @@ declare function nans( shape: Shape | number, options: Complex64Options ): compl
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -281,7 +281,7 @@ declare function nans( shape: Shape | number, options: Complex64Options ): compl
 declare function nans( shape: Shape | number, options: GenericOptions ): genericndarray<number>;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -290,7 +290,7 @@ declare function nans( shape: Shape | number, options: GenericOptions ): generic
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -308,7 +308,7 @@ declare function nans( shape: Shape | number, options: GenericOptions ): generic
 declare function nans( shape: Shape | number, options?: Options ): float64ndarray;
 
 /**
-* Creates a NaN-filled array having a specified shape and data type.
+* Creates a NaN-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -317,7 +317,7 @@ declare function nans( shape: Shape | number, options?: Options ): float64ndarra
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns NaN-filled array
+* @returns NaN-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/ones-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/docs/types/index.d.ts
@@ -246,7 +246,7 @@ interface OptionsWithDType extends Options {
 }
 
 /**
-* Creates a ones-filled array having the same shape and data type as a provided input ndarray.
+* Creates a ones-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
 * @param options - options
@@ -255,7 +255,7 @@ interface OptionsWithDType extends Options {
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -285,7 +285,7 @@ interface OptionsWithDType extends Options {
 declare function onesLike<T extends genericndarray<any> | typedndarray<number | ComplexLike>>( x: T, options?: Options ): T;
 
 /**
-* Creates a ones-filled array having the same shape and data type as a provided input ndarray.
+* Creates a ones-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
 * @param options - options
@@ -294,7 +294,7 @@ declare function onesLike<T extends genericndarray<any> | typedndarray<number | 
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -334,7 +334,7 @@ declare function onesLike( x: genericndarray<any>, options?: Options ): genericn
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -376,7 +376,7 @@ declare function onesLike( x: ndarray, options: Float64Options ): float64ndarray
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -418,7 +418,7 @@ declare function onesLike( x: ndarray, options: Float32Options ): float32ndarray
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -460,7 +460,7 @@ declare function onesLike( x: ndarray, options: Complex128Options ): complex128n
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -502,7 +502,7 @@ declare function onesLike( x: ndarray, options: Complex64Options ): complex64nda
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -544,7 +544,7 @@ declare function onesLike( x: ndarray, options: Int32Options ): int32ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -586,7 +586,7 @@ declare function onesLike( x: ndarray, options: Int16Options ): int16ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -628,7 +628,7 @@ declare function onesLike( x: ndarray, options: Int8Options ): int8ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -670,7 +670,7 @@ declare function onesLike( x: ndarray, options: Uint32Options ): uint32ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -712,7 +712,7 @@ declare function onesLike( x: ndarray, options: Uint16Options ): uint16ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -754,7 +754,7 @@ declare function onesLike( x: ndarray, options: Uint8Options ): uint8ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -796,7 +796,7 @@ declare function onesLike( x: ndarray, options: Uint8COptions ): uint8cndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -828,7 +828,7 @@ declare function onesLike( x: ndarray, options: Uint8COptions ): uint8cndarray;
 declare function onesLike( x: ndarray, options: GenericOptions ): genericndarray<number>;
 
 /**
-* Creates a ones-filled array having the same shape and data type as a provided input ndarray.
+* Creates a ones-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
 * @param options - options
@@ -838,7 +838,7 @@ declare function onesLike( x: ndarray, options: GenericOptions ): genericndarray
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/ones/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/ones/docs/types/index.d.ts
@@ -234,7 +234,7 @@ interface OptionsWithDType extends Options {
 }
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -243,7 +243,7 @@ interface OptionsWithDType extends Options {
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -263,7 +263,7 @@ interface OptionsWithDType extends Options {
 declare function ones( shape: Shape | number, options: Float64Options ): float64ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -272,7 +272,7 @@ declare function ones( shape: Shape | number, options: Float64Options ): float64
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -292,7 +292,7 @@ declare function ones( shape: Shape | number, options: Float64Options ): float64
 declare function ones( shape: Shape | number, options: Float32Options ): float32ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -301,7 +301,7 @@ declare function ones( shape: Shape | number, options: Float32Options ): float32
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -321,7 +321,7 @@ declare function ones( shape: Shape | number, options: Float32Options ): float32
 declare function ones( shape: Shape | number, options: Complex128Options ): complex128ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -330,7 +330,7 @@ declare function ones( shape: Shape | number, options: Complex128Options ): comp
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -350,7 +350,7 @@ declare function ones( shape: Shape | number, options: Complex128Options ): comp
 declare function ones( shape: Shape | number, options: Complex64Options ): complex64ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -359,7 +359,7 @@ declare function ones( shape: Shape | number, options: Complex64Options ): compl
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -379,7 +379,7 @@ declare function ones( shape: Shape | number, options: Complex64Options ): compl
 declare function ones( shape: Shape | number, options: Int32Options ): int32ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -388,7 +388,7 @@ declare function ones( shape: Shape | number, options: Int32Options ): int32ndar
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -408,7 +408,7 @@ declare function ones( shape: Shape | number, options: Int32Options ): int32ndar
 declare function ones( shape: Shape | number, options: Int16Options ): int16ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -417,7 +417,7 @@ declare function ones( shape: Shape | number, options: Int16Options ): int16ndar
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -437,7 +437,7 @@ declare function ones( shape: Shape | number, options: Int16Options ): int16ndar
 declare function ones( shape: Shape | number, options: Int8Options ): int8ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -446,7 +446,7 @@ declare function ones( shape: Shape | number, options: Int8Options ): int8ndarra
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -466,7 +466,7 @@ declare function ones( shape: Shape | number, options: Int8Options ): int8ndarra
 declare function ones( shape: Shape | number, options: Uint32Options ): uint32ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -475,7 +475,7 @@ declare function ones( shape: Shape | number, options: Uint32Options ): uint32nd
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -495,7 +495,7 @@ declare function ones( shape: Shape | number, options: Uint32Options ): uint32nd
 declare function ones( shape: Shape | number, options: Uint16Options ): uint16ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -504,7 +504,7 @@ declare function ones( shape: Shape | number, options: Uint16Options ): uint16nd
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -524,7 +524,7 @@ declare function ones( shape: Shape | number, options: Uint16Options ): uint16nd
 declare function ones( shape: Shape | number, options: Uint8Options ): uint8ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -533,7 +533,7 @@ declare function ones( shape: Shape | number, options: Uint8Options ): uint8ndar
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -553,7 +553,7 @@ declare function ones( shape: Shape | number, options: Uint8Options ): uint8ndar
 declare function ones( shape: Shape | number, options: Uint8COptions ): uint8cndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -562,7 +562,7 @@ declare function ones( shape: Shape | number, options: Uint8COptions ): uint8cnd
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -582,7 +582,7 @@ declare function ones( shape: Shape | number, options: Uint8COptions ): uint8cnd
 declare function ones( shape: Shape | number, options: GenericOptions ): genericndarray<number>;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -591,7 +591,7 @@ declare function ones( shape: Shape | number, options: GenericOptions ): generic
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -609,7 +609,7 @@ declare function ones( shape: Shape | number, options: GenericOptions ): generic
 declare function ones( shape: Shape | number, options?: Options ): float64ndarray;
 
 /**
-* Creates a ones-filled array having a specified shape and data type.
+* Creates a ones-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -618,7 +618,7 @@ declare function ones( shape: Shape | number, options?: Options ): float64ndarra
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns ones-filled array
+* @returns ones-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/zeros-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/zeros-like/docs/types/index.d.ts
@@ -246,7 +246,7 @@ interface OptionsWithDType extends Options {
 }
 
 /**
-* Creates a zero-filled array having the same shape and data type as a provided input ndarray.
+* Creates a zero-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
 * @param options - options
@@ -255,7 +255,7 @@ interface OptionsWithDType extends Options {
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -285,7 +285,7 @@ interface OptionsWithDType extends Options {
 declare function zerosLike<T extends genericndarray<any> | typedndarray<number | ComplexLike>>( x: T, options?: Options ): T;
 
 /**
-* Creates a zero-filled array having the same shape and data type as a provided input ndarray.
+* Creates a zero-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
 * @param options - options
@@ -294,7 +294,7 @@ declare function zerosLike<T extends genericndarray<any> | typedndarray<number |
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -334,7 +334,7 @@ declare function zerosLike( x: genericndarray<any>, options?: Options ): generic
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -376,7 +376,7 @@ declare function zerosLike( x: ndarray, options: Float64Options ): float64ndarra
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -418,7 +418,7 @@ declare function zerosLike( x: ndarray, options: Float32Options ): float32ndarra
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -460,7 +460,7 @@ declare function zerosLike( x: ndarray, options: Complex128Options ): complex128
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -502,7 +502,7 @@ declare function zerosLike( x: ndarray, options: Complex64Options ): complex64nd
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -544,7 +544,7 @@ declare function zerosLike( x: ndarray, options: Int32Options ): int32ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -586,7 +586,7 @@ declare function zerosLike( x: ndarray, options: Int16Options ): int16ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -628,7 +628,7 @@ declare function zerosLike( x: ndarray, options: Int8Options ): int8ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -670,7 +670,7 @@ declare function zerosLike( x: ndarray, options: Uint32Options ): uint32ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -712,7 +712,7 @@ declare function zerosLike( x: ndarray, options: Uint16Options ): uint16ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -754,7 +754,7 @@ declare function zerosLike( x: ndarray, options: Uint8Options ): uint8ndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -796,7 +796,7 @@ declare function zerosLike( x: ndarray, options: Uint8COptions ): uint8cndarray;
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -828,7 +828,7 @@ declare function zerosLike( x: ndarray, options: Uint8COptions ): uint8cndarray;
 declare function zerosLike( x: ndarray, options: GenericOptions ): genericndarray<number>;
 
 /**
-* Creates a zero-filled array having the same shape and data type as a provided input ndarray.
+* Creates a zero-filled ndarray having the same shape and data type as a provided input ndarray.
 *
 * @param x - input array
 * @param options - options
@@ -838,7 +838,7 @@ declare function zerosLike( x: ndarray, options: GenericOptions ): genericndarra
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );

--- a/lib/node_modules/@stdlib/ndarray/zeros/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/zeros/docs/types/index.d.ts
@@ -234,7 +234,7 @@ interface OptionsWithDType extends Options {
 }
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -243,7 +243,7 @@ interface OptionsWithDType extends Options {
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -263,7 +263,7 @@ interface OptionsWithDType extends Options {
 declare function zeros( shape: Shape | number, options: Float64Options ): float64ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -272,7 +272,7 @@ declare function zeros( shape: Shape | number, options: Float64Options ): float6
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -292,7 +292,7 @@ declare function zeros( shape: Shape | number, options: Float64Options ): float6
 declare function zeros( shape: Shape | number, options: Float32Options ): float32ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -301,7 +301,7 @@ declare function zeros( shape: Shape | number, options: Float32Options ): float3
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -321,7 +321,7 @@ declare function zeros( shape: Shape | number, options: Float32Options ): float3
 declare function zeros( shape: Shape | number, options: Complex128Options ): complex128ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -330,7 +330,7 @@ declare function zeros( shape: Shape | number, options: Complex128Options ): com
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -350,7 +350,7 @@ declare function zeros( shape: Shape | number, options: Complex128Options ): com
 declare function zeros( shape: Shape | number, options: Complex64Options ): complex64ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -359,7 +359,7 @@ declare function zeros( shape: Shape | number, options: Complex64Options ): comp
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -379,7 +379,7 @@ declare function zeros( shape: Shape | number, options: Complex64Options ): comp
 declare function zeros( shape: Shape | number, options: Int32Options ): int32ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -388,7 +388,7 @@ declare function zeros( shape: Shape | number, options: Int32Options ): int32nda
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -408,7 +408,7 @@ declare function zeros( shape: Shape | number, options: Int32Options ): int32nda
 declare function zeros( shape: Shape | number, options: Int16Options ): int16ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -417,7 +417,7 @@ declare function zeros( shape: Shape | number, options: Int16Options ): int16nda
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -437,7 +437,7 @@ declare function zeros( shape: Shape | number, options: Int16Options ): int16nda
 declare function zeros( shape: Shape | number, options: Int8Options ): int8ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -446,7 +446,7 @@ declare function zeros( shape: Shape | number, options: Int8Options ): int8ndarr
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -466,7 +466,7 @@ declare function zeros( shape: Shape | number, options: Int8Options ): int8ndarr
 declare function zeros( shape: Shape | number, options: Uint32Options ): uint32ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -475,7 +475,7 @@ declare function zeros( shape: Shape | number, options: Uint32Options ): uint32n
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -495,7 +495,7 @@ declare function zeros( shape: Shape | number, options: Uint32Options ): uint32n
 declare function zeros( shape: Shape | number, options: Uint16Options ): uint16ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -504,7 +504,7 @@ declare function zeros( shape: Shape | number, options: Uint16Options ): uint16n
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -524,7 +524,7 @@ declare function zeros( shape: Shape | number, options: Uint16Options ): uint16n
 declare function zeros( shape: Shape | number, options: Uint8Options ): uint8ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -533,7 +533,7 @@ declare function zeros( shape: Shape | number, options: Uint8Options ): uint8nda
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -553,7 +553,7 @@ declare function zeros( shape: Shape | number, options: Uint8Options ): uint8nda
 declare function zeros( shape: Shape | number, options: Uint8COptions ): uint8cndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -562,7 +562,7 @@ declare function zeros( shape: Shape | number, options: Uint8COptions ): uint8cn
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -582,7 +582,7 @@ declare function zeros( shape: Shape | number, options: Uint8COptions ): uint8cn
 declare function zeros( shape: Shape | number, options: GenericOptions ): genericndarray<number>;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -591,7 +591,7 @@ declare function zeros( shape: Shape | number, options: GenericOptions ): generi
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );
@@ -609,7 +609,7 @@ declare function zeros( shape: Shape | number, options: GenericOptions ): generi
 declare function zeros( shape: Shape | number, options?: Options ): float64ndarray;
 
 /**
-* Creates a zero-filled array having a specified shape and data type.
+* Creates a zero-filled ndarray having a specified shape and data type.
 *
 * @param shape - array shape
 * @param options - options
@@ -618,7 +618,7 @@ declare function zeros( shape: Shape | number, options?: Options ): float64ndarr
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
 * @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param options.readonly - boolean indicating whether an array should be read-only
-* @returns zero-filled array
+* @returns zero-filled ndarray
 *
 * @example
 * var getShape = require( '@stdlib/ndarray/shape' );


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between `8477cf466` (2026-06-10 22:43 -0700) and `6b79aece2` (2026-06-10 23:39 -0700) to sibling packages with the same underlying defect.

### Pattern: replace `array` with `ndarray` in `*-filled` JSDoc descriptions

Source commit `8477cf466` corrected `Creates a null-filled array having ...` to `Creates a null-filled ndarray having ...`, plus the matching `@returns null-filled array` → `@returns null-filled ndarray`, in `ndarray/base/nulls-like/docs/types/index.d.ts`. The identical defect — an ndarray-returning function described in `.d.ts` JSDoc as creating or returning an "array" — exists across 17 sibling `docs/types/index.d.ts` files spanning the `zeros`, `ones`, `nans`, `nulls`, `falses`, `trues`, and their `-like` variants under `ndarray/` and `ndarray/base/`, plus the two umbrella declaration files. The per-package README and `lib/main.js` already use "ndarray"; the `.d.ts` was the outlier in each case. 223 substitutions: 94 description lines and 129 `@returns` lines.

- `8477cf466` ([`docs: fix descriptions in \`ndarray/base/nulls-like\``](https://github.com/stdlib-js/stdlib/commit/8477cf466ddfda9e00d3cf246d16f1bc8499943c))
  - `@stdlib/ndarray/zeros-like`
  - `@stdlib/ndarray/ones-like`
  - `@stdlib/ndarray/nans-like`
  - `@stdlib/ndarray/zeros`
  - `@stdlib/ndarray/ones`
  - `@stdlib/ndarray/nans`
  - `@stdlib/ndarray` (umbrella `docs/types/index.d.ts`)
  - `@stdlib/ndarray/base/zeros-like`
  - `@stdlib/ndarray/base/ones-like`
  - `@stdlib/ndarray/base/nans-like`
  - `@stdlib/ndarray/base/zeros`
  - `@stdlib/ndarray/base/ones`
  - `@stdlib/ndarray/base/nans`
  - `@stdlib/ndarray/base/nulls`
  - `@stdlib/ndarray/base/falses`
  - `@stdlib/ndarray/base/trues`
  - `@stdlib/ndarray/base` (umbrella `docs/types/index.d.ts`)

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Search scope:** all `lib/node_modules/@stdlib/ndarray/{,base/}**/docs/types/index.d.ts` files matching `^\s*\* Creates an? \S+-filled array having ` (description form) or `^\s*\* @returns \S+-filled array$` (return form). 19 files matched; 2 excluded (see below).
- **Two independent opus validation passes** confirmed, at each of the 17 candidate sites: (a) the surrounding `declare function ...(...): *ndarray` signature returns an ndarray, (b) the per-package `README.md` and `lib/main.js` already use "ndarray" in the equivalent description (the `.d.ts` was the outlier), (c) no auto-generated marker is present, (d) no legitimate `array` reference (`@param x - input array`, `@param shape - array shape`, ``// returns <Float32Array>``) was touched.
- **Style consistency** is preserved by construction: the two regex anchors guarantee identical text substitution (`array` → `ndarray`) with no surrounding rewrites.

Deliberately excluded:

- `ndarray/empty/docs/types/index.d.ts:582` and `ndarray/base/empty/docs/types/index.d.ts:266` each contain a single `Creates a zero-filled array having a specified shape and data type.` line for the `dtype: 'generic'` overload of `empty`. The line is a copy-paste defect distinct from the source pattern (`empty` is documented as creating uninitialized memory, so "zero-filled" itself is questionable). The second validation pass flagged these as `needs-human`; dropped per the routine.
- `ndarray/{empty,empty-like}/docs/types/index.d.ts` and the `base/` counterparts have many `Creates an uninitialized [typed] array having ...` and `@returns output array` lines. The defect class is the same (function returns ndarray, doc says "array"), but the source commit's mechanical signature is `\S+-filled array`, not `uninitialized [...] array` or `output array`. A follow-up source commit in the `empty*` namespace establishing the canonical phrasing would unlock these on a future run.
- `blas/base/{dtrmv,strmv,dtrsv,strsv}` siblings of the `*gemv` `isMatrixTranspose` → `resolveTrans` refactor (`2c69cdd44`): these packages use the canonical `isTransposeOperation` (not the alias) and have no `.native.js` variants, so the source pattern's "swap separate validate+resolve for combined `resolveTrans` + null check before the native addon call" does not apply.
- The `// note:` → `// NOTE:` comment-style cleanup hinted at by `4dd901bb3` (206 occurrences across 71 files) — volume is unsuited to this routine's per-window cadence; better as a dedicated lint sweep.
- The four `test:` ULP-migration commits (`6b79aece2`, `8117e16e8`, `595660167`, `ba00d5ef5`): tracked via issue #11352 with maintainer-paced per-package PRs; bulk propagation would conflict with that workflow.
- Generator-owned related-packages metadata (`4b35470b5`) and the previous-day propagation commit (`cae533579`).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalisable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two opus validation passes plus a style-consistency check) before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01XB2bfrpVV63xM1BoiSWBEj)_