### PR TITLE
build: delete remote PR branch before recreating to fix force-push-with-lease failure

### DIFF
--- a/.github/workflows/markdown_equations.yml
+++ b/.github/workflows/markdown_equations.yml
@@ -168,6 +168,15 @@ jobs:
           fi
         timeout-minutes: 15
 
+      # Delete remote PR branch to ensure a clean push when the branch has diverged:
+      - name: 'Delete remote PR branch'
+        if: steps.svg-equations.outputs.changed == 'true' || steps.equation-elements.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.STDLIB_BOT_PAT_REPO_WRITE }}
+        run: |
+          gh api -X DELETE repos/stdlib-js/stdlib/git/refs/heads/markdown-insert-equations 2>/dev/null || true
+        timeout-minutes: 5
+
       # Create a pull request with the updated equations:
       - name: 'Create pull request'
         id: cpr


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a near-persistent failure (23/30 runs, 9+ consecutive) in the `markdown_equations` CI workflow where `peter-evans/create-pull-request@v8.1.1` exits non-zero with `git push --force-with-lease` after detecting `markdown-insert-equations` already exists on the remote

The workflow commits equation SVG and element updates, then calls `create-pull-request` to push those commits to `markdown-insert-equations` and open a PR. On subsequent daily runs, the remote branch exists from the previous run. The action fetches it, records the remote-tracking ref, then checks whether there are new commits to push. Because the diff from `develop` is identical run-to-run (same equation changes), it reports "No commits to push" but still attempts a force-push to sync branch metadata. The `--force-with-lease` check compares the local remote-tracking ref (recorded at checkout) against the actual remote tip (advanced by the previous run's push); they diverge, the lease breaks, and the push is rejected.

The fix adds a step that deletes the remote branch via the GitHub API immediately before `create-pull-request` runs. This ensures the action always pushes to a fresh branch, bypassing the stale-lease check. The step is guarded by the same condition as the create-pull-request step and uses `|| true` for idempotency when the branch does not exist.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Identified via CI audit on 2026-06-14. Note: deleting the remote branch causes GitHub to auto-close any open PR on `markdown-insert-equations` before `create-pull-request` opens a new one. For this automated maintenance workflow the tradeoff is acceptable; the content is fully regenerated each run and no review continuity is lost.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI failure investigation routine.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4WFsxz2M5vVrTc74hFFqT)_