### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/number/uint32/base/add/package.json
+++ b/lib/node_modules/@stdlib/number/uint32/base/add/package.json
@@ -63,6 +63,7 @@
     "number",
     "uint32",
     "integer",
+    "unsigned",
     "c"
   ],
   "__stdlib__": {

--- a/lib/node_modules/@stdlib/number/uint32/base/sub/package.json
+++ b/lib/node_modules/@stdlib/number/uint32/base/sub/package.json
@@ -62,6 +62,7 @@
     "number",
     "uint32",
     "integer",
+    "unsigned",
     "c"
   ],
   "__stdlib__": {


### PR DESCRIPTION
## Description

Adds the `"unsigned"` keyword to the `package.json` of `@stdlib/number/uint32/base/add` and `@stdlib/number/uint32/base/sub` to bring them in line with the 80% sibling conformance rate within `@stdlib/number/uint32/base`.

#### `@stdlib/number/uint32/base/add`

The `keywords` array lacked `"unsigned"`, which 8 of 10 packages (80%) in `@stdlib/number/uint32/base` include. The keyword applies: the package operates on unsigned 32-bit integers via `>>>0` coercion and documents operands as `{uinteger}`.

#### `@stdlib/number/uint32/base/sub`

The `keywords` array lacked `"unsigned"`, diverging from the 80% sibling conformance rate within `@stdlib/number/uint32/base`. The keyword is semantically correct given the package's use of `>>>0` coercion and `{uinteger}` JSDoc annotations.

## Related Issues

No.

## Questions

No.

## Other

Pure `package.json` metadata change; no runtime behavior, public signature, or test expectation is affected. Precedent for this exact correction shape: #12816 (`stats/base/dists/poisson` `counts` keyword) and #12830 (`stats/base/dists/negative-binomial` keyword alignment).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was drafted by Claude Code as part of a cross-package API drift audit of the `@stdlib/number/uint32/base` namespace: structural and semantic features were extracted across all 10 members, a single high-signal outlier feature was identified (`"unsigned"` keyword absent in `add` and `sub` despite 8/10 sibling conformance), and three-agent validation (semantic / cross-reference / structural) returned `confirmed-drift` for both packages before the fix was applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019SVGtKk9jEos5C9ecE4ni2)_