### PR TITLE
refactor: rename internal variables

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/t/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/t/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/t/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;


### PR DESCRIPTION
## Description

This pull request:

-   Renames the local `require('./main.js')` binding in `lib/index.js` from the function name to `main` for `@stdlib/stats/base/dists/t/mean`, `@stdlib/stats/base/dists/t/median`, and `@stdlib/stats/base/dists/t/mode`, and updates the corresponding `module.exports` identifier. The exported function value is unchanged.

#### Namespace summary

-   Namespace: `@stdlib/stats/base/dists/t`
-   Members analyzed: 14 (cdf, ctor, entropy, kurtosis, logcdf, logpdf, mean, median, mode, pdf, quantile, skewness, stdev, variance); 0 autogenerated
-   Features analyzed: file tree, `package.json` shape, README section list, `manifest.json` shape, test/benchmark/example file naming, `lib/index.js` internal-binding convention, `lib/main.js` JSDoc parameter types, `module.exports` identifier
-   Feature passing the ≥75% majority threshold and yielding actionable outliers: `lib/index.js` local-variable name (`main` at 11/14 = 78.6%)
-   Features excluded for falling below the threshold: presence of native C implementation (10/14 = 71.4%), `gypfile` in `package.json` (10/14 = 71.4%), `## C APIs` README section (10/14 = 71.4%), `@param {…} v` JSDoc type (8/13 `PositiveNumber` vs 5/13 `NonNegativeNumber` — semantic, reflecting each moment's true domain of definition)

#### Per outlier package

##### `@stdlib/stats/base/dists/t/mean`

Rename the local `require('./main.js')` binding in `lib/index.js` from `mean` to `main` and update `module.exports` accordingly. Aligns with 11/14 sibling packages under `stats/base/dists/t/*` and 80.6% of `stats/base/dists/*`, matching the normalization applied in #12925 (`stats/base/dists/lognormal/mean`). Exported function is unchanged.

##### `@stdlib/stats/base/dists/t/median`

Rename the local `require('./main.js')` binding from `median` to `main` in `lib/index.js` and update the `module.exports` identifier accordingly. Aligns with the prevailing convention across `stats/base/dists/t/*` (11/14) and `stats/base/dists/*` (80.6%), matching the normalization applied in #12925 for `stats/base/dists/lognormal/median`. Exported function is unchanged.

##### `@stdlib/stats/base/dists/t/mode`

Rename the local `require('./main.js')` binding from `mode` to `main` in `lib/index.js` and update the corresponding `module.exports` identifier. Aligns with 11/14 sibling packages under `stats/base/dists/t/*` and 80.6% of `stats/base/dists/*`, matching the normalization landed in `stats/base/dists/lognormal/mode` (#12925). Exported function is unchanged.

## Related Issues

No.

## Questions

No.

## Other

#### Validation

-   **Structural extraction** across all 14 members: file trees, `package.json` keys, README sections, `manifest.json` keys, test/benchmark/example file lists.
-   **Semantic extraction** of `lib/main.js` and `lib/index.js`: public signatures, validation prologues, error-construction patterns, JSDoc shape, internal binding names.
-   **Three-agent drift validation** (semantic review, cross-reference / impact, structural review): all three agents returned `confirmed-drift` for all three outliers. No tests, examples, benchmarks, REPL fixtures, TypeScript declarations, or the namespace aggregator depend on the local binding name; the change is purely cosmetic and propagates no behavior.
-   **Deliberately excluded** from this PR:
    -   Absence of native C implementation in `cdf`, `ctor`, `logcdf`, `quantile` (10/14 = 71.4%, below the 75% threshold).
    -   Absence of Julia test fixtures in `ctor` (13/14 = 92.9%, threshold met) — `ctor` is the Distribution constructor and is structurally distinct from the moment/density packages, so the deviation is intentional.
    -   `@param {…} v` JSDoc type inconsistency — reflects each moment's true mathematical domain of definition; not drift.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package API drift detection routine. The drift was identified by structural and semantic feature extraction across the 14-member namespace, validated by a three-agent panel (semantic / cross-reference / structural), and applied as a mechanical rename. Findings, conformance percentages, and excluded candidates were reviewed before commit.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_017NKX6TYGzATXCJeYyy1nAY)_