### PR TITLE
chore: follow-up fixes for prior commits

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dsome/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsome/docs/repl.txt
@@ -11,6 +11,8 @@
 
     If `N <= 0`, the function returns `false`.
 
+    The function explicitly treats `NaN` values as falsy.
+
     Parameters
     ----------
     N: integer

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dindex-of-falsy/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dindex-of-falsy/lib/main.js
@@ -1,4 +1,3 @@
-
 /**
 * @license Apache-2.0
 *

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-falsy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-falsy/README.md
@@ -74,7 +74,7 @@ var idx = gindexOfFalsy( [ x ] );
 
 ## Notes
 
--   The function treats `NaN` values a falsy.
+-   The function treats `NaN` values as falsy.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/lib/main.js
@@ -32,6 +32,12 @@ var strided = require( '@stdlib/blas/ext/base/gindex-of-truthy' ).ndarray;
 /**
 * Returns the index of the first truthy element in a one-dimensional ndarray.
 *
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {integer} index
 *

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-falsy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-falsy/README.md
@@ -312,6 +312,10 @@ int main( void ) {
 
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
 </section>
 
 <!-- /.links -->

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-falsy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-falsy/docs/repl.txt
@@ -11,7 +11,7 @@
 
     If `N <= 0`, the function returns `-1`.
 
-    The function treats `NaN` values as falsy.
+    The function explicitly treats `NaN` values as falsy.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between `b04b44547c` (2026-06-20 14:32 PDT) and `e6e7d42b10` (2026-06-21 02:36 PDT) — the new `blas/ext/base` predicate family (`dnone`, `dsome`, `sindex-of-falsy`) and three new ndarray siblings (`ndarray/dindex-of-falsy`, `ndarray/gindex-of-falsy`, `ndarray/gindex-of-truthy`).

This pull request:

-   Fixes typo in README Notes section: "treats `NaN` values a falsy" → "values **as** falsy". (`lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-falsy/README.md`, a071b8bdbb)
-   Adds missing `## Notes` block to function JSDoc, aligning with siblings `gindex-of-falsy` and `dindex-of-falsy`. (`lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-truthy/lib/main.js`, 99dac60171)
-   Removes spurious blank line before `/**` license header; every sibling and peer file in the batch opens on line 1. (`lib/node_modules/@stdlib/blas/ext/base/ndarray/dindex-of-falsy/lib/main.js`, 24ae0ea1e4)
-   Adds missing NaN-as-falsy note to REPL help, present in both the package README and sibling `dnone/docs/repl.txt` but absent here. (`lib/node_modules/@stdlib/blas/ext/base/dsome/docs/repl.txt`, 7cc82a344d)
-   Two doc fixes in `sindex-of-falsy`: restore `<!-- <related-links> -->` / `<!-- </related-links> -->` placeholder comments required by the related-packages tooling (`README.md`), and add missing adverb "explicitly" to NaN note to match README and the rest of the package family (`docs/repl.txt`). (`lib/node_modules/@stdlib/blas/ext/base/sindex-of-falsy/`, b04b44547c)

## Related Issues

None.

## Questions

No.

## Other

Generated by an automated drift-review routine over the 15 commits merged to `develop` in the 24h window ending 2026-06-21 12:00 UTC. The routine launched four parallel reviewers (two style-guide audits comparing against the closest established reference packages, two independent bug scans). Both bug scans returned zero findings; the surviving issues are all doc-style inconsistencies between siblings added in the same batch. Findings only made it into this PR if they could be re-verified by re-reading the diff and carried a concrete, in-scope fix that did not require touching any code outside the commit window.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was produced by an automated drift-review routine running in Claude Code. The routine enumerated commits merged to `develop` in the last 24h, ran four parallel reviewer agents (two style-guide audits, two independent bug scans), filtered findings to high-signal items re-verifiable from the diff alone, and applied the fixes. A human will audit and promote the PR from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKviww84iv1gQXCZvB31tV)_