### PR TITLE
docs: drop redundant "elements" qualifier

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/docs/types/index.d.ts
@@ -28,7 +28,7 @@ interface Routine {
 	* ## Notes
 	*
 	* -   If unable to find a truthy element, the function returns `-1`.
-	* -   The function explicitly treats `NaN` values as falsy elements.
+	* -   The function explicitly treats `NaN` values as falsy.
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
@@ -51,7 +51,7 @@ interface Routine {
 	* ## Notes
 	*
 	* -   If unable to find a truthy element, the function returns `-1`.
-	* -   The function explicitly treats `NaN` values as falsy elements.
+	* -   The function explicitly treats `NaN` values as falsy.
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
@@ -76,7 +76,7 @@ interface Routine {
 * ## Notes
 *
 * -   If unable to find a truthy element, the function returns `-1`.
-* -   The function explicitly treats `NaN` values as falsy elements.
+* -   The function explicitly treats `NaN` values as falsy.
 *
 * @param N - number of indexed elements
 * @param x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/lib/dindex_of_truthy.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/lib/dindex_of_truthy.js
@@ -32,7 +32,7 @@ var ndarray = require( './ndarray.js' );
 * ## Notes
 *
 * -   If unable to find a truthy element, the function returns `-1`.
-* -   The function explicitly treats `NaN` values as falsy elements.
+* -   The function explicitly treats `NaN` values as falsy.
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Float64Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/lib/dindex_of_truthy.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/lib/dindex_of_truthy.native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 * ## Notes
 *
 * -   If unable to find a truthy element, the function returns `-1`.
-* -   The function explicitly treats `NaN` values as falsy elements.
+* -   The function explicitly treats `NaN` values as falsy.
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Float64Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/lib/ndarray.js
@@ -26,7 +26,7 @@
 * ## Notes
 *
 * -   If unable to find a truthy element, the function returns `-1`.
-* -   The function explicitly treats `NaN` values as falsy elements.
+* -   The function explicitly treats `NaN` values as falsy.
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Float64Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/lib/ndarray.native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 * ## Notes
 *
 * -   If unable to find a truthy element, the function returns `-1`.
-* -   The function explicitly treats `NaN` values as falsy elements.
+* -   The function explicitly treats `NaN` values as falsy.
 *
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Float64Array} x - input array


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-06-15 21:53 PDT and 2026-06-16 04:06 PDT to sibling packages with the same defective wording.

### Pattern: drop redundant "elements" from `NaN` falsy-handling note

Source commit `6cfefb71` normalised the NaN-handling Notes bullet in the eight `blas/ext/base/{dcuany,dcuevery,dcunone,dcusome,scuany,scuevery,scunone,scusome}` READMEs, dropping the redundant noun "elements" from `treat \`NaN\` values as falsy elements.` — "falsy" already implies the elements under discussion. The newly-added `blas/ext/base/dindex-of-truthy` package (merged in the same window via PR #12910) shipped with the normalised wording in its README but with the stale form still embedded in its JSDoc and TypeScript declarations. This propagation aligns the per-function JSDoc and the `docs/types/index.d.ts` overload comments with the package's own README and the sibling canonical form. The singular "The function" wording is left intact because each per-function JSDoc block documents a single function or overload; the plural form ("Both functions") used in the README applies because the README's `## Notes` section covers both the main and the `.ndarray` API together.

- `6cfefb714d` ([`docs: make notes consistent`](https://github.com/stdlib-js/stdlib/commit/6cfefb714d4e4468c01c9096eba103ce110082cb))
  - `@stdlib/blas/ext/base/dindex-of-truthy`

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Search scope:** scoped to the source commit's namespace (`lib/node_modules/@stdlib/blas/ext/base/`) and widened repository-wide via `rg -F "as falsy elements"` to confirm coverage. The only remaining occurrences outside the source commit's eight READMEs were the seven cited lines, all inside `dindex-of-truthy`.
- **Two independent opus validation passes** confirmed at every candidate site that (a) the defect text appears as cited, (b) each JSDoc block documents a single function or overload (so "The function" is semantically correct), (c) the only edit required is the removal of the word " elements", and (d) no surrounding wording (tests, repl text, examples) would be left inconsistent — in particular, the in-package test descriptions that legitimately use the noun "falsy elements" (`'ignores falsy elements (e.g., 0, NaN)'`) remain untouched, as required.
- **A sonnet style-consistency pass** verified bullet indentation, terminal-period placement, and the wording match against both the package's own README and the sibling `dcuany`/`scuany` READMEs.

Deliberately excluded:

- Pattern (B) from the source commit (singular → plural, "The function" → "Both functions" in the C-API section) is not propagated to the JSDoc/types, because each JSDoc block documents a single function or overload in isolation. The plural form is only correct in shared sections (the README) that document both APIs together.
- Test fixture descriptions referencing "falsy elements" as a noun (e.g., `'ignores falsy elements'` in tape descriptions) — grammatically required and intentional in those contexts.
- The 36 `test: migrate <pkg> to ULP-based testing` commits merged in the same window — part of an active, maintainer-paced migration tracked by issue #11352, not propagation-class work.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalisable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two opus validation passes plus a sonnet style-consistency pass) before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GprfYbNgMEDg7wvNNrDuS3)_