### PR TITLE
docs: fix JSDoc type

### DIFF
--- a/lib/node_modules/@stdlib/number/float32/base/to-word/lib/main.js
+++ b/lib/node_modules/@stdlib/number/float32/base/to-word/lib/main.js
@@ -36,7 +36,7 @@ var UINT32_VIEW = new Uint32Array( FLOAT32_VIEW.buffer );
 * Returns an unsigned 32-bit integer corresponding to the IEEE 754 binary representation of a single-precision floating-point number.
 *
 * @param {number} x - single-precision floating-point number
-* @returns {unsigned32} unsigned 32-bit integer
+* @returns {uinteger32} unsigned 32-bit integer
 *
 * @example
 * var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );

--- a/lib/node_modules/@stdlib/number/float32/base/to-word/lib/native.js
+++ b/lib/node_modules/@stdlib/number/float32/base/to-word/lib/native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {number} x - single-precision floating-point number
-* @returns {unsigned32} unsigned 32-bit integer
+* @returns {uinteger32} unsigned 32-bit integer
 *
 * @example
 * var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );

--- a/lib/node_modules/@stdlib/number/float32/base/ulp-difference/lib/main.js
+++ b/lib/node_modules/@stdlib/number/float32/base/ulp-difference/lib/main.js
@@ -32,7 +32,7 @@ var abs = require( '@stdlib/math/base/special/abs' );
 * Converts an unsigned 32-bit integer corresponding to the IEEE 754 binary representation of a single-precision floating-point number to a lexicographically ordered integer.
 *
 * @private
-* @param {unsigned32} word - unsigned 32-bit integer
+* @param {uinteger32} word - unsigned 32-bit integer
 * @returns {integer} lexicographically ordered integer
 */
 function monotoneKey( word ) {


### PR DESCRIPTION
## Description

Replaces the non-canonical `{unsigned32}` JSDoc type tag with `{uinteger32}` at three sites in `number/float32/base`. `uinteger32` is the stdlib-wide alias for a 32-bit unsigned integer in the JS `number` value space (94% of stdlib occurrences) and is registered in `_tools/eslint/rules/jsdoc-typedef-typos/lib/defaults.json`; `unsigned32` is an older alias absent from that allowlist. JSDoc-only; no runtime behavior change.

### Namespace summary

- Members analyzed: 18 (`number/float32/base` direct children with `package.json`).
- Leaf packages used for the per-feature vote: 17 (the `assert/` namespace re-export was excluded from semantic analysis as inapplicable).
- Features extracted: file tree, `package.json` top-level/scripts/stdlib keys, `manifest.json` top-level keys, README sections (set and order), test/benchmark/example filenames, public signature, return kind, validation prologue, error construction, JSDoc shape, `require()` dependencies.
- Features with a clear majority (≥75%) that surfaced an outlier:
    - JSDoc unsigned-32-bit-integer type tag — 4/4 sibling uses are `{uinteger32}`; 3 sites use `{unsigned32}`. Fixed here.
    - `## See Also` README section — present in 14/17 leafs. **Excluded**: the section is auto-populated by the package-generator (`<!-- Section for related stdlib packages. Do not manually edit this section, as it is automatically populated. -->`).
- Features without a clear majority (excluded from drift analysis):
    - `lib/native.js` presence — 12/17 leafs (70.6%); below the 75% threshold and the absences (`from-binary-string`, `to-binary-string`, `to-int32`, `to-uint32`, `ulp-difference`) are semantically intentional (string parsing, simple bitwise ops).
    - `## C APIs` README section — 12/17 leafs (70.6%); tracks `lib/native.js`.
    - `@example` count, `@param`/`@returns` types — heterogeneous by function shape; no convergent majority and no candidate outlier.

### `number/float32/base/to-word`

`lib/main.js` and `lib/native.js` both document `@returns {unsigned32}`. Sibling packages document the identical concept as `{uinteger32}` (see `from-word` `@param`, `significand` `@returns`, `to-uint32` `@returns`), and `unsigned32` is not in the stdlib JSDoc typedef allowlist. Renamed at both sites; no other changes.

### `number/float32/base/ulp-difference`

`lib/main.js` documents `@param {unsigned32} word` on the private `monotoneKey` helper, whose argument is the `uint32` produced by `to-word`. Renamed to match the canonical alias. The exported `ulpdiff` JSDoc is unchanged.

## Related Issues

None.

## Questions

None.

## Other

### Validation

- Structural and semantic features were extracted across all 18 direct child packages of `lib/node_modules/@stdlib/number/float32/base/` (file tree excluding sub-package recursion, `package.json` / `manifest.json` key sets, README section list, `test/`/`benchmark/`/`examples/` filenames, JSDoc shape, validation prologue, error construction, dependency set).
- Three validation passes were run over the surfaced drift candidate:
    1. **Semantic.** Confirmed `unsigned32` and `uinteger32` denote the same JSDoc concept; sibling packages in the namespace already use `uinteger32` for the identical return/parameter type.
    2. **Cross-reference.** Tests (`to-word/test/test.js`, `ulp-difference/test/test.js`) assert runtime values only and do not depend on the JSDoc tag. `examples/index.js` and the `lib/index.js` `@module` docstrings do not reference either token. No README in `number/float32/base` references `unsigned32`.
    3. **Structural.** `uinteger32` is registered in `_tools/eslint/rules/jsdoc-typedef-typos/lib/defaults.json` and `_tools/eslint/rules/jsdoc-doctest-decimal-point/lib/integer_types.json`; `unsigned32` is absent from both. Production usage measured at 64 occurrences for `uinteger32` vs 4 for `unsigned32` (3 of the 4 are the sites fixed here; the remaining one is a test fixture inside `_tools/`).
- Deliberately excluded from this PR:
    - `## See Also` heading drift in `significand`, `to-float16`, `ulp-difference` — generator-owned section (scaffold present, content auto-populated by the package generator).
    - `assert/` outlier on file-tree features (missing `lib/main.js`, `docs/repl.txt`, `benchmark/`) — `assert/` is a namespace re-export package, not a leaf, and these files are inapplicable.
    - `lib/native.js` and `## C APIs` absences — below the 75% conformance threshold and absences track a real semantic distinction (string-valued / bitwise-trivial packages legitimately lack a C addon).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated routine that scans a randomly chosen stdlib namespace for cross-package API drift via majority vote. Structural and semantic features were extracted across all members of `number/float32/base`; the only feature with a clear majority that surfaced advance-able outliers was the JSDoc unsigned-32-bit-integer type tag. Three independent validation passes (semantic, cross-reference, structural) confirmed the rename is mechanical and matches the stdlib eslint typedef allowlist. A human maintainer should verify before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xrvn19Nt33rdRCFXYDswuf)_