### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/utils/key-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/key-by/examples/index.js
@@ -20,15 +20,12 @@
 
 var keyBy = require( './../lib' );
 
-var arr;
-var obj;
-var i;
-
 function toKey( value ) {
 	return value.name;
 }
 
-arr = [];
+var arr = [];
+var i;
 for ( i = 0; i < 100; i++ ) {
 	arr.push({
 		'name': 'v'+i,
@@ -36,5 +33,5 @@ for ( i = 0; i < 100; i++ ) {
 	});
 }
 
-obj = keyBy( arr, toKey );
+var obj = keyBy( arr, toKey );
 console.log( obj );

--- a/lib/node_modules/@stdlib/utils/key-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/key-by/examples/index.js
@@ -28,12 +28,12 @@ function toKey( value ) {
 	return value.name;
 }
 
-arr = new Array( 100 );
-for ( i = 0; i < arr.length; i++ ) {
-	arr[ i ] = {
+arr = [];
+for ( i = 0; i < 100; i++ ) {
+	arr.push({
 		'name': 'v'+i,
 		'value': i
-	};
+	});
 }
 
 obj = keyBy( arr, toKey );


### PR DESCRIPTION
Resolves #12977 

## Description

> What is the purpose of this pull request?

This pull request:

  -   updates `lib/node_modules/@stdlib/utils/key-by/examples/index.js` to replace `new Array( 100 )` with an array literal plus `push`
  -   fixes the JavaScript lint failure caused by `stdlib/no-new-array`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #12977 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Codex was used to help with the fix.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
