### PR TITLE
feat: add `toPrimitive` support in `number/uint64/ctor`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/ctor/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/README.md
@@ -189,7 +189,7 @@ var v = x.valueOf();
 
 ## Notes
 
--   a 64-bit unsigned integer has a range of \[`0`, `2^64-1`\].
+-   A 64-bit unsigned integer has a range of \[`0`, `2^64-1`\].
 
 </section>
 

--- a/lib/node_modules/@stdlib/number/uint64/ctor/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Uint64
 
-> Unsigned 64-bit integer.
+> 64-bit unsigned integer.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var Uint64 = require( '@stdlib/number/uint64/ctor' );
 
 #### Uint64( value )
 
-Unsigned 64-bit integer constructor.
+64-bit unsigned integer constructor.
 
 ```javascript
 var x = new Uint64( 5 );
@@ -95,7 +95,7 @@ var nbytes = x.byteLength;
 
 #### Uint64.prototype.hi
 
-High 32-bit word of an unsigned 64-bit integer.
+High 32-bit word of a 64-bit unsigned integer.
 
 ```javascript
 var x = Uint64.from( [ 1234, 5678 ] );
@@ -106,7 +106,7 @@ var w = x.hi;
 
 #### Uint64.prototype.lo
 
-Low 32-bit word of an unsigned 64-bit integer.
+Low 32-bit word of a 64-bit unsigned integer.
 
 ```javascript
 var x = Uint64.from( [ 1234, 5678 ] );
@@ -123,7 +123,7 @@ var w = x.lo;
 
 #### Uint64.from( array )
 
-Creates a new unsigned 64-bit integer from an array-like object containing a high and low word.
+Creates a new 64-bit unsigned integer from an array-like object containing a high and low word.
 
 ```javascript
 var x = Uint64.from( [ 1234, 5678 ] );
@@ -132,7 +132,7 @@ var x = Uint64.from( [ 1234, 5678 ] );
 
 #### Uint64.of( high, low )
 
