### PR TITLE
refactor: normalize empty-pad-string error construction in `string/left-pad` and `string/right-pad`

### DIFF
--- a/lib/node_modules/@stdlib/string/left-pad/lib/main.js
+++ b/lib/node_modules/@stdlib/string/left-pad/lib/main.js
@@ -67,7 +67,7 @@ function lpad( str, len, pad ) {
 			throw new TypeError( format( 'invalid argument. Third argument must be a string. Value: `%s`.', p ) );
 		}
 		if ( p.length === 0 ) {
-			throw new RangeError( 'invalid argument. Third argument must not be an empty string.' );
+			throw new RangeError( format( 'invalid argument. Third argument must not be an empty string.' ) );
 		}
 	} else {
 		p = ' ';

--- a/lib/node_modules/@stdlib/string/right-pad/lib/main.js
+++ b/lib/node_modules/@stdlib/string/right-pad/lib/main.js
@@ -67,7 +67,7 @@ function rpad( str, len, pad ) {
 			throw new TypeError( format( 'invalid argument. Third argument must be a string. Value: `%s`.', p ) );
 		}
 		if ( p.length === 0 ) {
-			throw new RangeError( 'invalid argument. Pad string must not be an empty string.' );
+			throw new RangeError( format( 'invalid argument. Pad string must not be an empty string.' ) );
 		}
 	} else {
 		p = ' ';


### PR DESCRIPTION
## Description

`@stdlib/string/left-pad` and `@stdlib/string/right-pad` each have a single residual plain-string `throw new RangeError( '...' )` at the empty-pad-string check that was missed during the migration to the canonical `format()` error-construction style. Every other throw in each file — including the adjacent `RangeError` guarding the maximum-string-length check — already wraps its message in `format()`. This pull request wraps the two empty-pad-string throws in `format()` to match. Across the 56 leaf packages in `@stdlib/string`, 114 of 117 `throw new ...Error(...)` calls already use `format()`; these two outliers were the only non-arity-guard residuals.

### `@stdlib/string/left-pad`

The `p.length === 0` check throws a plain-string `RangeError`. The four other throws in `lib/main.js` — three argument-validation `TypeError`s and the max-length `RangeError` two lines below — already wrap their messages in `format()`. `format` is already imported. Wrap the empty-pad-string message in `format()` so the file is internally consistent. Error class and message text are unchanged.

### `@stdlib/string/right-pad`

Same drift as `left-pad`: a single plain-string `RangeError` at the `p.length === 0` check, surrounded by `format()`-wrapped throws. Wrap the message in `format()`. Error class and message text are unchanged.

## Related Issues

No.

## Questions

No.

## Other

Pattern is identical to PR #12985 (`@stdlib/ndarray/iter`). `from-code-point/lib/main.js` has a related plain-string `throw new Error( 'insufficient arguments...' )` arity guard that is deliberately excluded per the convention established in PR #12227: arity-guard "insufficient arguments" plain messages are the stdlib-wide norm and should not be normalized.

Tests assert only the `RangeError` class, not the message text. REPL docs and TypeScript declarations paraphrase the throw in a `@throws` tag and do not quote the runtime message. No sibling package in `@stdlib/string/` references either message string.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding
-   [x] Review and debugging

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated cross-package API-drift audit of `@stdlib/string`. Candidate corrections were located via filesystem and source-string feature extraction across all 58 namespace members, validated by three parallel reviewer agents (opus semantic-review, opus cross-reference, sonnet structural-review), then applied as one mechanical patch per package in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019fKzdr3cB4376gehrRjQq9)_