### PR TITLE
docs: modernize `stats/base/dists/erlang/mgf` examples

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mgf/README.md
@@ -140,23 +140,19 @@ y = myMGF( -0.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mgf = require( '@stdlib/stats/base/dists/erlang/mgf' );
 
-var lambda;
-var k;
-var t;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var t = uniform( 20, 0.0, 3.0, opts );
+var k = discreteUniform( 20, 0, 10, opts );
+var lambda = uniform( 20, 0.0, 5.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    k = round( randu() * 10.0 );
-    lambda = randu() * 10.0;
-    t = randu() * lambda;
-    y = mgf( t, k, lambda );
-    console.log( 't: %d, k: %d, λ: %d, M_X(t;k,λ): %d', t.toFixed( 4 ), k, lambda.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 't: %0.4f, k: %d, λ: %0.4f, M_X(t;k,λ): %0.4f', t, k, lambda, mgf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mgf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mgf/examples/index.js
@@ -18,20 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mgf = require( './../lib' );
 
-var lambda;
-var k;
-var t;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var t = uniform( 20, 0.0, 3.0, opts );
+var k = discreteUniform( 20, 0, 10, opts );
+var lambda = uniform( 20, 0.0, 5.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	k = round( randu() * 10.0 );
-	lambda = randu() * 10.0;
-	t = randu() * lambda;
-	y = mgf( t, k, lambda );
-	console.log( 't: %d, k: %d, λ: %d, M_X(t;k,λ): %d', t.toFixed( 4 ), k, lambda.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 't: %0.4f, k: %d, λ: %0.4f, M_X(t;k,λ): %0.4f', t, k, lambda, mgf );


### PR DESCRIPTION
## Description

Modernizes the lone surviving legacy `examples/index.js` under `stats/base/dists/erlang` so that every package in the namespace (excluding `ctor`, which uses a constructor demonstration) uses the same array-based `@stdlib/random/array/*` + `@stdlib/console/log-each-map` idiom.

### Namespace summary

- Target namespace: `stats/base/dists/erlang` (13 direct packages, none autogenerated)
- Features analyzed: file tree, `package.json` shape, README headings, `manifest.json` shape, test/benchmark/example file names, public signatures, validation prologue, error construction, JSDoc shape, dependencies, `examples/index.js` random-input idiom, JSDoc module summary phrasing, REPL skeleton
- Features with a clear (≥75%) majority that surfaced an outlier: `examples/index.js` random-input idiom (12/13 = 92% modern, 1 legacy)
- Features without a clear majority (excluded): JSDoc module summary phrasing (`Erlang distribution <X>.` vs. `<X> for an Erlang distribution.`); `keywords` ordering between input-function and summary-stat sub-groups; C-example loop bound (`i < 10` vs. `i < 25`, 4/7 vs. 3/7)
- Features whose split tracked a semantic boundary (not drift): presence of `lib/factory.js`, presence of native C bindings (`binding.gyp`, `manifest.json`, `src/`, etc.), validation prologue (`isNonNegativeInteger` vs. `isPositiveInteger`), `@returns` JSDoc type (`number` vs. `NonNegativeNumber` vs. `Probability`)

### `stats/base/dists/erlang/mgf`

Migrates `examples/index.js` from the legacy `randu`/`Math.round`/`for`-loop pattern to the array-based idiom using `@stdlib/random/array/uniform`, `@stdlib/random/array/discrete-uniform`, and `@stdlib/console/log-each-map`, bringing this package into conformance with all other non-`ctor` siblings under `stats/base/dists/erlang`. Parameter ranges (`t ∈ [0.0, 3.0]`, `k ∈ [0, 10]`, `λ ∈ [0.0, 5.0]`) follow `stats/base/dists/gamma/mgf`, the natural analog given that Erlang is a Gamma special case. The README `## Examples` block is updated in lockstep to mirror the revised source.

## Related Issues

None.

## Questions

No.

## Other

### Validation

Structural and semantic features were extracted from all 13 namespace members. Semantic extraction (signatures, validation prologues, JSDoc shapes, dependencies) used per-package agents. Each surviving candidate correction was reviewed by three independent agents: (1) opus semantic-review to distinguish intentional deviation from drift, (2) opus cross-reference to confirm no tests or external consumers depend on the legacy example, and (3) sonnet structural-review to verify the claimed conformance count. All three returned `confirmed-drift` for this correction.

Deliberately excluded from the run:

- `stats/base/dists/erlang/mgf/lib/factory.js` ("of an Erlang distribution" → "for an Erlang distribution") — already proposed in open PR #12677.
- Differences tracking the input-function vs. summary-statistic semantic split — these are not drift.
- The JSDoc module-summary phrasing inconsistency (`logpdf` and `mgf` deviate from the `Erlang distribution <X>.` form) — the same split exists across sibling distributions, so the ≥90% ecosystem-wide gate is not satisfied.
- A whitespace nit in `mgf/lib/main.js` (`isnan( lambda )||` missing a space before `||`) — single-line style tweak with no other corrections in `main.js`, dropped per the materiality gate.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift-detection routine targeting `stats/base/dists/erlang`. Structural and semantic features were extracted from every namespace member, the majority pattern was identified per feature, and the lone outlier was validated by three independent agents before any source edits were applied. A human maintainer should verify the patch before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01YMhZMk7fHEUEW8amRow4mJ)_