### PR TITLE
style: add missing decimal

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mgf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mgf/src/main.c
@@ -30,7 +30,7 @@
 * @return        evaluated MGF
 *
 * @example
-* double v = stdlib_base_dists_erlang_mgf( 0.3, 1, 1.0 );
+* double v = stdlib_base_dists_erlang_mgf( 0.3, 1.0, 1.0 );
 * // returns ~1.429
 */
 double stdlib_base_dists_erlang_mgf( const double t, const double k, const double lambda ) {


### PR DESCRIPTION
## Description

Propagating the missing-decimal fix from `8e421b2b` ("style: add missing decimal") to the sibling Erlang MGF C implementation. The JSDoc `@example` block in `stats/base/dists/erlang/mgf/src/main.c` called `stdlib_base_dists_erlang_mgf( 0.3, 1, 1.0 )` — passing the integer literal `1` for the `k` shape parameter despite the function signature declaring `k` as `const double`. Replaces `1` with `1.0`, mirroring the source commit's exact substitution.

- `8e421b2b` ([`style: add missing decimal`](https://github.com/stdlib-js/stdlib/commit/8e421b2b823a08ff0e325792d3714d37fdf5a5da))
  - `@stdlib/stats/base/dists/erlang/mgf`

## Related Issues

None.

## Questions

No.

## Other

Split from PR #12934 per maintainer feedback: stdlib's squash-merge means the squashed commit type drives release semantics, so `fix:` and `style:` propagations must travel as separate PRs to avoid spurious patch releases for `style:`-only changes.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWosPKG9TeTsg5roujMrmi)_