-Creates a new unsigned 64-bit integer from a high and low word.
+Creates a new 64-bit unsigned integer from a high and low word.
 
 ```javascript
 var x = Uint64.of( 1234, 5678 );
@@ -141,7 +141,7 @@ var x = Uint64.of( 1234, 5678 );
 
 ### Accessor Methods
 
-These methods do **not** mutate a `Uint64` instance and, instead, return an unsigned 64-bit integer representation.
+These methods do **not** mutate a `Uint64` instance and, instead, return a 64-bit unsigned integer representation.
 
 #### Uint64.prototype.toString()
 
@@ -189,7 +189,7 @@ var v = x.valueOf();
 
 ## Notes
 
--   An unsigned 64-bit integer has a range of \[`0`, `2^64-1`\].
+-   a 64-bit unsigned integer has a range of \[`0`, `2^64-1`\].
 
 </section>
 

--- a/lib/node_modules/@stdlib/number/uint64/ctor/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/docs/repl.txt
@@ -36,7 +36,7 @@
     Parameters
     ----------
     words: ArrayLikeObject
-        High and low words.
+        High and low words as 32-bit unsigned integers.
 
     Returns
     -------
@@ -55,10 +55,10 @@
     Parameters
     ----------
     high: integer
-        High word.
+        High word (32-bit unsigned integer).
 
     low: integer
-        Low word.
+        Low word (32-bit unsigned integer).
 
     Returns
     -------
@@ -123,7 +123,7 @@
     Returns
     -------
     w: integer
-        High word.
+        High word (32-bit unsigned integer).
 
     Examples
     --------
@@ -139,7 +139,7 @@
     Returns
     -------
     w: integer
-        Low word.
+        Low word (32-bit unsigned integer).
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/number/uint64/ctor/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/docs/repl.txt
@@ -1,6 +1,6 @@
 
 {{alias}}( value )
-    Unsigned 64-bit integer constructor.
+    64-bit unsigned integer constructor.
 
     Parameters
     ----------
@@ -10,7 +10,7 @@
     Returns
     -------
     v: Uint64
-        Unsigned 64-bit integer.
+        64-bit unsigned integer.
 
     Examples
     --------
@@ -30,7 +30,7 @@
 
 
 {{alias}}.from( words )
-    Creates a new unsigned 64-bit integer from an array-like object containing a
+    Creates a new 64-bit unsigned integer from an array-like object containing a
     high and low word.
 
     Parameters
@@ -41,7 +41,7 @@
     Returns
     -------
     v: Uint64
-        Unsigned 64-bit integer.
+        64-bit unsigned integer.
 
     Examples
     --------
@@ -50,7 +50,7 @@
 
 
 {{alias}}.of( high, low )
-    Creates a new unsigned 64-bit integer from a high and low word.
+    Creates a new 64-bit unsigned integer from a high and low word.
 
     Parameters
     ----------
@@ -63,7 +63,7 @@
     Returns
     -------
     v: Uint64
-        Unsigned 64-bit integer.
+        64-bit unsigned integer.
 
     Examples
     --------
@@ -118,7 +118,7 @@
 
 
 {{alias}}.prototype.hi
-    Returns the high 32-bit word of an unsigned 64-bit integer.
+    Returns the high 32-bit word of a 64-bit unsigned integer.
 
     Returns
     -------
@@ -134,7 +134,7 @@
 
 
 {{alias}}.prototype.lo
-    Returns the low 32-bit word of an unsigned 64-bit integer.
+    Returns the low 32-bit word of a 64-bit unsigned integer.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/number/uint64/ctor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/docs/types/index.d.ts
@@ -49,7 +49,7 @@ declare class Uint64 {
 	/**
 	* Creates a new 64-bit unsigned integer from an array-like object containing a high and low word.
 	*
-	* @param words - high and low words
+	* @param words - high and low words as 32-bit unsigned integers
 	* @returns 64-bit unsigned integer
 	*
 	* @example
@@ -61,8 +61,8 @@ declare class Uint64 {
 	/**
 	* Creates a new 64-bit unsigned integer from a high and low word.
 	*
-	* @param high - high word
-	* @param low - low word
+	* @param high - high word (32-bit unsigned integer)
+	* @param low - low word (32-bit unsigned integer)
 	* @returns 64-bit unsigned integer
 	*
 	* @example
@@ -111,7 +111,7 @@ declare class Uint64 {
 	/**
 	* Returns the high 32-bit word of a 64-bit unsigned integer.
 	*
-	* @returns high 32-bit word
+	* @returns high word (32-bit unsigned integer)
 	*
 	* @example
 	* var x = Uint64.from( [ 1, 2 ] );
@@ -124,7 +124,7 @@ declare class Uint64 {
 	/**
 	* Returns the low 32-bit word of a 64-bit unsigned integer.
 	*
-	* @returns low 32-bit word
+	* @returns high word (32-bit unsigned integer)
 	*
 	* @example
 	* var x = Uint64.from( [ 1, 2 ] );

--- a/lib/node_modules/@stdlib/number/uint64/ctor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/docs/types/index.d.ts
@@ -31,14 +31,14 @@ interface SerializedUint64 {
 }
 
 /**
-* Unsigned 64-bit integer.
+* 64-bit unsigned integer.
 */
 declare class Uint64 {
 	/**
-	* Unsigned 64-bit integer constructor.
+	* 64-bit unsigned integer constructor.
 	*
 	* @param value - integer value
-	* @returns unsigned 64-bit integer
+	* @returns 64-bit unsigned integer
 	*
 	* @example
 	* var x = new Uint64( 5 );
@@ -47,10 +47,10 @@ declare class Uint64 {
 	constructor( value: number | bigint );
 
 	/**
-	* Creates a new unsigned 64-bit integer from an array-like object containing a high and low word.
+	* Creates a new 64-bit unsigned integer from an array-like object containing a high and low word.
 	*
 	* @param words - high and low words
-	* @returns unsigned 64-bit integer
+	* @returns 64-bit unsigned integer
 	*
 	* @example
 	* var x = Uint64.from( [ 1234, 5678 ] );
@@ -59,11 +59,11 @@ declare class Uint64 {
 	static from( words: ArrayLike<number> ): Uint64;
 
 	/**
-	* Creates a new unsigned 64-bit integer from a high and low word.
+	* Creates a new 64-bit unsigned integer from a high and low word.
 	*
 	* @param high - high word
 	* @param low - low word
-	* @returns unsigned 64-bit integer
+	* @returns 64-bit unsigned integer
 	*
 	* @example
 	* var x = Uint64.of( 1234, 5678 );
@@ -109,7 +109,7 @@ declare class Uint64 {
 	readonly byteLength: 8;
 
 	/**
-	* Returns the high 32-bit word of an unsigned 64-bit integer.
+	* Returns the high 32-bit word of a 64-bit unsigned integer.
 	*
 	* @returns high 32-bit word
 	*
@@ -122,7 +122,7 @@ declare class Uint64 {
 	readonly hi: number;
 
 	/**
-	* Returns the low 32-bit word of an unsigned 64-bit integer.
+	* Returns the low 32-bit word of a 64-bit unsigned integer.
 	*
 	* @returns low 32-bit word
 	*
@@ -135,10 +135,10 @@ declare class Uint64 {
 	readonly lo: number;
 
 	/**
-	* Serializes an unsigned 64-bit integer as a string.
+	* Serializes a 64-bit unsigned integer as a string.
 	*
 	* @param radix - radix (base) to use for string conversion (2-36)
-	* @returns serialized unsigned 64-bit integer
+	* @returns serialized 64-bit unsigned integer
 	*
 	* @example
 	* var x = new Uint64( 5 );
@@ -149,13 +149,13 @@ declare class Uint64 {
 	toString( radix?: number ): string;
 
 	/**
-	* Serializes an unsigned 64-bit integer as a JSON object.
+	* Serializes a 64-bit unsigned integer as a JSON object.
 	*
 	* ## Notes
 	*
 	* -   `JSON.stringify()` implicitly calls this method when stringifying a `Uint64` instance.
 	*
-	* @returns serialized unsigned 64-bit integer
+	* @returns serialized 64-bit unsigned integer
 	*
 	* @example
 	* var x = new Uint64( 5 );
@@ -166,7 +166,7 @@ declare class Uint64 {
 	toJSON(): SerializedUint64;
 
 	/**
-	* Converts an unsigned 64-bit integer to a primitive value.
+	* Converts a 64-bit unsigned integer to a primitive value.
 	*
 	* @returns primitive value
 	*

--- a/lib/node_modules/@stdlib/number/uint64/ctor/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/docs/types/test.ts
@@ -24,7 +24,7 @@ import Uint64 = require( './index' );
 
 // TESTS //
 
-// The function returns an unsigned 64-bit integer with the expected properties...
+// The function returns a 64-bit unsigned integer with the expected properties...
 {
 	const x = new Uint64( 5 ); // $ExpectType Uint64
 	x.hi; // $ExpectType number
@@ -72,7 +72,7 @@ import Uint64 = require( './index' );
 	new Uint64( 5, 3 ); // $ExpectError
 }
 
-// Attached to the constructor is a `from` method which returns an unsigned 64-bit integer...
+// Attached to the constructor is a `from` method which returns a 64-bit unsigned integer...
 {
 	Uint64.from( [ 0, 1 ] ); // $ExpectType Uint64
 	Uint64.from( new Uint32Array( [ 0, 1 ] ) ); // $ExpectType Uint64
@@ -88,7 +88,7 @@ import Uint64 = require( './index' );
 	Uint64.from( {} ); // $ExpectError
 }
 
-// Attached to the constructor is an `of` method which returns an unsigned 64-bit integer...
+// Attached to the constructor is an `of` method which returns a 64-bit unsigned integer...
 {
 	Uint64.of( 0, 1 ); // $ExpectType Uint64
 }

--- a/lib/node_modules/@stdlib/number/uint64/ctor/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Unsigned 64-bit integer constructor.
+* 64-bit unsigned integer constructor.
 *
 * @module @stdlib/number/uint64/ctor
 *

--- a/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
@@ -109,7 +109,7 @@ setReadOnly( Uint64, 'name', 'Uint64' );
 * @name from
 * @memberof Uint64
 * @type {Function}
-* @param {Collection} words - high and low words
+* @param {Collection} words - high and low words as 32-bit unsigned integers
 * @throws {TypeError} must provide an array-like object containing two elements
 * @returns {Uint64} 64-bit unsigned integer
 *
@@ -154,8 +154,8 @@ setReadOnly( Uint64, 'from', function fromWords( words ) {
 * @name of
 * @memberof Uint64
 * @type {Function}
-* @param {NonNegativeInteger} high - high word
-* @param {NonNegativeInteger} low - low word
+* @param {uinteger} high - high word (32-bit unsigned integer)
+* @param {uinteger} low - low word (32-bit unsigned integer)
 * @throws {TypeError} first argument must be a nonnegative integer
 * @throws {TypeError} second argument must be a nonnegative integer
 * @returns {Uint64} 64-bit unsigned integer
@@ -230,7 +230,7 @@ setReadOnly( Uint64.prototype, 'byteLength', 8 );
 * @name hi
 * @memberof Uint64.prototype
 * @type {uinteger}
-* @returns {uinteger} 32-bit unsigned integer
+* @returns {uinteger} high word (32-bit unsigned integer)
 *
 * @example
 * var x = Uint64.from( [ 1234, 5678 ] );
@@ -248,7 +248,7 @@ setReadOnlyAccessor( Uint64.prototype, 'hi', function getHighWord() {
 * @name lo
 * @memberof Uint64.prototype
 * @type {uinteger}
-* @returns {uinteger} 32-bit unsigned integer
+* @returns {uinteger} low word (32-bit unsigned integer)
 *
 * @example
 * var x = Uint64.from( [ 1234, 5678 ] );

--- a/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
@@ -361,8 +361,11 @@ setReadOnly( Uint64.prototype, 'valueOf', function valueOf() {
 * if ( hasSymbol() ) {
 *     v = x[ ToPrimitiveSymbol ]( 'number' );
 *     // returns 5
+*
 *     v = x[ ToPrimitiveSymbol ]( 'string' );
 *     // returns '5'
+* 
+*
 *     v = x[ ToPrimitiveSymbol ]();
 *     // e.g., returns <bigint>
 * }

--- a/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
@@ -364,7 +364,7 @@ setReadOnly( Uint64.prototype, 'valueOf', function valueOf() {
 *
 *     v = x[ ToPrimitiveSymbol ]( 'string' );
 *     // returns '5'
-* 
+*
 *     v = x[ ToPrimitiveSymbol ]();
 *     // e.g., returns <bigint>
 * }

--- a/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
@@ -365,7 +365,6 @@ setReadOnly( Uint64.prototype, 'valueOf', function valueOf() {
 *     v = x[ ToPrimitiveSymbol ]( 'string' );
 *     // returns '5'
 * 
-*
 *     v = x[ ToPrimitiveSymbol ]();
 *     // e.g., returns <bigint>
 * }

--- a/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
@@ -23,6 +23,7 @@
 // MODULES //
 
 var hasBigIntSupport = require( '@stdlib/assert/has-bigint-support' );
+var hasToPrimitiveSymbolSupport = require( '@stdlib/assert/has-to-primitive-symbol-support' ); // eslint-disable-line id-length
 var isUint32Array = require( '@stdlib/assert/is-uint32array' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var isBigInt = require( '@stdlib/assert/is-bigint' ).isPrimitive;
@@ -37,6 +38,7 @@ var join = require( '@stdlib/array/base/join' );
 var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
 var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
 var format = require( '@stdlib/string/format' );
+var ToPrimitiveSymbol = require( '@stdlib/symbol/to-primitive' );
 var indices = require( './indices.js' );
 var int2str = require( './to_string.js' );
 
@@ -339,6 +341,43 @@ setReadOnly( Uint64.prototype, 'valueOf', function valueOf() {
 	}
 	return ( this._buffer[ indices.HIGH ] * TWO_32 ) + this._buffer[ indices.LOW ];
 });
+
+/**
+* Returns the primitive value of a 64-bit unsigned integer.
+*
+* @name toPrimitive
+* @memberof Uint64.prototype
+* @type {Function}
+* @param {string} hint - conversion hint
+* @returns {(string|number|bigint)} primitive value
+*
+* @example
+* var hasSymbol = require( '@stdlib/assert/has-to-primitive-symbol-support' );
+* var ToPrimitiveSymbol = require( '@stdlib/symbol/to-primitive' );
+*
+* var x = new Uint64( 5 );
+*
+* var v;
+* if ( hasSymbol() ) {
+*     v = x[ ToPrimitiveSymbol ]( 'number' );
+*     // returns 5
+*     v = x[ ToPrimitiveSymbol ]( 'string' );
+*     // returns '5'
+*     v = x[ ToPrimitiveSymbol ]();
+*     // e.g., returns <bigint>
+* }
+*/
+if ( hasToPrimitiveSymbolSupport() ) {
+	setReadOnly( Uint64.prototype, ToPrimitiveSymbol, function toPrimitive( hint ) {
+		if ( hint === 'number' ) {
+			return ( this._buffer[ indices.HIGH ] * TWO_32 ) + this._buffer[ indices.LOW ];
+		}
+		if ( hint === 'string' ) {
+			return this.toString();
+		}
+		return this.valueOf();
+	});
+}
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/lib/main.js
@@ -50,13 +50,13 @@ var TWO_32 = 0x100000000; // 2^32
 // MAIN //
 
 /**
-* Unsigned 64-bit integer constructor.
+* 64-bit unsigned integer constructor.
 *
 * @constructor
 * @param {(NonNegativeInteger|bigint)} value - integer value
 * @throws {TypeError} must invoke using the `new` keyword
 * @throws {TypeError} must provide a valid number
-* @returns {Uint64} unsigned 64-bit integer
+* @returns {Uint64} 64-bit unsigned integer
 *
 * @example
 * var v = new Uint64( 5 );
@@ -102,14 +102,14 @@ function Uint64( value ) {
 setReadOnly( Uint64, 'name', 'Uint64' );
 
 /**
-* Creates a new unsigned 64-bit integer from an array-like object containing a high and low word.
+* Creates a new 64-bit unsigned integer from an array-like object containing a high and low word.
 *
 * @name from
 * @memberof Uint64
 * @type {Function}
 * @param {Collection} words - high and low words
 * @throws {TypeError} must provide an array-like object containing two elements
-* @returns {Uint64} unsigned 64-bit integer
+* @returns {Uint64} 64-bit unsigned integer
 *
 * @example
 * var x = Uint64.from( [ 1234, 5678 ] );
@@ -147,7 +147,7 @@ setReadOnly( Uint64, 'from', function fromWords( words ) {
 });
 
 /**
-* Creates a new unsigned 64-bit integer from a high and low word.
+* Creates a new 64-bit unsigned integer from a high and low word.
 *
 * @name of
 * @memberof Uint64
@@ -156,7 +156,7 @@ setReadOnly( Uint64, 'from', function fromWords( words ) {
 * @param {NonNegativeInteger} low - low word
 * @throws {TypeError} first argument must be a nonnegative integer
 * @throws {TypeError} second argument must be a nonnegative integer
-* @returns {Uint64} unsigned 64-bit integer
+* @returns {Uint64} 64-bit unsigned integer
 *
 * @example
 * var x = Uint64.of( 1234, 5678 );
@@ -223,7 +223,7 @@ setReadOnly( Uint64.prototype, 'BYTES_PER_ELEMENT', 8 );
 setReadOnly( Uint64.prototype, 'byteLength', 8 );
 
 /**
-* Returns the high 32-bit word of an unsigned 64-bit integer.
+* Returns the high 32-bit word of a 64-bit unsigned integer.
 *
 * @name hi
 * @memberof Uint64.prototype
@@ -241,7 +241,7 @@ setReadOnlyAccessor( Uint64.prototype, 'hi', function getHighWord() {
 });
 
 /**
-* Returns the low 32-bit word of an unsigned 64-bit integer.
+* Returns the low 32-bit word of a 64-bit unsigned integer.
 *
 * @name lo
 * @memberof Uint64.prototype
@@ -259,14 +259,14 @@ setReadOnlyAccessor( Uint64.prototype, 'lo', function getLowWord() {
 });
 
 /**
-* Serializes an unsigned 64-bit integer as a string.
+* Serializes a 64-bit unsigned integer as a string.
 *
 * @name toString
 * @memberof Uint64.prototype
 * @type {Function}
 * @param {PositiveInteger} [radix=10] - radix (base) to use for string conversion (2-36)
 * @throws {TypeError} must provide an integer on the interval [2,36]
-* @returns {string} serialized unsigned 64-bit integer
+* @returns {string} serialized 64-bit unsigned integer
 *
 * @example
 * var str = new Uint64( 5 ).toString();
@@ -295,7 +295,7 @@ setReadOnly( Uint64.prototype, 'toString', function toString( radix ) {
 });
 
 /**
-* Serializes an unsigned 64-bit integer as a JSON object.
+* Serializes a 64-bit unsigned integer as a JSON object.
 *
 * ## Notes
 *
@@ -304,7 +304,7 @@ setReadOnly( Uint64.prototype, 'toString', function toString( radix ) {
 * @name toJSON
 * @memberof Uint64.prototype
 * @type {Function}
-* @returns {Object} serialized unsigned 64-bit integer
+* @returns {Object} serialized 64-bit unsigned integer
 *
 * @example
 * var x = new Uint64( 5 );
@@ -320,7 +320,7 @@ setReadOnly( Uint64.prototype, 'toJSON', function toJSON() {
 });
 
 /**
-* Converts an unsigned 64-bit integer to a primitive value.
+* Converts a 64-bit unsigned integer to a primitive value.
 *
 * @name valueOf
 * @memberof Uint64.prototype

--- a/lib/node_modules/@stdlib/number/uint64/ctor/lib/to_string.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/lib/to_string.js
@@ -78,7 +78,7 @@ var WORKSPACE = new Uint32Array( 2 );
 // FUNCTIONS //
 
 /**
-* Performs division and modulo for an unsigned 64-bit integer represented as high-low words.
+* Performs division and modulo for a 64-bit unsigned integer represented as high-low words.
 *
 * ## Notes
 *
@@ -133,12 +133,12 @@ function chunkedDivMod( words, divisor, out ) {
 // MAIN //
 
 /**
-* Serializes an unsigned 64-bit integer as a string in the specified base.
+* Serializes a 64-bit unsigned integer as a string in the specified base.
 *
 * @private
 * @param {Uint32Array} words - high and low words
 * @param {PositiveInteger} radix - radix (base) to use for string conversion
-* @returns {string} serialized unsigned 64-bit integer
+* @returns {string} serialized 64-bit unsigned integer
 */
 function int2str( words, radix ) {
 	var quo;

--- a/lib/node_modules/@stdlib/number/uint64/ctor/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/number/uint64/ctor",
   "version": "0.0.0",
-  "description": "Unsigned 64-bit integer.",
+  "description": "64-bit unsigned integer.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/number/uint64/ctor/test/test.from.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/test/test.from.js
@@ -47,7 +47,7 @@ tape( 'attached to the main export is a read-only `from` method', function test(
 	}
 });
 
-tape( 'the method throws an error if not provided an array-like object containing two 32-bit words', function test( t ) {
+tape( 'the method throws an error if not provided an array-like object containing two 32-bit unsigned integers', function test( t ) {
 	var values;
 	var i;
 

--- a/lib/node_modules/@stdlib/number/uint64/ctor/test/test.from.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/test/test.from.js
@@ -79,7 +79,7 @@ tape( 'the method throws an error if not provided an array-like object containin
 	}
 });
 
-tape( 'the method returns an unsigned 64-bit integer', function test( t ) {
+tape( 'the method returns a 64-bit unsigned integer', function test( t ) {
 	var x;
 
 	x = Uint64.from( [ 0, 1 ] );

--- a/lib/node_modules/@stdlib/number/uint64/ctor/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/test/test.js
@@ -23,9 +23,11 @@
 var tape = require( 'tape' );
 var hasBigIntSupport = require( '@stdlib/assert/has-bigint-support' );
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
-var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
+var hasToPrimitiveSymbolSupport = require( '@stdlib/assert/has-to-primitive-symbol-support' ); // eslint-disable-line id-length
 var BigInt = require( '@stdlib/bigint/ctor' );
+var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
 var Number = require( '@stdlib/number/ctor' );
+var ToPrimitiveSymbol = require( '@stdlib/symbol/to-primitive' );
 var Uint64 = require( './../lib' );
 
 
@@ -274,6 +276,30 @@ tape( 'the constructor returns an instance which supports converting an instance
 
 		x = Uint64.from( [ 0xDEADBEEF, 0xBADF00D2 ] );
 		t.strictEqual( x.valueOf(), Number( '0xDEADBEEFBADF00D2' ), 'returns expected value' );
+	}
+
+	t.end();
+});
+
+tape( 'if an environment supports `Symbol.toPrimitive`, the constructor returns an instance which supports type coercion', function test( t ) {
+	var x;
+
+	if ( !hasToPrimitiveSymbolSupport() ) {
+		t.ok( true, 'environment does not support Symbol.toPrimitive' );
+		t.end();
+		return;
+	}
+	x = new Uint64( 5 );
+
+	t.strictEqual( x[ ToPrimitiveSymbol ]( 'number' ), 5, 'returns expected value' );
+	t.strictEqual( x[ ToPrimitiveSymbol ]( 'string' ), '5', 'returns expected value' );
+
+	if ( HAS_BIGINT ) {
+		t.strictEqual( x[ ToPrimitiveSymbol ]( 'default' ), BigInt( 5 ), 'returns expected value' );
+		t.strictEqual( x[ ToPrimitiveSymbol ](), BigInt( 5 ), 'returns expected value' );
+	} else {
+		t.strictEqual( x[ ToPrimitiveSymbol ]( 'default' ), 5, 'returns expected value' );
+		t.strictEqual( x[ ToPrimitiveSymbol ](), 5, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/number/uint64/ctor/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/test/test.js
@@ -131,7 +131,7 @@ tape( 'the constructor throws an error if provided an invalid/unsupported BigInt
 	}
 });
 
-tape( 'the constructor returns an unsigned 64-bit integer', function test( t ) {
+tape( 'the constructor returns a 64-bit unsigned integer', function test( t ) {
 	var x;
 
 	x = new Uint64( 0 );

--- a/lib/node_modules/@stdlib/number/uint64/ctor/test/test.of.js
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/test/test.of.js
@@ -77,7 +77,7 @@ tape( 'the method throws an error if not provided two unsigned 32-bit integers',
 	}
 });
 
-tape( 'the method returns an unsigned 64-bit integer', function test( t ) {
+tape( 'the method returns a 64-bit unsigned integer', function test( t ) {
 	var x;
 
 	x = Uint64.of( 0, 1 );


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds toPrimitive support to `Uint64` in `number/uint64/ctor`.
-   Updates descriptions by replacing `unsigned 64-bit integer` with `64-bit unsigned integer`.
-   Updates descriptions to clarify that 32-bit high/low words are in fact 32-bit **unsigned** integers to remove ambiguity as other [JS libs](https://github.com/dcodeIO/long.js#fields) often store/return high/low words as  32-bit **signed** integers.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
