### PR TITLE
fix: ensure consistent behavior between JavaScript and C

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dcunone/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcunone/README.md
@@ -134,6 +134,7 @@ dcunone.ndarray( 3, x, 2, 2, out, 1, 0 );
 ## Notes
 
 -   If `N <= 0`, both functions return `out` unchanged.
+-   Both functions explicitly treat `NaN` values as falsy elements.
 
 </section>
 
@@ -254,6 +255,10 @@ void stdlib_strided_dcunone_ndarray( const CBLAS_INT N, const double *X, const C
 <!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="notes">
+
+### Notes
+
+-   The function explicitly treats `NaN` values as falsy.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcunone/manifest.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcunone/manifest.json
@@ -37,6 +37,7 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/blas/base/shared",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/strided/base/stride2offset",
         "@stdlib/napi/export",
         "@stdlib/napi/argv",
@@ -57,6 +58,7 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/blas/base/shared",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/strided/base/stride2offset"
       ]
     },
@@ -72,6 +74,7 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/blas/base/shared",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/strided/base/stride2offset"
       ]
     }

--- a/lib/node_modules/@stdlib/blas/ext/base/dcunone/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcunone/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/blas/ext/base/dcunone.h"
+#include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/blas/base/shared.h"
 #include "stdlib/strided/base/stride2offset.h"
 #include <stdbool.h>
@@ -60,7 +61,7 @@ void API_SUFFIX(stdlib_strided_dcunone_ndarray)( const CBLAS_INT N, const double
 	ix = offsetX;
 	io = offsetOut;
 	for ( i = 0; i < N; i++ ) {
-		if ( flg && X[ ix ] != 0.0 ) {
+		if ( flg && X[ ix ] != 0.0 && !stdlib_base_is_nan( X[ ix ] ) ) {
 			flg = false;
 		}
 		Out[ io ] = flg;

--- a/lib/node_modules/@stdlib/blas/ext/base/dcunone/test/test.dcunone.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcunone/test/test.dcunone.js
@@ -168,3 +168,25 @@ tape( 'the function supports a negative `out` stride', function test( t ) {
 
 	t.end();
 });
+
+tape( 'the function treats `NaN` as a falsy element', function test( t ) {
+	var expected;
+	var out;
+	var x;
+
+	x = new Float64Array( [ NaN, NaN, 1.0, 1.0 ] );
+	out = new BooleanArray( 4 );
+	expected = new BooleanArray( [ true, true, false, false ] );
+
+	dcunone( x.length, x, 1, out, 1 );
+	t.ok( isEqualBooleanArray( out, expected ), 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN, NaN, NaN ] );
+	out = new BooleanArray( 4 );
+	expected = new BooleanArray( [ true, true, true, true ] );
+
+	dcunone( x.length, x, 1, out, 1 );
+	t.ok( isEqualBooleanArray( out, expected ), 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/blas/ext/base/dcunone/test/test.dcunone.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcunone/test/test.dcunone.native.js
@@ -177,3 +177,25 @@ tape( 'the function supports a negative `out` stride', opts, function test( t ) 
 
 	t.end();
 });
+
+tape( 'the function treats `NaN` as a falsy element', opts, function test( t ) {
+	var expected;
+	var out;
+	var x;
+
+	x = new Float64Array( [ NaN, NaN, 1.0, 1.0 ] );
+	out = new BooleanArray( 4 );
+	expected = new BooleanArray( [ true, true, false, false ] );
+
+	dcunone( x.length, x, 1, out, 1 );
+	t.ok( isEqualBooleanArray( out, expected ), 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN, NaN, NaN ] );
+	out = new BooleanArray( 4 );
+	expected = new BooleanArray( [ true, true, true, true ] );
+
+	dcunone( x.length, x, 1, out, 1 );
+	t.ok( isEqualBooleanArray( out, expected ), 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/blas/ext/base/dcunone/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcunone/test/test.ndarray.js
@@ -184,3 +184,25 @@ tape( 'the function supports a negative `out` stride', function test( t ) {
 
 	t.end();
 });
+
+tape( 'the function treats `NaN` as a falsy element', function test( t ) {
+	var expected;
+	var out;
+	var x;
+
+	x = new Float64Array( [ NaN, NaN, 1.0, 1.0 ] );
+	out = new BooleanArray( 4 );
+	expected = new BooleanArray( [ true, true, false, false ] );
+
+	dcunone( x.length, x, 1, 0, out, 1, 0 );
+	t.ok( isEqualBooleanArray( out, expected ), 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN, NaN, NaN ] );
+	out = new BooleanArray( 4 );
+	expected = new BooleanArray( [ true, true, true, true ] );
+
+	dcunone( x.length, x, 1, 0, out, 1, 0 );
+	t.ok( isEqualBooleanArray( out, expected ), 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/blas/ext/base/dcunone/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcunone/test/test.ndarray.native.js
@@ -193,3 +193,25 @@ tape( 'the function supports a negative `out` stride', opts, function test( t ) 
 
 	t.end();
 });
+
+tape( 'the function treats `NaN` as a falsy element', opts, function test( t ) {
+	var expected;
+	var out;
+	var x;
+
+	x = new Float64Array( [ NaN, NaN, 1.0, 1.0 ] );
+	out = new BooleanArray( 4 );
+	expected = new BooleanArray( [ true, true, false, false ] );
+
+	dcunone( x.length, x, 1, 0, out, 1, 0 );
+	t.ok( isEqualBooleanArray( out, expected ), 'returns expected value' );
+
+	x = new Float64Array( [ NaN, NaN, NaN, NaN ] );
+	out = new BooleanArray( 4 );
+	expected = new BooleanArray( [ true, true, true, true ] );
+
+	dcunone( x.length, x, 1, 0, out, 1, 0 );
+	t.ok( isEqualBooleanArray( out, expected ), 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: passed
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: missing_dependencies
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/826.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fix `NaN` handling in `blas/ext/base/dcunone` C implementation

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/826.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Primarily written by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
