### PR TITLE
docs: fix heading levels

### DIFF
--- a/lib/node_modules/@stdlib/constants/float64/smallest-normal/README.md
+++ b/lib/node_modules/@stdlib/constants/float64/smallest-normal/README.md
@@ -30,7 +30,7 @@ limitations under the License.
 var FLOAT64_SMALLEST_NORMAL = require( '@stdlib/constants/float64/smallest-normal' );
 ```
 
-##### FLOAT64_SMALLEST_NORMAL
+#### FLOAT64_SMALLEST_NORMAL
 
 Smallest positive **normalized** [double-precision floating-point number][ieee754].
 

--- a/lib/node_modules/@stdlib/constants/float64/smallest-subnormal/README.md
+++ b/lib/node_modules/@stdlib/constants/float64/smallest-subnormal/README.md
@@ -32,7 +32,7 @@ limitations under the License.
 var FLOAT64_SMALLEST_SUBNORMAL = require( '@stdlib/constants/float64/smallest-subnormal' );
 ```
 
-##### FLOAT64_SMALLEST_SUBNORMAL
+#### FLOAT64_SMALLEST_SUBNORMAL
 
 Smallest positive **denormalized** [double-precision floating-point number][ieee754].
 


### PR DESCRIPTION
## Description

Cross-package drift analysis of `@stdlib/constants/float64` identified two high-confidence mechanical corrections. Both files have an H5 (`#####`) heading for the constant-identifier sub-section inside `## Usage` where 65 of 67 sibling packages (97% conformance) and both float32 siblings use H4 (`####`).

### Namespace summary

- **Members analyzed:** 67 non-autogenerated packages.
- **Features analyzed:** file tree, `package.json` shape (top keys, scripts, `keywords`), `manifest.json` shape, README section structure and heading levels, README `<section class="…">` wrappers, README usage-block variable vs `lib/index.js` `MAIN` variable name, test/example file naming, module- and main-docblock JSDoc tags, `lib/index.js` structural conventions (`MODULES`/`MAIN`/`EXPORTS` markers), C header guard/define structure.
- **Features with a clear majority (≥75%):** file tree (100%), `package.json` top keys (100%), `manifest.json` shape (100%, byte-identical across all 67 packages), C header structure (100%), constant-identifier sub-heading uses `####` (97%, this PR), `## See Also` README section presence (78%, excluded — auto-populated), `dbl` keyword (87%), `double` keyword (91%), `float64` keyword (85%), `math`/`mathematics` keywords (84%).
- **Features without a clear majority:** README `var` prefix convention (52% `FLOAT64_`-prefixed vs 40% bare in both README and lib, 8% split — no convention to enforce).

### `@stdlib/constants/float64/smallest-normal`

`README.md` line 33: the `FLOAT64_SMALLEST_NORMAL` identifier sub-heading inside `## Usage` is rendered at H5 (`##### FLOAT64_SMALLEST_NORMAL`) instead of H4 (`#### FLOAT64_SMALLEST_NORMAL`). The C-API counterpart in the same file (line 91, `#### STDLIB_CONSTANT_FLOAT64_SMALLEST_NORMAL`) already uses H4, as does the float32 sibling — so the H5 here is internally inconsistent and a typo, not an intentional deeper nesting. 97% conformance (65/67) for `####` at this position across the namespace.

### `@stdlib/constants/float64/smallest-subnormal`

`README.md` line 35: identical shape to `smallest-normal`. `##### FLOAT64_SMALLEST_SUBNORMAL` inside `## Usage` where 65 of 67 siblings, the same file's C-API section at line 97, and the float32 sibling all use `####`. Same 97% conformance.

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural extraction** over all 67 packages: file trees, `package.json` and `manifest.json` shapes, README heading-level lists, README `<section class="…">` wrappers, test/example filenames, C header structure.
- **Semantic extraction** over `lib/index.js` for each package: module-docblock and main-docblock JSDoc tag sets, `MAIN` var name, `@example` var name, `// MODULES //`/`MAIN`/`EXPORTS` section presence.
- **Three-agent drift validation:**
  - *Agent 1 (opus, semantic-review)* and *Agent 2 (opus, cross-reference)* (consolidated): verified no test, example, type declaration, REPL fixture, doc generator, or other consumer in the @stdlib tree references `##### FLOAT64_SMALLEST_NORMAL` or `##### FLOAT64_SMALLEST_SUBNORMAL`; the 5-hash heading appears nowhere outside these two READMEs.
  - *Agent 3 (sonnet, structural-review)* sampled `pi`, `e`, `max`, and both float32 siblings, confirming `####` is the convention at the structurally identical position and that `##### → ####` is the right repair.

### Deliberately excluded

- **Auto-populated sections:** `## See Also` README section (15 packages omit; section is generator-owned per project convention, content varies per package).
- **Intentional deviations confirmed via float32-sibling cross-check (mirroring the convention documented in PR #12967):**
  - `float64` keyword absent in `exponent-bias`, `max/min-base{2,10}-exponent[-subnormal]`, `precision` — float32 siblings omit `float32` in the same slot;
  - `double`/`dbl` keywords absent in `gamma-lanczos-g`, `high-word-{abs,exponent,sign,significand}-mask`, `num-high-word-significand-bits`, `num-bytes`, `smallest-normal`, `smallest-subnormal` — float32 siblings omit `single`/`single-precision` in the same slots and instead use the `float`/`floatN`/`Nbit` triplet;
  - `math`/`mathematics` keywords absent in `max-safe-*`, `max-nth-*`, `min-safe-integer` — float32 siblings omit; tagged as integer-bound constants by convention.
- **Content-judgment fixes (not mechanical):**
  - 11 packages missing a main-docblock `@see` URL (would require choosing a Wikipedia/OEIS/Mathworld reference per constant);
  - `cbrt-eps`, `eps`, `sqrt-eps`, `fourth-root-eps`, `gamma-lanczos-g`, `glaisher-kinkelin` README-vs-lib identifier mismatches (e.g., `EPS` in README, `FLOAT64_EPSILON` in lib): pre-existing inconsistency mirrored in `constants/float32` per PR #12967; reconciling requires a maintainer call on the canonical spelling and whether to carry the `FLOAT64_` prefix in README usage blocks (52% prefixed vs 40% bare — no majority).
- **Features without a clear majority dropped from drift analysis:**
  - README usage-block `var` prefix convention (split 52/40);
  - Test count per package (87% have 2 tests, 13% have 3 — the third test is a definition-equivalence test that varies per constant and is intentional).
- **Cross-run dedup:** open PRs #12154, #11768, #8982 touch `constants/float64` but do not modify either candidate file; no recent merged PR in the last 14 days touches `smallest-normal/README.md` or `smallest-subnormal/README.md`.

### Cross-namespace tie-in

This run reuses the float32-sibling cross-check pattern from PR #12967 to drop intentional cross-namespace keyword omissions. The fix pattern "correct an H5 → H4 heading typo" is structurally identical to a propagation fix pattern; future runs can deduplicate by comparing heading-level distributions across precision-sibling namespaces.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated cross-package API-drift detection run against the `@stdlib/constants/float64` namespace. Drift was identified by extracting structural and semantic features from every package, computing a per-feature majority pattern (≥75% threshold), and filtering candidate corrections through a three-agent validation pass plus a sibling cross-check against `@stdlib/constants/float32` (PR #12967) to drop intentional cross-namespace deviations. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9dW2htmeMXocwd2khYF4a)_