### PR TITLE
bench: fix description and fix JSDoc annotation

### DIFF
--- a/lib/node_modules/@stdlib/array/typed/benchmark/benchmark.length.float16.js
+++ b/lib/node_modules/@stdlib/array/typed/benchmark/benchmark.length.float16.js
@@ -87,7 +87,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( format( '%s:dtype=%s,len=%d', pkg, 'float32', len ), f );
+		bench( format( '%s:dtype=%s,len=%d', pkg, 'float16', len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/ml/strided/dkmeans-distance/lib/metrics.js
+++ b/lib/node_modules/@stdlib/ml/strided/dkmeans-distance/lib/metrics.js
@@ -32,7 +32,7 @@ var dcosine = require( '@stdlib/stats/strided/distances/dcosine-distance' );
 * Table mapping a metric to a corresponding strided function.
 *
 * @private
-* @name {metric2strided}
+* @name metric2strided
 * @type {Object}
 */
 var metric2strided = {


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-06-22T22:35:50Z and 2026-06-23T08:38:47Z (44 commits in window). Two high-signal issues were validated by an automated review pass (two style-compliance auditors plus two parallel bug-hunt agents) and survived deduplication.

This pull request:

-   **`array/typed`** — In 4467556, `benchmark.length.float16.js:90` passes the literal `'float32'` to `format(...)` for the bench title, causing TAP output to misreport the dtype as `float32` despite the benchmark allocating `float16` arrays. Fix: replace `'float32'` with `'float16'` in that `format(...)` call.
-   **`ml/strided/dkmeans-distance`** — In 187ce19e (`lib/node_modules/@stdlib/ml/strided/dkmeans-distance/lib/metrics.js:35`), the `@name` tag incorrectly wraps its namepath in curly braces (`@name {metric2strided}`); curly braces are reserved for type expressions and every other `@name` in stdlib uses a bare namepath. Remove the braces: `@name metric2strided`.

## Related Issues

This pull request does not have any related issues.

## Questions

No.

## Other

**Validation**

Reviewed: stdlib style-guide compliance (JS, JSDoc, TypeScript declarations) across BLAS ext/base new packages, the float16 dtype rollout, the new `ml/strided/dkmeans-distance` native package, and the complex-parse unification; plus a diff-only and a deeper-logic bug pass over the same window.

Deliberately excluded: subjective findings, "consider"-style suggestions, anything requiring interpretation, and anything requiring edits outside the 24h diff window. Four candidate "operator spacing" findings in `blas/ext/base/glogspace` were dropped after cross-referencing sister packages (`array/linspace`, `blas/ext/base/dlinspace`, `blas/ext/base/slinspace`) — the unspaced `(stop-start)` / `(d*i)` form is the established stdlib convention.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by an automated post-merge review routine running on Claude Code. The routine enumerated commits merged to `develop` in the last 24 hours, fanned out parallel style and bug auditors, deduplicated and verified each finding against the worktree, dropped false positives by cross-referencing sister packages, and applied the surviving fixes. A human maintainer should audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARnJmPrAAinuMJja1CVQ3N)_