### PR TITLE
docs: update descriptions and example

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/daxpby/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/daxpby/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Multiply a double-precision floating-point ndarray by a scalar constant and add the result to a second double-precision floating-point ndarray multiplied by a scalar constant.
+* Multiply a one-dimensional double-precision floating-point ndarray by a scalar constant and add the result to a second one-dimensional double-precision floating-point ndarray multiplied by a scalar constant.
 *
 * @module @stdlib/blas/ext/base/ndarray/daxpby
 *

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/daxpby/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/daxpby/lib/main.js
@@ -31,7 +31,7 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 // MAIN //
 
 /**
-* Multiplies a double-precision floating-point ndarray by a scalar constant and adds the result to a second double-precision floating-point ndarray multiplied by a scalar constant.
+* Multiplies a one-dimensional double-precision floating-point ndarray by a scalar constant and adds the result to a second one-dimensional double-precision floating-point ndarray multiplied by a scalar constant.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/daxpby/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/daxpby/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/daxpby",
   "version": "0.0.0",
-  "description": "Multiply a double-precision floating-point ndarray by a scalar constant and add the result to a second double-precision floating-point ndarray multiplied by a scalar constant.",
+  "description": "Multiply a one-dimensional double-precision floating-point ndarray by a scalar constant and add the result to a second one-dimensional double-precision floating-point ndarray multiplied by a scalar constant.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/saxpby/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/saxpby/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Multiply a single-precision floating-point ndarray by a scalar constant and add the result to a second single-precision floating-point ndarray multiplied by a scalar constant.
+* Multiply a one-dimensional single-precision floating-point ndarray by a scalar constant and add the result to a second one-dimensional single-precision floating-point ndarray multiplied by a scalar constant.
 *
 * @module @stdlib/blas/ext/base/ndarray/saxpby
 *

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/saxpby/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/saxpby/lib/main.js
@@ -31,7 +31,7 @@ var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
 // MAIN //
 
 /**
-* Multiplies a single-precision floating-point ndarray by a scalar constant and adds the result to a second single-precision floating-point ndarray multiplied by a scalar constant.
+* Multiplies a one-dimensional single-precision floating-point ndarray by a scalar constant and adds the result to a second one-dimensional single-precision floating-point ndarray multiplied by a scalar constant.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/saxpby/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/saxpby/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/saxpby",
   "version": "0.0.0",
-  "description": "Multiply a single-precision floating-point ndarray by a scalar constant and add the result to a second single-precision floating-point ndarray multiplied by a scalar constant.",
+  "description": "Multiply a one-dimensional single-precision floating-point ndarray by a scalar constant and add the result to a second one-dimensional single-precision floating-point ndarray multiplied by a scalar constant.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/constants/float32/e/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/e/lib/index.js
@@ -25,7 +25,7 @@
 * @type {number}
 *
 * @example
-* var E = require( '@stdlib/constants/float32/e' );
+* var FLOAT32_E = require( '@stdlib/constants/float32/e' );
 * // returns 2.7182817459106445
 */
 


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-06-21 18:18 UTC and 2026-06-22 08:23 UTC to sibling packages.

### `docs:` propagate one-dimensional ndarray qualifier to `{d,s}axpby`

Source: d826990 ("docs: update function descriptions"). Adds the "one-dimensional" qualifier to the brief description in `lib/index.js`, `lib/main.js`, and `package.json` for two sibling packages whose READMEs, TypeScript declarations, REPL help, and JSDoc `## Notes` sections already document them as operating on one-dimensional ndarrays. Mirrors the `dxpy`/`sxpy` precedent exactly.

- `blas/ext/base/ndarray/daxpby`
- `blas/ext/base/ndarray/saxpby`

### `chore:` propagate `FLOAT32_`-prefixed example variable to `constants/float32/e`

Source: 4154fdc ("chore: update examples and add keyword"). Renames the JSDoc `@example` variable from `E` to `FLOAT32_E` in `lib/index.js`, aligning the package with the `FLOAT32_`-prefixed naming convention used by every other `constants/float32/*` package.

- `constants/float32/e`

## Related Issues

No.

## Questions

No.

## Other

### Validation

- Pattern search scoped to siblings under the same namespace as each source commit (`blas/ext/base/ndarray/*` and `constants/float32/*`).
- Two independent opus validation passes confirmed the defect at each target site and the absence of contradicting context (no AUTOGENERATED markers; READMEs/TypeScript types/REPL help already use the one-dimensional wording for the `{d,s}axpby` targets; every other `constants/float32/*` package uses the `FLOAT32_` prefix).
- Style-consistency check confirms each patch mirrors the exact wording used in the source commit.

### Deliberately excluded

- C compiler-warning fix (dadabba, fa820b3) — all `stats/base/ndarray/*/src/addon.c` files already use the const-qualified pointer-list pattern; no sites remain.
- BLAS `*xsy` README copy fix (f87196f) — sibling `cxsy`, `gxsy`, `sxsy`, `zxsy` READMEs already use the corrected "subtract" wording.
- `PDF`→`PMF` typo fix (83e6c53) — no remaining `"probability mass function (PDF)"` or `"probability density function (PMF)"` instances under `stats/` or `math/`.
- `"number"` keyword + `// MAIN //` heading additions (68d7a66) — all `number/float64/base/*` packages already have the keyword and section heading.
- Slice internal-variable rename (71f4c29) — stylistic refactor, not a defect; no objective criterion to flag other call sites.
- `array/base/reject` typed-array return annotation fix (794978c, ed5107b) — limited to the originating package; no sibling exhibits the same incorrect type annotation.
- The same `E`→`FLOAT32_E` rename in `constants/float32/e/README.md` (lines 30, 55) was held out — the source commit narrowed scope to the JSDoc `@example` block in `lib/index.js`. A follow-up can sweep the README if desired.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated routine that scans recent `develop` commits for fix patterns and propagates equivalent fixes to sibling packages. Each target site was independently validated by two opus passes before any patch was applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_014i6wyekcLvRe782G6X4wiX)_