### PR TITLE
docs: describe `mu` as location parameter in `stats/base/dists/logistic/mgf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/include/stdlib/stats/base/dists/logistic/mgf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/include/stdlib/stats/base/dists/logistic/mgf.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the moment-generating function (MGF) for a logistic distribution with mean `mu` and scale parameter `s` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a logistic distribution with location parameter `mu` and scale parameter `s` at a value `t`.
 */
 double stdlib_base_dists_logistic_mgf( const double t, const double mu, const double s );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/lib/factory.js
@@ -31,9 +31,9 @@ var abs = require( '@stdlib/math/base/special/abs' );
 // MAIN //
 
 /**
-* Returns a function for evaluating the moment-generating function (MGF) of a logistic distribution with mean `mu` and scale parameter `s`.
+* Returns a function for evaluating the moment-generating function (MGF) of a logistic distribution with location parameter `mu` and scale parameter `s`.
 *
-* @param {number} mu - mean
+* @param {number} mu - location parameter
 * @param {NonNegativeNumber} s - scale parameter
 * @returns {Function} MGF
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/lib/main.js
@@ -29,10 +29,10 @@ var abs = require( '@stdlib/math/base/special/abs' );
 // MAIN //
 
 /**
-* Evaluates the moment-generating function (MGF) for a logistic distribution with mean `mu` and scale parameter `s` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a logistic distribution with location parameter `mu` and scale parameter `s` at a value `t`.
 *
 * @param {number} t - input value
-* @param {number} mu - mean
+* @param {number} mu - location parameter
 * @param {NonNegativeNumber} s - scale parameter
 * @returns {number} evaluated MGF
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/lib/native.js
@@ -26,11 +26,11 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the moment-generating function (MGF) for a logistic distribution with mean `mu` and scale parameter `s` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a logistic distribution with location parameter `mu` and scale parameter `s` at a value `t`.
 *
 * @private
 * @param {number} t - input value
-* @param {number} mu - mean
+* @param {number} mu - location parameter
 * @param {NonNegativeNumber} s - scale parameter
 * @returns {number} evaluated MGF
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/src/main.c
@@ -23,10 +23,10 @@
 #include "stdlib/math/base/special/sinc.h"
 
 /**
-* Evaluates the moment-generating function (MGF) for a logistic distribution with mean `mu` and scale parameter `s` at a value `t`.
+* Evaluates the moment-generating function (MGF) for a logistic distribution with location parameter `mu` and scale parameter `s` at a value `t`.
 *
 * @param t   input value
-* @param mu  mean
+* @param mu  location parameter
 * @param s   scale parameter
 * @return    evaluated MGF
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request normalizes the JSDoc `mu` description in `stats/base/dists/logistic/mgf` to match the namespace-wide convention used by the other 13 native-binding packages: `"location parameter"` instead of `"mean"`.

### Namespace summary

- Members analyzed: 15 (`cdf`, `ctor`, `entropy`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `median`, `mgf`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`).
- Autogenerated members excluded from the vote: 0.
- Features with a clear majority (≥75%) and an applicable correction: 1.
- Features without a clear majority (excluded from drift analysis): the presence of `lib/factory.js` (a 6-of-15 semantic split between factory-producing kernels and direct-arithmetic ones).

### Per outlier package

#### `stats/base/dists/logistic/mgf`

`@param {number} mu` and the surrounding JSDoc summary referred to `mu` as `"mean"` in `lib/main.js`, `lib/factory.js`, and `lib/native.js`, and the matching block comments in `src/main.c` and `include/stdlib/stats/base/dists/logistic/mgf.h` carried the same wording. The 13 sibling packages under `stats/base/dists/logistic/` describe `mu` as the `"location parameter"` (13/14 = 93% conformance among the native-binding members), and the same `mgf` package's `README.md`, `docs/types/index.d.ts`, and `docs/repl.txt` already use `"location parameter"` — only the `lib/` and `src/` doc comments lagged. Sibling location-family `mgf` packages (`laplace/mgf`, `gumbel/mgf`) follow the same convention; `normal/mgf` is the one legitimate `"mean"` user, because for the normal distribution `mu` IS canonically the mean, which is not the case for the logistic family.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

- Structural feature extraction over all 15 members (file trees, `package.json` shape, README headings, manifest shape, test/benchmark/example file naming).
- Semantic feature extraction per package (public signature, validation prologue, error construction, JSDoc shape, dependencies).
- Three-agent drift validation (semantic-review, cross-reference, structural-review) ran in parallel on the `mgf` candidate; all three returned `confirmed-drift`.

Deliberately excluded from this PR:
- `ctor` is the canonical "missing native-binding artifacts" outlier in this namespace (no `binding.gyp`, `src/`, Julia fixtures, etc.) — intentional, since `ctor` is a JS-only distribution-class constructor.
- `stdev` uses Python rather than Julia test fixtures (`test/fixtures/python/` vs the 13-of-14 majority `test/fixtures/julia/`). Marked `needs-human`: the test file imports the Python fixture, so migrating would require regenerating fixtures and rewriting the test — out of scope for a drift-correction PR.
- `mean`/`median`/`mode` use `var <pkg> = require( './main.js' )` rather than the 12-of-15 majority `var main = ...`. The named-variable form is the ecosystem-wide convention across ≥27 sibling distributions, so this is not local drift.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of the namespace drift-detection routine. A randomly selected namespace (`stats/base/dists/logistic`) was feature-extracted across all 15 members; majority patterns were computed at 75% conformance; outliers were gated through a three-agent validation pass before any patch was applied. A human maintainer should verify the patch before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019zwLdasBiEtBizDDt3dJqL)_