### PR TITLE
refactor: rename test/example namespace var to `constants` in three `@stdlib/constants/*` outliers

### DIFF
--- a/lib/node_modules/@stdlib/constants/array/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/array/examples/index.js
@@ -19,6 +19,6 @@
 'use strict';
 
 var objectKeys = require( '@stdlib/utils/keys' );
-var ns = require( './../lib' );
+var constants = require( './../lib' );
 
-console.log( objectKeys( ns ) );
+console.log( objectKeys( constants ) );

--- a/lib/node_modules/@stdlib/constants/array/test/test.js
+++ b/lib/node_modules/@stdlib/constants/array/test/test.js
@@ -22,19 +22,19 @@
 
 var tape = require( 'tape' );
 var objectKeys = require( '@stdlib/utils/keys' );
-var ns = require( './../lib' );
+var constants = require( './../lib' );
 
 
 // TESTS //
 
 tape( 'main export is an object', function test( t ) {
 	t.ok( true, __filename );
-	t.strictEqual( typeof ns, 'object', 'main export is an object' );
+	t.strictEqual( typeof constants, 'object', 'main export is an object' );
 	t.end();
 });
 
-tape( 'the exported object contains key-value pairs', function test( t ) {
-	var keys = objectKeys( ns );
+tape( 'the exported object contains constants', function test( t ) {
+	var keys = objectKeys( constants );
 	t.strictEqual( keys.length > 0, true, 'has keys' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/constants/path/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/path/examples/index.js
@@ -19,6 +19,6 @@
 'use strict';
 
 var objectKeys = require( '@stdlib/utils/keys' );
-var ns = require( './../lib' );
+var constants = require( './../lib' );
 
-console.log( objectKeys( ns ) );
+console.log( objectKeys( constants ) );

--- a/lib/node_modules/@stdlib/constants/path/test/test.js
+++ b/lib/node_modules/@stdlib/constants/path/test/test.js
@@ -22,19 +22,19 @@
 
 var tape = require( 'tape' );
 var objectKeys = require( '@stdlib/utils/keys' );
-var ns = require( './../lib' );
+var constants = require( './../lib' );
 
 
 // TESTS //
 
 tape( 'main export is an object', function test( t ) {
 	t.ok( true, __filename );
-	t.strictEqual( typeof ns, 'object', 'main export is an object' );
+	t.strictEqual( typeof constants, 'object', 'main export is an object' );
 	t.end();
 });
 
-tape( 'the exported object contains key-value pairs', function test( t ) {
-	var keys = objectKeys( ns );
+tape( 'the exported object contains constants', function test( t ) {
+	var keys = objectKeys( constants );
 	t.strictEqual( keys.length > 0, true, 'has keys' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/constants/unicode/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/unicode/examples/index.js
@@ -19,6 +19,6 @@
 'use strict';
 
 var objectKeys = require( '@stdlib/utils/keys' );
-var ns = require( './../lib' );
+var constants = require( './../lib' );
 
-console.log( objectKeys( ns ) );
+console.log( objectKeys( constants ) );

--- a/lib/node_modules/@stdlib/constants/unicode/test/test.js
+++ b/lib/node_modules/@stdlib/constants/unicode/test/test.js
@@ -22,19 +22,19 @@
 
 var tape = require( 'tape' );
 var objectKeys = require( '@stdlib/utils/keys' );
-var ns = require( './../lib' );
+var constants = require( './../lib' );
 
 
 // TESTS //
 
 tape( 'main export is an object', function test( t ) {
 	t.ok( true, __filename );
-	t.strictEqual( typeof ns, 'object', 'main export is an object' );
+	t.strictEqual( typeof constants, 'object', 'main export is an object' );
 	t.end();
 });
 
-tape( 'the exported object contains key-value pairs', function test( t ) {
-	var keys = objectKeys( ns );
+tape( 'the exported object contains constants', function test( t ) {
+	var keys = objectKeys( constants );
 	t.strictEqual( keys.length > 0, true, 'has keys' );
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Renames the local namespace binding from `ns` to `constants` in `test/test.js` and `examples/index.js` of three outlier packages in the `@stdlib/constants/*` namespace (`array`, `path`, `unicode`), and aligns the corresponding `tape` description string. Pure rename — no public API, runtime behavior, test assertion, or import path is changed.

### Namespace summary

-   **Target namespace:** `@stdlib/constants` (15 direct child packages — `array`, `complex128`, `complex64`, `float16`, `float32`, `float64`, `int16`, `int32`, `int8`, `path`, `time`, `uint16`, `uint32`, `uint8`, `unicode`; all non-autogenerated).
-   **Features analyzed:** file tree, `package.json` top-level/`scripts`/`stdlib` keys, `docs/types/{index.d.ts,test.ts}` presence, README heading sequence, `lib/index.js` prologue + export var, `test/test.js` body (var name + description string), `examples/index.js` body (var name), `README.md` Usage var name.
-   **Features with clear majority (≥75%):** file tree (100%), `package.json` shape (100%), `docs/types/` presence (100%), README headings `## Usage` / `#### constants` / `## Examples` (100%), `lib/index.js` prologue (100%), `docs/types/test.ts` body (100% — byte-identical), `README.md` Usage var name `constants` (100%), `test/test.js` + `examples/index.js` namespace var name `constants` (**12/15 = 80%**), `test/test.js` second-tape description `'the exported object contains constants'` (**12/15 = 80%**).
-   **Features without clear majority (excluded):** `lib/index.js` namespace var name (9/15 = 60% `constants` vs 6/15 `ns` — below threshold, not corrected); `examples/index.js` copyright year (13/15 = 2021 vs 2/15 = 2018 — copyright is historical metadata, not stylistic drift, deliberately excluded).

### Per outlier package

#### `@stdlib/constants/array`

`test/test.js` and `examples/index.js` were the only two files in this package's surface using `var ns = require( './../lib' )`; the README's Usage block, by contrast, already documents the export as `var constants = require( '@stdlib/constants/array' )`. Renamed to `constants` to match the documented user-facing name and the 80% sibling convention, and updated the second `tape` description from `'the exported object contains key-value pairs'` to `'the exported object contains constants'` (same 80% conformance). 6 LOC across 2 files.

#### `@stdlib/constants/path`

Same drift, same fix. `path/test/test.js` and `path/examples/index.js` use `ns` despite the README's Usage block reading `var constants = require( '@stdlib/constants/path' )`; the test description is the stale `'... key-value pairs'` boilerplate. Both are renamed/aligned to the namespace majority (80% conformance on each item). 6 LOC across 2 files.

#### `@stdlib/constants/unicode`

Identical drift to `path` — the test and example files are byte-for-byte clones of the `path` versions. Renamed `ns` → `constants` in both files and updated the description string; the README's Usage already names the binding `constants`. 6 LOC across 2 files.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Checked:

-   Structural extraction across all 15 namespace members (file tree, `package.json` shape, `docs/types/` shape, README headings, `lib/index.js` prologue, test/example body shapes).
-   Three-agent drift validation on the only feature with a clear majority that had outliers (`test/test.js` + `examples/index.js` namespace var name + description string):
    -   Agent 1 (opus, semantic review) — confirmed-drift for `array`, `path`, `unicode`: the `ns` binding in test/example files is stale boilerplate that predates the `constants` user-facing convention; no semantic difference distinguishes these three packages from the 12 majority siblings.
    -   Agent 2 (opus, cross-reference) — confirmed-drift for all three: zero external `require` references to `constants/{array,path,unicode}/{test,examples}`, the `'key-value pairs'` description string is asserted by no external harness/fixture, and the binding is file-local. (Flagged for the local report: the scaffold template at `_tools/scaffold/namespace/data/test/test__js.txt` still uses `ns`/`'key-value pairs'`, so the 12 siblings drifted away from the scaffold first — a separate generator-side issue, out of scope here.)
    -   Agent 3 (sonnet, structural review) — confirmed-drift for all three: `constants` is the right majority pattern to standardize on (READMEs are 100% `constants` and 80% of sibling test/example files agree); the fix is purely textual with no runtime or assertion impact.

Deliberately excluded:

-   `lib/index.js` namespace var name — 60% conformance, below the 75% threshold; not touched.
-   `examples/index.js` copyright year — historical metadata, not drift.
-   Generator-side drift in the namespace scaffold template — logged in the local report; an upstream generator concern, not a per-package fix.
-   Any change to public API, test expectations beyond a description label, or example output.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running a cross-package drift-detection routine: the target namespace (`@stdlib/constants`) was picked at random across all stdlib namespaces of ≥8 non-generated members, structural and semantic features were extracted for every member, majority patterns were computed at a 75% threshold, and three independent validation agents (two opus, one sonnet) confirmed each correction before it was applied. The only feature with a clear (≥75%) majority that had outliers was the `test/test.js` + `examples/index.js` namespace var name (`constants`, 80% conformance) and the corresponding `tape` description string — both were mechanically renamed in the three outlier packages (`array`, `path`, `unicode`).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6AgS87PysSbUyZ8JUHLhm)_