### PR TITLE
docs: align JSDoc and C comments

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/ndarray.js
@@ -31,10 +31,10 @@ var dpcorr = require( '@stdlib/stats/strided/dpcorr' ).ndarray;
 * @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float64Array} x - first input array
 * @param {integer} strideX - stride length of `x`
-* @param {NonNegativeInteger} offsetX - starting index of `x`
+* @param {NonNegativeInteger} offsetX - starting index for `x`
 * @param {Float64Array} y - second input array
 * @param {integer} strideY - stride length of `y`
-* @param {NonNegativeInteger} offsetY - starting index of `y`
+* @param {NonNegativeInteger} offsetY - starting index for `y`
 * @returns {number} correlation distance
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/lib/ndarray.native.js
@@ -31,10 +31,10 @@ var addon = require( './../src/addon.node' );
 * @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float64Array} x - first input array
 * @param {integer} strideX - stride length of `x`
-* @param {NonNegativeInteger} offsetX - starting index of `x`
+* @param {NonNegativeInteger} offsetX - starting index for `x`
 * @param {Float64Array} y - second input array
 * @param {integer} strideY - stride length of `y`
-* @param {NonNegativeInteger} offsetY - starting index of `y`
+* @param {NonNegativeInteger} offsetY - starting index for `y`
 * @returns {number} correlation distance
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/src/main.c
@@ -26,9 +26,9 @@
 * Computes the correlation distance between two double-precision floating-point strided arrays.
 *
 * @param N        number of indexed elements
-* @param X        first array
+* @param X        first input array
 * @param strideX  X stride length
-* @param Y        second array
+* @param Y        second input array
 * @param strideY  Y stride length
 * @return         correlation distance
 */
