### PR TITLE
build: fix push failure when PR branch exists

### DIFF
--- a/.github/workflows/markdown_equations.yml
+++ b/.github/workflows/markdown_equations.yml
@@ -174,6 +174,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.STDLIB_BOT_PAT_REPO_WRITE }}
         run: |
+          # Fetch the branch first so that --force-with-lease in the subsequent push
+          # has a local tracking reference and can verify the remote state:
+          git fetch origin markdown-insert-equations 2>/dev/null || true
           gh api -X DELETE repos/stdlib-js/stdlib/git/refs/heads/markdown-insert-equations 2>/dev/null || true
         timeout-minutes: 5
 

--- a/.github/workflows/markdown_equations.yml
+++ b/.github/workflows/markdown_equations.yml
@@ -174,8 +174,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.STDLIB_BOT_PAT_REPO_WRITE }}
         run: |
-          # Fetch the branch first so that --force-with-lease in the subsequent push
-          # has a local tracking reference and can verify the remote state:
+          # Fetch the branch first so that --force-with-lease in the subsequent push has a local tracking reference and can verify the remote state:
           git fetch origin markdown-insert-equations 2>/dev/null || true
           gh api -X DELETE repos/stdlib-js/stdlib/git/refs/heads/markdown-insert-equations 2>/dev/null || true
         timeout-minutes: 5


### PR DESCRIPTION
Resolves N/A — automated CI fix; no tracking issue.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a persistent failure in the `markdown_equations` scheduled workflow where `peter-evans/create-pull-request` produces `error: failed to push some refs` when the `markdown-insert-equations` branch already exists on the remote.

**Root cause.** The workflow's shallow clone (`fetch-depth: 100`) only fetches the `develop` branch. The `markdown-insert-equations` branch is never fetched, so no local tracking reference exists for it. When peter-evans internally calls `git push --force-with-lease origin markdown-insert-equations`, git cannot verify the expected remote state against a missing tracking ref and rejects the push.

**Fix.** A single `git fetch origin markdown-insert-equations 2>/dev/null || true` is added at the top of the "Delete remote PR branch" step, immediately before the API delete call. This establishes the tracking reference before peter-evans runs. Two outcomes:

1. **Delete succeeds** — peter-evans creates the branch from scratch; no force-with-lease concern.
2. **Delete fails** (permissions, race) — the tracking reference is present, force-with-lease can verify the remote state, and the push succeeds.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The workflow has failed on 14 of 15 runs in the past 30 days. The one success (2026-06-19) was likely a run where the `markdown-insert-equations` branch did not yet exist at push time.

The `git commit` calls in the "Generate SVG equations" and "Update equation elements" steps are intentionally preserved: the `remark-img-equations-src-urls` remark plugin calls `git rev-list -1 HEAD <svg-file>` to obtain a commit SHA for building jsdelivr URLs, so the SVG files must be committed before that plugin runs.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was written primarily by Claude Code as part of an automated CI failure investigation routine. The root-cause analysis (shallow-clone missing the PR branch → missing `--force-with-lease` tracking ref) and the fix (adding `git fetch`) were generated and validated by Claude Code. A human operator reviewed the final diff before merge.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxM7pSh76qaHqGoSgENEda)_