### PR TITLE
feat: wire `zxpy` into `blas/ext/base` namespace

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/README.md
@@ -301,6 +301,7 @@ var o = ns;
 -   <span class="signature">[`zunitspace( N, start, x, strideX )`][@stdlib/blas/ext/base/zunitspace]</span><span class="delimiter">: </span><span class="description">fill a double-precision complex floating-point strided array with linearly spaced numeric elements which increment by `1` starting from a specified value.</span>
 -   <span class="signature">[`zwhere( N, condition, strideC, x, strideX, y, strideY, out, strideOut )`][@stdlib/blas/ext/base/zwhere]</span><span class="delimiter">: </span><span class="description">take elements from one of two double-precision complex floating-point strided arrays depending on a condition.</span>
 -   <span class="signature">[`zwxsa( N, alpha, x, strideX, w, strideW )`][@stdlib/blas/ext/base/zwxsa]</span><span class="delimiter">: </span><span class="description">subtract a scalar constant from each element in a double-precision complex floating-point strided array `x` and assign the results to elements in a double-precision complex floating-point strided array `w`.</span>
+-   <span class="signature">[`zxpy( N, x, strideX, y, strideY )`][@stdlib/blas/ext/base/zxpy]</span><span class="delimiter">: </span><span class="description">add elements of a double-precision complex floating-point strided array `x` to the corresponding elements of a double-precision complex floating-point strided array `y` and assign the results to `y`.</span>
 -   <span class="signature">[`zxsa( N, alpha, x, strideX )`][@stdlib/blas/ext/base/zxsa]</span><span class="delimiter">: </span><span class="description">subtract a scalar constant from each element in a double-precision complex floating-point strided array.</span>
 -   <span class="signature">[`zzeroTo( N, x, strideX )`][@stdlib/blas/ext/base/zzero-to]</span><span class="delimiter">: </span><span class="description">fill a double-precision complex floating-point strided array with linearly spaced numeric elements which increment by `1` starting from zero.</span>
 
@@ -868,6 +869,8 @@ console.log( objectKeys( ns ) );
 [@stdlib/blas/ext/base/zwhere]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/ext/base/zwhere
 
 [@stdlib/blas/ext/base/zwxsa]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/ext/base/zwxsa
+
+[@stdlib/blas/ext/base/zxpy]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/ext/base/zxpy
 
 [@stdlib/blas/ext/base/zxsa]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/ext/base/zxsa
 

--- a/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
@@ -278,6 +278,7 @@ import zsumkbn = require( '@stdlib/blas/ext/base/zsumkbn' );
 import zunitspace = require( '@stdlib/blas/ext/base/zunitspace' );
 import zwhere = require( '@stdlib/blas/ext/base/zwhere' );
 import zwxsa = require( '@stdlib/blas/ext/base/zwxsa' );
+import zxpy = require( '@stdlib/blas/ext/base/zxpy' );
 import zxsa = require( '@stdlib/blas/ext/base/zxsa' );
 import zzeroTo = require( '@stdlib/blas/ext/base/zzero-to' );
 
@@ -7960,6 +7961,36 @@ interface Namespace {
 	* // w => <Complex128Array>[ -4.0, -1.0, -2.0, 1.0, 0.0, 3.0, 2.0, 5.0 ]
 	*/
 	zwxsa: typeof zwxsa;
+
+	/**
+	* Adds elements of a double-precision complex floating-point strided array `x` to the corresponding elements of a double-precision complex floating-point strided array `y` and assigns the results to `y`.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - `x` stride length
+	* @param y - output array
+	* @param strideY - `y` stride length
+	* @returns output array
+	*
+	* @example
+	* var Complex128Array = require( '@stdlib/array/complex128' );
+	*
+	* var x = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	* var y = new Complex128Array( [ 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ] );
+	*
+	* ns.zxpy( x.length, x, 1, y, 1 );
+	* // y => <Complex128Array>[ 3.0, 5.0, 7.0, 9.0, 11.0, 13.0 ]
+	*
+	* @example
+	* var Complex128Array = require( '@stdlib/array/complex128' );
+	*
+	* var x = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	* var y = new Complex128Array( [ 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ] );
+	*
+	* ns.zxpy.ndarray( x.length, x, 1, 0, y, 1, 0 );
+	* // y => <Complex128Array>[ 3.0, 5.0, 7.0, 9.0, 11.0, 13.0 ]
+	*/
+	zxpy: typeof zxpy;
 
 	/**
 	* Subtracts a scalar constant from each element in a double-precision complex floating-point strided array.

--- a/lib/node_modules/@stdlib/blas/ext/base/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/lib/index.js
@@ -2359,6 +2359,15 @@ setReadOnly( ns, 'zwhere', require( '@stdlib/blas/ext/base/zwhere' ) );
 setReadOnly( ns, 'zwxsa', require( '@stdlib/blas/ext/base/zwxsa' ) );
 
 /**
+* @name zxpy
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/blas/ext/base/zxpy}
+*/
+setReadOnly( ns, 'zxpy', require( '@stdlib/blas/ext/base/zxpy' ) );
+
+/**
 * @name zxsa
 * @memberof ns
 * @readonly


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-06-14 11:46 PT and 2026-06-15 02:51 PT (SHA range `fcca4355a..9a1837946`).

## Description

This pull request:

-   Wires the new `blas/ext/base/zxpy` package into the parent `blas/ext/base` namespace. Commit `d33390094` introduced `blas/ext/base/zxpy` but omitted the wiring in the parent `blas/ext/base` namespace; `index.js` was missing the `setReadOnly( ns, 'zxpy', ... )` block, `index.d.ts` was missing the import and `Namespace` property, and `README.md` was missing the TOC entry and link reference, leaving `zxpy` unreachable via the namespace and absent from the TypeScript types.

## Related Issues

None.

## Questions

No.

## Other

Source of the patch — automated review routine covering the last 24 hours of commits merged to `develop`.

Commit window:

-   Start: `fcca4355a` (2026-06-14 11:46 PT)
-   End:   `9a1837946` (2026-06-15 02:51 PT)
-   12 commits inspected.

Validation audit:

-   Style-guide compliance reviewed across the new `blas/ext/base/zxpy` package and the sweeping import-path / benchmark modernization commits.
-   Bug scan over the union diff (`6810` lines) — both narrow (diff-only) and broader (cross-reference against the `cxpy` sibling).
-   Deliberately excluded: subjective preferences, hypothetical edge cases that cannot be validated from the diff alone, and any change that would require touching code outside the window.

Findings:

-   1 validated, high-signal class of issue (the namespace wiring omissions above, reported as 3 file-level findings).
-   No bugs of any kind detected in the implementation, tests, declarations, or CI/build changes.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code running as a scheduled review routine: four reviewer subagents (two style, two bug) inspected the last 24 hours of merges to `develop` in parallel, findings were de-duplicated and independently re-verified against the working tree, and the surviving fixes were applied programmatically. A human will audit before this is taken out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017SAkC98T69UVFhEtmS8PzV)_