### PR TITLE
fix: disallow number objects

### DIFF
--- a/lib/node_modules/@stdlib/iter/strided/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/strided/lib/main.js
@@ -22,7 +22,7 @@
 
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
-var isPositiveInteger = require( '@stdlib/assert/is-positive-integer' );
+var isPositiveInteger = require( '@stdlib/assert/is-positive-integer' ).isPrimitive;
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isFunction = require( '@stdlib/assert/is-function' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   tightens the `stride` validation in `@stdlib/iter/strided` to reject boxed `Number` objects, bringing the package into line with the other 10 of 11 `@stdlib/iter` packages that import `@stdlib/assert/is-positive-integer` (91% conformance).

### `@stdlib/iter/strided`

`lib/main.js` imported `@stdlib/assert/is-positive-integer` without the `.isPrimitive` suffix, while every sibling iter package using the same predicate (`cusome`, `cusome-by`, `head`, `replicate`, `replicate-by`, `slice`, `some`, `some-by`, `step`, `unshift`) uses `.isPrimitive`. The package's `@param {PositiveInteger} stride` JSDoc, the `stride: number` TypeScript declaration, and the existing test fixtures all assume a primitive integer; the loose check was a copy-paste oversight rather than an intentional contract. One-line change at `lib/main.js:25`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Surfaced by a cross-package consistency audit of `@stdlib/iter` predicate-import variants. Audit verified that:

-   no test in `iter/strided/test/test.js` exercises a boxed `Number` for `stride`;
-   `examples/index.js`, `README.md`, `docs/repl.txt`, and `docs/types/index.d.ts` all document `stride` as a primitive integer;
-   `iter/strided` is the only outlier across 65 `@stdlib/iter` packages on this predicate variant.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

Surfaced by a cross-package drift-detection routine run with Claude Code: structural and semantic features were extracted from every `@stdlib/iter` package, a 75% majority pattern was computed per feature, the single outlier was independently confirmed by three validation agents, and the one-line fix was authored and reviewed by myself before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01NUkgLUQqyMVUQWmro4QGaV)_