### PR TITLE
docs: propagate fixes to sibling packages

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/besselj1/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/manifest.json
@@ -55,7 +55,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/special/sqrt",
+        "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/sincos",
         "@stdlib/constants/float64/pinf",
@@ -73,7 +73,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/special/sqrt",
+        "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/sincos",
         "@stdlib/constants/float64/pinf",

--- a/lib/node_modules/@stdlib/math/base/special/ceilsd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ceilsd/manifest.json
@@ -59,7 +59,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/pow",
         "@stdlib/math/base/special/log10",
@@ -81,7 +81,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/pow",
         "@stdlib/math/base/special/log10",

--- a/lib/node_modules/@stdlib/math/base/special/csch/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/csch/manifest.json
@@ -65,7 +65,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/special/sinh"
+        "@stdlib/math/base/special/sinh"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/digamma/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/manifest.json
@@ -55,7 +55,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/tan",
         "@stdlib/math/base/special/ln",
@@ -73,7 +73,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/tan",
         "@stdlib/math/base/special/ln",

--- a/lib/node_modules/@stdlib/math/base/special/floor10/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/floor10/manifest.json
@@ -63,7 +63,7 @@
       ],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/pow",
         "@stdlib/math/base/special/floor",
@@ -87,7 +87,7 @@
       ],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/pow",
         "@stdlib/math/base/special/floor",

--- a/lib/node_modules/@stdlib/math/base/special/truncsd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/truncsd/manifest.json
@@ -59,7 +59,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/pow",
         "@stdlib/math/base/special/log10",
@@ -81,7 +81,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/pow",
         "@stdlib/math/base/special/log10",

