### PR TITLE
chore: fix JavaScript lint errors (issue #12959)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/dispatch-workflow/lib/query.js
+++ b/lib/node_modules/@stdlib/_tools/github/dispatch-workflow/lib/query.js
@@ -23,6 +23,7 @@
 var logger = require( 'debug' );
 var string2buffer = require( '@stdlib/buffer/from-string' );
 var replace = require( '@stdlib/string/replace' );
+var isnan = require( '@stdlib/assert/is-nan' ).isPrimitive;
 var getOpts = require( './options.js' );
 var getData = require( './data.js' );
 var request = require( './request.js' );
@@ -83,7 +84,9 @@ function query( slug, id, options, clbk ) {
 		info = ratelimit( response.headers );
 		debug( 'Rate limit: %d', info.limit );
 		debug( 'Rate limit remaining: %d', info.remaining );
-		debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
+		if ( !isnan( info.reset ) ) {
+	        debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
+        }
 
 		if ( error ) {
 			return clbk( error, info );


### PR DESCRIPTION
Resolves #12959.

## Description

This pull request fixes a lint failure in `@stdlib/_tools/github/dispatch-workflow`.

The failure occurs when rate limit reset information is unavailable and `info.reset` evaluates to `NaN`. In that case, attempting to format the value using `Date.prototype.toISOString()` results in a `RangeError: Invalid time value`.

This change adds a guard before formatting the reset timestamp to ensure that only valid values are passed to `toISOString()`.

## Related Issues

* #12959

## Questions

No.

## Other

The lint failure originated from the following code path:

```javascript
debug( 'Rate limit reset: %s', (new Date( info.reset*1000 )).toISOString() );
```

When rate limit reset information is unavailable, `info.reset` may be `NaN`. This change prevents attempting to format an invalid date by checking the value before calling `toISOString()`.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

## AI Assistance

* [ ] Yes
* [x] No

## Disclosure

N/A.

---

@stdlib-js/reviewers