### PR TITLE
refactor: normalize dimension-check error construction across `ndarray/iter`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/iter/column-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/column-entries/lib/main.js
@@ -120,7 +120,7 @@ function nditerColumnEntries( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having two or more dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having two or more dimensions.' ) );
 	}
 
 	// Check whether the input array is empty...

--- a/lib/node_modules/@stdlib/ndarray/iter/columns/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/columns/lib/main.js
@@ -120,7 +120,7 @@ function nditerColumns( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having two or more dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having two or more dimensions.' ) );
 	}
 	// Check whether the input array is empty...
 	N = numel( shape );

--- a/lib/node_modules/@stdlib/ndarray/iter/matrices/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/matrices/lib/main.js
@@ -114,7 +114,7 @@ function nditerMatrices( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 3 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least three dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having at least three dimensions.' ) );
 	}
 	// Check whether the input array is empty...
 	N = numel( shape );

--- a/lib/node_modules/@stdlib/ndarray/iter/matrix-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/matrix-entries/lib/main.js
@@ -120,7 +120,7 @@ function nditerMatrixEntries( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 3 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having at least three dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having at least three dimensions.' ) );
 	}
 
 	// Check whether the input array is empty...

--- a/lib/node_modules/@stdlib/ndarray/iter/row-entries/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/row-entries/lib/main.js
@@ -120,7 +120,7 @@ function nditerRowEntries( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having two or more dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having two or more dimensions.' ) );
 	}
 
 	// Check whether the input array is empty...

--- a/lib/node_modules/@stdlib/ndarray/iter/rows/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/iter/rows/lib/main.js
@@ -120,7 +120,7 @@ function nditerRows( x ) {
 
 	// Ensure that the input array has sufficient dimensions...
 	if ( ndims < 2 ) {
-		throw new TypeError( 'invalid argument. First argument must be an ndarray having two or more dimensions.' );
+		throw new TypeError( format( 'invalid argument. First argument must be an ndarray having two or more dimensions.' ) );
 	}
 	// Check whether the input array is empty...
 	N = numel( shape );


### PR DESCRIPTION
## Description

Six packages in `@stdlib/ndarray/iter` have a single residual plain-string `throw new TypeError( '...' )` at the dimension-count check that was missed during the migration to the canonical `format()` error-construction style. Every other throw in each of these same files — including a no-argument `throw new Error( format( 'invalid option. Cannot write to read-only array.' ) );` for the read-only check — already wraps the message in `format()`. This pull request wraps the dimension-count throws in `format()` to match. Error message text and `TypeError` class are unchanged.

### Namespace summary

- Members analyzed: 14 (no autogenerated members in this namespace)
- Features analyzed: file tree, `package.json` shape, README section order, top-level `manifest.json` shape, `test/` / `benchmark/` / `examples/` filenames, JSDoc shape, return kind, validation prologue, error construction, dependency set
- Features with a clear majority (≥75%) and zero outliers: file tree, top-level `package.json` keys, `directories` keys, README section sequence (`## Usage` → `## Notes` → `## Examples` → `## See Also`), JSDoc `@example` present, `returnKind: iterator`
- Drift surfaced: error construction. 8 of 14 packages (`entries`, `indices`, `interleave-subarrays`, `select-dimension`, `stacks`, `subarrays`, `to-array-each`, `values`) use `format()` for every throw; the 6 outliers below each have one residual plain-string throw. At the throw-site level, 50 of 56 throws across the namespace (89%) already use `format()`.
- Features excluded for absence of a clear majority: public signature shape, validation prologue sequence, JSDoc `@param` count, `@throws` count — each varies with the underlying function (some packages take `(x)`, others `(x, dim)`, `(x, dims)`, `(arrays, ndims)`, etc.), so cross-package vote does not apply.

### `@stdlib/ndarray/iter/columns`

The `ndims < 2` check throws a plain-string `TypeError`. Every other throw in `lib/main.js` — including the no-argument `format()` call guarding the read-only `Error` — already uses `format()`. Wrap the dimension-check message in `format()` so the file is internally consistent.

### `@stdlib/ndarray/iter/column-entries`

Same drift as `columns`: a single plain-string `TypeError` at the `ndims < 2` check, surrounded by `format()`-wrapped throws. Wrap the message in `format()`.

### `@stdlib/ndarray/iter/rows`

Twin of `columns` and carries the same drift at the `ndims < 2` check. Wrap the message in `format()`.

### `@stdlib/ndarray/iter/row-entries`

Twin of `column-entries` and carries the same drift at the `ndims < 2` check. Wrap the message in `format()`.

### `@stdlib/ndarray/iter/matrices`

Same drift, three-dimension variant: the `ndims < 3` check throws a plain-string `TypeError` while every other throw uses `format()`. Wrap the message in `format()`.

### `@stdlib/ndarray/iter/matrix-entries`

Same drift as `matrices` at the `ndims < 3` check. Wrap the message in `format()`.

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural extraction.** File trees, top-level `package.json` keys, `scripts` / `stdlib` / `directories` shapes, README heading sequences, and `test/` / `benchmark/` / `examples/` filenames compared across all 14 members. No structural drift.
- **Semantic extraction.** One per-package agent read each package's `lib/main.js` and `lib/index.js` and returned a strict-schema JSON bundle covering public signature, return kind, validation prologue, error-construction style, JSDoc shape, and the `@stdlib/*` dependency set.
- **Three-agent validation** (one opus semantic-review, one opus cross-reference, one sonnet structural-review) confirmed `confirmed-drift` for all 6 outliers. Tests rely on the `TypeError` class only — no assertions on message text. No `@throws` annotation, REPL doc, README example, or TypeScript declaration depends on the construction call.
- **Cross-run dedup.** Open and recently-merged PRs touching `@stdlib/ndarray/iter` searched; no collision (PR #1686 touches namespace examples only; PR #12661 updates TypeScript declarations only; PR #12642 touches `interleave-subarrays/docs/repl.txt` only).

### Deliberately excluded

- Public-signature, validation-prologue, JSDoc-param-count, and `@throws`-count features: vary with the underlying function and have no cross-namespace majority. Per-package corrections to these would require human judgement and are out of scope for an automated drift pass.
- The `nditerColumns` `S0`/`nditerRows` `S1` variable-naming difference: the two functions iterate over the trailing and second-to-last dimensions respectively, so the two-letter suffix encodes a deliberate dimension index — not drift.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding
-   [x] Review and debugging

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated cross-package API-drift audit of `@stdlib/ndarray/iter`. Candidate corrections were located via per-package semantic-feature extraction (one sonnet agent per package), validated by three parallel reviewer agents (opus semantic-review, opus cross-reference, sonnet structural-review), then applied as one mechanical patch per package in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013UanWDWQfRrvdrZHnjhETe)_