### PR TITLE
refactor: use a function wrapper for native binding

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/median/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/median/lib/native.js
@@ -56,7 +56,9 @@ var addon = require( './../src/addon.node' );
 * var v = median( NaN );
 * // returns NaN
 */
-var median = addon;
+function median( c ) {
+	return addon( c );
+}
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Replaces the `var median = addon;` alias in `@stdlib/stats/base/dists/bradford/median/lib/native.js` with a `function median( c ) { return addon( c ); }` wrapper, matching the convention used in every other `lib/native.js` in `stats/base/dists` (426/427 ≈ 99.8%) — including the nine sibling `bradford` sub-packages (`cdf`, `entropy`, `mean`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`).

The wrapper also matches the function-style JSDoc declaration already in the file (`* function median( c )`) and the TypeScript declaration in `docs/types/index.d.ts` (`declare function median( c: number ): number;`).

### `bradford/median`

Sole `lib/native.js` in `stats/base/dists` (out of 427) still using the `var name = addon;` alias form rather than a function wrapper. Behavior is unchanged: both forms invoke the same C addon with the shape parameter, and the existing test (`test/test.native.js`) exercises the call site, not the export identity. The wrapper restores consistency with the surrounding JSDoc and TypeScript declaration in the same package.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by an automated cross-package drift audit of the `@stdlib/stats/base/dists/bradford` namespace (10 members). The only correction that survived gating and three-axis validation (semantic equivalence, test-cascade check, structural conformance). Two other findings were logged but dropped: `skewness` is missing `docs/img/equation_bradford_skewness.svg` and the matching `<div class="equation">` placeholder in its README, but both are produced by the `makie` generator (auto-populated, excluded by gate); `mode` lacks `test/fixtures/python/` data because the mode of a Bradford distribution is the constant `0.0` and the test asserts this directly without numerical fixtures (intentional deviation).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This change was surfaced and authored by an automated Claude Code drift audit of the `stats/base/dists/bradford` namespace. The audit compared structural and semantic features across the namespace's ten members and against all 427 `lib/native.js` files under `stats/base/dists`; the export-pattern outlier in `bradford/median/lib/native.js` was the sole correction that survived materiality and validation gating. The patch and conformance counts were verified before submission, and the change is reviewable as a 4-line refactor with no behavior change.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01VadMcj4xEFiKAZZ9zUwF7R)_