### PR TITLE
chore: follow-up fixes for recent commits

### DIFF
--- a/lib/node_modules/@stdlib/fft/base/fftpack/cffti/lib/main.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/cffti/lib/main.js
@@ -158,7 +158,7 @@ function cffti( N, workspace, strideW, offsetW ) {
 
 	// When a sub-sequence is a single data point, the FFT is the identity, so no initialization necessary...
 	if ( N === 1 ) {
-		return;
+		return workspace;
 	}
 	// Resolve the starting indices for storing twiddle factors and factorization results:
 	offsetT = offsetW + ( 2*N*strideW ); // index offset for twiddle factors

--- a/lib/node_modules/@stdlib/number/uint64/base/assert/is-equal/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/assert/is-equal/test/test.js
@@ -56,7 +56,7 @@ tape( 'the function tests whether two 64-bit unsigned integers are equal', funct
 	t.strictEqual( isEqual( a, b ), true, 'returns expected value' );
 
 	a = new Uint64( 1234 );
-	a = new Uint64( 5678 );
+	b = new Uint64( 5678 );
 	t.strictEqual( isEqual( a, b ), false, 'returns expected value' );
 
 	if ( HAS_BIGINT ) {

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/README.md
@@ -88,7 +88,7 @@ a = new Uint64( 10000000000 );
 w = toWords( a );
 // returns [ 2, 1410065408 ]
 
-a = new Uint64.of( 12, 34 );
+a = Uint64.of( 12, 34 );
 w = toWords( a );
 // returns [ 12, 34 ]
 ```

--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/examples/index.js
@@ -31,7 +31,7 @@ w = toWords( a );
 console.log( w );
 // => [ 2, 1410065408 ]
 
-a = new Uint64.of( 12, 34 );
+a = Uint64.of( 12, 34 );
 w = toWords( a );
 console.log( w );
 // => [ 12, 34 ]


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Lands follow-up fixes for commits merged to `develop` between 2026-06-16 14:56 -0500 and 2026-06-17 02:29 -0700 (SHA range `d6575009..ae56fc58`, 44 commits). Three high-signal issues were identified by an automated multi-reviewer pass and verified by re-reading the diff.

Fixes, grouped by package:

-   **`fft/base/fftpack/cffti`** — Fix `cffti` early-return bug introduced in `61cc8a70`: `lib/node_modules/@stdlib/fft/base/fftpack/cffti/lib/main.js` returned `undefined` instead of `workspace` when `N === 1`, violating the `@returns {Collection}` contract and breaking the documented `out === workspace` invariant.
-   **`number/uint64/base/to-words`** — Remove erroneous `new` keyword from `Uint64.of` calls in `README.md` (L91) and `examples/index.js` (L34); `of` is a static factory, not a constructor. Introduced in `06a03d7a`.
-   **`number/uint64/base/assert/is-equal`** — Fix variable reassignment bug introduced in `dee3dfae`: in `lib/node_modules/@stdlib/number/uint64/base/assert/is-equal/test/test.js` L59, `a` was clobbered instead of `b`, leaving `b` stale from the prior test case and failing to exercise a genuine two-value inequality check.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Review window summary.** 44 commits across 318 files (+18,833 / −7,584). New packages: `blas/ext/base/dminheap-sift-down`, `blas/ext/base/sindex-of-truthy`, `fft/base/fftpack/cffti`, `number/uint64/base/to-words`, `number/uint64/base/assert/is-equal`, and a C implementation for `stats/base/dists/erlang/logpdf`. A coordinated batch of ULP-based test migrations (11 packages, ref #11352). Broad TypeScript declaration sweeps across `array/*` and `blas/ext/base/*`. A new `/stdlib todo` slash-command workflow.

**Validation audit.**

-   Style guide compliance (`docs/style-guides/{javascript,c,text}`) — clear, unambiguous violations only.
-   Bug scan over the diff alone, without expanding scope beyond the changed lines.
-   Security review of the new workflow + shell script (`.github/workflows/create_todo_issue.yml`, `.github/workflows/scripts/create_todo_issue/run`) — no actionable findings.
-   Logic review of the new C implementations (`dminheap-sift-down`, `sindex-of-truthy`, `erlang/logpdf`) against their JS reference implementations — no actionable findings.

**Deliberately excluded.**

-   Subjective concerns and style preferences not stated in the style guide.
-   Anything requiring interpretation beyond the diff window.
-   Intentional propagation patterns (the `array` / `blas/ext/base` / ndarray TypeScript sweeps, the ULP migration campaign, the sibling-fix propagations).
-   Findings that could not be independently re-verified by re-reading the diff; see the local report attached to the routine for the full dropped-finding list and the reasoning.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was prepared by a scheduled Claude Code routine that reviews the last 24 hours of merges to `develop`. The routine ran four independent reviewer agents (two style, two bug-hunting) in parallel, merged and filtered their findings down to high-signal issues, and applied the validated fixes. Each fix was re-read against the source before commit. A maintainer should audit before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoSjuqrg5t3rgqWUd2DyHL)_