### PR TITLE
chore: propagate fixes across `blas/ext/base` and `regexp`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-truthy/docs/repl.txt
@@ -9,7 +9,7 @@
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
 
-    if `N <= 0`, the function returns `-1`.
+    If `N <= 0`, the function returns `-1`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of/docs/repl.txt
@@ -9,7 +9,7 @@
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
 
-    if `N <= 0`, the function returns `-1`.
+    If `N <= 0`, the function returns `-1`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-truthy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-truthy/docs/repl.txt
@@ -8,7 +8,7 @@
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
 
-    if `N <= 0`, the function returns `-1`.
+    If `N <= 0`, the function returns `-1`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of/docs/repl.txt
@@ -8,7 +8,7 @@
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
 
-    if `N <= 0`, the function returns `-1`.
+    If `N <= 0`, the function returns `-1`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-truthy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-truthy/docs/repl.txt
@@ -9,7 +9,7 @@
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
 
-    if `N <= 0`, the function returns `-1`.
+    If `N <= 0`, the function returns `-1`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of/docs/repl.txt
@@ -9,7 +9,7 @@
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
 
-    if `N <= 0`, the function returns `-1`.
+    If `N <= 0`, the function returns `-1`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/regexp/color-hexadecimal/test/test.js
+++ b/lib/node_modules/@stdlib/regexp/color-hexadecimal/test/test.js
@@ -33,19 +33,16 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'attached to the main export is a regular expression to match full hexadecimal colors', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( reColorHexadecimal.REGEXP instanceof RegExp, true, '`REGEXP` export is a regular expression' );
 	t.end();
 });
 
 tape( 'attached to the main export is a regular expression to match shorthand hexadecimal colors', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( reColorHexadecimal.REGEXP_SHORTHAND instanceof RegExp, true, '`REGEXP_SHORTHAND` export is a regular expression' );
 	t.end();
 });
 
 tape( 'attached to the main export is a regular expression to match shorthand or full length hexadecimal colors', function test( t ) {
-	t.ok( true, __filename );
 	t.strictEqual( reColorHexadecimal.REGEXP_EITHER instanceof RegExp, true, '`REGEXP_EITHER` export is a regular expression' );
 	t.end();
 });


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-06-18 17:52 UTC and 2026-06-19 06:03 UTC to sibling packages.

### `docs: fix capitalization across `blas/ext/base``

Propagates a1c00d0, which corrected a sentence-initial lowercase `if` to `If` in the REPL help text for `blas/ext/base/gindex-of-falsy`. The same malformed sentence appeared verbatim in six sibling packages and is fixed here uniformly.

Source: a1c00d0

Targets:

-   `blas/ext/base/dindex-of-truthy`
-   `blas/ext/base/dindex-of`
-   `blas/ext/base/gindex-of-truthy`
-   `blas/ext/base/gindex-of`
-   `blas/ext/base/sindex-of-truthy`
-   `blas/ext/base/sindex-of`

### `test: remove redundant filename output in `regexp/color-hexadecimal``

Removes three redundant `t.ok( true, __filename );` assertions from non-first `tape(...)` blocks in `regexp/color-hexadecimal/test/test.js`. Per the `stdlib/first-unit-test` ESLint rule, only the leading test block carries the filename assertion; repeating it in subsequent blocks adds no signal. A second candidate (`math/base/special/ellipj/test/test.sncndn.js`) was excluded because that file carries an explicit `/* eslint-disable stdlib/first-unit-test */` directive.

Source: f4bc442

Targets:

-   `regexp/color-hexadecimal`

## Related Issues

No related issues.

## Questions

No.

## Other

### Validation

-   Pattern search scoped to sibling directories of each source commit (`blas/ext/base/*/docs/repl.txt` for the capitalization fix; all `lib/node_modules/@stdlib/**/test/*.js` with multiple `t.ok( true, __filename );` occurrences for the redundant-assertion fix).
-   Two independent validation agents read each candidate file in full and confirmed the defect; a style-consistency pass confirmed indentation and surrounding-line integrity.
-   Excluded from this PR:
    -   `math/base/special/ellipj/test/test.sncndn.js` — file carries `/* eslint-disable stdlib/first-unit-test */`, indicating the author opted out of the convention.
    -   `math/base/special/xlogy/test/test.native.js` — flagged `needs-human`; the duplicate `t.ok( true, __filename );` lines reflect a duplicated `tape(...)` block rather than the redundant-assertion pattern.
    -   `_tools/eslint/rules/first-unit-test/**` — the lint rule's own fixtures and implementation; intentionally retain matching strings.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated fix-propagation routine: candidate fixes from the prior 24h on `develop` were specified, sibling sites were located by pattern search, then two independent validation agents and a style-consistency agent confirmed each target before patches were applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_015AQUiPfhDfiKewrgPcUWRk)_