### PR TITLE
docs: update descriptions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # isPow2Uint32
 
-> Test whether an unsigned integer is a power of 2.
+> Test if an unsigned integer is a power of 2.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var isPow2Uint32 = require( '@stdlib/math/base/assert/uint32-is-pow2' );
 
 #### isPow2Uint32( x )
 
-Tests whether `x` is a power of 2.
+Tests if `x` is a power of 2.
 
 ```javascript
 var bool = isPow2Uint32( 2 );
@@ -100,7 +100,7 @@ for ( i = 0; i < 100; i++ ) {
 
 #### stdlib_base_uint32_is_pow2( x )
 
-Tests whether an unsigned integer is a power of 2.
+Tests if an unsigned integer is a power of 2.
 
 ```c
 #include <stdbool.h>

--- a/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Tests whether an unsigned integer is a power of 2.
+* Tests if an unsigned integer is a power of 2.
 *
 * @param x - value to test
 * @returns boolean indicating whether a value is a power of 2

--- a/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Test whether an unsigned integer is a power of 2.
+* Test if an unsigned integer is a power of 2.
 *
 * @module @stdlib/math/base/assert/uint32-is-pow2
 *
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var isPow2Uint32 = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = isPow2Uint32;
+module.exports = main;

--- a/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/lib/main.js
@@ -21,7 +21,7 @@
 // MAIN //
 
 /**
-* Tests whether an unsigned integer is a power of 2.
+* Tests if an unsigned integer is a power of 2.
 *
 * @param {uinteger32} x - value to test
 * @returns {boolean} boolean indicating whether a value is a power of 2

--- a/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/lib/native.js
@@ -27,7 +27,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Tests whether an unsigned integer is a power of 2.
+* Tests if an unsigned integer is a power of 2.
 *
 * @private
 * @param {number} x - value to test

--- a/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/math/base/assert/uint32-is-pow2",
   "version": "0.0.0",
-  "description": "Test whether an unsigned integer is a power of 2.",
+  "description": "Test if an unsigned integer is a power of 2.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

This pull request:

-   Normalizes the package summary in `@stdlib/math/base/assert/uint32-is-pow2` from "Test whether"/"Tests whether" to "Test if"/"Tests if" across `package.json`, `README.md` (blockquote, Usage, C APIs), `lib/index.js`, `lib/main.js`, `lib/native.js`, and `docs/types/index.d.ts`. The convention is used by 34/35 sibling packages in the namespace (97% conformance per location; 23/24 for the C APIs narrative).
-   Renames the `lib/index.js` import variable from `isPow2Uint32` to `main` and updates the corresponding `module.exports` to the `var main = require( './main.js' ); module.exports = main;` indirection pattern used by 34/35 siblings (97% conformance). The exported function is unchanged.

### Namespace summary

-   Members analyzed: 35 (zero autogenerated)
-   Features with a clear majority (≥75%) and corrections applied: 9 stylistic items, all in `uint32-is-pow2`
-   Features without a clear majority: README `## See Also` (74%), `## C APIs` (69%), `## Notes` (37%) — excluded from drift analysis
-   No semantic drift found (uniform `boolean` return, single `x: number/integer32/uinteger32` parameter, no validation prologue, no thrown errors)

### `uint32-is-pow2`

Sole outlier in the namespace. The package predates the namespace-wide normalization to `"Test if ..."` phrasing and the `var main` indirection. The proposed corrections are pure docstring / local-identifier edits — no signature, behavior, or test expectation changes. `docs/repl.txt` is left untouched as a generator-owned file.

### Validation

Three independent agent reviews confirmed all nine items as unintentional drift:

-   semantic review (no mathematical justification for "whether" over "if"; the predicate is a one-line bit-twiddle comparable in complexity to siblings using "Tests if");
-   cross-reference review (no tests, examples, or external consumers rely on the deviating strings; the `module.exports` rename is internal-only — test files declare their own local `var isPow2Uint32 = require('./../lib')`);
-   structural review (majority pattern confirmed by reading sibling packages directly).

Deliberately excluded:

-   `is-coprime` missing C-implementation files — open PR #4169 is adding the C implementation.
-   `is-negative-integerf` missing `docs/repl.txt` — generator-owned.
-   6 packages using legacy `src/addon.cpp` + `src/<name>.c` instead of `src/addon.c` + `src/main.c` — non-mechanical refactor; warrants a separate maintainer pass.
-   `is-composite`, `is-coprime`, `is-prime` JSDoc summary "Returns a boolean ..." vs majority "Tests if ..." — plausibly intentional for number-theoretic predicates; needs human judgment.
-   The same "Tests whether" drift at line 836 of the namespace-aggregate `math/base/assert/docs/types/index.d.ts` — outside per-package scope.

## Related Issues

No.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running a cross-package drift detection routine on `@stdlib/math/base/assert`. The routine extracted structural and semantic features per package, identified `uint32-is-pow2` as the sole outlier on nine related stylistic features (≥75% conformance per feature), and three independent agent reviews confirmed each item as unintentional drift before any edits were applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZXpkkqMMffNV6CWutMWRP)_