### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mean/package.json
@@ -60,6 +60,9 @@
     "dist",
     "parameter",
     "discrete",
+    "mean",
+    "average",
+    "avg",
     "negative",
     "binomial",
     "univariate"

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/pmf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/pmf/package.json
@@ -56,7 +56,7 @@
     "distribution",
     "dist",
     "probability",
-    "pdf",
+    "pmf",
     "density",
     "negative",
     "binomial",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request aligns two `package.json` `keywords`-array outliers in `@stdlib/stats/base/dists/negative-binomial` with the sibling discrete-distribution convention. Metadata only; no source, test, or behavioral change.

### Namespace summary

- **Target namespace:** `@stdlib/stats/base/dists/negative-binomial`
- **Member count:** 12 non-autogenerated members (`cdf`, `ctor`, `kurtosis`, `logpmf`, `mean`, `mgf`, `mode`, `pmf`, `quantile`, `skewness`, `stdev`, `variance`)
- **Features analyzed:** file tree, `package.json` top-level / `scripts` / `directories` / `keywords` shape, README `##`/`###` heading sequence, `manifest.json` shape, test/benchmark/example filenames, public signature, `returnKind`, validation prologue, `errorConstruction`, JSDoc shape, `require()` dependencies.
- **Features with clear majority (≥75%):** `package.json` top-level key set (modulo `gypfile`) — 12/12; `directories.{doc,example,lib,test,benchmark}` — 12/12; README `## Usage`/`## Examples` headings — 12/12; `examples/index.js`, `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, `benchmark/benchmark.js`, `test/test.js` presence — 12/12; 10 shared keywords (`stdlib`, `stdmath`, `statistics`, `stats`, `distribution`, `dist`, `negative`, `binomial`, `univariate`, `discrete`) — 12/12; `.d.ts` `@param r` description = "number of successes until experiment is stopped" — 12/12; `(r, p)`-signature summary-stat validation prologue `isnan(r) || isnan(p) || r <= 0.0 || p < 0.0 || p > 1.0 → NaN` — 6/6 within the summary-stat sub-cluster; "package's own function name present as a keyword" — 9/12 = 75%.
- **Features without clear majority (excluded):** `binding.gyp` / `src/` / `include/` / `manifest.json` / `lib/native.js` (7/12, tied to native-vs-JS package type); `lib/factory.js` (5/12, tied to whether the function has a factory form); `LICENSE` file at package root (2/12 present, 10/12 absent — removal is destructive, deferred); `test/julia/` vs `test/fixtures/julia/` data-fixture location (5/12 vs 1/12); `lib/main.js` JSDoc `@param r` "successes" vs "failures" (6/6 split — surfaced for a follow-up routine that aligns source-side JSDoc with `.d.ts`); per-function validation prologue across distribution functions (`cdf`, `logpmf`, `pmf`, `quantile`, `mgf` differ for sound mathematical reasons); `errorConstruction` (`ctor` uses `format`, others return NaN — intentional).

### `@stdlib/stats/base/dists/negative-binomial/mean`

Adds `mean`, `average`, and `avg` to the `keywords` array in `package.json`, bringing `@stdlib/stats/base/dists/negative-binomial/mean` into conformance with all seven sibling discrete distribution mean packages (`bernoulli/mean`, `binomial/mean`, `geometric/mean`, `hypergeometric/mean`, `poisson/mean`, `planck/mean`, `discrete-uniform/mean` — 100% ecosystem conformance). PR #12647 (merged 2026-06-07) resolved the same gap in `hypergeometric/mean` and identified this package as the remaining outlier. Insertion position (between `discrete` and `negative`) mirrors `bernoulli/mean` and `hypergeometric/mean`. Metadata-only change; no source, tests, or behavior affected.

### `@stdlib/stats/base/dists/negative-binomial/pmf`

The `keywords` array in `package.json` carries `'pdf'` instead of `'pmf'`, misclassifying the negative binomial PMF as a continuous-distribution function. This contradicts the package name, description (`Negative binomial distribution probability mass function (PMF).`), README, the sibling `negative-binomial/logpmf` package (which already carries `'pmf'`), and all seven other discrete-distribution `pmf` packages in the ecosystem (`bernoulli`, `binomial`, `geometric`, `hypergeometric`, `poisson`, `planck`, `discrete-uniform` — 100% carry `'pmf'`, 0% carry `'pdf'`). Single in-place replacement of `'pdf'` with `'pmf'` in the keywords array; metadata only, no behavioral change.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Checked:

- Structural feature extraction across all 12 members (file tree, `package.json` shape, `keywords`, `directories`, `manifest.json`, README headings, test/benchmark/example/lib filenames, `.d.ts` shape).
- Semantic feature extraction per package (`lib/main.js`, `lib/index.js`, `lib/factory.js` where present) via parallel per-package agents: `publicSignature`, `factorySignature`, `returnKind`, validation prologue, `errorConstruction`, JSDoc shape, `require()`-derived dependencies. The semantic extractor false-positived on `kurtosis` (reported empty validation prologue); manual re-read of `kurtosis/lib/main.js` confirmed the standard `isnan(r) || isnan(p) || r <= 0.0 || p < 0.0 || p > 1.0 → NaN` prologue is present, matching the 5 other `(r, p)`-signature summary-stat siblings.
- Three-agent drift validation on both surviving outliers:
  - Agent 1 (opus semantic-review): both `confirmed-drift`. README, JSDoc, and source semantics confirm `pmf` is a discrete PMF and `mean` is the standard expected value.
  - Agent 2 (opus cross-reference): both `confirmed-drift`. No test, example, or sibling-package code references the keyword strings; the only consumer is `_tools/search/pkg-index/lib/create.js`, which joins `keywords` into a free-text lunr-index blob (no structured contract).
  - Agent 3 (sonnet structural-review): both `confirmed-drift`. Insertion positions match sibling conventions exactly.
- Cross-run dedup: no open or recently-merged PR proposes either keyword change to these packages. Open PRs #10132 (adds C source for `negative-binomial/logpmf`) and #12677 (propagates the `for a`/`an → and` typo fix to `negative-binomial/mgf/lib/factory.js`) are disjoint from this run's outlier set.

Deliberately excluded:

- **`quantile` keyword on `negative-binomial/quantile`** — within-namespace function-name-as-keyword majority is 75% (just at threshold), but the sibling discrete-distribution convention is `cdf, inverse` without `quantile` (1/7 = 14% ecosystem-wide). Fails the ≥90% ecosystem-wide presence gate.
- **`lib/main.js` JSDoc `@param r` "successes" vs "failures"** — 6/6 split within the namespace; no within-namespace majority. Every `.d.ts` already carries "successes" (canonical per PR #12482). Flagged for a follow-up routine that reconciles source-side JSDoc against `.d.ts`.
- **`ctor` README + error-message "trials" vs "successes"** — internally inconsistent (`ctor` JSDoc and `.d.ts` say "successes"; README + thrown-error message say "trials"). Out of scope for a within-namespace majority routine; flagged for a docs PR.
- **`LICENSE` files in `pmf` and `logpmf`** — absent is the namespace majority (10/12) but removal is destructive and has publish-time implications. Out of mechanical-fix scope.
- **`density` keyword on `negative-binomial/pmf`** — 0/7 sibling discrete `pmf` packages carry `density`. Conservative one-shot drift PR keeps single-direction (add/swap) edits only; flag for a future pass.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: the namespace `@stdlib/stats/base/dists/negative-binomial` was selected by uniform-random pick over the 123 eligible directories (≥8 direct child packages with `package.json`) under `lib/node_modules/@stdlib/`, structural and per-package semantic features were extracted across all 12 members, majority patterns were computed at the 75% conformance threshold, and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed each correction as `confirmed-drift` before any file was edited. Both edits are `package.json` `keywords` array operations; no source, behavior, test, doc, or generator output is touched.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvRRn9qQA2PTnBpfJxzxgG)_