### PR TITLE
fix(@stdlib/string/base/atob): prevent ReferenceError on load in Node.js < 16

### DIFF
--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -20,7 +20,7 @@
 
 // MAIN //
 
-var main = ( typeof atob === 'function' ) ? atob : null;
+var main = ( typeof atob === 'function' ) ? atob : null; // eslint-disable-line n/no-unsupported-features/node-builtins
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MAIN //
+
+var main = ( typeof atob === 'function' ) ? atob : null;
+
+
 // EXPORTS //
 
-module.exports = atob;
+module.exports = main;


### PR DESCRIPTION
## Description

This pull request:

-   Fixes `lib/node_modules/@stdlib/string/base/atob/lib/global.js` to guard the `atob` global reference with `typeof` before exporting, preventing a `ReferenceError` on module load in Node.js < 16.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/27340838876

**Symptom:** The `Node.js v12` and `Node.js v14` jobs in `linux_test` fail every nightly run with:

```
ReferenceError: atob is not defined
    at Object.<anonymous> (.../string/base/atob/lib/global.js:23:18)
```

This has reproduced on every run for 30+ consecutive `develop` SHAs.

**Root cause:** `global.js` exported the bare identifier `atob` directly:

```js
module.exports = atob;
```

In JavaScript, evaluating an undeclared identifier throws a `ReferenceError` at module load time. `atob` was added as a global to Node.js in v16; on v12/v14 it does not exist. Because `index.js` eagerly `require`s `./main.js` (which in turn loads `global.js`) before the `hasAtobSupport()` routing check, the throw happens unconditionally on those runtimes — even though the polyfill path would have been selected.

**Fix:** Replace the bare reference with a `typeof` guard, identical to the pattern already used by `@stdlib/assert/has-atob-support/lib/atob.js`:

```js
var main = ( typeof atob === 'function' ) ? atob : null;
module.exports = main;
```

In environments with `atob` (Node.js >= 16, modern browsers), the native function is exported as before. In environments without it, `null` is exported; `main.js` catches the resulting `TypeError` from `null(str)` and returns `null` via its existing try/catch, consistent with its contract.

## Related Issues

This pull request has the following related issues:

-   No open issue on file; identified via automated CI failure analysis on 2026-06-11.

## Questions

No.

## Other

**Validation:** Module loads without error with `atob` removed from globals (verified by deleting `global.atob` before requiring). Encoding/decoding smoke test passes on Node.js v22. Three independent agent reviews (correctness, regression scope, style) all approved with no blocking findings.

**Reviewer note (non-blocking):** The sibling workflows `linux_test` also run Node.js v12 where `atob` is absent; this fix resolves those jobs as well. The Node.js v16 `linux_test` failure (a floating-point tolerance issue in `@stdlib/stats/incr/mpcorrdist`) is addressed by the separate draft PR #12680.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code as part of an automated CI failure investigation routine. The root cause (`global.js` bare identifier) was identified by reading the failing job logs, confirmed against the sibling `has-atob-support/lib/atob.js` canonical pattern, and validated by three independent agent reviews (correctness, regression scope, style).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDBUNkdQWJAFvdwKWAsmnB)_