### PR TITLE
docs: add Git notes correcting recent commit messages

### DIFF
--- a/docs/git-notes/b04b44547cf1514df488d69b906d17338783af75.txt
+++ b/docs/git-notes/b04b44547cf1514df488d69b906d17338783af75.txt
@@ -1,0 +1,9 @@
+---
+type: amend-message
+---
+feat: add `blas/ext/base/sindex-of-falsy`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/12975
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Signed-off-by: Athan Reines <kgryte@gmail.com>
+Closes: https://github.com/stdlib-js/metr-issue-tracker/issues/840


### PR DESCRIPTION
## Summary

Audit of the 15 non-merge commits landed on `develop` in the 24 hours ending 2026-06-21 UTC. One commit was flagged for a missing trailer.

## Notes

- `b04b44547`: missing `Signed-off-by: Athan Reines <kgryte@gmail.com>` — all five other headlessNode commits merged by Athan in this same window (`7cc82a3`, `ecf3df1`, `99dac60`, `24ae0ea`, `a071b8b`) carry `Signed-off-by`; it was omitted from this one.

## PR references verified

All 12 `PR-URL` values in the window were confirmed against the GitHub API; every number exists and its title matches the commit subject. No wrong or non-existent PR references were found.

## Commits with no trailers (direct pushes — not flagged)

- `e6e7d42b`, `5609f46b`, `b3383d13` — no `PR-URL` block; pre-commit static analysis report only.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
