### PR TITLE
chore: correct keyword and JSDoc `@returns` type in `ml/base/kmeans`

### DIFF
--- a/lib/node_modules/@stdlib/ml/base/kmeans/algorithms/package.json
+++ b/lib/node_modules/@stdlib/ml/base/kmeans/algorithms/package.json
@@ -55,7 +55,7 @@
     "machine",
     "learning",
     "kmeans",
-    "algorithms",
+    "algorithm",
     "utilities",
     "utility",
     "utils",

--- a/lib/node_modules/@stdlib/ml/base/kmeans/metrics/lib/main.js
+++ b/lib/node_modules/@stdlib/ml/base/kmeans/metrics/lib/main.js
@@ -28,7 +28,7 @@ var DATA = require( './data.json' );
 /**
 * Returns a list of k-means distance metrics.
 *
-* @returns {StringArray} list of distance metrics
+* @returns {Array<string>} list of distance metrics
 *
 * @example
 * var list = metrics();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Normalizes two cross-package drift findings in the `ml/base/kmeans` namespace surfaced by a structural+semantic diff against sibling packages.

### `ml/base/kmeans/algorithms`

Replaces the plural `algorithms` topic keyword in `package.json` with the singular `algorithm`. Every other algorithm-family package (`algorithm-enum2str`, `algorithm-str2enum`, `algorithm-resolve-enum`, `algorithm-resolve-str`) tags itself with the singular `algorithm`, and the parallel `metric-*` family is uniformly singular as well. Singular topic-keyword conformance across the namespace: **9/10 (90%)**.

### `ml/base/kmeans/metrics`

Replaces `@returns {StringArray}` with `@returns {Array<string>}` in `lib/main.js`. The package's own `docs/types/index.d.ts` already declares `Array<string>`, and `docs/repl.txt` reports `out: Array<string>`. The sibling `ml/base/kmeans/algorithms` JSDoc also uses `Array<string>`. The `StringArray` form in `metrics/lib/main.js` was the lone outlier across these five doc surfaces.

No observable behavior, signatures, or test expectations change.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Findings sourced from a cross-package structural and semantic diff of the ten packages in `ml/base/kmeans/`. Other candidates inspected and deliberately excluded: the `Notes` README section (semantically warranted only in `str2enum`/`resolve-enum` packages whose output is an opaque integer); the `C APIs` section (semantically warranted only in the two C-binding packages); and any signature/validation differences between the `algorithm-*` and `metric-*` families (legitimate semantic mirroring, not drift).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of a cross-package drift detection routine over the `ml/base/kmeans` namespace.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01V3LV2MJcKXXyRgsBVShVYb)_