### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-expected-html-sections/package.json
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-expected-html-sections/package.json
@@ -41,6 +41,7 @@
     "linter",
     "markdown",
     "md",
+    "mdown",
     "remark",
     "remark-plugin",
     "plugin",

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-html-section-structure/package.json
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-lint-html-section-structure/package.json
@@ -41,6 +41,7 @@
     "linter",
     "markdown",
     "md",
+    "mdown",
     "remark",
     "remark-plugin",
     "plugin",

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/package.json
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/package.json
@@ -45,6 +45,8 @@
     "examples",
     "demo",
     "javascript",
-    "js"
+    "js",
+    "remark",
+    "plugin"
   ]
 }

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-github/package.json
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-github/package.json
@@ -41,6 +41,8 @@
     "stdlib",
     "repository",
     "repo",
-    "github"
+    "github",
+    "remark",
+    "plugin"
   ]
 }

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-www/package.json
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-stdlib-urls-www/package.json
@@ -42,6 +42,8 @@
     "repository",
     "repo",
     "www",
-    "website"
+    "website",
+    "remark",
+    "plugin"
   ]
 }


### PR DESCRIPTION
## Description

Adds missing keywords in five `_tools/remark/plugins` packages identified via majority-vote analysis of `package.json` metadata across the namespace (threshold: ≥75% sibling conformance, 14 members).

### Namespace summary

- Members analyzed: 14 hand-written remark plugins.
- Features extracted: top-level `package.json` key set, `keywords`, `directories`, `engines`, `scripts`, file tree, README `##`/`###` section list.
- Features with a clear majority (≥75%): top-level key set (100%), `directories.example` / `directories.lib` (100%), README `## Usage` / `## Examples` (100%), and the keyword subset `tools` / `markdown` / `md` / `mdown` / `remark` / `plugin`.
- Features excluded for lacking a clear majority: `engines.node` range (57%/43% split between `>=0.10.0` and `>=6.0.0`), `directories.test` (29%), README `## Notes` (43%), `mdast` keyword (64%).

### Per outlier package

#### `_tools/remark/plugins/remark-lint-expected-html-sections`

Lacked the `mdown` keyword. Twelve of fourteen siblings (86%) list `mdown` next to `markdown` and `md`; the package processes the same file format as every other plugin in the namespace, so the omission is drift, not an intentional deviation.

#### `_tools/remark/plugins/remark-lint-html-section-structure`

Same drift as above: missing `mdown` against 86% sibling conformance.

#### `_tools/remark/plugins/remark-run-javascript-examples`

Lacked the `remark` and `plugin` keywords carried by eleven of fourteen siblings (79%). The package's description and the JSDoc module header in `lib/index.js` both open with "remark plugin to..."; absence of both keywords is unambiguous drift.

#### `_tools/remark/plugins/remark-stdlib-urls-github`

Same drift as above: missing `remark` and `plugin` against 79% sibling conformance.

#### `_tools/remark/plugins/remark-stdlib-urls-www`

Same drift as above: missing `remark` and `plugin` against 79% sibling conformance.

### Validation

- Structural extraction: full file tree, `package.json` top-level / `scripts` / `directories` / `keywords` / `engines`, and `README.md` `##` / `###` headings collected for all 14 namespace members.
- Drift review: a sonnet structural-review validator received the majority pattern and outlier list for every candidate correction; all five returned `confirmed-drift`.
- Out of scope: features without ≥75% majority (notably `engines.node`, `directories.test`, the `## Notes` README section, the `mdast` keyword); the hyphenated `remark-plugin` keyword present in only two lint packages (2/14, below majority threshold).
- No public API, runtime behavior, or test expectation is affected — the diff is purely additive metadata in `keywords` arrays.

## Related Issues

None.

## Questions

No.

## Other

Cross-run dedup: no open PR targets this namespace or proposes the same fix. Related drift-detection PRs in flight (#12831, #12830, #12816) target unrelated namespaces.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by Claude Code running an automated cross-package API drift detection routine. The routine extracted structural features from every package in `@stdlib/_tools/remark/plugins`, computed majority keyword sets at a ≥75% conformance threshold, and proposed mechanical metadata-only corrections for the outliers. A separate validation agent independently confirmed each correction as drift rather than intentional deviation. No runtime code, tests, or documentation prose was modified; the entire diff consists of additions to `keywords` arrays in `package.json`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8SSXygL5djmUq4EujLDwE)_