### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/array/base/reject/examples/index.js
+++ b/lib/node_modules/@stdlib/array/base/reject/examples/index.js
@@ -29,7 +29,7 @@ var x = discreteUniform( 10, -5, 5, {
 // returns <Int32Array>
 
 var out = reject( x, naryFunction( isPositiveInteger, 1 ) );
-// returns <Int32Array>
+// returns <Array>
 
 console.log( x );
 console.log( out );


### PR DESCRIPTION
## Description

This pull request fixes the doctest annotation in the `@stdlib/array/base/reject` example. The `reject` implementation returns a plain array, so the example now documents the output as `<Array>` instead of `<Int32Array>`.

## Related Issues

Resolves #12890

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored with assistance from AI.

## Validation

- `node --check lib/node_modules/@stdlib/array/base/reject/examples/index.js`
- `git diff --check`

Note: the full stdlib `make lint-javascript-files` target was not run locally because `make` is not installed in this Windows environment.