### PR TITLE
refactor: rename internal variable

### DIFF
--- a/lib/node_modules/@stdlib/slice/base/slice2seq/lib/index.js
+++ b/lib/node_modules/@stdlib/slice/base/slice2seq/lib/index.js
@@ -39,9 +39,9 @@
 
 // MODULES //
 
-var slice2seq = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = slice2seq;
+module.exports = main;


### PR DESCRIPTION
## Description

Renames the `./main.js` import variable in `lib/node_modules/@stdlib/slice/base/slice2seq/lib/index.js` from `slice2seq` to `main`. The deviation was the lone outlier in `@stdlib/slice/base`: 13 of 14 sibling packages already use `main`, and the convention holds across 765 of 779 base-namespace packages stdlib-wide (98.2%).

### `@stdlib/slice/base/slice2seq`

`lib/index.js` declared `var slice2seq = require( './main.js' );` and re-exported it as `module.exports = slice2seq;`. Every other `slice/base/*` package binds the import to `main`. Renaming the local identifier brings the file in line with the namespace and stdlib-wide convention; no observable behaviour, no consumer of the package, no test, example, type declaration, or README sample changes.

## Related Issues

None.

## Questions

No.

## Other

Diff is 4 lines across a single file. The full namespace summary, per-feature majority table, and three-agent validation transcript are in the local drift report (not pushed).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated cross-package API-drift detection run against the `@stdlib/slice/base` namespace. Drift was identified by extracting structural and semantic features from every package, computing a per-feature majority pattern (≥75% threshold), and filtering candidate corrections through a three-agent validation pass (one opus semantic-review, one opus cross-reference, one sonnet structural-review). A maintainer will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_014YTJsc98Ve11KbLmsUUECp)_