### PR TITLE
docs: add `C APIs` section placeholder to four `lapack/base` packages

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/clacgv/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/clacgv/README.md
@@ -149,6 +149,76 @@ console.log( cx.get( cx.length-1 ).toString() );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/lapack/base/crot/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/crot/README.md
@@ -184,6 +184,76 @@ logEach( '(%s,%s) => (%s,%s)', cxc, cyc, cx, cy );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/lapack/base/zlacgv/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/zlacgv/README.md
@@ -149,6 +149,76 @@ console.log( zx.get( zx.length-1 ).toString() );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/lapack/base/zrot/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/zrot/README.md
@@ -184,6 +184,76 @@ logEach( '(%s,%s) => (%s,%s)', zxc, zyc, zx, zy );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">


### PR DESCRIPTION
## Description

This pull request inserts the canonical `## C APIs` placeholder section into four `lapack/base` packages whose READMEs currently skip the section: `clacgv`, `crot`, `zlacgv`, and `zrot`. The stub is byte-identical to the boilerplate already used by 27/31 (≈87%) siblings, including `dgttrf`, `dladiv`, `dlassq`, `slaswp`, `iladlc`, and `dlapy2`. No JavaScript, tests, examples, or public API are touched.

The four outliers are all valid LAPACK BLAS-like routines whose Fortran counterparts exist upstream; like most siblings, none ships a native binding today, but the placeholder is the documented convention for the namespace and keeps the namespace consistent for future C-bridge work.

### Namespace summary

- **Namespace:** `@stdlib/lapack/base`
- **Members analyzed:** 31 (autogenerated exclusions: 0)
- **Structural features with clear majority (≥75%):** README `## C APIs` placeholder section (27/31 = 87%), `## Usage`, `## Notes`, `## Examples`, `### Usage`, `### Examples`, `examples/index.js`, top-level `package.json` keys, `test/test.js`, `benchmark/benchmark.js`.
- **Features excluded for no clear majority:** native-binding artifacts (`binding.gyp`, `include.gypi`, `src/`, `manifest.json` — only 2-3/31 packages), `lib/native.js` (1/31), `package.json` `keywords` arrays (heterogeneous by routine type).

### Per outlier package

#### `lapack/base/clacgv`

Adds the standard `## C APIs` placeholder section (27/31 = 87% of siblings). The README previously jumped from `<!-- /.examples -->` directly to the auto-populated `<section class="related">`, skipping the stub used by every other complex/single-precision routine in the namespace that has a C-bridge stub queued. Stub content is identical to `lapack/base/dgttrf`; no signature, behavior, or test surface changes.

#### `lapack/base/crot`

Adds the standard `## C APIs` placeholder section (27/31 = 87% of siblings). `crot` is the single-precision complex plane-rotation routine; like its real-precision siblings, it now carries the placeholder TODO stub in preparation for a future C bridge. Stub content is byte-identical to the canonical boilerplate.

#### `lapack/base/zlacgv`

Adds the standard `## C APIs` placeholder section (27/31 = 87% of siblings). `zlacgv` is the double-precision complex counterpart of `clacgv`; the omission mirrored `clacgv`'s and is corrected for consistency. Stub content is byte-identical to the canonical boilerplate.

#### `lapack/base/zrot`

Adds the standard `## C APIs` placeholder section (27/31 = 87% of siblings). `zrot` is the double-precision complex counterpart of `crot`; the omission mirrored `crot`'s. Stub content is byte-identical to the canonical boilerplate.

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural extraction:** file trees, `package.json` shapes, README heading lists, `manifest.json` shapes, and test/benchmark/example file names were extracted across all 31 members of `@stdlib/lapack/base`.
- **Semantic extraction:** `lib/main.js` and the routine-named entry (e.g. `lib/clacgv.js`) of each outlier were inspected to confirm structural parity with majority-pattern siblings (`setReadOnly`-wrapped `ndarray` attachment, identical export shape).
- **Three-agent drift validation:** semantic review confirmed the four outliers are routine ports of upstream LAPACK Fortran routines (no JS-only justification); cross-reference review confirmed no tooling, tests, examples, REPL fixtures, or namespace aggregator depends on the `## C APIs` anchor or content of these packages; structural review confirmed the stub is character-for-character identical across the 27 conforming siblings sampled.
- **Deliberately excluded:**
  - The `## C APIs` headings present in the 27 conforming packages were not modified.
  - Native-binding artifacts (`src/`, `include/`, `binding.gyp`, `manifest.json`) and `lib/native.js` were *not* added — only 1-3 packages in the namespace currently have these, so absence is not drift.
  - `## Notes` is missing from `xerbla` and `shared`, but those packages are an error handler and an internal include-path helper respectively (intentional deviation from the routine pattern); excluded.
  - `test.ndarray.js`/`benchmark.ndarray.js` are absent from `dlaisnan`, `dlamch`, `dlapy2`, `dlapy3`, `xerbla`, `shared` — these are scalar/utility packages without an ndarray API, so absence is intentional.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package drift-detection routine. The routine extracted structural features from all 31 `@stdlib/lapack/base` packages, identified that 27/31 (87%) include a placeholder `## C APIs` README section, flagged the four outliers (`clacgv`, `crot`, `zlacgv`, `zrot`), ran a three-agent validation gate (semantic review, cross-reference review, and structural review) which independently confirmed advance, and inserted the canonical placeholder stub byte-identically into each. The inserted text is unchanged boilerplate (no AI-generated technical content). A maintainer should promote out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_017E3KYw7AmwKe4wdL5EEuR7)_