### PR TITLE
style: remove extra trailing newlines

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/benchmark/c/Makefile
@@ -144,4 +144,3 @@ clean:
 	$(QUIET) -rm -f *.o *.out
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/kurtosis/examples/c/Makefile
@@ -144,4 +144,3 @@ clean:
 	$(QUIET) -rm -f *.o *.out
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/mean/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/mean/include.gypi
@@ -51,4 +51,3 @@
     ],
   }, # end variables
 }
-

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/skewness/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/skewness/benchmark/c/Makefile
@@ -144,4 +144,3 @@ clean:
 	$(QUIET) -rm -f *.o *.out
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/skewness/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/skewness/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request strips stray trailing blank lines from five files across three outlier packages in `@stdlib/stats/base/dists/planck`, bringing each in line with the within-namespace majority and the universal stdlib convention of ending these files with a single trailing newline. Whitespace-only; no source, behavior, or test change.

### Namespace summary

- **Target:** `@stdlib/stats/base/dists/planck`
- **Members analyzed:** 14 (`cdf`, `entropy`, `kurtosis`, `logcdf`, `logpmf`, `mean`, `median`, `mgf`, `mode`, `pmf`, `quantile`, `skewness`, `stdev`, `variance`)
- **Features with a clear majority (≥75%):** `package.json` top-level shape, `directories`, `manifest.json` keys (`confs` / `fields` / `options`), `binding.gyp`, `lib/main.js` validation prologue (`isnan + lambda <= 0 → NaN`), `lib/main.js` error construction (no errors thrown — all surface invalid input as `NaN`), JSDoc tag set (`@param` / `@returns` / `@example`), `docs/types/index.d.ts` / `docs/repl.txt` / `examples/index.js` / `examples/c/example.c` / `benchmark/benchmark.js` / `benchmark/benchmark.native.js` presence, `src/main.c` function-naming convention, and the `## Usage` / `## Examples` / `## C APIs` / `### Usage` / `### Examples` README section sequence.
- **Trailing-newline convention:** 100% of sampled `benchmark/c/Makefile` files across seven sibling distributions (`arcsine`, `bernoulli`, `beta`, `binomial`, `normal`, `exponential`, `poisson` — 83 packages) end with exactly one trailing newline; 12-13/14 within `planck` already conform. The remaining outliers are the corrections in this PR.
- **Surfaced but deliberately excluded** (no within-namespace majority, or majority is intentional): see Validation below.

### `@stdlib/stats/base/dists/planck/kurtosis`

Strips a stray trailing blank line from `benchmark/c/Makefile` and `examples/c/Makefile`. The single-newline form holds for 12/14 sibling Makefiles and 100% of sampled sibling distributions ecosystem-wide.

### `@stdlib/stats/base/dists/planck/skewness`

Strips a stray trailing blank line from `benchmark/c/Makefile` and `src/Makefile`. The single-newline form holds for 12/14 (`benchmark/c/Makefile`) and 13/14 (`src/Makefile`) sibling files within the namespace.

### `@stdlib/stats/base/dists/planck/mean`

Strips a stray trailing blank line from `include.gypi`. The single-newline form holds for 13/14 sibling `include.gypi` files; `mean` was the lone outlier.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Checked:

- **Structural feature extraction** across all 14 members (file tree, `package.json` shape, `directories`, `manifest.json`, README headings, `lib/`, `src/`, `test/`, `benchmark/`, `examples/`, `docs/types/`, `docs/repl.txt`, `binding.gyp`, `include.gypi`, Makefiles).
- **Semantic feature extraction** across all 14 `lib/main.js`, `lib/index.js`, `lib/native.js`, and `src/main.c` files (signature shape, return kind, validation prologue, error-construction style, JSDoc tag set, `require()`-derived dependencies). Performed programmatically rather than via per-package agents because every member follows the same `if (isnan(...) || lambda <= 0.0) return NaN;` prologue, no member throws or calls `format`, and the JSDoc tag set is identical across the namespace; an agent pass would not have surfaced additional drift.
- **Ecosystem-wide convention** for trailing newlines in `benchmark/c/Makefile`, sampled across seven sibling distributions (100% single-newline).
- **Cross-run dedup.** Searched open PRs (`is:open dists/planck`, `is:open trailing newline Makefile`) and recently-merged PRs (`merged:>=2026-06-05 planck`); none touch the five files modified here.

Deliberately excluded:

- **`mode/test/fixtures/python/runner.py` missing.** `mode(λ) = 0.0` for all `λ > 0`; the test only verifies the trivial constant property, so no Python reference fixture is needed. Intentional deviation, not drift.
- **`logcdf` and `logpmf` extra `## Notes` README section.** Log-domain variants legitimately carry numerical-stability notes that the non-log siblings do not need. Intentional deviation.
- **`benchmark/benchmark.js` shape variation.** The 7-package cluster (`entropy`, `kurtosis`, `mean`, `median`, `mode`, `skewness`, `variance`) shares a single-argument `(lambda)` signature; the other 7 split by signature arity (`(x, lambda)`, `(t, lambda)`, `(p, lambda)`). Signature-driven variation, not drift.
- **`src/addon.c`, `examples/index.js`, `docs/repl.txt`, `docs/types/index.d.ts`, `benchmark/c/benchmark.c`** all show 14 distinct shapes because they embed the package's own function name; normalized-shape comparison confirms identical templates.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine. The target namespace `@stdlib/stats/base/dists/planck` was selected by uniform-random pick (seed `1781870567`) over the 113 eligible directories (≥8 direct child packages with `package.json` under `lib/node_modules/@stdlib/`, excluding `_tools/`). Structural feature extraction across all 14 members surfaced trailing-newline drift in five files across three packages; semantic features were verified programmatically (uniform validation prologue, no errors thrown, identical JSDoc tag set across all 14). Ecosystem-wide validation against seven sibling distributions confirmed the 13/14 single-newline pattern as the universal stdlib convention.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_0179reZLQcVkWPNYze8SRFPi)_