### PR TITLE
chore: propagate `Uint64.from` and decimal-literal fixes to siblings

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/to-words/test/test.assign.js
@@ -98,7 +98,7 @@ tape( 'the function splits a 64-bit unsigned integer into a higher order word an
 		w = toWords( v, out, 1, 0 );
 		t.strictEqual( w, out, 'returns expected value' );
 
-		u = new Uint64.from( w );
+		u = Uint64.from( w );
 		t.strictEqual( u.toString(), v.toString(), 'returns expected value' );
 	}
 	t.end();
@@ -140,7 +140,7 @@ tape( 'the function splits a 64-bit unsigned integer into a higher order word an
 		w = toWords( v, out, 1, 0 );
 		t.strictEqual( w, out, 'returns expected value' );
 
-		u = new Uint64.from( w );
+		u = Uint64.from( w );
 		t.strictEqual( u.toString(), v.toString(), 'returns expected value' );
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/variance/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/variance/src/main.c
@@ -27,7 +27,7 @@
 * @return     variance
 *
 * @example
-* double v = stdlib_base_dists_negative_binomial_variance( 10, 0.5 );
+* double v = stdlib_base_dists_negative_binomial_variance( 10.0, 0.5 );
 * // returns 20.0
 */
 double stdlib_base_dists_negative_binomial_variance( const double r, const double p ) {


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between `46fd304d` (2026-06-17 21:42 UTC) and `d51b3653` (2026-06-18 10:46 UTC) to sibling packages.

### Fixes by pattern

-   Fixes erroneous `new` keyword usage when calling the static factory method `Uint64.from`, following `46fd304` ("chore: follow-up fixes for recent commits") which removed `new` from `Uint64.of(...)` calls in the README and example for the same package. `Uint64.from` is registered via `setReadOnly( Uint64, 'from', ... )` and must be invoked without `new`. Updates `number/uint64/base/to-words` (two parallel test blocks in `test/test.assign.js`).

-   Fixes a style inconsistency identified in `b8c28ee` ("style: add missing decimal"): C `@example` blocks must use decimal-point literals for `double` parameters. Updates `stats/base/dists/negative-binomial/variance` to write `r` as `10.0` instead of `10`, matching the declared `const double` signature and the pattern established across all sibling `negative-binomial` packages (`mean`, `kurtosis`, `skewness`, `stdev`, `mode`).

## Related Issues

No.

## Questions

No.

## Other

### Validation

-   Scoped pattern searches: (a) ``new TYPED.METHOD(`` literal across all of `lib/node_modules/@stdlib/`, where `TYPED` is any typed-numeric ctor (`Uint8`, `Uint16`, ..., `Uint64`, `Int8`, ..., `Int64`, `Float32`, `Float64`, `Complex64`, `Complex128`, `Bool`) and `METHOD` is `of` or `from`; (b) bare integer literals passed where the corresponding parameter is declared `double` / `float` in JSDoc `@example` blocks across `lib/node_modules/@stdlib/stats/base/dists/*/src/main.c`.
-   Two independent validation passes per candidate site, an adaptation pass, and a style-consistency pass. All three sites returned `confirmed` / `approved` on every pass.
-   Verified that `Uint64.from` is a `setReadOnly`-registered static factory matching the `Uint64.of` source pattern.
-   Verified the dominant style for `r` arguments across all sibling `negative-binomial` C source files.

Deliberately excluded:

-   The 14 hits for `'%s::ndarray:` (double colon) in `utils/map*`, `utils/reduce*`, and `ndarray/base/*` benchmark files. The `::` is the intentional category separator in those packages (parallel to `'%s::array:...'`), distinguishing API-variant scenarios within a single benchmark file. The source fix in `5d56e47` corrected a copy-paste in `blas/ext/base/g*` benchmarks, where each API variant lives in its own file and the separator should be `:` — not the same defect.
-   42 candidate C `@example` integer-literal arguments under `stats/base/dists/*/src/main.c` where the corresponding parameter is an integer type (`int32_t`), not `double` — correct usage.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was generated by a scheduled fix-propagation routine: enumerate fix-shaped commits merged to `develop` in the last 24 hours, specify each commit's defect into a grep-able pattern, search for sibling sites with the same defect, validate each candidate with two independent verification passes plus a style-consistency pass, then apply the equivalent fix. Each per-pattern commit groups all sites that share the same source pattern. Only sites confirmed by every validator advanced.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md