### PR TITLE
docs: add Git notes correcting recent commit messages

### DIFF
--- a/docs/git-notes/454c11ba8cbf3d98da513295412c0d94488ff4bd.txt
+++ b/docs/git-notes/454c11ba8cbf3d98da513295412c0d94488ff4bd.txt
@@ -1,0 +1,9 @@
+---
+type: amend-message
+---
+feat: add `blas/ext/base/swapx`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/12869
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Signed-off-by: Athan Reines <kgryte@gmail.com>
+Closes: https://github.com/stdlib-js/metr-issue-tracker/issues/736


### PR DESCRIPTION
## Summary

This PR adds one Git note correcting a malformed trailer in a recent commit.

## Notes

- `454c11ba`: missing `Signed-off-by` — commit `feat: add \`blas/ext/base/swapx\`` (PR #12869) has no `Signed-off-by` trailer, while all other GitHub-merged commits in the same batch include `Signed-off-by: Athan Reines <kgryte@gmail.com>` between `Reviewed-by` and `Closes`.

## Audit scope

50 commits inspected from the last 24 hours on `develop` (since 2026-06-15). PR-URLs and issue references were verified via the GitHub API. All other trailers, subjects, and scopes were checked against stdlib Conventional Commits style. Only the above commit was flagged.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)