### PR TITLE
docs: fix descriptions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Natural logarithm of the probability mass function (PDF) for a degenerate distribution.
+* Natural logarithm of the probability mass function (PMF) for a degenerate distribution.
 *
 * @module @stdlib/stats/base/dists/degenerate/logpmf
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Degenerate distribution probability mass function (PDF).
+* Degenerate distribution probability mass function (PMF).
 *
 * @module @stdlib/stats/base/dists/degenerate/pmf
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Corrects two module-level JSDoc summary typos in `stats/base/dists/degenerate` where `(PDF)` was used in place of `(PMF)`. Both packages implement probability mass functions, and every other location in each package (`main.js` JSDoc, `docs/repl.txt`, `docs/types/index.d.ts`, `README.md`) already uses the correct `(PMF)` acronym.

### `stats/base/dists/degenerate/pmf`

`lib/index.js` summary read `Degenerate distribution probability mass function (PDF).`; all 8 sibling `*/pmf` packages in `stats/base/dists` use `(PMF)` (100% conformance). Corrected to `(PMF)`.

### `stats/base/dists/degenerate/logpmf`

`lib/index.js` summary read `Natural logarithm of the probability mass function (PDF) for a degenerate distribution.`; all 7 sibling `*/logpmf` packages in `stats/base/dists` use `(PMF)` (100% conformance). Corrected to `(PMF)`.

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Discovered by a cross-package drift scan over the `stats/base/dists/degenerate` namespace. Total diff is two single-character corrections (one per package); no behavior change, no test changes, no public API change.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a cross-package drift detection routine over the `stats/base/dists/degenerate` namespace. The routine extracted structural and semantic features from every package in the namespace, identified deviations from majority patterns, validated them against ecosystem-wide conventions, and applied only the high-signal, mechanical, behavior-preserving corrections.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01NPNpuQsREp7eK1GxjZR6iY)_