### PR TITLE
docs: remove unused import

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dmidrange/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmidrange/lib/index.js
@@ -34,7 +34,6 @@
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
-* var floor = require( '@stdlib/math/base/special/floor' );
 * var dmidrange = require( '@stdlib/stats/strided/dmidrange' );
 *
 * var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ] );

--- a/lib/node_modules/@stdlib/stats/strided/dmskmin/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dmskmin/lib/ndarray.js
@@ -41,7 +41,6 @@ var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
 * var Uint8Array = require( '@stdlib/array/uint8' );
-* var floor = require( '@stdlib/math/base/special/floor' );
 *
 * var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, -5.0, -6.0 ] );
 * var mask = new Uint8Array( [ 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 ] );

--- a/lib/node_modules/@stdlib/stats/strided/dnanmin/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dnanmin/lib/ndarray.js
@@ -37,7 +37,6 @@ var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
-* var floor = require( '@stdlib/math/base/special/floor' );
 *
 * var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ] );
 *

--- a/lib/node_modules/@stdlib/stats/strided/dnanminabs/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dnanminabs/lib/ndarray.js
@@ -37,7 +37,6 @@ var abs = require( '@stdlib/math/base/special/abs' );
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
-* var floor = require( '@stdlib/math/base/special/floor' );
 *
 * var x = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ] );
 *

--- a/lib/node_modules/@stdlib/stats/strided/dsmean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsmean/lib/index.js
@@ -34,7 +34,6 @@
 *
 * @example
 * var Float32Array = require( '@stdlib/array/float32' );
-* var floor = require( '@stdlib/math/base/special/floor' );
 * var dsmean = require( '@stdlib/stats/strided/dsmean' );
 *
 * var x = new Float32Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ] );

--- a/lib/node_modules/@stdlib/stats/strided/nanvariancetk/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/strided/nanvariancetk/lib/index.js
@@ -32,7 +32,6 @@
 * // returns ~4.3333
 *
 * @example
-* var floor = require( '@stdlib/math/base/special/floor' );
 * var nanvariancetk = require( '@stdlib/stats/strided/nanvariancetk' );
 *
 * var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ];


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Removes a vestigial `var floor = require( '@stdlib/math/base/special/floor' );` line from a JSDoc `@example` block in six `@stdlib/stats/strided` packages. In each file the `floor` symbol is declared but never invoked in the example body, so the line is dead. The fix touches one line per package and changes no runtime, type, test, or example behavior.

### Namespace summary

-   **Target namespace:** `@stdlib/stats/strided`
-   **Members analyzed:** 240 direct children; 239 leaf packages compared (the `distances` sub-namespace wrapper is structurally distinct and excluded from the comparison set).
-   **Features extracted (cheap structural pass):** file tree, `package.json` shape, README `##`/`###` heading sets and orders, `manifest.json` shape, `test/`, `benchmark/`, `examples/` filename sets, copyright-year distribution per file type.
-   **Features extracted (semantic pass):** function-attached JSDoc shape (`@param`, `@returns`, `@throws`, `@example` presence and body contents) on `lib/main.js`, `lib/ndarray.js`, and the per-package impl file; signature shape; error-construction style; require sets for `lib/`, `benchmark/`, `examples/`, `test/`.
-   **Features with a clear ≥75% majority and conformance ≥99%:** presence of `README.md`, `lib/{index,main,ndarray}.js`, `examples/index.js`, `test/test.js`, `test/test.ndarray.js`, `benchmark/benchmark.js`, `benchmark/benchmark.ndarray.js`, `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, `package.json` top-level key set, `@param N` type (`PositiveInteger`), `@param strideX` type (`integer`), `@param offsetX` type (`NonNegativeInteger`), function-attached `@example` presence (100% on `lib/main.js` and `lib/ndarray.js`).
-   **Features excluded for no clear majority:** `lib/main.js` dispatch shape (split 183 legacy / 54 modern / 2 other; reflects the in-progress `stride2offset` refactor, not drift), `benchmark/benchmark.js` lib-import path (split 172 `./../lib/<pkg>.js` / 54 `./../lib/main.js` / 13 `./../lib`; same architectural divide), README `##` section sequence (largest pattern only 76/239 = 32%; varies with C-API and References-section presence), `examples/index.js` random-source dependency (top pattern 122/239 = 51%), keyword count (no mode dominant), copyright year (84% are `2020` but reflects creation date, not drift).
-   **Features excluded by routine gates:** `## See Also` section presence (200/239 = 83%, missing in 39; gated as auto-populated by the package generator), `docs/repl.txt` and `docs/types/*` shape (generator-owned).

