### PR TITLE
chore: update examples and add keyword

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/ln-half/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/ln-half/lib/index.js
@@ -25,7 +25,7 @@
 * @type {number}
 *
 * @example
-* var LN_HALF = require( '@stdlib/constants/float32/ln-half' );
+* var FLOAT32_LN_HALF = require( '@stdlib/constants/float32/ln-half' );
 * // returns -0.6931471824645996
 */
 

--- a/lib/node_modules/@stdlib/constants/float32/ln-ten/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/ln-ten/lib/index.js
@@ -25,7 +25,7 @@
 * @type {number}
 *
 * @example
-* var LN10 = require( '@stdlib/constants/float32/ln-ten' );
+* var FLOAT32_LN10 = require( '@stdlib/constants/float32/ln-ten' );
 * // returns  2.3025851249694824
 */
 

--- a/lib/node_modules/@stdlib/constants/float32/num-bytes/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/num-bytes/package.json
@@ -59,6 +59,7 @@
     "single-precision",
     "floating-point",
     "float",
+    "float32",
     "ieee754",
     "size",
     "sizeof",


### PR DESCRIPTION
## Description

Cross-package drift analysis of `@stdlib/constants/float32` identified three high-confidence mechanical corrections.

### Namespace summary

- **Members analyzed:** 68 non-autogenerated packages.
- **Features analyzed:** file tree, `package.json` shape (top keys, scripts, stdlib, keywords), `manifest.json` shape, README section structure, test/benchmark/example file naming, module- and main-docblock JSDoc tags, `lib/index.js` structural conventions (`MODULES`/`MAIN`/`EXPORTS` sections, MAIN var name, `@example` var name, dependencies).
- **Features with a clear majority (≥75%):** file tree (100%), `package.json` top keys (100%), `manifest` shape (100%), test/example naming (100%), main `@constant`/`@type`/`@default` tags (100%), main `@see` (82.4%), `@example`-var-matches-MAIN-var (97.1%), `float32` keyword (83.8%), `float` keyword (86.8%), `math`/`mathematics` keywords (83.8%).
- **Features excluded:** `## See Also` README section (auto-populated, `Do not manually edit` marker); `<!-- TODO: better example -->` marker (57.4%, no majority); `// MODULES //` header presence (38.2%, semantically driven by whether the package requires any helpers).
- **Intentional cross-namespace deviations dropped after sibling check against `@stdlib/constants/float64`:** the `float`/`float32` and `math`/`mathematics` keyword outliers — bit-representation constants (`exponent-bias`, `max/min-base{2,10}-exponent[-subnormal]`, `precision`), `e`/`phi`/`sqrt-*` mathematical constants, and `max-safe-*`/`max-nth-*`/`min-safe-integer` integer-bound constants — all mirror the same omission in their float64 siblings and reflect a consistent cross-namespace tagging convention.

### `@stdlib/constants/float32/ln-half`

The module-level `@example` declared `var LN_HALF`, but the package's main export is `FLOAT32_LN_HALF`. README, test, examples, and TypeScript declarations were updated to the prefixed identifier during an earlier rename; the `@example` block was missed. Conformance of the `@example`-var-matches-MAIN-var pattern across the namespace: 66 of 68 (97%).

### `@stdlib/constants/float32/ln-ten`

Same shape as `ln-half`: `@example` declared `var LN10`, MAIN declared `var FLOAT32_LN10`. The unprefixed identifier in the example is a remnant of the earlier rename. Same 97% conformance pattern.

### `@stdlib/constants/float32/num-bytes`

`package.json` `keywords` array omitted `float32`. The sibling `@stdlib/constants/float64/num-bytes` carries `float64` in the analogous position between `float` and `ieee754`. Of the 11 float32 packages missing the precision-specific keyword, 10 (the bit-representation constants) mirror the same omission in their float64 siblings and were dropped as intentional. `num-bytes` is the lone outlier whose float64 sibling carries the precision tag.

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural extraction** over all 68 packages: file trees, `package.json` and `manifest.json` shapes, README section lists and orders, test/benchmark/example filenames.
- **Semantic extraction** over `lib/index.js` for each package: module-docblock and main-docblock JSDoc tag sets, MAIN var name, `@example` var name, `// MODULES //`/`MAIN`/`EXPORTS` section presence, dependencies. JSDoc tags parsed with a manual scanner; cross-checked against three sample packages.
- **Three-agent drift validation:**
  - *Agent 1 (opus, semantic-review)* read `lib/index.js` for `ln-half` and `ln-ten` along with their float64 siblings and returned `confirmed-drift` for both: the float64 versions are internally consistent (unprefixed everywhere), the float32 versions were partially renamed to use the `FLOAT32_` prefix, and the `@example` blocks were the residue.
  - *Agent 2 (opus, cross-reference)* confirmed that the bare `LN_HALF`/`LN10` identifiers appear only on the `@example` line in each package, and that no test, example, type declaration, REPL fixture, or build tool depends on the comment text or on the absence of `float32` from `num-bytes` keywords.
  - *Agent 3 (sonnet, structural-review)* compared `constants/float32/num-bytes` and `constants/float64/num-bytes` `package.json` files and returned `confirmed-drift`: parallel precision-tagged descriptions, identical shape, and the float64 sibling carries `float64` in the same slot.

### Deliberately excluded

- **Auto-populated sections:** `## See Also` README sections (21 packages omit; section is generator-owned, `Do not manually edit this section, as it is automatically populated.` marker present in every existing instance).
- **Intentional deviations confirmed via float64-sibling cross-check:**
  - `float` keyword absent in `e`, `ln-two`, `phi`, `sqrt-{half,half-pi,phi,pi,three,two}` — float64 siblings also omit;
  - `float32` keyword absent in `exponent-bias`, `max/min-base{2,10}-exponent[-subnormal]`, `precision` — float64 siblings omit `float64`;
  - `math`/`mathematics` keywords absent in `max-safe-*`, `max-nth-*`, `min-safe-integer` — float64 siblings omit; tagged as integer constants by convention.
- **Content-judgment fixes (not mechanical):**
  - 12 packages missing a main-docblock `@see` URL (would require choosing a Wikipedia/OEIS reference per constant);
  - `eps`, `cbrt-eps`, `sqrt-eps` README-vs-lib identifier mismatch (`FLOAT32_EPS` in README, `FLOAT32_EPSILON` in lib): pre-existing naming inconsistency mirrored in `constants/float64`; reconciling requires a maintainer call on which spelling to canonicalise.
- **Cross-run dedup:** open PR #12446 touches `constants/float64/*` but does not collide with any candidate file in this run; no recent merged PR in the last 14 days touches the three candidate files.

### Cross-namespace tie-in

The fix pattern "add a missing keyword that the sibling-precision package has" is structurally identical to a propagation fix pattern. This run's `num-bytes` correction is reconcilable with the cross-namespace propagation routine (PR #12446) by sibling-precision: future runs can deduplicate by checking both routine outputs.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated cross-package API-drift detection run against the `@stdlib/constants/float32` namespace. Drift was identified by extracting structural and semantic features from every package, computing a per-feature majority pattern (≥75% threshold), and filtering candidate corrections through a three-agent validation pass (one opus semantic-review, one opus cross-reference, one sonnet structural-review) plus a sibling cross-check against `@stdlib/constants/float64` to drop intentional cross-namespace deviations. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpDDzkmzUn2txBbS9SwxWp)_