### PR TITLE
style: follow-up fixes for develop commits (2026-06-24 → 2026-06-25)

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsy/docs/repl.txt
@@ -75,7 +75,7 @@
     <Float64Array>[ 0.0, 0.0, 0.0, -4.0, -2.0, 0.0 ]
 
 
-{{alias}}.ndarray( N, x,strideX,offsetX, y,strideY,offsetY, w,strideW,offsetW )
+{{alias}}.ndarray( N, x, strideX, offsetX, y, strideY, offsetY, w, strideW, offsetW )
     Subtracts elements of a strided array `y` from the corresponding elements of
     a strided array `x` and assigns the results to elements in a strided array
     `w` using alternative indexing semantics.


### PR DESCRIPTION
Resolves #na.

## Description

Follow-up fixes for commits merged to `develop` between 2026-06-24 23:56 UTC and 2026-06-25 10:24 UTC (SHAs `4a1467352..f0362db28`, 20 commits).

This pull request:

-   In `blas/ext/base/gwxsy/docs/repl.txt` (3eace6242, line 78), the `.ndarray` signature is missing spaces after several commas — `x,strideX,offsetX`, `y,strideY,offsetY`, `w,strideW,offsetW` — inconsistent with every peer package in the directory (gxpy, gxsy, gwaxpb, gxmy). Replace with `N, x, strideX, offsetX, y, strideY, offsetY, w, strideW, offsetW`.

## Related Issues

None.

## Questions

No.

## Other

### Validation

What was checked across the 20 develop commits in the window:

-   stdlib code style compliance for the three new BLAS ext/base packages (`gwaxpb`, `gwxsy`, `gxmy`) against established peer packages (`gxpy`, `gxsy`, `gwaxpb`).
-   stdlib code style compliance for the modified files (`blas/base/dtrmv` enum refactor, `.d.ts` simplifications, doc fixes, EditorConfig fixes, stats namespace removal, CI workflow patch, `ndarray/base/assert` TS additions).
-   Bug scan over the union diff (`git diff 4a1467352^..f0362db28`) for arithmetic, stride/index, off-by-one, wrong-argument, and copy-paste errors.
-   Logic/security scan for missing returns, resource leaks, command injection in workflow changes, missing argument validation, wrong enum mappings in the `dtrmv` refactor, and `.d.ts`-vs-runtime mismatches.

Deliberately excluded (low signal):

-   Stale code comments and any subjective preferences.
-   Anything requiring reads outside the window's diff to validate (e.g. cross-file invariants, downstream consumer behavior).
-   Author-intentional choices: `fcca2dc42` namespace removals from `stats/base`, `f30fe0156` `.d.ts` generic simplification, `e2e391ed1` operator-assignment swap in `gxpy`, `22afd69bd` resolved enum values passed through `dtrmv`, `3db715718`/`1977f9294` documented `submode` default correction, and the `git fetch ... || true` scaffolding in `7b03f883e`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was assembled by an automated commit-review routine: four parallel review agents (two style-compliance, two bug/security) audited the 20 commits merged to `develop` in the last 24 hours, and findings were filtered down to a single high-signal style violation. The fix itself is a one-line whitespace change; no logic was changed.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_015eVscR6DET57ykqvvLj2e8)_