### PR TITLE
docs: fix capitalization

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-falsy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-falsy/docs/repl.txt
@@ -8,7 +8,7 @@
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
 
-    if `N <= 0`, the function returns `-1`.
+    If `N <= 0`, the function returns `-1`.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between `46fd304d` (2026-06-17 21:42 UTC) and `d51b3653` (2026-06-18 10:46 UTC).

This pull request:

-   Fixes capitalization of `if` → `If` at line 11 in `lib/node_modules/@stdlib/blas/ext/base/gindex-of-falsy/docs/repl.txt` to match corpus convention (5a60a91).

### Fixes by package

**`blas/ext/base/gindex-of-falsy`**

-   Capitalize sentence-initial `if` → `If` at `docs/repl.txt:11`. Every other REPL doc in `blas/ext/base/` (including the sibling new packages `glast-index-of-truthy` and `gminheapify` added in the same batch) capitalizes this line. Inherited from the `gindex-of-truthy` template, which has the same defect. (5a60a91)

## Related Issues

No.

## Questions

No.

## Other

### Validation audit

Reviewed the 20 commits merged to `develop` in the window across two style-guide compliance passes and two bug-scan passes (one diff-only, one with cross-reference). Surviving issues had to be (a) reported with a concrete fix, (b) independently re-verifiable against `docs/style-guides/` or the sibling-package corpus, and (c) resolvable without touching code outside the window.

Deliberately excluded:

-   The same lowercase `if` defect in `gindex-of-truthy/docs/repl.txt` (pre-existing, outside the window).
-   Missing `<section class="intro">`/`<section class="references">` blocks in `gminheapify/README.md` — the closest sibling reference (`gminheap-sift-down`) also omits them, so this is not a clear template violation.
-   `Create a benchmark function.` JSDoc vs. `Creates a benchmark function.` — both forms occur roughly equally across `blas/ext/base/*/benchmark/benchmark.js`; not a style-guide rule.
-   N-API, carry-logic, sift-down invariant, and stride/offset forwarding in the seven new packages — verified correct.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was generated by a scheduled review routine: a fan-out of style-guide and bug-scan agents over the 24h window of commits merged to `develop`, with findings filtered to those independently re-verifiable from the diff and the surrounding corpus. The fix itself was applied mechanically and audited by hand before commit.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01NovtRMm9jy5qTzqmooAXh6)_