### PR TITLE
refactor: rename internal variables

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Renames the `lib/index.js` import binding in `stats/base/dists/chisquare/mean`, `stats/base/dists/chisquare/median`, and `stats/base/dists/chisquare/mode` from the function name to the conventional `main` identifier, aligning the three packages with the majority convention in the namespace.

### Namespace summary

-   **Namespace:** `@stdlib/stats/base/dists/chisquare`
-   **Members analyzed:** 14 (`cdf`, `ctor`, `entropy`, `kurtosis`, `logpdf`, `mean`, `median`, `mgf`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`)
-   **Features with a clear ≥75% majority:** `package.json` top-level key set (100%), `lib/main.js` presence (100%), `lib/index.js` import binding name (`main`, 78%), `README.md` presence (100%), `examples/index.js` presence (100%), `benchmark/benchmark.js` presence (100%).
-   **Features without a clear majority (excluded from drift analysis):** native-addon files (`binding.gyp`, `manifest.json`, `lib/native.js`, `src/main.c`, `src/addon.c`, `test/test.native.js`) at 71%; factory-pattern files (`lib/factory.js`, `test/test.factory.js`) at 36%; `## C APIs` README section at 71%. All track the package's mathematical/native-port status and are intentional rather than drift.

### Per outlier package

#### `stats/base/dists/chisquare/mean`

Rebinds the `require( './main.js' )` import from `mean` to `main` in `lib/index.js`. Eleven of the fourteen sibling packages in the namespace already use the `main` identifier (78%); ecosystem-wide, 401 of 505 `stats/base/dists/**/lib/index.js` files do (79%). Internal-only rename; the public export and the entry-point identity are unchanged.

#### `stats/base/dists/chisquare/median`

Same rebind in `median/lib/index.js`. Tests `require( './../lib' )` and rebind the export to a local `median` symbol, so the internal identifier is invisible to consumers.

#### `stats/base/dists/chisquare/mode`

Same rebind in `mode/lib/index.js`. Smoke-tested: `mode(9)` → `7`, `mode(-1)` → `NaN`, `mode(NaN)` → `NaN`.

### Validation

-   Structural feature extraction across all 14 packages (file tree, `package.json`/`manifest.json` shape, README headings, test/benchmark/example file naming).
-   Semantic feature inspection (signatures, validation prologues, error construction, JSDoc shape) on `lib/main.js` and `lib/index.js` per package.
-   Confirmed mean/median/mode tests import via `require( './../lib' )` and do not depend on the internal binding name.
-   Confirmed the public CommonJS export is unchanged (`module.exports` still resolves to the same function object).
-   Cross-checked the convention ecosystem-wide: 79% of `stats/base/dists` packages already use `var main = require( './main.js' );`.
-   Deliberately excluded: native-addon presence (intentional, tracks per-package C-port progress; an open PR — #11634 — adds C for `pdf`); factory-pattern files (intentional, only function-generators have them); JSDoc `k` typing as `PositiveNumber` vs `NonNegativeNumber` (reflects whether `k = 0` is mathematically defined for the function).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Diff is 6 lines across 3 files (2 lines per package). Each correction is committed separately for a per-package audit trail.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated cross-package drift-detection routine over the `stats/base/dists/chisquare` namespace. Author reviewed the diff before opening.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01VG6TwD9NjiJ55PrEHeCquF)_