--- a/lib/node_modules/@stdlib/ndarray/array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/array/docs/types/index.d.ts
@@ -43,7 +43,7 @@ interface Options {
 	mode?: Mode;
 
 	/**
-	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw']).
+	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode]).
 	*/
 	submode?: Array<string>;
 
@@ -139,7 +139,7 @@ interface ExtendedOptions extends Options {
 * @param options.order - specifies the memory layout of the array as either row-major (C-style) or column-major (Fortran-style) (default: 'row-major')
 * @param options.shape - array shape
 * @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 * @param options.copy - boolean indicating whether to copy source data to a new data buffer (default: false)
 * @param options.flatten - boolean indicating whether to automatically flatten generic array data sources (default: true)
 * @param options.ndmin - minimum number of dimensions (default: 0)
@@ -176,7 +176,7 @@ declare function array<T = unknown>( options: OptionsWithShape | OptionsWithBuff
 * @param options.order - specifies the memory layout of the array as either row-major (C-style) or column-major (Fortran-style) (default: 'row-major')
 * @param options.shape - array shape
 * @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 * @param options.copy - boolean indicating whether to copy source data to a new data buffer (default: false)
 * @param options.flatten - boolean indicating whether to automatically flatten generic array data sources (default: true)
 * @param options.ndmin - minimum number of dimensions (default: 0)

--- a/lib/node_modules/@stdlib/ndarray/ctor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/ctor/docs/types/index.d.ts
@@ -34,7 +34,7 @@ interface Options {
 	mode?: Mode;
 
 	/**
-	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw']).
+	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode]).
 	*/
 	submode?: ArrayLike<Mode>;
 
@@ -59,7 +59,7 @@ interface Constructor {
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 	* @param options - function options
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 	* @param options.readonly - specifies whether an array should be read-only (default: false)
 	* @throws `buffer` argument `get` and `set` properties must be functions
 	* @throws `shape` argument must be an array-like object containing nonnegative integers
@@ -94,7 +94,7 @@ interface Constructor {
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 	* @param options - function options
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 	* @param options.readonly - specifies whether an array should be read-only (default: false)
 	* @throws `buffer` argument `get` and `set` properties must be functions
 	* @throws `shape` argument must be an array-like object containing nonnegative integers
@@ -130,7 +130,7 @@ interface Constructor {
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 * @param options - function options
 * @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 * @param options.readonly - specifies whether an array should be read-only (default: false)
 * @throws `buffer` argument `get` and `set` properties must be functions
 * @throws `shape` argument must be an array-like object containing nonnegative integers

--- a/lib/node_modules/@stdlib/ndarray/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/docs/types/index.d.ts
@@ -305,7 +305,7 @@ interface Namespace {
 	* @param options.order - specifies the memory layout of the array as either row-major (C-style) or column-major (Fortran-style) (default: 'row-major')
 	* @param options.shape - array shape
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 	* @param options.copy - boolean indicating whether to copy source data to a new data buffer (default: false)
 	* @param options.flatten - boolean indicating whether to automatically flatten generic array data sources (default: true)
 	* @param options.ndmin - minimum number of dimensions (default: 0)
@@ -945,7 +945,7 @@ interface Namespace {
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 	* @param options - function options
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 	* @param options.readonly - specifies whether an array should be read-only (default: false)
 	* @throws `buffer` argument `get` and `set` properties must be functions
 	* @throws `shape` argument must be an array-like object containing nonnegative integers
@@ -1405,7 +1405,7 @@ interface Namespace {
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 	* @param options - function options
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 	* @param options.readonly - specifies whether an array should be read-only (default: false)
 	* @throws `buffer` argument `get` and `set` properties must be functions
 	* @throws `shape` argument must be an array-like object containing nonnegative integers
@@ -2580,7 +2580,7 @@ interface Namespace {
 	* @param x - input ndarray
 	* @param options - function options
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 	* @param options.readonly - specifies whether an array should be read-only
 	* @returns ndarray
 	*

--- a/lib/node_modules/@stdlib/ndarray/fancy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/fancy/docs/types/index.d.ts
@@ -34,7 +34,7 @@ interface Options {
 	mode?: Mode;
 
 	/**
-	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw']).
+	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode]).
 	*/
 	submode?: Array<Mode>;
 
@@ -59,7 +59,7 @@ interface Constructor {
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 	* @param options - function options
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 	* @param options.readonly - specifies whether an array should be read-only (default: false)
 	* @throws `buffer` argument `get` and `set` properties must be functions
 	* @throws `shape` argument must be an array-like object containing nonnegative integers
@@ -94,7 +94,7 @@ interface Constructor {
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 	* @param options - function options
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 	* @param options.readonly - specifies whether an array should be read-only (default: false)
 	* @throws `buffer` argument `get` and `set` properties must be functions
 	* @throws `shape` argument must be an array-like object containing nonnegative integers
@@ -130,7 +130,7 @@ interface Constructor {
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 * @param options - function options
 * @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 * @param options.readonly - specifies whether an array should be read-only (default: false)
 * @throws `buffer` argument `get` and `set` properties must be functions
 * @throws `shape` argument must be an array-like object containing nonnegative integers

--- a/lib/node_modules/@stdlib/ndarray/fancy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/fancy/docs/types/index.d.ts
@@ -34,7 +34,7 @@ interface Options {
 	mode?: Mode;
 
 	/**
-	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode]).
+	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw']).
 	*/
 	submode?: Array<Mode>;
 
@@ -59,7 +59,7 @@ interface Constructor {
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 	* @param options - function options
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
 	* @param options.readonly - specifies whether an array should be read-only (default: false)
 	* @throws `buffer` argument `get` and `set` properties must be functions
 	* @throws `shape` argument must be an array-like object containing nonnegative integers
@@ -94,7 +94,7 @@ interface Constructor {
 	* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 	* @param options - function options
 	* @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
+	* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
 	* @param options.readonly - specifies whether an array should be read-only (default: false)
 	* @throws `buffer` argument `get` and `set` properties must be functions
 	* @throws `shape` argument must be an array-like object containing nonnegative integers
@@ -130,7 +130,7 @@ interface Constructor {
 * @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
 * @param options - function options
 * @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
 * @param options.readonly - specifies whether an array should be read-only (default: false)
 * @throws `buffer` argument `get` and `set` properties must be functions
 * @throws `shape` argument must be an array-like object containing nonnegative integers

--- a/lib/node_modules/@stdlib/ndarray/ndarraylike2ndarray/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/ndarraylike2ndarray/docs/types/index.d.ts
@@ -33,7 +33,7 @@ interface Options {
 	mode?: Mode;
 
 	/**
-	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw']).
+	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode]).
 	*/
 	submode?: ArrayLike<Mode>;
 
@@ -53,7 +53,7 @@ interface Options {
 * @param x - input ndarray
 * @param options - function options
 * @param options.mode - specifies how to handle indices which exceed array dimensions (default: 'throw')
-* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw'])
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: [options.mode])
 * @param options.readonly - specifies whether an array should be read-only
 * @returns ndarray
 *


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-06-24 23:26 PDT and 2026-06-25 03:24 PDT to sibling packages.

### docs: `submode` default value

Propagates the JSDoc correction from commits `1977f92` and `3db7157`: the `submode` option default was documented as `['throw']` but the runtime sets it to `[options.mode]`. Updated TypeScript declaration files to match.

Affected packages:

-   `@stdlib/ndarray/array`
-   `@stdlib/ndarray/ctor`
-   `@stdlib/ndarray`
-   `@stdlib/ndarray/ndarraylike2ndarray`

### chore: `manifest.json` indentation

Propagates the fix from `d9e748f` (PR #13115), which corrected 7-space-indented `dependencies` entries in `ceil10/manifest.json` that should use 8 spaces to match the surrounding array. The same off-by-one defect appears in 11 sites across 6 sibling packages.

Affected packages:

-   `@stdlib/math/base/special/floor10`
-   `@stdlib/math/base/special/truncsd`
-   `@stdlib/math/base/special/ceilsd`
-   `@stdlib/math/base/special/digamma`
-   `@stdlib/math/base/special/besselj1`
-   `@stdlib/math/base/special/csch`

## Related Issues

None.

## Questions

No.

## Other

**Validation.** Each target file was read in full by two independent validation passes to confirm the defect is present and surrounding context does not change the semantics. A style-consistency pass confirmed each proposed patch matches the surrounding package's JSDoc / JSON style. Search scope: `lib/node_modules/@stdlib/**/*.d.ts` for the `submode` default and `lib/node_modules/@stdlib/**/manifest.json` for the indent defect.

**Deliberately excluded.**

-   The other `fix:` candidate in the 24h window (`92b5eb47` — error-message argument interpolation in `ndarray/matrix/ctor/lib/main.js`) had no remaining sibling sites: a sweep across all `ndarray/**/main.js` files confirmed every `<ordinal> argument` validation block matches its `argN` reference.
-   The `e6cc42b` typo / C-example fix had no remaining propagation sites either: bare `NaN` as a C literal no longer appears in C code blocks or `@example` function-call arguments across the repo.
-   The `build:` workflow fix (`7b03f88`) targeted a single workflow with a unique `gh api DELETE + force-with-lease push` pattern; no other workflow uses that pattern.

Bot-generated docs (related-packages regen, namespace TOC, type-decl regen) were not considered since they re-emit on the next bot run.

**Dropped after CI signal.** The `@stdlib/ndarray/fancy` site was initially included but dropped (commit `9fb0955`) — the file's pre-existing `@example` blocks reference an undeclared `FancyArray` symbol, which fails `stdlib/tsdoc-declarations-doctest` whenever the file enters CI's changed-files set. The doctest failure is unrelated to the propagation; the `submode` default in that file remains at `['throw']` until the `FancyArray` example issue is resolved separately.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the fix-propagation routine, which scans recent `develop` commits, identifies propagatable defect patterns, validates candidate target sites through independent agents, and applies mechanical fixes. Each propagation site was verified to contain the same defect as the source commit's fix.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
