### PR TITLE
docs: fix heading levels

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-boolean/README.md
+++ b/lib/node_modules/@stdlib/assert/is-boolean/README.md
@@ -24,7 +24,7 @@ limitations under the License.
 
 <section class="usage">
 
-### Usage
+## Usage
 
 ```javascript
 var isBoolean = require( '@stdlib/assert/is-boolean' );
@@ -93,7 +93,7 @@ bool = isBoolean.isObject( new Boolean( false ) );
 
 <section class="examples">
 
-### Examples
+## Examples
 
 <!-- eslint-disable no-new-wrappers -->
 


### PR DESCRIPTION
## Description

Promote the `Usage` and `Examples` section headings in the `@stdlib/assert/is-boolean` README from H3 to H2 to match the canonical structure used by 342 of the 343 packages in `@stdlib/assert/*` (99.7% conformance). Flagged by a cross-package API-drift scan of the `assert` namespace; this is the sole structural outlier on README heading levels in the namespace.

### `@stdlib/assert/is-boolean`

The `## Usage` and `## Examples` headings open the canonical JS sections in every other `@stdlib/assert/*` README; `is-boolean` was the only package opening them at H3. Content is unchanged — two heading lines only. The nested function-signature sub-headings (`#### isBoolean( value )`, `#### isBoolean.isPrimitive( value )`, `#### isBoolean.isObject( value )`) are already at H4 and remain so; promoting the parent headings restores the intended H2 → H4 nesting.

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural extraction** over all 343 packages: file tree, `package.json` top-level keys / scripts / `directories`, README `##`/`###` heading lists (case- and order-preserved), and `test/`/`benchmark/`/`examples/` file naming.
- **Refined heading-drift pass:** an initial naive analysis flagged 82 packages with `Usage`/`Examples` at H3, but every false positive carried the H3 occurrence inside an outer `## CLI` block. Restricting to the FIRST `Usage` / `Examples` heading in document order narrows the set to a single true outlier: `is-boolean`.
- **Open-PR collision check:** no open pull request targets `@stdlib/assert/is-boolean`'s README.
- **Cross-reference:** no test, example, or doc generator reads `is-boolean`'s README heading levels. The change cannot affect any consumer or CI gate.

Deliberately excluded:

- 25 packages missing `lib/main.js` (`is-X-array` predicates built inline via `assert/tools/array-like-function`; environment-constant packages such as `is-darwin` / `is-windows`; multi-platform packages with `posix.js` + `win32.js`) — intentional, not drift.
- 44 packages missing `benchmark/benchmark.js` — split between environment-detection constants with no benchmarkable code and array-equality packages whose benchmarks need package-specific input fixtures rather than mechanical boilerplate. Out of scope for this routine.
- 2 packages with `lib/validate.js` (`deep-has-own-property`, `deep-has-property`) — outliers against the namespace-wide "no `validate.js`" majority, but the policy bias is to add validation rather than remove it.
- 6 packages with `### Notes` (`is-binary-string`, `is-blank-string`, `is-current-year`, `is-regexp-string`, `is-semver`, `is-unc-path`) — each instance is correctly nested inside an outer `## CLI` H2, not drift.
- `napi` and `tools` — meta-packages aggregating sub-namespaces, structurally distinct (no `docs/repl.txt`, no `examples/index.js`) by design.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated cross-package API-drift scan of the `assert` namespace. Structural features were extracted from all 343 members; a 75% majority threshold flagged a single outlier (`is-boolean`) on README heading levels; self-review confirmed the diff is mechanical and does not touch any test expectation, JSDoc, or generated artifact. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_019m8JMgSLGy3pfia52gt9JT)_