@@ -42,10 +42,10 @@ double API_SUFFIX(stdlib_strided_dcorrelation)( const CBLAS_INT N, const double 
 * Computes the correlation distance between two double-precision floating-point strided arrays using alternative indexing semantics.
 *
 * @param N        number of indexed elements
-* @param X        first array
+* @param X        first input array
 * @param strideX  X stride length
 * @param offsetX  starting index for X
-* @param Y        second array
+* @param Y        second input array
 * @param strideY  Y stride length
 * @param offsetY  starting index for Y
 * @return         correlation distance

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcorrelation/src/main.c
@@ -25,12 +25,12 @@
 /**
 * Computes the correlation distance between two double-precision floating-point strided arrays.
 *
-* @param N            number of indexed elements
-* @param X            first input array
-* @param strideX      stride length of `X`
-* @param Y            second input array
-* @param strideY      stride length of `Y`
-* @return             output value
+* @param N        number of indexed elements
+* @param X        first array
+* @param strideX  X stride length
+* @param Y        second array
+* @param strideY  Y stride length
+* @return         correlation distance
 */
 double API_SUFFIX(stdlib_strided_dcorrelation)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const double *Y, const CBLAS_INT strideY ) {
 	const CBLAS_INT ox = stdlib_strided_stride2offset( N, strideX );
@@ -41,14 +41,14 @@ double API_SUFFIX(stdlib_strided_dcorrelation)( const CBLAS_INT N, const double 
 /**
 * Computes the correlation distance between two double-precision floating-point strided arrays using alternative indexing semantics.
 *
-* @param N            number of indexed elements
-* @param X            first input array
-* @param strideX      stride length of `X`
-* @param offsetX      starting index for X
-* @param Y            second input array
-* @param strideY      stride length of `Y`
-* @param offsetY      starting index for Y
-* @return             output value
+* @param N        number of indexed elements
+* @param X        first array
+* @param strideX  X stride length
+* @param offsetX  starting index for X
+* @param Y        second array
+* @param strideY  Y stride length
+* @param offsetY  starting index for Y
+* @return         correlation distance
 */
 double API_SUFFIX(stdlib_strided_dcorrelation_ndarray)( const CBLAS_INT N, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX, const double *Y, const CBLAS_INT strideY, const CBLAS_INT offsetY ) {
 	if ( N <= 0 ) {


### PR DESCRIPTION
## Description

This pull request aligns the JSDoc and C source documentation in `@stdlib/stats/strided/distances/dcorrelation` with the seven sibling packages in the namespace.

### Namespace summary

-   **Target:** `@stdlib/stats/strided/distances`
-   **Members analyzed:** 8 (`dchebyshev`, `dcityblock`, `dcorrelation`, `dcosine-distance`, `dcosine-similarity`, `deuclidean`, `dminkowski`, `dsquared-euclidean`)
-   **Features extracted:** complete file tree, `package.json` shape (top-level keys, `scripts`, `directories`, `keywords`), `manifest.json` shape, README heading sequence and parameter names, semantic features (public signature, JSDoc shape, dependency set, validation prologue, return kind, error construction) from `lib/main.js`, the per-package wrapper, `lib/ndarray.js`, `lib/ndarray.native.js`, and `src/main.c`.
-   **Features with clear majority (≥75% = 6/8):** identical 33-file structure (100%); `package.json` top-level key set, `directories` keys, empty `scripts`, `gypfile: true`, `os` array, `main: "./lib"` (100%); `manifest.json` keys `confs`/`fields`/`options` (100%); 14 universal keywords at 100%; `metric` keyword at 100% (post #12729); JS `@param N` `NonNegativeInteger` annotation across the 4 JS lib files at 100% (post #12729); README H2/H3 heading sequence `Usage` / `Notes` / `Examples` / `C APIs` / `Usage` / `Examples` (100%); JS `lib/ndarray.js` and `lib/ndarray.native.js` `@param offsetX/offsetY` description `starting index for \`x\``/`for \`y\`` at 7/8 = 87.5%; C `src/main.c` `@param`/`@return` doc-block style (8-space column alignment, `first array`/`X stride length` phrasing, per-distance `@return` label) at 7/8 = 87.5%.
-   **Features without clear majority (excluded):** REPL phrasing `Stride length of`/`for` and TypeScript declaration phrasing `stride length of`/`\`x\` stride length` — both were flagged `needs-human` in the previous run on this namespace (#12729) and remain out of scope here. Metric-specific keywords (`cosine`, `euclidean`, etc.) are package-specific by design.
-   **Drift already corrected (PR #12729, merged 2026-06-10):** JSDoc `@param N` retype to `NonNegativeInteger` and `metric` keyword addition — both excluded from this run via cross-run dedup.

### `@stdlib/stats/strided/distances/dcorrelation`

Three documentation-only deviations remained in `dcorrelation` after #12729 landed. (1) `lib/ndarray.js` and `lib/ndarray.native.js` use `starting index of \`x\``/`of \`y\`` for the `offsetX`/`offsetY` JSDoc, where all seven siblings use `for \`x\``/`for \`y\``. (2) `src/main.c` uses a different doc-block style — 12-space column alignment, `first input array`/`second input array`, `stride length of \`X\``/`stride length of \`Y\``, and a generic `output value` in `@return` — where all seven siblings use 8-space alignment, `first array`/`second array`, `X stride length`/`Y stride length`, and a per-distance `@return` label (e.g. `Chebyshev distance`). The diff replaces `output value` with `correlation distance`, matching the sibling convention.

### Validation

Three independent validation agents reviewed each candidate fix before any edit was applied:

1.  **Semantic-review (Opus):** read both `dcorrelation/src/main.c` doc blocks, both `lib/ndarray.js`/`lib/ndarray.native.js` JSDoc blocks, and the same files for `dchebyshev` and `deuclidean` for comparison. Verdict: `confirmed-drift` on all three corrections — the parameter set is identical across all eight packages (`N`, `X`, `strideX`, `offsetX`, etc., with identical types and semantics), so the comment differences carry no semantic signal; the `output value` → `correlation distance` substitution is the natural fill-in under the sibling convention.
2.  **Cross-reference (Opus):** read `dcorrelation/test/test.dcorrelation.js`, `test/test.ndarray.js`, both `.native.js` test counterparts, `examples/index.js`, both benchmark files, and grepped the wider `lib/node_modules/@stdlib/` tree for consumers. Verdict: `safe-to-fix` on all three — no test asserts on comment text; the few cross-package references to `stats/strided/distances/dcorrelation` are namespace re-exports and error-tools ID maps that do not parse JSDoc or C comment strings.
3.  **Structural-review (Sonnet):** confirmed the 7/8 sibling pattern applies cleanly to `dcorrelation` for all three corrections, with no "missing file/field is inapplicable" objection (this is text-normalization, not file addition).

### Cross-run dedup

PR #12729 ran the same routine on this namespace 6 days ago. The corrections it applied (JSDoc `PositiveInteger` → `NonNegativeInteger` for `N`, `metric` keyword addition) are skipped here. The drifts it explicitly dropped as `needs-human` or out-of-scope are NOT re-proposed: the `Stride length of`/`for` REPL substitution (conflated with the universal JS `stride length of` form), the TypeScript declaration word-order rewrite (`stride length of \`x\`` → `\`x\` stride length` etc.), the README `## C APIs` `ndarray` H4 heading parameter names (reverted in #12729 due to a `remark-lint` `maximum-heading-length: 80` regression that would re-trigger here), and the self-referential `dcorrelation` keyword (1/8 occurrence). The C `src/main.c` doc-block style was acknowledged in #12729 as "real drift, but outside the agent-validated scope of this run" — it is included in this run after passing all three validation agents.

### Other deliberately excluded

-   REPL phrasing (`docs/repl.txt`) and TypeScript declaration phrasing (`docs/types/index.d.ts`) — the underlying drift exists but the prior run's `needs-human` verdict stands; would need a targeted pass that disambiguates between `for`/`of` substitutions in the REPL and word-order rewrites in the `.d.ts`.
-   README `## C APIs` `ndarray` H4 heading parameter names — would re-trigger the heading-length lint that caused #12729 to revert the same fix. Resolving it requires a separate namespace-wide pass addressing the underlying 80-character rule violation.
-   Removal of the self-referential `dcorrelation` keyword from `package.json` — outside the validated scope of this run.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

-   Final diff: 18 lines across 3 files (4 JSDoc lines in `lib/ndarray.js`, 4 in `lib/ndarray.native.js`, 10 in `src/main.c`).
-   All changes are comment-only. No JavaScript or C executable code was modified.
-   No tests, examples, benchmarks, REPL fixtures, TypeScript declarations, or REPL docs were modified.
-   Full local report (member list, feature distributions, per-agent verdicts, dropped findings, prior-PR dedup notes, future-run notes) saved at `~/drift-reports/drift-stats-strided-distances-2026-06-15.md` outside the repo working tree.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package API drift detection routine on the randomly-selected `@stdlib/stats/strided/distances` namespace. Structural features (file tree, `package.json` shape, README headings, etc.) were extracted across all eight members; semantic features (JSDoc shape, public signature, dependency set, validation prologue, return kind) were read directly from each member's `lib/main.js`, per-package wrapper, `lib/ndarray.js`, `lib/ndarray.native.js`, and `src/main.c`. Three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) reviewed each candidate fix before any file was edited. Cross-run dedup against PR #12729 (the previous run on this namespace, merged 2026-06-10) was applied to avoid re-proposing already-fixed or already-dropped corrections. A human should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbpnPcHtFteJRJXcDuDPXn)_