### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/utils/keys/lib/builtin.js
+++ b/lib/node_modules/@stdlib/utils/keys/lib/builtin.js
@@ -18,6 +18,16 @@
 
 'use strict';
 
+// MODULES //
+
+var Object = require( '@stdlib/object/ctor' );
+
+
+// VARIABLES //
+
+var builtin = Object.keys;
+
+
 // MAIN //
 
 /**
@@ -41,7 +51,7 @@
 * // e.g., returns [ 'beep', 'foo' ]
 */
 function keys( value ) {
-	return Object.keys( Object( value ) ); // eslint-disable-line no-restricted-syntax, stdlib/require-globals
+	return builtin( Object( value ) );
 }
 
 

--- a/lib/node_modules/@stdlib/utils/keys/lib/builtin.js
+++ b/lib/node_modules/@stdlib/utils/keys/lib/builtin.js
@@ -41,7 +41,7 @@
 * // e.g., returns [ 'beep', 'foo' ]
 */
 function keys( value ) {
-	return Object.keys( Object( value ) );
+	return Object.keys( Object( value ) ); // eslint-disable-line no-restricted-syntax, stdlib/require-globals
 }
 
 


### PR DESCRIPTION
Resolves #12859.

## Description

> What is the purpose of this pull request?

This pull request:

- suppresses lint errors for Object.keys() call in `@stdlib/utils/keys/lib/builtin.js`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #12859

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
