### PR TITLE
build: skip packages without C benchmarks when benchmarking random packages

### DIFF
--- a/tools/make/lib/benchmark/c.mk
+++ b/tools/make/lib/benchmark/c.mk
@@ -114,11 +114,13 @@ benchmark-c-files:
 #/
 benchmark-random-c: $(NODE_MODULES)
 	$(QUIET) $(MAKE) -f $(this_file) -s list-random-lib-pkgs PACKAGES_PATTERN='manifest.json' | while read -r pkg; do \
-		echo ""; \
-		echo "Running benchmark: $$pkg"; \
-		NODE_ENV="$(NODE_ENV_BENCHMARK)" \
-		NODE_PATH="$(NODE_PATH_BENCHMARK)" \
-		$(MAKE) -f $(this_file) benchmark-c BENCHMARKS_FILTER="$$pkg/.*" || exit 1; \
+		if find "$$pkg/benchmark" -name "*.c" 2>/dev/null | grep -q .; then \
+			echo ""; \
+			echo "Running benchmark: $$pkg"; \
+			NODE_ENV="$(NODE_ENV_BENCHMARK)" \
+			NODE_PATH="$(NODE_PATH_BENCHMARK)" \
+			$(MAKE) -f $(this_file) benchmark-c BENCHMARKS_FILTER="$$pkg/.*" || exit 1; \
+		fi; \
 	done
 
 .PHONY: benchmark-random-c


### PR DESCRIPTION
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

## Summary

Fixes persistent `random_benchmarks` CI failures (~97% failure rate, 29/30 runs in the last 30 days).

### Root cause

`benchmark-random-c` uses `PACKAGES_PATTERN='manifest.json'` to select random packages. WASM packages (e.g. `@stdlib/blas/base/wasm/dasum`, `@stdlib/blas/base/wasm/dswap`) carry a `manifest.json` listing their C dependencies **but ship no `benchmark/c/*.c` file** and require Emscripten to compile — which is not available in the CI runner. When one of these 47 WASM packages was selected from the pool of 1845, `benchmark-c` failed and the workflow aborted.

The very high failure rate (97%) reflects that at least one WASM package is statistically nearly certain to appear in 10 randomly drawn packages from 1845 when 47 are problematic.

### Fix

Add a pre-flight `find` guard before calling `benchmark-c`. If a selected package has no `*.c` files under its `benchmark/` directory, it is silently skipped.

```diff
 benchmark-random-c: $(NODE_MODULES)
 	$(QUIET) $(MAKE) -f $(this_file) -s list-random-lib-pkgs PACKAGES_PATTERN='manifest.json' | while read -r pkg; do \
+		if find "$$pkg/benchmark" -name "*.c" 2>/dev/null | grep -q .; then \
 			echo ""; \
 			echo "Running benchmark: $$pkg"; \
 			NODE_ENV="$(NODE_ENV_BENCHMARK)" \
 			NODE_PATH="$(NODE_PATH_BENCHMARK)" \
 			$(MAKE) -f $(this_file) benchmark-c BENCHMARKS_FILTER="$$pkg/.*" || exit 1; \
+		fi; \
 	done
```

This keeps the original `PACKAGES_PATTERN='manifest.json'` selection pool (changing it to `benchmark*.c` would be excluded by `FIND_LIB_PACKAGES_EXCLUDE_FLAGS` which strips `**/benchmark/*` paths, silently returning 0 packages and running nothing).

### Validation

- Guard tested: WASM packages have no `*.c` in `benchmark/` (confirmed), math/blas packages do
- 3-agent review caught that `FIND_LIB_PACKAGES_EXCLUDE_FLAGS` excludes `benchmark/` subdirs, ruling out the pattern-change approach