### PR TITLE
refactor: rename internal variables

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/package.json
@@ -60,6 +60,7 @@
     "cdf",
     "logcdf",
     "lognormal",
+    "gaussian",
     "normal",
     "bell-shape",
     "logarithm",

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Tidies four small drift items in the `@stdlib/stats/base/dists/lognormal` namespace surfaced by a structural majority-vote sweep over the 14 sibling packages.

### Namespace summary

-   **Target:** `@stdlib/stats/base/dists/lognormal` — 14 sibling packages (`cdf`, `ctor`, `entropy`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `median`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`), none autogenerated.
-   **Features analyzed:** file tree; `package.json` top-level / `scripts` / `directories` / `keywords` sets; `manifest.json` shape; README heading set and tagline; `lib/index.js` exported-symbol identifier; test/benchmark/example file inventories; semantic features (function name, parameter list, validation prologue, error-construction style, dependency set) parsed from every `lib/main.js`.
-   **Features with clear majority (≥75%):** `lib/main.js` / `lib/index.js` / `docs/repl.txt` / `docs/types/index.d.ts` presence (100%); `package.json` top-level key set (100%); README `## Usage` / `## Examples` sections (100%); a 13-keyword common set (`stdlib`, `stdmath`, `statistics`, `stats`, `distribution`, `dist`, `continuous`, `gaussian`, `log`, `logarithm`, `lognormal`, `normal`, `univariate`) at 13–14/14; `var main = require( './main.js' ); module.exports = main;` in `lib/index.js` at 11/14 = 78.6%.
-   **Features without clear majority (excluded):** native-bindings group (`binding.gyp`, `lib/native.js`, `src/`, `manifest.json`, `include/`, `gypfile` `package.json` key) at 10/14 = 71.4% — below the threshold, and the four absences (`cdf`, `ctor`, `logcdf`, `logpdf`) are actively being filled in by open PRs #10809, #10881, #10882, #10883; README h1 title (each member uses a function-specific title); semantic features (`publicSignature`, `validationPrologue`, `errorConstruction`) heterogeneous by construction (`ctor` vs summary-statistic vs distribution-function shapes — no single shape reaches 75%).

### `@stdlib/stats/base/dists/lognormal/logcdf`

Adds `gaussian` to the `keywords` array. `logcdf` is the lone outlier missing it (13/14 = 92.9% conformance); the implementation wraps `normal/logcdf` after a `ln(x)` transform, so the keyword is semantically appropriate and consistent with every other lognormal package. The unique `bell-shape` keyword is retained — it is shared with `normal/pdf`, `normal/logpdf`, `normal/logcdf`, and `truncated-normal/pdf`, so it is intentional, not drift. Metadata only; no code, behavior, or test expectations touched.

### `@stdlib/stats/base/dists/lognormal/mean`

Renames the local `lib/index.js` variable from `mean` to `main`, matching the pattern carried by 11/14 = 78.6% of namespace siblings (including `variance`, `entropy`, `kurtosis`, `cdf`, `pdf`, `logpdf`, `logcdf`, `quantile`, `skewness`, `stdev`, `ctor`). Same `./main.js` re-export, same module surface; purely an in-file identifier change.

### `@stdlib/stats/base/dists/lognormal/median`

Identical fix shape to `mean`: renames the local `lib/index.js` variable from `median` to `main`. The named-variable form (78.6% minority within the namespace) is the older convention — `median` predates the `main` normalization and was not updated when the convention switched.

### `@stdlib/stats/base/dists/lognormal/mode`

Identical fix shape to `mean` and `median`: renames the local `lib/index.js` variable from `mode` to `main`. Same `./main.js` re-export; module-internal cosmetic change.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Checked:

-   **Structural feature extraction** across all 14 members: file tree, `package.json` shape and field values, `manifest.json` shape, README heading set and tagline, `lib/index.js` exported-symbol identifier, test/benchmark/example filename inventories.
-   **Semantic feature extraction** parsed directly from each `lib/main.js` (function name, parameter list, validation prologue sequence, error-construction mode, dependency set). No semantic feature reached a 75% majority within the namespace, so no semantic correction was attempted.
-   **Three-agent drift validation** on each candidate:
    -   Agent 1 (opus semantic-review): `confirmed-drift` on both — `gaussian` is semantically appropriate for `logcdf` (the implementation wraps the gaussian CDF), and the `lib/index.js` rename is purely cosmetic with no semantic impact.
    -   Agent 2 (opus cross-reference): `confirmed-drift` on both — no test, example, or sibling-package doc reads the `logcdf` keyword array; the local `lib/index.js` variable is module-internal and not referenced externally.
    -   Agent 3 (sonnet structural-review): `confirmed-drift` on both — `main` is the dominant in-namespace pattern and the rename is unambiguous, `gaussian` is the missing namespace-standard keyword with no conflicts.
-   **Open-PR collision check.** The four open C-implementation PRs (#10809 `cdf`, #10881 `logpdf`, #10882 `logcdf`, #10883 `cdf`) touch `src/`, `manifest.json`, `binding.gyp`, `lib/native.js`, and `package.json` `gypfile` for `cdf`/`logcdf`/`logpdf`. This PR touches `keywords` in `logcdf/package.json` and the `lib/index.js` of `mean`/`median`/`mode`. No overlap.
-   **14-day cross-run dedup.** No prior drift PR for this namespace.

Deliberately excluded:

-   **Native-bindings group** (`binding.gyp`, `lib/native.js`, `src/`, `manifest.json`, `include/`, `gypfile`) at 10/14 = 71.4% — below the 75% threshold, and the four absences are actively being filled in by the open-PR set above.
-   **`stdev/lib/main.js` empty validation prologue.** `stdev` delegates as `return sqrt( variance( mu, sigma ) );`; `variance` performs the canonical NaN/sigma check and `sqrt(NaN) === NaN` preserves observable behavior. Intentional, matching the `stdev` precedent in PR #11902 on `stats/base/dists/binomial`.
-   **`logcdf/lib/main.js` empty validation prologue.** Delegates to `normal/logcdf` which performs the canonical NaN/sigma/range check; observable behavior matches the documented `@example` outputs. Intentional delegation, not drift.
-   **`ctor` deviations.** `ctor` legitimately exposes a constructor with `## Writable Properties` / `## Computed Properties` / `## Methods` README sub-sections, a Python+SciPy benchmark, and a `format()`-based `throw` (the only `throw` in the namespace). Each is required by the constructor's distinct API surface — not drift.
-   **`ctor` and `logcdf` missing `test/fixtures/julia/{REQUIRE,runner.jl}`.** `ctor` uses a Python+SciPy benchmark fixture instead, and `logcdf` uses an R fixture (`test/fixtures/r/{DESCRIPTION,data.json,runner.R}`) — intentional alternative fixture strategies, not drift.
-   **Per-package keyword additions beyond the 13-key common set.** Function-specific keywords (e.g. `cdf`'s `exponential family`, `mean`'s `expected`, `entropy`'s `nats`/`shannon`) vary legitimately.
-   **`package.json` `description` text variations** — each is accurate for its package.
-   **`logcdf`'s unique `bell-shape` keyword.** Shared with `normal/pdf`, `normal/logpdf`, `normal/logcdf`, and `truncated-normal/pdf`; the deliberate cross-namespace cluster around the normal distribution makes its presence intentional. Not removed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored end-to-end by Claude Code as part of the cross-package drift-detection routine: structural features were extracted across all 14 members of `@stdlib/stats/base/dists/lognormal`, per-feature majority patterns were computed at the 75% conformance threshold, and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed each correction before any file was edited. All four edits are purely additive (one keyword) or cosmetic (three local-variable renames in module-internal scope); no source semantics, test expectations, or example behavior changed. A maintainer should audit before promoting this PR from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee1HEHGDn2Kq32GpqouToM)_