### PR TITLE
chore: clean-up for changes introduced in previous commits

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-truthy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-truthy/README.md
@@ -125,7 +125,7 @@ var idx = gindexOfTruthy.ndarray( 3, x, 1, x.length-3 );
 
 ## Notes
 
--   Both functions return `-1`, if the functions are unable to find a truthy element.
+-   If unable to find a truthy element, both functions return `-1`.
 -   Both functions support array-like objects having getter and setter accessors for array element access (e.g., [`@stdlib/array/base/accessor`][@stdlib/array/base/accessor]).
 
 </section>

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ddiff/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ddiff/README.md
@@ -124,6 +124,14 @@ console.log( 'out: ', ndarray2array( out ) );
 
 <!-- /.examples -->
 
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/blas/ext/base/swapx/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/swapx/README.md
@@ -305,6 +305,14 @@ int main( void ) {
 
 <!-- /.c -->
 
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-06-15 13:22 PDT and 2026-06-16 04:06 PDT.

This pull request:

-   Adds the missing `<section class="references">` block to `blas/ext/base/swapx` README — every sibling BLAS-ext package carries it. Originating commit: `454c11ba8c` (`feat: add blas/ext/base/swapx`).
-   Adds the same missing `<section class="references">` block to `blas/ext/base/ndarray/ddiff` README. Originating commit: `8498df4daf` (`feat: add blas/ext/base/ndarray/ddiff`).
-   Fixes awkward repetition in the `blas/ext/base/gindex-of-truthy` README notes bullet ("Both functions return `-1`, if the functions are unable to find…") to match the sibling `dindex-of-truthy` phrasing. Originating commit: `ec3f1dde3a` (`feat: add blas/ext/base/gindex-of-truthy`).

> **Note:** an earlier revision of this PR also carried the 1-ULP tolerance to the `cabs2`, `cabs2f`, and `cbrt` `test.native.js` files. Those changes were dropped: the ULP-migration commits **intentionally** set the native tests to exact `t.strictEqual` (replacing the prior EPS-tolerance fallback), so applying a tolerance there would reverse a deliberate decision rather than fix an omission.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

### Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
