### PR TITLE
refactor: add enum support in `blas/base/dtrmv`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dtrmv/lib/dtrmv.js
+++ b/lib/node_modules/@stdlib/blas/base/dtrmv/lib/dtrmv.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var max = require( '@stdlib/math/base/special/fast/max' );
-var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
-var isMatrixTriangle = require( '@stdlib/blas/base/assert/is-matrix-triangle' );
-var isTransposeOperation = require( '@stdlib/blas/base/assert/is-transpose-operation' );
-var isDiagonal = require( '@stdlib/blas/base/assert/is-diagonal-type' );
+var resolveLayout = require( '@stdlib/blas/base/layout-resolve-str' );
+var resolveTriangle = require( '@stdlib/blas/base/matrix-triangle-resolve-str' );
+var resolveTranspose = require( '@stdlib/blas/base/transpose-operation-resolve-str' );
+var resolveDiagonal = require( '@stdlib/blas/base/diagonal-type-resolve-str' );
 var isColumnMajor = require( '@stdlib/ndarray/base/assert/is-column-major-string' );
 var stride2offset = require( '@stdlib/strided/base/stride2offset' );
 var format = require( '@stdlib/string/format' );
@@ -36,10 +36,10 @@ var base = require( './base.js' );
 /**
 * Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix.
 *
-* @param {string} order - storage layout
-* @param {string} uplo - specifies whether `A` is an upper or lower triangular matrix
-* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
-* @param {string} diag - specifies whether `A` has a unit diagonal
+* @param {(integer|string)} order - storage layout
+* @param {(integer|string)} uplo - specifies whether `A` is an upper or lower triangular matrix
+* @param {(integer|string)} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {(integer|string)} diag - specifies whether `A` has a unit diagonal
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
 * @param {Float64Array} A - input matrix
 * @param {integer} LDA - stride of the first dimension of `A` (a.k.a., leading dimension of the matrix `A`)
@@ -67,17 +67,25 @@ function dtrmv( order, uplo, trans, diag, N, A, LDA, x, strideX ) {
 	var sa1;
 	var sa2;
 	var ox;
+	var l;
+	var u;
+	var t;
+	var d;
 
-	if ( !isLayout( order ) ) {
+	l = resolveLayout( order );
+	if ( l === null ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a valid order. Value: `%s`.', order ) );
 	}
-	if ( !isMatrixTriangle( uplo ) ) {
+	u = resolveTriangle( uplo );
+	if ( u === null ) {
 		throw new TypeError( format( 'invalid argument. Second argument must specify whether the lower or upper triangular matrix is supplied. Value: `%s`.', uplo ) );
 	}
-	if ( !isTransposeOperation( trans ) ) {
+	t = resolveTranspose( trans );
+	if ( t === null ) {
 		throw new TypeError( format( 'invalid argument. Third argument must be a valid transpose operation. Value: `%s`.', trans ) );
 	}
-	if ( !isDiagonal( diag ) ) {
+	d = resolveDiagonal( diag );
+	if ( d === null ) {
 		throw new TypeError( format( 'invalid argument. Fourth argument must be a valid diagonal type. Value: `%s`.', diag ) );
 	}
 	if ( N < 0 ) {
@@ -92,7 +100,7 @@ function dtrmv( order, uplo, trans, diag, N, A, LDA, x, strideX ) {
 	if ( N === 0 ) {
 		return x;
 	}
-	if ( isColumnMajor( order ) ) {
+	if ( isColumnMajor( l ) ) {
 		sa1 = 1;
 		sa2 = LDA;
 	} else { // order === 'row-major'
@@ -100,7 +108,7 @@ function dtrmv( order, uplo, trans, diag, N, A, LDA, x, strideX ) {
 		sa2 = 1;
 	}
 	ox = stride2offset( N, strideX );
-	return base( uplo, trans, diag, N, A, sa1, sa2, 0, x, strideX, ox );
+	return base( u, t, d, N, A, sa1, sa2, 0, x, strideX, ox );
 }
 
 

--- a/lib/node_modules/@stdlib/blas/base/dtrmv/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dtrmv/lib/ndarray.js
@@ -20,9 +20,9 @@
 
 // MODULES //
 
-var isMatrixTriangle = require( '@stdlib/blas/base/assert/is-matrix-triangle' );
-var isTransposeOperation = require( '@stdlib/blas/base/assert/is-transpose-operation' );
-var isDiagonal = require( '@stdlib/blas/base/assert/is-diagonal-type' );
+var resolveTriangle = require( '@stdlib/blas/base/matrix-triangle-resolve-str' );
+var resolveTranspose = require( '@stdlib/blas/base/transpose-operation-resolve-str' );
+var resolveDiagonal = require( '@stdlib/blas/base/diagonal-type-resolve-str' );
 var format = require( '@stdlib/string/format' );
 var base = require( './base.js' );
 
@@ -32,9 +32,9 @@ var base = require( './base.js' );
 /**
 * Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix.
 *
-* @param {string} uplo - specifies whether `A` is an upper or lower triangular matrix
-* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
-* @param {string} diag - specifies whether `A` has a unit diagonal
+* @param {(integer|string)} uplo - specifies whether `A` is an upper or lower triangular matrix
+* @param {(integer|string)} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {(integer|string)} diag - specifies whether `A` has a unit diagonal
 * @param {NonNegativeInteger} N - number of elements along each dimension of `A`
 * @param {Float64Array} A - input matrix
 * @param {integer} strideA1 - stride of the first dimension of `A`
@@ -62,13 +62,20 @@ var base = require( './base.js' );
 * // x => <Float64Array>[ 14.0, 8.0, 3.0 ]
 */
 function dtrmv( uplo, trans, diag, N, A, strideA1, strideA2, offsetA, x, strideX, offsetX ) { // eslint-disable-line max-params, max-len
-	if ( !isMatrixTriangle( uplo ) ) {
+	var u;
+	var t;
+	var d;
+
+	u = resolveTriangle( uplo );
+	if ( u === null ) {
 		throw new TypeError( format( 'invalid argument. First argument must specify whether the lower or upper triangular matrix is supplied. Value: `%s`.', uplo ) );
 	}
-	if ( !isTransposeOperation( trans ) ) {
+	t = resolveTranspose( trans );
+	if ( t === null ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be a valid transpose operation. Value: `%s`.', trans ) );
 	}
-	if ( !isDiagonal( diag ) ) {
+	d = resolveDiagonal( diag );
+	if ( d === null ) {
 		throw new TypeError( format( 'invalid argument. Third argument must be a valid diagonal type. Value: `%s`.', diag ) );
 	}
 	if ( N < 0 ) {
@@ -86,7 +93,7 @@ function dtrmv( uplo, trans, diag, N, A, strideA1, strideA2, offsetA, x, strideX
 	if ( N === 0 ) {
 		return x;
 	}
-	return base( uplo, trans, diag, N, A, strideA1, strideA2, offsetA, x, strideX, offsetX ); // eslint-disable-line max-len
+	return base( u, t, d, N, A, strideA1, strideA2, offsetA, x, strideX, offsetX ); // eslint-disable-line max-len
 }
 
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: na
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #{{TODO: add issue number}}.

## Description

> What is the purpose of this pull request?

This pull request:

-   Resolves option arguments (`order`, `uplo`, `trans`, and `diag`) prior to dispatching to the underlying implementation in `blas/base/dtrmv`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{{TODO: add related issue number}}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- Are the resolver function names (`resolveLayout`, `resolveTriangle`, `resolveTranspose`, and `resolveDiagonal`) consistent with project naming conventions, or would different names be preferred?
-  I introduced the local variables `l`, `u`, `t`, and `d` to hold the resolved options. Are these names acceptable, or would more descriptive variable names be preferred?
-  Should the `layout` option be resolved, as it is not passed directly to the base implementation?

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
