### PR TITLE
test: remove redundant filename output in test blocks

### DIFF
--- a/lib/node_modules/@stdlib/complex/float32/base/add/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/add/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( add, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( add, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float32/base/add3/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/add3/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( add3, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( add3, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float32/base/mul-add/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/mul-add/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( muladd, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( muladd, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float32/base/mul/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/mul/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( mul, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( mul, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float32/base/scale/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float32/base/scale/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( scale, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( scale, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float64/base/add/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/add/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( add, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( add, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float64/base/add3/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/add3/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( add3, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( add3, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float64/base/div/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/div/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( div, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( div, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float64/base/mul-add/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/mul-add/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( muladd, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( muladd, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float64/base/mul/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/mul/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( mul, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( mul, 'strided' ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/complex/float64/base/scale/test/test.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/scale/test/test.js
@@ -34,13 +34,11 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is an `assign` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( scale, 'assign' ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'attached to the main export is a `strided` method', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( isMethod( scale, 'strided' ), true, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Removes the redundant lines in test files that print the filename from multiple packages under `complex/float32` and `complex/float64` namespace.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The following regex was used for the find and replace:
<img width="700" height="600" alt="Screenshot_20260618_170816" src="https://github.com/user-attachments/assets/8184d386-0ee9-4d4f-9464-94527c186090" />

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
