### PR TITLE
build: guard grep pipeline against pipefail when no benchmark files exist

### DIFF
--- a/tools/make/lib/benchmark/javascript.mk
+++ b/tools/make/lib/benchmark/javascript.mk
@@ -36,7 +36,7 @@
 # make benchmark-javascript BENCHMARKS_FILTER=".*/utils/group-by/.*"
 #/
 benchmark-javascript: $(NODE_MODULES)
-	$(QUIET) $(FIND_BENCHMARKS_CMD) | grep '^[\/]\|^[a-zA-Z]:[/\]' | while read -r file; do \
+	$(QUIET) $(FIND_BENCHMARKS_CMD) | { grep '^[\/]\|^[a-zA-Z]:[/\]' || true; } | while read -r file; do \
 		echo ""; \
 		echo "Running benchmark: $$file"; \
 		NODE_ENV="$(NODE_ENV_BENCHMARK)" \


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a 100%-failure-rate regression in the `random_benchmarks` CI workflow caused by `set -o pipefail` propagating `grep`'s exit code 1 (no matches) through the `benchmark-javascript` make recipe pipeline when a randomly selected package has no `benchmark/` directory

The top-level `tools/make/Makefile` sets `.SHELLFLAGS := -eu -o pipefail -c`, so every make recipe runs under `bash -eu -o pipefail`. In `benchmark-javascript`, the pipeline is:

```makefile
$(FIND_BENCHMARKS_CMD) | grep '^[\/]\|^[a-zA-Z]:[/\]' | while read -r file; do ...
```

When `FIND_BENCHMARKS_CMD` returns no output (package has no benchmarks), `grep` exits 1. Under `pipefail`, that 1 propagates as the pipeline exit code even though the `while` loop exits 0. The recipe fails, and `benchmark-random-javascript` aborts via its `|| exit 1` guard.

The fix wraps `grep` in `{ grep ... || true; }` so its no-match exit code does not propagate. Matching behavior and real benchmark failure semantics (the `$(NODE) ... || exit 1` inside the loop) are preserved.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Identified via CI audit on 2026-06-14. The `random_benchmarks` workflow showed a 30/30 (100%) failure rate going back at least to 2026-05-16. All failures terminated at `make[1]: Error 1` inside `benchmark-javascript` when the randomly selected package set included `@stdlib/time/iso-weeks-in-year` (no benchmark directory).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI failure investigation routine.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4WFsxz2M5vVrTc74hFFqT)_