### PR TITLE
fix: guard `atob` global reference in `@stdlib/string/base/atob`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -20,7 +20,7 @@
 
 // MAIN //
 
-var main = ( typeof atob === 'function' ) ? atob : null;
+var main = ( typeof atob === 'function' ) ? atob : null; // eslint-disable-line n/no-unsupported-features/node-builtins
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MAIN //
+
+var main = ( typeof atob === 'function' ) ? atob : null;
+
+
 // EXPORTS //
 
-module.exports = atob;
+module.exports = main;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `ReferenceError: atob is not defined` thrown during module load on Node.js v12 and v14.

On those versions, `atob` is not a global (added in Node.js v16.0.0). `lib/node_modules/@stdlib/string/base/atob/lib/global.js` previously exported the bare identifier `atob` at require-time, crashing before any feature detection could run. The fix wraps the reference in a `typeof` guard, which never throws for undeclared identifiers, and exports `null` on environments lacking native `atob`. The existing try/catch in `main.js` handles the null case correctly. Pattern matches `@stdlib/assert/has-atob-support/lib/atob.js`.

Failing CI runs (develop, 2026-06-21): https://github.com/stdlib-js/stdlib/actions/runs/27901198731

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers?

No.

## Other

> Any other information relevant?

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If yes, how:
-   [x] Code generation
-   [ ] Test/benchmark generation
-   [ ] Documentation
-   [x] Research and understanding

#### Disclosure

This PR was prepared with the assistance of Claude (claude-sonnet-4-6). Root cause identification, fix implementation, and three-reviewer validation were AI-assisted. The fix was verified against existing codebase patterns in `@stdlib/assert/has-atob-support/lib/atob.js`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_0116goNvkDr7ZQ7w5vpvseiw)_