### Per outlier package

#### `@stdlib/stats/strided/dmidrange`

Drop unused `floor` import from the second `@example` block in `lib/index.js`. The symbol is never invoked in the example body, so the `require` is vestigial and out of step with 233/239 (97.5%) of `@stdlib/stats/strided` leaf packages, whose JSDoc examples carry no such dead import.

#### `@stdlib/stats/strided/dsmean`

Drop unused `floor` import from the second `@example` block in `lib/index.js`. The symbol is never invoked in the example body, so the `require` is vestigial and out of step with 233/239 (97.5%) of `@stdlib/stats/strided` leaf packages, whose JSDoc examples carry no such dead import.

#### `@stdlib/stats/strided/nanvariancetk`

Drop unused `floor` import from the second `@example` block in `lib/index.js`. The symbol is never invoked in the example body, so the `require` is vestigial and out of step with 233/239 (97.5%) of `@stdlib/stats/strided` leaf packages, whose JSDoc examples carry no such dead import.

#### `@stdlib/stats/strided/dmskmin`

Drop unused `floor` import from the function-attached `@example` block in `lib/ndarray.js`. The symbol is never invoked in the example body, so the `require` is vestigial and out of step with 233/239 (97.5%) of `@stdlib/stats/strided` leaf packages, whose JSDoc examples carry no such dead import.

#### `@stdlib/stats/strided/dnanmin`

Drop unused `floor` import from the function-attached `@example` block in `lib/ndarray.js`. The symbol is never invoked in the example body, so the `require` is vestigial and out of step with 233/239 (97.5%) of `@stdlib/stats/strided` leaf packages, whose JSDoc examples carry no such dead import.

#### `@stdlib/stats/strided/dnanminabs`

Drop unused `floor` import from the function-attached `@example` block in `lib/ndarray.js`. The symbol is never invoked in the example body, so the `require` is vestigial and out of step with 233/239 (97.5%) of `@stdlib/stats/strided` leaf packages, whose JSDoc examples carry no such dead import.

### Validation

Each candidate was confirmed by an independent reviewer:

-   **Semantic verdict (per file):** the declared `floor` identifier appears only on its own `var floor = require(...)` line within the `@example` body — no call, no member access, no reference. Removing the line cannot change what the example demonstrates.
-   **Cross-reference verdict:** the changes touch JSDoc comment text only. No `test/`, `examples/`, `benchmark/`, or types file imports `floor` for these packages, so no other artifact depends on the comment line.
-   **Structural verdict:** every affected `lib/index.js` / `lib/ndarray.js` is hand-written. None carry an `AUTOGENERATED` / `Do not manually edit` marker, and the `lib/` layout itself is not generator-owned in this namespace.

Deliberately excluded from the run:

-   **Intentional API deviations.** `dcovmatmtk` uses `@param {NonNegativeInteger} N` and a `format`-based validation prologue (1/239 vs `PositiveInteger`, no-validation in the rest) because it is a matrix function, not a strided-iteration function; the looser bound and the `M < 0` / `N < 0` checks are correct for that semantics.
-   **Architectural transition, not drift.** The `lib/main.js` legacy/modern dispatch split (183/54), the corresponding `benchmark/benchmark.js` lib-import split, and the `lib/` layout split (with or without a `lib/<pkg>.js` impl file) all track the in-progress migration to the `stride2offset` + `./ndarray.js` shape. They reach the 75% threshold in opposite directions depending on which sub-population is treated as "majority", and any rewrite would change observable file structure and the public re-export surface.
-   **Generator-owned artifacts.** `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, and the `## See Also` README section (200/239 = 83% present, missing in 39).
-   **The `distances` sub-namespace package.** A namespace wrapper, not a leaf strided function; it legitimately lacks `lib/main.js`, `lib/ndarray.js`, `benchmark/*`, `test/test.ndarray.js`, and `docs/repl.txt`. Removed from the comparison set up front rather than fed through validation gates.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

Per-package commits and their diffs are kept separate so the audit trail reads per-package rather than per-feature. Total diff: 6 lines removed across 6 files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated drift-detection routine that pseudo-randomly selected the `@stdlib/stats/strided` namespace, extracted structural and semantic features from every leaf package, computed per-feature majority patterns, and proposed corrections only for outliers that survived a separate validation pass. The per-package commit messages and PR description were drafted by Claude Code (Anthropic) under my supervision; I reviewed each diff before approving the push.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzH2v6Brt4Qg8RoaLN879P)_