### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dxsy/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dxsy/package.json
@@ -62,7 +62,7 @@
     "linear",
     "algebra",
     "subroutines",
-    "add",
+    "subtract",
     "transform",
     "strided",
     "array",

--- a/lib/node_modules/@stdlib/blas/ext/base/sxsy/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/sxsy/package.json
@@ -62,7 +62,7 @@
     "linear",
     "algebra",
     "subroutines",
-    "add",
+    "subtract",
     "transform",
     "strided",
     "array",

--- a/lib/node_modules/@stdlib/blas/ext/base/zxsy/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/zxsy/package.json
@@ -74,7 +74,7 @@
     "complex128",
     "complex128array",
     "float64",
-    "single"
+    "double"
   ],
   "__stdlib__": {
     "wasm": false


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-06-21 13:49 UTC-7 and 2026-06-22 01:52 UTC-7 (56 commits, range `e6e7d42b..e0d79b3e`).

This pull request:

-   Stray `add` keyword copied from an axpy-style sibling in `lib/node_modules/@stdlib/blas/ext/base/sxsy/package.json` (c7a7bd4); `sxsy` implements `y = x - y`, so replaced with `subtract` to align with `cxsy`, `gxsy`, and `zxsy`.
-   Same `add` → `subtract` keyword fix in `lib/node_modules/@stdlib/blas/ext/base/dxsy/package.json` (096398f); `dxsy` is the double-precision counterpart of the same operation.
-   Stale `single` keyword in `lib/node_modules/@stdlib/blas/ext/base/zxsy/package.json` (2a40396), copied verbatim from the single-precision `cxsy` sibling. Replaced with `double` to match the double-precision complex semantics; sits alongside the existing `complex128`/`float64` tags.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

No.

## Other

Audit scope: the 56 first-parent commits to `develop` in the 24h window (range `e6e7d42b..e0d79b3e`). Four reviewer agents (two style, two bug) ran in parallel against the union diff and per-package files, cross-checking against sibling packages of similar complexity. Findings were de-duplicated and filtered to high-signal only — objective bugs and unambiguous copy-paste typos in package metadata. Findings that matched pre-existing patterns in sibling packages (e.g. `lib/index.js` shape in the `*-sorted` family) were intentionally dropped to avoid expanding scope beyond the diff window. A local report with the full audit trail (validated issues, dropped candidates and rationale, PR URL) lives at `~/drift-reports/commit-review-2026-06-22.md`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as a scheduled commit-review routine: four reviewer agents audited the last 24h of commits to `develop`, findings were filtered for high-signal items, and Philipp validated and applied the resulting one-line `package.json` keyword corrections.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMugJgBV4NEK47VRre5kwR)_