### PR TITLE
fix: improve type specificity for JSON serialization in `stats/base/ztest/one-sample`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ztest/one-sample/results/to-json/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ztest/one-sample/results/to-json/docs/types/index.d.ts
@@ -69,6 +69,59 @@ interface Results {
 }
 
 /**
+* Interface describing a serialized results object.
+*/
+interface ResultsJSON {
+	/**
+	* Boolean indicating whether the null hypothesis was rejected.
+	*/
+	rejected: boolean;
+
+	/**
+	* Alternative hypothesis.
+	*/
+	alternative: string;
+
+	/**
+	* Significance level.
+	*/
+	alpha: number;
+
+	/**
+	* p-value.
+	*/
+	pValue: number;
+
+	/**
+	* Test statistic.
+	*/
+	statistic: number;
+
+	/**
+	* Confidence interval.
+	*/
+	ci: {
+		type: string;
+		data: Array<number>;
+	};
+
+	/**
+	* Value of the mean under the null hypothesis.
+	*/
+	nullValue: number;
+
+	/**
+	* Standard error of the mean.
+	*/
+	sd: number;
+
+	/**
+	* Test method.
+	*/
+	method: string;
+}
+
+/**
 * Serializes a one-sample Z-test results object as a JSON object.
 *
 * @param results - one-sample Z-test results object
@@ -92,7 +145,7 @@ interface Results {
 * var obj = res2json( results );
 * // returns {...}
 */
-declare function res2json( results: Results ): Results;
+declare function res2json( results: Results ): ResultsJSON;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/base/ztest/one-sample/results/to-json/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/base/ztest/one-sample/results/to-json/docs/types/test.ts
@@ -34,7 +34,7 @@ import res2json = require( './index' );
 		'alternative': 'two-sided',
 		'method': 'One-sample Z-test'
 	};
-	res2json( res ); // $ExpectType Results
+	res2json( res ); // $ExpectType ResultsJSON
 }
 
 // The compiler throws an error if not provided a results object...


### PR DESCRIPTION
## Description

Propagating the type-specificity fix from `d8fdfb7f` ("fix: improve type specificity for JSON serialization") to the one-sample Z-test results to-json sibling, which shared the same defect: `res2json` was typed as returning the input `Results` interface, but the serialized form differs in the shape of `ci` (`Float64Array | Float32Array` -> `{ type: string; data: Array<number> }`). Adds a distinct `ResultsJSON` interface and updates the return type and `$ExpectType` assertion accordingly.

- `d8fdfb7f` ([`fix: improve type specificity for JSON serialization`](https://github.com/stdlib-js/stdlib/commit/d8fdfb7f6a2db0cce8664d288887789b8f0987b8))
  - `@stdlib/stats/base/ztest/one-sample/results/to-json`

## Related Issues

None.

## Questions

No.

## Other

This PR was originally a single-PR bundle covering three source patterns from the prior 24-hour window. Per maintainer feedback (squash-merge requires per-commit-type accuracy to avoid spurious patch releases), the bundle was split:

- `fix:` Pattern (this PR): `d8fdfb7f` type-specificity fix propagated to `@stdlib/stats/base/ztest/one-sample/results/to-json`.
- `style:` Pattern (split into a sibling PR): `8e421b2b` missing-decimal fix propagated to `@stdlib/stats/base/dists/erlang/mgf`.
- `style:` Pattern (deferred): `91c5dd10` `0.0/0.0` -> `0.0 / 0.0` spacing sweep across 212 `stats/base/dists/*/src/main.c` files exceeded the `Run affected tests` CI 30-minute budget and was dropped from same-day propagation. Recommended as a maintainer-direct push with `[skip ci]`.

### Validation

- Search scoped to `stats/base/ztest/*/results/to-json`; the one-sample sibling was the only candidate site.
- Two independent opus validation passes plus a sonnet style-consistency pass confirmed the new `ResultsJSON` interface mirrors the one-sample `Results` interface field-for-field, with `ci` replaced by `{ type, data }` exactly as in the two-sample reference.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md