### PR TITLE
build: skip packages without C examples when running examples for random packages

### DIFF
--- a/tools/make/lib/examples/c.mk
+++ b/tools/make/lib/examples/c.mk
@@ -114,11 +114,13 @@ examples-c-files:
 #/
 examples-random-c: $(NODE_MODULES)
 	$(QUIET) $(MAKE) -f $(this_file) -s list-random-lib-pkgs PACKAGES_PATTERN='binding.gyp' | while read -r pkg; do \
-		echo ""; \
-		echo "Running example: $$pkg"; \
-		NODE_ENV="$(NODE_ENV_EXAMPLES)" \
-		NODE_PATH="$(NODE_PATH_EXAMPLES)" \
-		$(MAKE) -f $(this_file) examples-c EXAMPLES_FILTER="$$pkg/.*" || exit 1; \
+		if find "$$pkg/examples" -name "*.c" 2>/dev/null | grep -q .; then \
+			echo ""; \
+			echo "Running example: $$pkg"; \
+			NODE_ENV="$(NODE_ENV_EXAMPLES)" \
+			NODE_PATH="$(NODE_PATH_EXAMPLES)" \
+			$(MAKE) -f $(this_file) examples-c EXAMPLES_FILTER="$$pkg/.*" || exit 1; \
+		fi; \
 	done
 
 .PHONY: examples-random-c


### PR DESCRIPTION
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

## Summary

Fixes persistent `random_examples` CI failures (~53% failure rate, 16/30 runs in the last 30 days).

### Root cause

`examples-random-c` uses `PACKAGES_PATTERN='binding.gyp'` to select random packages. NAPI utility packages (e.g. `@stdlib/napi/argv-complex64`, `@stdlib/napi/argv-dataview-cast`) have a `binding.gyp` for their Node.js native add-on **but ship no `examples/c/*.c` file**. When one of these 98 packages was selected from the pool of 1514, `examples-c` failed, aborting the workflow.

With ~98/1514 (~6.5%) packages lacking C examples, the probability that at least one of 10 randomly selected packages fails is ~49%, matching the observed 53% failure rate.

### Fix

Add a pre-flight `find` guard before calling `examples-c`. If a selected package has no `*.c` files under its `examples/` directory, it is silently skipped.

```diff
 examples-random-c: $(NODE_MODULES)
 	$(QUIET) $(MAKE) -f $(this_file) -s list-random-lib-pkgs PACKAGES_PATTERN='binding.gyp' | while read -r pkg; do \
+		if find "$$pkg/examples" -name "*.c" 2>/dev/null | grep -q .; then \
 			echo ""; \
 			echo "Running example: $$pkg"; \
 			NODE_ENV="$(NODE_ENV_EXAMPLES)" \
 			NODE_PATH="$(NODE_PATH_EXAMPLES)" \
 			$(MAKE) -f $(this_file) examples-c EXAMPLES_FILTER="$$pkg/.*" || exit 1; \
+		fi; \
 	done
```

This keeps the original `PACKAGES_PATTERN='binding.gyp'` selection pool (changing it to `example.c` would be excluded by `FIND_LIB_PACKAGES_EXCLUDE_FLAGS` which strips `**/examples/*` paths, silently returning 0 packages).

### Validation

- Guard tested locally: NAPI packages return exit 1 from guard (skipped), math packages return exit 0 (run)
- 3-agent review on initial approach caught that `FIND_LIB_PACKAGES_EXCLUDE_FLAGS` excludes `examples/` subdirs, leading to the guard approach