### PR TITLE
docs: add Git notes correcting recent commit messages

### DIFF
--- a/docs/git-notes/d6575009529673f2cd56ae36893388ce3013f305.txt
+++ b/docs/git-notes/d6575009529673f2cd56ae36893388ce3013f305.txt
@@ -1,0 +1,11 @@
+---
+type: amend-message
+---
+feat: add C implementation for `stats/base/dists/erlang/logpdf`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/10719
+Closes: https://github.com/stdlib-js/stdlib/issues/3571
+Co-authored-by: Neeraj Pathak <neerajrpathak710@gmail.com>
+Co-authored-by: Philipp Burckhardt <pburckhardt@outlook.com>
+Reviewed-by: Philipp Burckhardt <pburckhardt@outlook.com>
+Assisted-by: Claude <noreply@anthropic.com>


### PR DESCRIPTION
## Summary

This PR adds a `docs/git-notes/` amendment note for one commit from the last 24 hours whose trailer block was malformed.

## Notes

- `d657500`: blank line between `Closes:` and `Co-authored-by:` broke the contiguous trailer block — git only recognized `Co-authored-by:` / `Reviewed-by:` / `Assisted-by:` as trailers; `PR-URL:` and `Closes:` were parsed as message body. Also had a double blank line after the subject. The corrected message removes both extra blank lines so all six trailers form a single contiguous block.

## Audit scope

45 non-merge commits from the last 24 hours on `develop` were inspected:
- All PR-URL, Closes, and Ref numbers were verified to exist and match the correct PR/issue via the GitHub API.
- No spelling or grammar errors found in subjects.
- No conventional-commits style violations found.
- One malformed-trailer instance found (above).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
