### PR TITLE
bench: add benchmark to `utils/async/series-waterfall`

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/series-waterfall/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/utils/async/series-waterfall/benchmark/benchmark.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var waterfall = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var fcns;
+	var i;
+
+	fcns = [ foo, bar, fun ];
+
+	i = 0;
+	b.tic();
+
+	return next();
+
+	function next( error ) {
+		i += 1;
+		if ( error ) {
+			b.fail( 'should not return an error' );
+		}
+		if ( i <= b.iterations ) {
+			return waterfall( fcns, done );
+		}
+		b.toc();
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+
+	function foo( clbk ) {
+		setTimeout( onTimeout, 0 );
+		function onTimeout() {
+			clbk( null, 'beep' );
+		}
+	}
+
+	function bar( str, clbk ) {
+		setTimeout( onTimeout, 0 );
+		function onTimeout() {
+			clbk( null, str + ' boop' );
+		}
+	}
+
+	function fun( str, clbk ) {
+		setTimeout( onTimeout, 0 );
+		function onTimeout() {
+			clbk( null );
+		}
+	}
+
+	function done( error ) {
+		if ( error ) {
+			next( error );
+			return;
+		}
+		next();
+	}
+});

--- a/lib/node_modules/@stdlib/utils/async/series-waterfall/package.json
+++ b/lib/node_modules/@stdlib/utils/async/series-waterfall/package.json
@@ -15,6 +15,7 @@
   ],
   "main": "./lib",
   "directories": {
+    "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
     "lib": "./lib",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Adds the missing `benchmark/benchmark.js` and matching `directories.benchmark` `package.json` entry to `@stdlib/utils/async/series-waterfall`, bringing it in line with the structural convention of its sibling packages.

### Namespace summary

-   **Namespace:** `@stdlib/utils/async`
-   **Members analyzed:** 33 non-generated packages
-   **Features with a clear majority (>=75% conformance):** `README.md` presence, `package.json` presence + top-level key set, `lib/index.js` + `lib/main.js` presence, `test/test.js` presence, `docs/repl.txt` + `docs/types/{index.d.ts,test.ts}` presence, `examples/index.js` presence, `benchmark/benchmark.js` presence (32/33 — 97%), `directories.benchmark` key in `package.json` (32/33 — 97%), `@example` JSDoc tag in `lib/main.js` (33/33 — 100%).
-   **Features without a clear majority (excluded):** `lib/factory.js` / `lib/limit.js` / `lib/validate.js` / `test/test.factory.js` / `test/test.validate.js` / `benchmark/benchmark.factory.js` presence — these split along an "iterator-with-options" (~22) vs "control-flow primitive" (~10) archetype boundary, with neither side reaching 75%. Per-package `publicSignature` and `validationPrologue` were excluded for the same reason.

### Per outlier package

#### `@stdlib/utils/async/series-waterfall`

`@stdlib/utils/async/series-waterfall` was the only package in the 33-member `@stdlib/utils/async` namespace missing `benchmark/benchmark.js` and the corresponding `directories.benchmark` entry in `package.json`. The added benchmark drives the waterfall through a three-function async sequence (`foo` -> `bar` -> `fun`), matching the convention established by `function-sequence/benchmark/benchmark.js` and `parallel/benchmark/benchmark.js`. Purely additive fixture and metadata; no lib, public API, or test changes.

### Validation

Checked:

-   Structural extraction over all 33 namespace members (file-tree presence, `package.json` shape, README section headings).
-   Bulk semantic extraction over `lib/main.js`, `lib/validate.js`, and `lib/index.js` (validation-prologue predicates, `format()`-vs-plain `Error` construction, `@example` tag counts, top-level export shape).
-   Three-agent review of the outlier and the proposed fix (cross-reference, structural-review, semantic-review).

Deliberately excluded:

-   The `## See Also` README section is missing from `parallel` and `series-waterfall`; dropped because it is generator-populated and not safe to edit manually.
-   The `compose` and `function-sequence` `throw new Error('insufficient arguments...')` calls — intentional, since `format()` adds nothing without a placeholder.
-   The `parallel/lib/validate.js` lack of a `series` option — semantically required (parallel cannot be serial), not drift.
-   A cosmetic preallocated-array vs `push()` split inside the `next()` callbacks of several control-flow primitives — no 75% majority either way.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The added benchmark was syntax-checked with `node --check`; an end-to-end `node benchmark/benchmark.js` run was not possible in the development environment because the local `node_modules/` (`debug`, transitively required by `@stdlib/bench`) is not installed, but the file is a near-mechanical adaptation of the established sibling pattern.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code as part of a cross-package drift-detection routine: the `@stdlib/utils/async` namespace was scanned for structural and semantic features, the majority pattern (>=75% conformance) was computed per feature, outliers were flagged, and the surviving correction was applied to bring `series-waterfall` into line with its 32 siblings. The proposed fix was validated by three independent agents (one cross-reference, one structural-review, one semantic-review) before being committed.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsCTTGRHVKQXw7neufij48)_