### PR TITLE
docs: fix note

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/t/entropy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/entropy/docs/repl.txt
@@ -4,7 +4,7 @@
 
     If provided `NaN` as any argument, the function returns `NaN`.
 
-    If provided `v < 0`, the function returns `NaN`.
+    If provided `v <= 0`, the function returns `NaN`.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

Fix a documentation inconsistency in `@stdlib/stats/base/dists/t/entropy`.

### `stats/base/dists/t/entropy`

`docs/repl.txt` stated the function returns `NaN` for `v < 0`, but the
implementation in `lib/main.js` (`if ( isnan( v ) || v <= 0.0 )`) returns
`NaN` for any `v <= 0`. The README and TypeScript declaration already
use `v <= 0`; this aligns the REPL help with code and sibling docs
(13/14 packages in the namespace pair REPL boundary wording with the
`lib/main.js` check verbatim — 93% conformance).

## Related Issues

None.

## Questions

None.

## Other

None.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

Authored by Claude Code via a within-namespace API drift detection routine. A
random namespace was selected, structural and semantic features were extracted
from every package, and a three-agent validation pass (semantic-review,
cross-reference, structural-review) confirmed the single drift candidate
before the fix was applied. No tests or observable behavior were modified.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01EueUhouPYd54kavGYZkCpb)_