### PR TITLE
style: add missing spaces

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logpdf/src/main.c
@@ -46,7 +46,7 @@ double stdlib_base_dists_logistic_logpdf( const double x, const double mu, const
 		stdlib_base_is_nan( s ) ||
 		s < 0.0
 	) {
-		return 0.0 / 0.0; //NaN
+		return 0.0 / 0.0; // NaN
 	}
 	if ( x == STDLIB_CONSTANT_FLOAT64_NINF ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/src/main.c
@@ -40,7 +40,7 @@ double stdlib_base_dists_logistic_stdev( const double mu, const double s ) {
 		stdlib_base_is_nan( s ) ||
 		s <= 0.0
 	) {
-		return 0.0/0.0; // NaN
+		return 0.0 / 0.0; // NaN
 	}
 	return s * PI_OVER_SQRT_THREE;
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Normalizes the C-source NaN-return whitespace in `stats/base/dists/logistic/logpdf` and `stats/base/dists/logistic/stdev` to the canonical form `return 0.0 / 0.0; // NaN` used by the other 12 native-binding members of the namespace.

### Namespace summary

- Members analyzed: 15 (`cdf`, `ctor`, `entropy`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `median`, `mgf`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`).
- Autogenerated members excluded from the vote: 0.
- Native-binding members (those with `src/main.c`): 14 (`ctor` is a pure-JS constructor class and has none).
- Features with a clear majority (≥75%) and an applicable correction: 1 — the spacing of the `return 0.0 / 0.0; // NaN` statement in `src/main.c`.
- Features without a clear majority (excluded from drift analysis): the presence of `lib/factory.js` (6/15 semantic split between factory-producing kernels and direct-arithmetic ones); the `s < 0.0` vs `s <= 0.0` guard predicate (intentional cohort split between density/quantile-family and summary-statistic-family kernels); `@returns` JSDoc type (no ≥75% majority).

### Per outlier package

#### `stats/base/dists/logistic/logpdf`

`src/main.c` ended the NaN-return guard with `return 0.0 / 0.0; //NaN` — no space between `//` and `NaN`. The 12 conforming sibling kernels (`cdf`, `entropy`, `kurtosis`, `logcdf`, `mean`, `median`, `mgf`, `mode`, `pdf`, `quantile`, `skewness`, `variance`; ~93% conformance among the 14 native-binding members of the namespace, with `stdev` being the other deviating package) use `// NaN` with a single leading space, the convention applied uniformly across `@stdlib`'s C-source comments.

#### `stats/base/dists/logistic/stdev`

`src/main.c` ended the NaN-return guard with `return 0.0/0.0; // NaN` — no spaces around the division operator. The 12 conforming siblings (~93% conformance) use `0.0 / 0.0` with single spaces around `/`, matching the operator-spacing convention used throughout the namespace's NaN guards and throughout the `@stdlib` C sources more broadly. No behavioural change — the compiler emits identical IR.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

- Structural feature extraction over all 15 members (file trees, `package.json` shape, README headings, `manifest.json` shape, test/benchmark/example filenames).
- Direct cross-file comparison of `src/main.c` NaN-return statements across the 14 native-binding members of the namespace.
- Two-agent drift validation: cross-reference (Agent 2) confirmed no test, benchmark, example, or repo tooling parses the affected text in either package; structural-review (Agent 3) verified the 12-of-14 majority pattern and ruled out any lint, formatter, or style policy that would single these files out for a divergent form.

Deliberately excluded from this PR:

- `ctor` is the canonical pure-JS structural outlier in this namespace (no `binding.gyp`, `src/`, `lib/native.js`, etc.) — intentional.
- `mgf/lib/factory.js` summary wording (`of a` → `for a`) — already covered by open PR #12677.
- Within-namespace majority `var main = require( './main.js' )` vs the named-variable form used by `mean`, `median`, `mode`: the named-variable form is the ecosystem-wide convention across sibling `stats/base/dists/*/{mean,median,mode}` packages, so the local 12/15 majority is the wrong direction.
- `stdev` using Python rather than Julia test fixtures — out of scope (the test file imports the Python fixture, so migrating would require regenerating fixtures and rewriting the test).
- `@returns` JSDoc type variation across summary-statistic kernels — no ≥75% majority; reflects genuine semantic differences (e.g. `stdev`/`variance` legitimately use `PositiveNumber`).
- `s < 0.0` vs `s <= 0.0` validation guards — intentional semantic split between density/quantile kernels (where `s = 0` is a defined degenerate case) and summary-statistic kernels (where `s = 0` is undefined).

PR #12874 (merged 2026-06-15) ran the same routine on this namespace and landed the `mu` "mean" → "location parameter" JSDoc normalization; this PR addresses two C-source style items that fell outside that pass.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of the cross-package API drift detection routine. The routine extracted structural and semantic features from every member of `stats/base/dists/logistic/`, computed per-feature majority patterns at 75% conformance, and validated each surviving candidate through two parallel review agents before any edit. The corrections in this PR are pure C-source whitespace changes; no behaviour, signatures, generated machine code, or tests changed. A human maintainer should verify the patches before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01URhKUCtk3fhQ5VJ6XmyT9x)_