### PR TITLE
style: format `if` conditions in `stats/base/dists/rayleigh`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/median/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/median/src/main.c
@@ -32,7 +32,10 @@ static const double SQRT2LN2 = 1.1774100225154747; // sqrt(2*ln(2))
 * // returns ~10.597
 */
 double stdlib_base_dists_rayleigh_median( const double sigma ) {
-	if ( stdlib_base_is_nan( sigma ) || sigma < 0 ) {
+	if (
+		stdlib_base_is_nan( sigma ) ||
+		sigma < 0.0
+	) {
 		return 0.0 / 0.0; // NaN
 	}
 	return sigma * SQRT2LN2;

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/variance/src/main.c
@@ -31,7 +31,10 @@
 * // returns ~34.765
 */
 double stdlib_base_dists_rayleigh_variance( const double sigma ) {
-	if ( stdlib_base_is_nan( sigma ) || sigma < 0.0 ) {
+	if (
+		stdlib_base_is_nan( sigma ) ||
+		sigma < 0.0
+	) {
 		return 0.0 / 0.0; // NaN
 	}
 	return ( 4.0 - STDLIB_CONSTANT_FLOAT64_PI ) * sigma * sigma / 2.0;


### PR DESCRIPTION
## Description

This pull request aligns two C source files in `@stdlib/stats/base/dists/rayleigh` with the formatting and floating-point-literal conventions used across the rest of the namespace.

### Namespace summary

- **Members analyzed:** 15 (cdf, ctor, entropy, kurtosis, logcdf, logpdf, mean, median, mgf, mode, pdf, quantile, skewness, stdev, variance).
- **C-binding members:** 14 (all except `ctor`, which is a JS-only constructor).
- **Features with a clear majority (≥75%):** C-source `if` predicate format (12/14, 85.7%), floating-point-literal use in `sigma < 0.0` comparisons (13/14, 92.8%), `lib/main.js` validation predicate (`sigma < 0.0`, 7/8 sigma-only packages), `@param {NonNegativeNumber} sigma` JSDoc type (7/8), `package.json` top-level shape, `README.md` section order, `lib/native.js` / `manifest.json` / `binding.gyp` presence, `examples/c/example.c` shape, `docs/types/index.d.ts` shape.
- **Features without a clear majority (excluded):** `README ## Notes` section presence (2/6 in factory packages), `0.0/0.0` vs `0.0 / 0.0` whitespace in NaN literals (8 vs 6, no majority).

### Outlier packages

#### `stats/base/dists/rayleigh/median`

Reformats the `if` predicate in `src/main.c` to the multi-line form used across 12 of 14 sibling distributions and replaces the integer literal `0` with `0.0` to match the floating-point convention established in #12204. Both deviations were introduced when `median` was added in 2025 and went undetected. Brings the file into conformance with the rest of the package.

#### `stats/base/dists/rayleigh/variance`

Reformats the `if` predicate in `src/main.c` to the multi-line form used by 12 of 14 sibling distributions in the namespace. The single-line guard was the only divergence from the established pattern; no behavioral change.

## Related Issues

None.

## Questions

None.

## Other

### Validation

- Structural features (file tree, `package.json` shape, README sections, manifest shape) were extracted across all 15 members and compared against a 75% majority threshold.
- Semantic features (validation predicates, error construction, JSDoc shape, public signatures) were extracted from `lib/main.js`, `lib/index.js`, and any `lib/factory.js` in each package.
- Each candidate correction was reviewed by three independent agents (semantic-review, cross-reference, structural-review). All three returned `confirmed-drift` for the items in this PR.
- Deliberately excluded:
  - `entropy/lib/main.js` uses `sigma <= 0.0` and `@param {PositiveNumber}` rather than the sibling pattern `sigma < 0.0` / `@param {NonNegativeNumber}`. The C source and JS tests are internally consistent; aligning would change observable behavior at `sigma === 0`, which is out of scope for a drift-correction PR.
  - `mgf/lib/factory.js` lacks the `sigma === 0.0` → `degenerate` short-circuit present in the other five factory packages. Applying it would change `mgf(t, 0)` from `SQRT_HALF_PI` to `1.0`. Worth a separate bug-fix PR, but out of scope here.
  - `mgf` lacks `test/fixtures/julia/`; the closed-form MGF formula does not need empirical comparison fixtures, so absence is intentional.
  - `ctor` lacks C-binding artifacts entirely (intentional — it is a JS-only constructor).

### Disclosure

This pull request was produced by an automated cross-package drift-detection routine running under Claude Code. The agent extracted structural and semantic features across all members of the namespace, computed per-feature majorities, validated each candidate correction with three independent reviewer agents, and applied only those corrections that did not change observable behavior. All changes were reviewed before commit.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by an automated drift-detection routine running under Claude Code: feature extraction, three-agent validation, code changes, commit composition, and PR body. A maintainer should review before merging.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6HGxRz5AYMB8SJpKd6Zum)_