### PR TITLE
style: remove extra trailing newlines

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acos/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/acos/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/acosd/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/acosd/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/acosdf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/acosdf/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/acosh/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/acoshf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/acoshf/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/asinh/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/asinh/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/asinhf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/asinhf/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/atan/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/atan/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/atan2/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/atan2/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/atan2d/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/atan2d/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/atanh/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/atanh/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/besselj1/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/cosh/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/cosh/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/coshf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/coshf/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/erf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/erf/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/erfc/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/erfc/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/erfcx/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/erfcx/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/src/Makefile
@@ -68,4 +68,3 @@ clean-addon:
 clean: clean-addon
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/kernel-cos/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-cos/benchmark/c/native/Makefile
@@ -144,4 +144,3 @@ clean:
 	$(QUIET) -rm -f *.o *.out
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/kernel-sincos/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-sincos/benchmark/c/native/Makefile
@@ -144,4 +144,3 @@ clean:
 	$(QUIET) -rm -f *.o *.out
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/math/base/special/kernel-sincosf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-sincosf/benchmark/c/native/Makefile
@@ -144,4 +144,3 @@ clean:
 	$(QUIET) -rm -f *.o *.out
 
 .PHONY: clean
-

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/logpdf/benchmark/c/Makefile
@@ -144,5 +144,3 @@ clean:
 	$(QUIET) -rm -f *.o *.out
 
 .PHONY: clean
-
-


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between `b04b44547c` (2026-06-20 14:32 PDT) and `e6e7d42b10` (2026-06-21 02:36 PDT) to sibling packages.

This pull request:

-   Removes the extra trailing blank line at EOF from 22 Makefiles under `math/base/special/*` and one Makefile under `stats/base/dists/halfnormal/logpdf` that exhibit the identical EOF pattern fixed in `50a34cff` ([`style: remove extra trailing newlines`](https://github.com/stdlib-js/stdlib/commit/50a34cffd477b655ab96d0aefd61744ef964a58f)). The source commit removed a single trailing blank line from five files under `stats/base/dists/planck`; the same one-byte fix applies verbatim here. Targets — all 23 ending `.PHONY: clean\n\n` (or, for `halfnormal/logpdf/benchmark/c/Makefile`, `\n\n\n`):
    -   `@stdlib/math/base/special/acos/src/Makefile`
    -   `@stdlib/math/base/special/acosd/src/Makefile`
    -   `@stdlib/math/base/special/acosdf/src/Makefile`
    -   `@stdlib/math/base/special/acosh/src/Makefile`
    -   `@stdlib/math/base/special/acoshf/src/Makefile`
    -   `@stdlib/math/base/special/asinh/src/Makefile`
    -   `@stdlib/math/base/special/asinhf/src/Makefile`
    -   `@stdlib/math/base/special/atan/src/Makefile`
    -   `@stdlib/math/base/special/atan2/src/Makefile`
    -   `@stdlib/math/base/special/atan2d/src/Makefile`
    -   `@stdlib/math/base/special/atanh/src/Makefile`
    -   `@stdlib/math/base/special/besselj1/src/Makefile`
    -   `@stdlib/math/base/special/cosh/src/Makefile`
    -   `@stdlib/math/base/special/coshf/src/Makefile`
    -   `@stdlib/math/base/special/erf/src/Makefile`
    -   `@stdlib/math/base/special/erfc/src/Makefile`
    -   `@stdlib/math/base/special/erfcinv/src/Makefile`
    -   `@stdlib/math/base/special/erfcx/src/Makefile`
    -   `@stdlib/math/base/special/erfinv/src/Makefile`
    -   `@stdlib/math/base/special/kernel-cos/benchmark/c/native/Makefile`
    -   `@stdlib/math/base/special/kernel-sincos/benchmark/c/native/Makefile`
    -   `@stdlib/math/base/special/kernel-sincosf/benchmark/c/native/Makefile`
    -   `@stdlib/stats/base/dists/halfnormal/logpdf/benchmark/c/Makefile`

    Each file now ends with exactly one `\n`, conforming to the repository-wide `insert_final_newline = true` and `trim_trailing_whitespace = true` `.editorconfig` directives.

## Related Issues

None.

## Questions

No.

## Other

Generated by an automated fix-propagation routine over the 15 commits merged to `develop` in the 24h window ending 2026-06-21. Four other source commits were inspected and dropped during pattern specification or pre-validation:

-   `1f05813f` (`docs: fix note` — t-entropy `v < 0` → `v <= 0`) — sibling t-distribution packages either already use `<=` semantics or are validly defined at `v = 0` (e.g. `t/median`, `t/mode` return `0.0` at `v = 0`), so the doc-text correction does not apply.
-   `b3383d13` (`fix: use correct element type` — `typedndarray<number>` → `typedndarray<unknown>` for the generic `gindex-of-falsy`) — the only direct-parameter sibling (`gindex-of-truthy`) is already on `<unknown>`; remaining g-prefixed packages legitimately constrain elements to `number` for sum/cumsum/axpy arithmetic.
-   `7f1c224c` (`docs: update descriptions` — anglit/mean Greek symbols, `σ > 0` constraint, `Evaluates` → `Returns`) — the only anglit sibling (`anglit/median`) already carries both edits.
-   `5c56631c` (`test: fix mismatched test filenames`) and `7f87b929` (`chore: fix JavaScript lint errors`) — no concrete grep-able search signature; dropped at pattern specification.

### Validation

Two independent opus validation passes verified each target file ends with at least one trailing blank line after `.PHONY: clean`, carries no `Do not manually edit` / `AUTOGENERATED` marker, and is not the artifact of a template generator. A sonnet style-consistency pass sampled 20 sibling Makefiles and the root `.editorconfig` to confirm "single newline at EOF" is the dominant convention. Deliberately excluded from this PR:

-   `gypi`/`Makefile` files under other namespaces that did not exhibit the trailing-blank-line pattern (scan covered 4,926 Makefiles and 1,500 `include.gypi` files repo-wide).
-   Source commits whose pattern produced zero confirmed propagation sites after sibling-package inspection (see "Other" above).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rxqmx2YHw5u5dPpffbLRLV)_