### PR TITLE
docs: update documented default value for `submode` option

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/linspace/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/linspace/lib/main.js
@@ -62,7 +62,7 @@ var base = require( './base.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order] - ndarray order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} second argument must be either a number, complex number, or an ndarray-like object
 * @throws {TypeError} third argument must be either a number, complex number, or an ndarray-like object

--- a/lib/node_modules/@stdlib/blas/ext/one-to/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/one-to/lib/main.js
@@ -49,7 +49,7 @@ var base = require( './base.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order] - ndarray order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object
 * @throws {Error} must provide valid options

--- a/lib/node_modules/@stdlib/blas/ext/unitspace/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/unitspace/lib/main.js
@@ -59,7 +59,7 @@ var base = require( './base.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order] - ndarray order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} second argument must be either a number, complex number, or an ndarray-like object
 * @throws {TypeError} second argument must have a supported data type

--- a/lib/node_modules/@stdlib/blas/ext/zero-to/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/zero-to/lib/main.js
@@ -49,7 +49,7 @@ var base = require( './base.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order] - ndarray order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object
 * @throws {Error} must provide valid options

--- a/lib/node_modules/@stdlib/ndarray/array/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/array/lib/main.js
@@ -73,7 +73,7 @@ var defaults = getDefaults();
 * @param {string} [options.order="row-major"] - specifies the memory layout of the array as either row-major (C-style) or column-major (Fortran-style)
 * @param {NonNegativeIntegerArray} [options.shape] - array shape
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.copy=false] - boolean indicating whether to copy source data to a new data buffer
 * @param {boolean} [options.flatten=true] - boolean indicating whether to automatically flatten generic array data sources
 * @param {NonNegativeInteger} [options.ndmin=0] - minimum number of dimensions

--- a/lib/node_modules/@stdlib/ndarray/copy/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/copy/lib/main.js
@@ -42,7 +42,7 @@ var format = require( '@stdlib/string/format' );
 * @param {*} [options.dtype] - output array data type (overrides the input array's inferred data type)
 * @param {string} [options.order] - specifies whether the output array should be 'row-major' (C-style) or 'column-major' (Fortran-style) (overrides the input array's inferred order)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @throws {TypeError} first argument must be an ndarray-like object
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} `dtype` option must be a supported ndarray data type

--- a/lib/node_modules/@stdlib/ndarray/empty-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/lib/main.js
@@ -49,7 +49,7 @@ var format = require( '@stdlib/string/format' );
 * @param {string} [options.order] - specifies whether the output array should be 'row-major' (C-style) or 'column-major' (Fortran-style) (overrides the input array's inferred order)
 * @param {(NonNegativeIntegerArray|NonNegativeInteger)} [options.shape] - output array shape (overrides the input array's inferred shape)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @throws {TypeError} first argument must have a recognized data type
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} `dtype` option must be a supported ndarray data type

--- a/lib/node_modules/@stdlib/ndarray/empty/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/empty/lib/main.js
@@ -54,7 +54,7 @@ var DEFAULT_ORDER = defaults.get( 'order' );
 * @param {*} [options.dtype='float64'] - data type
 * @param {string} [options.order='row-major'] - array order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} `dtype` option must be a recognized data type

--- a/lib/node_modules/@stdlib/ndarray/falses-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/falses-like/lib/main.js
@@ -57,7 +57,7 @@ var isDataType = contains( DTYPES );
 * @param {string} [options.order] - specifies whether the output array should be 'row-major' (C-style) or 'column-major' (Fortran-style) (overrides the input array's inferred order)
 * @param {(NonNegativeIntegerArray|NonNegativeInteger)} [options.shape] - output array shape (overrides the input array's inferred shape)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must have a recognized data type
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/ndarray/falses/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/falses/lib/main.js
@@ -55,7 +55,7 @@ var isDataType = contains( DTYPES );
 * @param {*} [options.dtype='bool'] - data type
 * @param {string} [options.order='row-major'] - array order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/ndarray/fancy/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/fancy/lib/main.js
@@ -42,7 +42,7 @@ var ndarray2fancy = require( '@stdlib/ndarray/to-fancy' );
 * @param {string} order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 * @param {Options} [options] - function options
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} `dtype` argument must be a supported ndarray data type
 * @throws {TypeError} `buffer` argument must be an array-like object, typed-array-like, or a Buffer

--- a/lib/node_modules/@stdlib/ndarray/nans-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/nans-like/lib/main.js
@@ -59,7 +59,7 @@ var isDataType = contains( DTYPES );
 * @param {string} [options.order] - specifies whether the output array should be 'row-major' (C-style) or 'column-major' (Fortran-style) (overrides the input array's inferred order)
 * @param {(NonNegativeIntegerArray|NonNegativeInteger)} [options.shape] - output array shape (overrides the input array's inferred shape)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must have a recognized data type
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/ndarray/nans/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/nans/lib/main.js
@@ -57,7 +57,7 @@ var isDataType = contains( DTYPES );
 * @param {*} [options.dtype='float64'] - data type
 * @param {string} [options.order='row-major'] - array order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/ndarray/ndarraylike2ndarray/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/ndarraylike2ndarray/lib/main.js
@@ -50,7 +50,7 @@ var DEFAULT_ORDER = defaults( 'order' );
 * @param {string} x.order - specifies whether `x` is row-major (C-style) or column-major (Fortran-style)
 * @param {Options} [options] - function options
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {Error} cannot write to a read-only array
 * @returns {ndarray} ndarray

--- a/lib/node_modules/@stdlib/ndarray/ones-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/ones-like/lib/main.js
@@ -57,7 +57,7 @@ var isDataType = contains( DTYPES );
 * @param {string} [options.order] - specifies whether the output array should be 'row-major' (C-style) or 'column-major' (Fortran-style) (overrides the input array's inferred order)
 * @param {(NonNegativeIntegerArray|NonNegativeInteger)} [options.shape] - output array shape (overrides the input array's inferred shape)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must have a recognized data type
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/ndarray/ones/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/ones/lib/main.js
@@ -34,7 +34,7 @@ var fill = require( '@stdlib/ndarray/base/fill' );
 * @param {*} [options.dtype='float64'] - data type
 * @param {string} [options.order='row-major'] - array order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/ndarray/trues-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/trues-like/lib/main.js
@@ -57,7 +57,7 @@ var isDataType = contains( DTYPES );
 * @param {string} [options.order] - specifies whether the output array should be 'row-major' (C-style) or 'column-major' (Fortran-style) (overrides the input array's inferred order)
 * @param {(NonNegativeIntegerArray|NonNegativeInteger)} [options.shape] - output array shape (overrides the input array's inferred shape)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must have a recognized data type
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/ndarray/trues/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/trues/lib/main.js
@@ -55,7 +55,7 @@ var isDataType = contains( DTYPES );
 * @param {*} [options.dtype='bool'] - data type
 * @param {string} [options.order='row-major'] - array order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/ndarray/zeros-like/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros-like/lib/main.js
@@ -56,7 +56,7 @@ var isDataType = contains( DTYPES );
 * @param {string} [options.order] - specifies whether the output array should be 'row-major' (C-style) or 'column-major' (Fortran-style) (overrides the input array's inferred order)
 * @param {(NonNegativeIntegerArray|NonNegativeInteger)} [options.shape] - output array shape (overrides the input array's inferred shape)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must have a recognized data type
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/ndarray/zeros/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros/lib/main.js
@@ -54,7 +54,7 @@ var isDataType = contains( DTYPES );
 * @param {*} [options.dtype='float64'] - data type
 * @param {string} [options.order='row-major'] - array order
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed array dimensions
-* @param {ArrayLikeObject<string>} [options.submode=["throw"]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param {ArrayLikeObject<string>} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an array should be read-only
 * @throws {TypeError} first argument must be either a nonnegative integer or an array of nonnegative integers
 * @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/random/arcsine/lib/main.js
+++ b/lib/node_modules/@stdlib/random/arcsine/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/bernoulli/lib/main.js
+++ b/lib/node_modules/@stdlib/random/bernoulli/lib/main.js
@@ -36,7 +36,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/beta/lib/main.js
+++ b/lib/node_modules/@stdlib/random/beta/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/betaprime/lib/main.js
+++ b/lib/node_modules/@stdlib/random/betaprime/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/binomial/lib/main.js
+++ b/lib/node_modules/@stdlib/random/binomial/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/cauchy/lib/main.js
+++ b/lib/node_modules/@stdlib/random/cauchy/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/chi/lib/main.js
+++ b/lib/node_modules/@stdlib/random/chi/lib/main.js
@@ -36,7 +36,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/chisquare/lib/main.js
+++ b/lib/node_modules/@stdlib/random/chisquare/lib/main.js
@@ -36,7 +36,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/cosine/lib/main.js
+++ b/lib/node_modules/@stdlib/random/cosine/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/discrete-uniform/lib/main.js
+++ b/lib/node_modules/@stdlib/random/discrete-uniform/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/erlang/lib/main.js
+++ b/lib/node_modules/@stdlib/random/erlang/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/exponential/lib/main.js
+++ b/lib/node_modules/@stdlib/random/exponential/lib/main.js
@@ -36,7 +36,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/f/lib/main.js
+++ b/lib/node_modules/@stdlib/random/f/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/frechet/lib/main.js
+++ b/lib/node_modules/@stdlib/random/frechet/lib/main.js
@@ -38,7 +38,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/gamma/lib/main.js
+++ b/lib/node_modules/@stdlib/random/gamma/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/geometric/lib/main.js
+++ b/lib/node_modules/@stdlib/random/geometric/lib/main.js
@@ -36,7 +36,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/gumbel/lib/main.js
+++ b/lib/node_modules/@stdlib/random/gumbel/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/hypergeometric/lib/main.js
+++ b/lib/node_modules/@stdlib/random/hypergeometric/lib/main.js
@@ -38,7 +38,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/invgamma/lib/main.js
+++ b/lib/node_modules/@stdlib/random/invgamma/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/kumaraswamy/lib/main.js
+++ b/lib/node_modules/@stdlib/random/kumaraswamy/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/laplace/lib/main.js
+++ b/lib/node_modules/@stdlib/random/laplace/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/levy/lib/main.js
+++ b/lib/node_modules/@stdlib/random/levy/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/logistic/lib/main.js
+++ b/lib/node_modules/@stdlib/random/logistic/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/lognormal/lib/main.js
+++ b/lib/node_modules/@stdlib/random/lognormal/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/negative-binomial/lib/main.js
+++ b/lib/node_modules/@stdlib/random/negative-binomial/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/normal/lib/main.js
+++ b/lib/node_modules/@stdlib/random/normal/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/pareto-type1/lib/main.js
+++ b/lib/node_modules/@stdlib/random/pareto-type1/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/poisson/lib/main.js
+++ b/lib/node_modules/@stdlib/random/poisson/lib/main.js
@@ -36,7 +36,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/rayleigh/lib/main.js
+++ b/lib/node_modules/@stdlib/random/rayleigh/lib/main.js
@@ -36,7 +36,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/t/lib/main.js
+++ b/lib/node_modules/@stdlib/random/t/lib/main.js
@@ -36,7 +36,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/triangular/lib/main.js
+++ b/lib/node_modules/@stdlib/random/triangular/lib/main.js
@@ -38,7 +38,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/uniform/lib/main.js
+++ b/lib/node_modules/@stdlib/random/uniform/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters

--- a/lib/node_modules/@stdlib/random/weibull/lib/main.js
+++ b/lib/node_modules/@stdlib/random/weibull/lib/main.js
@@ -37,7 +37,7 @@ var factory = require( './factory.js' );
 * @param {*} [options.dtype] - output ndarray data type
 * @param {string} [options.order="row-major"] - memory layout (either row-major or column-major)
 * @param {string} [options.mode="throw"] - specifies how to handle indices which exceed ndarray dimensions
-* @param {StringArray} [options.submode=["throw"]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
+* @param {StringArray} [options.submode=[options.mode]] - specifies how to handle subscripts which exceed ndarray dimensions on a per dimension basis
 * @param {boolean} [options.readonly=false] - boolean indicating whether an ndarray should be read-only
 * @throws {TypeError} first argument must be a valid shape
 * @throws {TypeError} must provide valid distribution parameters


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-06-23 13:03 UTC and 2026-06-24 13:03 UTC to sibling packages.

### `docs:` correct `submode` JSDoc default annotation

Source: c68f1d9f (`docs: fix default option value`). The JSDoc default annotation for `options.submode` read `["throw"]`, but the runtime resolves an unset `submode` to `[ this._mode ]` in `@stdlib/ndarray/ctor` (lines 165–168 of its `lib/main.js`). Every sibling factory that threads `submode` through to `ndarray/ctor` — directly, via `@stdlib/ndarray/empty`, or via the `random/tools/{unary,binary,ternary}-factory` wrappers — inherits the same misdocumentation. The corrected default is `[options.mode]`, matching the source fix.

Target packages (53):

- `blas/ext`: `linspace`, `one-to`, `unitspace`, `zero-to`
- `ndarray`: `array`, `copy`, `empty`, `empty-like`, `falses`, `falses-like`, `fancy`, `nans`, `nans-like`, `ndarraylike2ndarray`, `ones`, `ones-like`, `trues`, `trues-like`, `zeros`, `zeros-like`
- `random`: `arcsine`, `bernoulli`, `beta`, `betaprime`, `binomial`, `cauchy`, `chi`, `chisquare`, `cosine`, `discrete-uniform`, `erlang`, `exponential`, `f`, `frechet`, `gamma`, `geometric`, `gumbel`, `hypergeometric`, `invgamma`, `kumaraswamy`, `laplace`, `levy`, `logistic`, `lognormal`, `negative-binomial`, `normal`, `pareto-type1`, `poisson`, `rayleigh`, `t`, `triangular`, `uniform`, `weibull`

## Related Issues

No.

## Questions

No.

## Other

### Validation

- Search scope: literal `[options.submode=["throw"]]` in `.js` source under `lib/node_modules/@stdlib/`.
- Initial hits: 56 (53 sibling factories + 3 scaffold templates).
- Pre-validation drops: 3 scaffold templates at `random/scripts/scaffolds/{unary,binary,ternary}/data/lib/main__js.txt` — generator-owned, fix belongs in the scaffold generator.
- Two independent validation agents read each candidate file in full and traced the runtime resolution of `submode` to `@stdlib/ndarray/ctor`. Both returned `confirmed` for all 53 sites; intersection: 53.
- Adaptation: mechanical — identical one-line substring replacement at every site.
- Style consistency: each touched line is a single JSDoc `@param` annotation; the replacement matches the form used in the source commit.

### Patterns considered but not propagated

- `bench:` benchmark dtype-label mismatch (`0f81ad2f`): a repo-wide scan of `benchmark.*.<dtype>.js` files across all 13 ndarray dtypes found no other label mismatches. Zero propagation sites.
- `bench:` malformed JSDoc `@name {ident}` (`0f81ad2f`): all eight grep hits live in scaffold template `.txt` files under `_tools/scaffold/*` and `random/scripts/scaffolds/*` — generator-owned.
- `fix:` missing `.isPrimitive` on assert import (`691b9cb7`): the signature requires per-site interpretation of each package's public JSDoc contract to decide whether the combined check is an oversight or deliberate. Outside the routine's high-signal criteria.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code running the daily fix-propagation routine. The propagation pattern was derived from a maintainer-authored source commit on `develop`; two independent automated agents validated each candidate site against the source's runtime semantics before the JSDoc annotation was updated.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01MoJsGkwpbCAxza8Xj9xsM7)_