### PR TITLE
docs: add links

### DIFF
--- a/lib/node_modules/@stdlib/math/iter/special/deg2rad/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/deg2rad/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # iterDeg2rad
 
-> Create an [iterator][mdn-iterator-protocol] which converts an angle from degrees to radians for each iterated value.
+> Create an [iterator][mdn-iterator-protocol] which [converts][@stdlib/math/base/special/deg2rad] an angle from degrees to radians for each iterated value.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var iterDeg2rad = require( '@stdlib/math/iter/special/deg2rad' );
 
 #### iterDeg2rad( iterator )
 
-Returns an [iterator][mdn-iterator-protocol] which iteratively converts an angle from degrees to radians.
+Returns an [iterator][mdn-iterator-protocol] which iteratively [converts][@stdlib/math/base/special/deg2rad] an angle from degrees to radians.
 
 ```javascript
 var array2iterator = require( '@stdlib/array/to-iterator' );

--- a/lib/node_modules/@stdlib/math/iter/special/rad2deg/README.md
+++ b/lib/node_modules/@stdlib/math/iter/special/rad2deg/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # iterRad2deg
 
-> Create an [iterator][mdn-iterator-protocol] which converts an angle from radians to degrees for each iterated value.
+> Create an [iterator][mdn-iterator-protocol] which [converts][@stdlib/math/base/special/rad2deg] an angle from radians to degrees for each iterated value.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var iterRad2deg = require( '@stdlib/math/iter/special/rad2deg' );
 
 #### iterRad2deg( iterator )
 
-Returns an [iterator][mdn-iterator-protocol] which iteratively converts an angle from radians to degrees.
+Returns an [iterator][mdn-iterator-protocol] which iteratively [converts][@stdlib/math/base/special/rad2deg] an angle from radians to degrees.
 
 ```javascript
 var array2iterator = require( '@stdlib/array/to-iterator' );


### PR DESCRIPTION
## Description

Adds the missing inline `[@stdlib/math/base/special/<name>]` link to the README summary blockquote and Usage-section description in `@stdlib/math/iter/special/deg2rad` and `@stdlib/math/iter/special/rad2deg`, matching the verb-link convention used by 95/97 (97.9%) of sibling packages in the namespace.

### Namespace summary

- **Members analyzed:** 97 non-autogenerated packages under `lib/node_modules/@stdlib/math/iter/special/`.
- **Features with a clear majority (≥75%):** file tree, `package.json` top-level / `scripts` / `directories` shape, universal keywords, README H2 section list, `docs/repl.txt` section order, `lib/index.js` body, JSDoc `@param` / `@throws` / `@returns` shape (per arity), `examples/index.js` PRNG choice, README inline link to the base function.
- **Features excluded for no clear majority:** README summary verb prefix `iteratively` (51/97 = 53%); package-level `mathematics` keyword (64/97 = 66%); README/JSDoc Notes "non-numeric (NaN)" bullet (consistent within-package but split across surfaces — out of scope for this routine).
- **Conformance on the corrected feature:** 95/97 (97.9%) of sibling packages link the underlying base function inline in both the summary blockquote and the Usage-section description.

### `@stdlib/math/iter/special/deg2rad`

The README summary blockquote (the `>` line under `# iterDeg2rad`) and the Usage-section description (the line right after `#### iterDeg2rad( iterator )`) were missing an inline markdown link to `[@stdlib/math/base/special/deg2rad]`, despite the link reference being defined in the `<section class="links">` block. 95 of 97 sibling packages (98%) carry this link in both slots. Wraps the verb `converts` as `[converts][@stdlib/math/base/special/deg2rad]`, matching the verb-link pattern used by the `ceil`, `floor`, `round`, and `trunc` family.

### `@stdlib/math/iter/special/rad2deg`

Same drift, same shape: the summary blockquote under `# iterRad2deg` and the Usage-section description under `#### iterRad2deg( iterator )` were both missing the inline `[@stdlib/math/base/special/rad2deg]` link, while the reference itself was already defined in `<section class="links">`. Wraps the verb `converts` in both slots as `which [converts][@stdlib/math/base/special/rad2deg] an angle from radians to degrees`, matching the verb-link shape used by the `ceil` / `floor` / `round` / `trunc` family.

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural extraction:** filesystem walk + `package.json` / README / `docs/repl.txt` / `docs/types/index.d.ts` / `lib/index.js` / `lib/main.js` shape capture across all 97 members. 100% conformance on every set-valued structural feature except the inline-link feature corrected here.
- **Semantic extraction:** programmatic cross-package scan over `lib/main.js` JSDoc shape (param types, throws messages, returns type, example presence), public signatures, validation prologues, error construction, and require'd dependencies — every feature 100% conforming within its arity class (92 arity-1 + 5 arity-2). Per-package semantic agents were skipped in favor of the direct scan because the namespace is template-uniform and the per-package read would have surfaced no additional signal.
- **Three-agent drift validation:** opus cross-reference (`needs-human` check against tests, examples, and sibling-package docs) and sonnet structural-review (closest-cousin convention match) returned `confirmed-drift` for both outliers. Semantic-review was skipped because the feature is purely structural (README content).

### Deliberately excluded

- **`@stdlib/math/iter/special/pow`** — currently the subject of open PR #12473 (different fix, but covered by the open-PR collision gate); no overlapping correction proposed in this PR.
- **`factorial` / `factorialln`** — the 2 packages whose `examples/index.js` uses `discreteUniform` instead of `uniform`: this is a domain-driven choice (factorials are defined on non-negative integers) and was marked `intentional-deviation` and dropped.
- **`ceil` / `floor` / `round` / `trunc` family + `cospi` / `sinpi`** — 14 packages whose JSDoc summary in `lib/main.js` reads `Returns an iterator which {rounds|computes} ...` rather than the majority `Returns an iterator which iteratively ...`: phrasing matches each package's own README and `docs/repl.txt`, so flipping to the majority would introduce a within-package inconsistency. Marked `intentional-deviation`.
- **README / JSDoc "non-numeric (NaN)" Notes bullet** — README includes the bullet 97/97 times, JSDoc includes it 5/97 times (the arity-2 packages only). The within-package README-vs-JSDoc inconsistency is itself uniform across the namespace and is not a cross-package drift; out of scope for this routine.
- **`package.json` keyword `mathematics`** (64/97 = 66%) — below the 75% majority threshold.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as the output of an automated cross-package API-drift scan over `@stdlib/math/iter/special`. Candidate corrections were derived from structural + programmatic-semantic majority votes across all 97 namespace members, gated by an open-PR / autogen / materiality pre-filter, and confirmed by two independent reviewer agents (opus cross-reference + sonnet structural-review) before commits were applied in the primary worktree. A maintainer will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01FGVS7M9pXqVRdPit7iZdby)_