### PR TITLE
chore: update keywords and add missing section heading

### DIFF
--- a/lib/node_modules/@stdlib/number/float64/base/get-high-word/package.json
+++ b/lib/node_modules/@stdlib/number/float64/base/get-high-word/package.json
@@ -75,6 +75,7 @@
     "mantissa",
     "exponent",
     "fraction",
-    "ieee754"
+    "ieee754",
+    "number"
   ]
 }

--- a/lib/node_modules/@stdlib/number/float64/base/get-low-word/package.json
+++ b/lib/node_modules/@stdlib/number/float64/base/get-low-word/package.json
@@ -73,6 +73,7 @@
     "frac",
     "signficand",
     "mantissa",
-    "ieee754"
+    "ieee754",
+    "number"
   ]
 }

--- a/lib/node_modules/@stdlib/number/float64/base/identity/lib/main.js
+++ b/lib/node_modules/@stdlib/number/float64/base/identity/lib/main.js
@@ -18,6 +18,8 @@
 
 'use strict';
 
+// MAIN //
+
 /**
 * Evaluates the identity function for a double-precision floating-point number `x`.
 *

--- a/lib/node_modules/@stdlib/number/float64/base/identity/package.json
+++ b/lib/node_modules/@stdlib/number/float64/base/identity/package.json
@@ -60,7 +60,8 @@
     "double",
     "double-precision",
     "dbl",
-    "float64"
+    "float64",
+    "number"
   ],
   "__stdlib__": {}
 }

--- a/lib/node_modules/@stdlib/number/float64/base/set-high-word/package.json
+++ b/lib/node_modules/@stdlib/number/float64/base/set-high-word/package.json
@@ -76,6 +76,7 @@
     "mantissa",
     "exponent",
     "fraction",
-    "ieee754"
+    "ieee754",
+    "number"
   ]
 }

--- a/lib/node_modules/@stdlib/number/float64/base/set-low-word/package.json
+++ b/lib/node_modules/@stdlib/number/float64/base/set-low-word/package.json
@@ -73,6 +73,7 @@
     "significand",
     "mantissa",
     "fraction",
-    "ieee754"
+    "ieee754",
+    "number"
   ]
 }

--- a/lib/node_modules/@stdlib/number/float64/base/to-words/package.json
+++ b/lib/node_modules/@stdlib/number/float64/base/to-words/package.json
@@ -75,6 +75,7 @@
     "significand",
     "mantissa",
     "exponent",
-    "fraction"
+    "fraction",
+    "number"
   ]
 }

--- a/lib/node_modules/@stdlib/number/float64/base/ulp-difference/package.json
+++ b/lib/node_modules/@stdlib/number/float64/base/ulp-difference/package.json
@@ -63,6 +63,7 @@
     "numbers",
     "ulp",
     "float64",
-    "double"
+    "double",
+    "number"
   ]
 }


### PR DESCRIPTION
## Description

This pull request corrects metadata and source-style drift across seven packages in `@stdlib/number/float64/base` so that each outlier conforms to the prevailing convention in the namespace.

### Namespace summary

-   Namespace: `@stdlib/number/float64/base`
-   Members analyzed: 28 (1 namespace re-export; 27 leaf packages)
-   Features with a clear majority (≥75%): `package.json` top-level keys, `keywords` membership (`stdlib`, `double`, `number`), `lib/main.js` section-marker style, `lib/index.js` shape, file-tree skeleton (`README.md`, `docs/types/`, `examples/index.js`, `test/test.js`).
-   Features without a clear majority (excluded): native (C/`binding.gyp`) presence (19/28 = 68%), `## C APIs` README heading, `## Notes` heading, `__stdlib__` package.json field, presence of `benchmark/c/native/` subdirectory.

### Per outlier

#### `number/float64/base/get-high-word`, `get-low-word`, `set-high-word`, `set-low-word`, `to-words`, `ulp-difference`

Each is missing the bare `number` keyword in `package.json`. The keyword is present in 21/28 (75%) of siblings, including the closely related `from-words`, `from-binary-string`, `to-binary-string`, `exponent`, `signbit`, `normalize`, `to-int32`, `to-uint32`, `to-int64-bytes`, and `from-int64-bytes`. All seven packages operate on double-precision numbers and there is no semantic reason for the omission. Appended `"number"` to the keyword array in each.

#### `number/float64/base/identity`

Two corrections. (1) Missing `number` keyword, as above. (2) Missing `// MAIN //` section marker between the file prologue and the function JSDoc in `lib/main.js`. The marker is present in 26/27 (96%) of leaf siblings — `identity` is the lone omission, even though the file already uses the matching `// EXPORTS //` marker. Inserted the marker using the same one-blank-line stanza as `add`, `mul`, `sub`.

### Validation

-   Structural-feature extraction across all 28 members (file tree, `package.json`/`manifest.json` key sets, README headings).
-   Semantic-feature scan of `lib/main.js` for validation prologues, error construction, and JSDoc shape — these packages have no validation prologues and a single `format`-based throw in `from-binary-string`, so no semantic drift to correct.
-   Cross-reference check confirming no test, example, or build script (`tools/`, `_tools/scaffold/package-json/lib/validate.js`, `_tools/search/pkg-index/lib/create.js`) is sensitive to keyword ordering or section comments.

### Deliberately excluded

-   `## See Also` heading absent in `sub3`, `to-float16`, `to-float32`, `ulp-difference` — auto-populated section, generator-owned.
-   `identity` missing top-level `benchmark/c/benchmark.c` / `Makefile` — a naive C reference benchmark for the identity function would be tautological; treated as intentional.
-   `exponent`, `mul`, `sub` use `src/<pkg>.c` instead of `src/main.c` — alternate-but-internally-consistent convention; renaming would cascade through `manifest.json` and is out of scope.
-   The `assert` member is a namespace re-export, structurally distinct from leaf function packages; excluded from leaf-shape drift.

## Related Issues

No.

## Questions

No.

## Other

Generated as part of a cross-package drift-detection routine over `@stdlib/number/float64/base`. Majority threshold: ≥⌈28×0.75⌉ = 21. Full per-feature distribution and the corrections that were considered then dropped are recorded in the local audit log.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a scheduled cross-package drift-detection routine: structural and semantic features were extracted from every member of `@stdlib/number/float64/base`, the majority pattern was computed per feature, and outliers were validated by a separate review agent before any patch was applied. Each correction is mechanical (one `keywords` entry per package; one section-marker stanza in `identity/lib/main.js`).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjmPHnsddwei2nDqPb5XDN)_