### PR TITLE
refactor: add explicit NaN guard to `stats/base/dists/arcsine/median` native source

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/median/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/median/manifest.json
@@ -38,7 +38,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/napi/binary"
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/assert/is-nan"
       ]
     },
     {
@@ -52,7 +53,9 @@
       ],
       "libraries": [],
       "libpath": [],
-      "dependencies": []
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan"
+      ]
     },
     {
       "task": "examples",
@@ -65,7 +68,9 @@
       ],
       "libraries": [],
       "libpath": [],
-      "dependencies": []
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan"
+      ]
     }
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/median/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/median/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dists/arcsine/median.h"
+#include "stdlib/math/base/assert/is_nan.h"
 
 /**
 * Returns the median of an arcsine distribution.
@@ -30,7 +31,7 @@
 * // returns 0.5
 */
 double stdlib_base_dists_arcsine_median( const double a, const double b ) {
-	if ( a >= b ) {
+	if ( stdlib_base_is_nan( a ) || stdlib_base_is_nan( b ) || a >= b ) {
 		return 0.0 / 0.0; // NaN
 	}
 	return ( a + b ) / 2.0;


### PR DESCRIPTION
## Description

This pull request:

- Aligns the native `stats/base/dists/arcsine/median` implementation with the validation prologue used by 6 of 8 sibling 2-argument distribution functions in the same namespace and by 23 of 25 (92%) `*/median/src/main.c` files across `stats/base/dists`.

### Namespace summary

- Namespace: `@stdlib/stats/base/dists/arcsine` (14 members)
- Features analyzed: file tree, `package.json` / `manifest.json` keys, README structure, JS validation prologue and JSDoc shape, presence of native/Julia/factory artifacts
- Features with a clear majority (≥75% conformance): native implementation suite (12/14), Julia fixture suite (12/14), README skeleton `[Usage, Examples, C APIs, Usage, Examples]` (11/14), `stdlib_base_is_nan` guard in 2-arg C sources (6/8)
- Features excluded for lack of majority: JS validation prologue `isnan` guard (4/8 for 2-arg, 9/13 across non-`ctor`), `lib/factory.js` presence (5/14)

### `stats/base/dists/arcsine/median`

`median/src/main.c` previously guarded with `if ( a >= b )` only, where the sibling C sources `mean`, `stdev`, `entropy`, `kurtosis`, `mode`, and `skewness` all open with `if ( stdlib_base_is_nan( a ) || stdlib_base_is_nan( b ) || a >= b )`. Behavior is unchanged — NaN inputs already propagate to a NaN return via the arithmetic path; this only makes the early-return explicit and matches the namespace convention. Adds the corresponding `#include "stdlib/math/base/assert/is_nan.h"` and registers `@stdlib/math/base/assert/is-nan` under `build`, `benchmark`, and `examples` in `manifest.json` so the native build resolves the header.

## Related Issues

None.

## Questions

No.

## Other

### Validation

Structural features were extracted by reading the file tree and `package.json` / `manifest.json` / `README.md` of each of the 14 namespace members. Semantic features (JS public signature, validation prologue, JSDoc shape) were extracted directly from `lib/main.js` of every member; native-source content was inspected manually as a follow-on once structural analysis showed near-uniform native-file presence (12/14). Each surviving outlier was put through three independent validation agents (semantic review, cross-reference, structural review) before any patch was applied — the cross-reference agent caught that the original patch sketch was incomplete (`manifest.json` also needed the `is-nan` dependency or the build would break), and the patch was extended before commit.

Deliberately excluded from this PR:

- Missing C implementation for `stats/base/dists/arcsine/logcdf` — open-PR collision with #3389 and #10739
- Missing C implementation for `stats/base/dists/arcsine/ctor` — `ctor` is a constructor class, not a scalar function; the native skeleton is not applicable
- Missing Julia fixtures for `kurtosis` and `skewness` — both return mathematical constants (`-1.5` and `0.0` respectively), so reference values would be uninformative
- Missing JS `isnan` guard in `mean`, `median`, `stdev`, `variance` — 4-of-8 split in the 2-arg JS sources, below the 75% threshold for declaring a majority pattern
- `stats/base/dists/arcsine/variance/src/main.c` NaN guard — ecosystem-wide presence for `*/variance/src/main.c` is 78%, below the 90% threshold for treating absence as drift

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of the automated cross-package drift detection routine. Candidate-outlier enumeration and within-namespace majority computation ran locally; each surviving candidate was validated by three independent agents (semantic review, cross-reference against tests / docs / consumers, structural review including manifest implications) before the patch was applied. A human maintainer should verify the patch before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_011CHwKEYXxebBZTGiNpdSPV)_