### PR TITLE
docs: add Git notes correcting recent commit messages

### DIFF
--- a/docs/git-notes/fcca2dc42eb46f8957fc9e3a4fd0691917f38daf.txt
+++ b/docs/git-notes/fcca2dc42eb46f8957fc9e3a4fd0691917f38daf.txt
@@ -1,0 +1,13 @@
+---
+type: amend-message
+---
+remove!: remove migrated `stats/strided/*` imports from `stats/base/*` namespace
+
+This commit removes leftover symbols from package migration. The removed symbols are all now present in the `stats/strided/*` namespace.
+
+BREAKING CHANGE: remove `d*` symbols from namespace
+
+To migrate, users should access the same symbols in the `stats/strided/*` namespace.
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/13103
+Reviewed-by: Athan Reines <kgryte@gmail.com>


### PR DESCRIPTION
## Summary

Adds one Git note file for a commit from the last 24 hours that contains a clear style guide violation.

## Flagged commits

- `fcca2dc42`: missing `!` in breaking-change type — commit has a `BREAKING CHANGE:` footer but subject uses `remove:` instead of the required `remove!:`. The stdlib git style guide ([`docs/style-guides/git/README.md`](https://github.com/stdlib-js/stdlib/blob/develop/docs/style-guides/git/README.md)) states: *"Breaking changes **must** include an exclamation point as part of the type."*

## Notes

- Only one commit was flagged out of 20 non-merge commits in the last 24 hours.
- All 17 PR-URL references were verified to exist and match their respective commits.
- All other commit messages follow the correct `type(scope): description` format.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)