### PR TITLE
docs: update example

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/from-scalar/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/from-scalar/examples/index.js
@@ -22,16 +22,12 @@ var dtypes = require( '@stdlib/ndarray/dtypes' );
 var scalar2ndarray = require( './../lib' );
 
 // Get a list of data types:
-var dt = dtypes();
+var dt = dtypes( 'integer_and_generic' );
 
 // Generate zero-dimensional arrays...
 var x;
 var i;
 for ( i = 0; i < dt.length; i++ ) {
-	// Skip dtypes whose buffer constructors are not yet implemented:
-	if ( dt[ i ] === 'float16' || dt[ i ] === 'complex32' ) {
-		continue;
-	}
 	x = scalar2ndarray( i, {
 		'dtype': dt[ i ]
 	});

--- a/lib/node_modules/@stdlib/ndarray/from-scalar/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/from-scalar/examples/index.js
@@ -28,6 +28,10 @@ var dt = dtypes();
 var x;
 var i;
 for ( i = 0; i < dt.length; i++ ) {
+	// Skip dtypes whose buffer constructors are not yet implemented:
+	if ( dt[ i ] === 'float16' || dt[ i ] === 'complex32' ) {
+		continue;
+	}
 	x = scalar2ndarray( i, {
 		'dtype': dt[ i ]
 	});


### PR DESCRIPTION
## Description

This pull request:

-   Adds a guard in `@stdlib/ndarray/from-scalar` example to skip `float16` and `complex32` dtypes, whose buffer constructors in `@stdlib/ndarray/base/buffer-ctors` are placeholder `notImplemented` functions that throw `Error: not implemented` when invoked as constructors.

The example iterates over all dtypes returned by `dtypes()` (which includes every registered dtype in `dtypes.json`). For `float16` and `complex32`, the internal call chain is:

```
scalar2ndarray(i, { dtype: 'float16' })
  → buffer('float16', 1)
    → bufferCtors('float16')   // returns notImplemented (truthy)
      → new notImplemented(1)  // throws Error: not implemented
```

The `if (buf === null)` guard in `from-scalar/lib/main.js` never fires because the throw happens before `buffer()` can return. The fix skips these two dtypes in the example until their constructors are implemented (tracked by the `FIXME` comments in `buffer-ctors/lib/ctors.js`).

This resolves the `random_examples` CI job failure seen in workflow run [27923327635](https://github.com/stdlib-js/stdlib/actions/runs/27923327635).

## Related Issues

-   No dedicated issue; failure surfaced via CI job `random_examples` on `develop`.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code as part of an automated CI failure investigation routine. The root cause was identified by tracing the call chain from the failing example through `@stdlib/ndarray/base/buffer` and `@stdlib/ndarray/base/buffer-ctors`. The fix was validated by running the example locally and by three independent automated reviewers (correctness, regression, and style checks).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjXm6xzBmShTtZZqS9pgYq)_