### PR TITLE
docs: fix examples, notes, and return description

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/matrix/complex128/README.md
+++ b/lib/node_modules/@stdlib/ndarray/matrix/complex128/README.md
@@ -118,7 +118,7 @@ var sh = getShape( arr );
 
 The function accepts the following arguments:
 
--   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array- like objects, each of which must have the same number of elements.
+-   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array-like objects, each of which must have the same number of elements.
 -   **options**: function options. See above.
 
 #### Complex128Matrix( buffer\[, byteOffset\[, shape]]\[, options] )

--- a/lib/node_modules/@stdlib/ndarray/matrix/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/matrix/complex128/docs/types/index.d.ts
@@ -443,7 +443,7 @@ interface Complex128Matrix {
 	* var ArrayBuffer = require( '@stdlib/array/buffer' );
 	*
 	* var buf = new ArrayBuffer( 64 );
-	* var arr = new Complex128Matrix( buf, 16, [ 2, 1 ] );
+	* var arr = new Complex128Matrix( buf, 16, 2, 1 );
 	* // returns <ndarray>
 	*
 	* var sh = getShape( arr );

--- a/lib/node_modules/@stdlib/ndarray/matrix/complex64/README.md
+++ b/lib/node_modules/@stdlib/ndarray/matrix/complex64/README.md
@@ -118,7 +118,7 @@ var sh = getShape( arr );
 
 The function accepts the following arguments:
 
--   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array- like objects, each of which must have the same number of elements.
+-   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array-like objects, each of which must have the same number of elements.
 -   **options**: function options. See above.
 
 #### Complex64Matrix( buffer\[, byteOffset\[, shape]]\[, options] )

--- a/lib/node_modules/@stdlib/ndarray/matrix/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/matrix/complex64/docs/types/index.d.ts
@@ -443,7 +443,7 @@ interface Complex64Matrix {
 	* var ArrayBuffer = require( '@stdlib/array/buffer' );
 	*
 	* var buf = new ArrayBuffer( 64 );
-	* var arr = new Complex64Matrix( buf, 16, [ 2, 1 ] );
+	* var arr = new Complex64Matrix( buf, 16, 2, 1 );
 	* // returns <ndarray>
 	*
 	* var sh = getShape( arr );

--- a/lib/node_modules/@stdlib/ndarray/matrix/ctor/README.md
+++ b/lib/node_modules/@stdlib/ndarray/matrix/ctor/README.md
@@ -161,7 +161,7 @@ var sh2 = getShape( arr2 );
 
 The function accepts the following arguments:
 
--   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array- like objects, each of which must have the same number of elements.
+-   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array-like objects, each of which must have the same number of elements.
 -   **dtype**: [data type][@stdlib/ndarray/dtypes].
 -   **options**: function options. See above.
 

--- a/lib/node_modules/@stdlib/ndarray/matrix/float32/README.md
+++ b/lib/node_modules/@stdlib/ndarray/matrix/float32/README.md
@@ -116,7 +116,7 @@ var sh = getShape( arr );
 
 The function accepts the following arguments:
 
--   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array- like objects, each of which must have the same number of elements.
+-   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array-like objects, each of which must have the same number of elements.
 -   **options**: function options. See above.
 
 #### Float32Matrix( buffer\[, byteOffset\[, shape]]\[, options] )

--- a/lib/node_modules/@stdlib/ndarray/matrix/float32/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/matrix/float32/docs/types/index.d.ts
@@ -443,7 +443,7 @@ interface Float32Matrix {
 	* var ArrayBuffer = require( '@stdlib/array/buffer' );
 	*
 	* var buf = new ArrayBuffer( 32 );
-	* var arr = new Float32Matrix( buf, 8, [ 2, 1 ] );
+	* var arr = new Float32Matrix( buf, 8, 2, 1 );
 	* // returns <ndarray>
 	*
 	* var sh = getShape( arr );

--- a/lib/node_modules/@stdlib/ndarray/matrix/float64/README.md
+++ b/lib/node_modules/@stdlib/ndarray/matrix/float64/README.md
@@ -116,7 +116,7 @@ var sh = getShape( arr );
 
 The function accepts the following arguments:
 
--   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array- like objects, each of which must have the same number of elements.
+-   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array-like objects, each of which must have the same number of elements.
 -   **options**: function options. See above.
 
 #### Float64Matrix( buffer\[, byteOffset\[, shape]]\[, options] )

--- a/lib/node_modules/@stdlib/ndarray/matrix/float64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/matrix/float64/docs/types/index.d.ts
@@ -443,7 +443,7 @@ interface Float64Matrix {
 	* var ArrayBuffer = require( '@stdlib/array/buffer' );
 	*
 	* var buf = new ArrayBuffer( 32 );
-	* var arr = new Float64Matrix( buf, 8, [ 2, 1 ] );
+	* var arr = new Float64Matrix( buf, 8, 2, 1 );
 	* // returns <ndarray>
 	*
 	* var sh = getShape( arr );

--- a/lib/node_modules/@stdlib/ndarray/matrix/int32/README.md
+++ b/lib/node_modules/@stdlib/ndarray/matrix/int32/README.md
@@ -116,7 +116,7 @@ var sh = getShape( arr );
 
 The function accepts the following arguments:
 
--   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array- like objects, each of which must have the same number of elements.
+-   **obj**: array-like object or iterable from which to generate an [ndarray][@stdlib/ndarray/ctor]. If an array-like object, the value must be a nested array (i.e., an array-like object of array-like objects), where each nested array must have the same number of elements. If an iterable, the iterable must return array-like objects, each of which must have the same number of elements.
 -   **options**: function options. See above.
 
 #### Int32Matrix( buffer\[, byteOffset\[, shape]]\[, options] )

--- a/lib/node_modules/@stdlib/ndarray/matrix/int32/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/matrix/int32/docs/types/index.d.ts
@@ -443,7 +443,7 @@ interface Int32Matrix {
 	* var ArrayBuffer = require( '@stdlib/array/buffer' );
 	*
 	* var buf = new ArrayBuffer( 32 );
-	* var arr = new Int32Matrix( buf, 8, [ 2, 1 ] );
+	* var arr = new Int32Matrix( buf, 8, 2, 1 );
 	* // returns <ndarray>
 	*
 	* var sh = getShape( arr );

--- a/lib/node_modules/@stdlib/number/uint64/ctor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/ctor/docs/types/index.d.ts
@@ -124,7 +124,7 @@ declare class Uint64 {
 	/**
 	* Returns the low 32-bit word of a 64-bit unsigned integer.
 	*
-	* @returns high word (32-bit unsigned integer)
+	* @returns low word (32-bit unsigned integer)
 	*
 	* @example
 	* var x = Uint64.from( [ 1, 2 ] );


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-06-25 19:40 UTC and 2026-06-26 08:21 UTC (SHA range `a8789cce9..ba7afec2a`, 22 commits reviewed).

This pull request:

-   Fixes a copy-paste typo and twelve propagated documentation issues introduced by the new `ndarray/matrix/{float64,float32,complex64,complex128,int32}` packages, the `ndarray/matrix/ctor` README expansion, and the `number/uint64/ctor` `toPrimitive` addition.

### Fixes by package

**`number/uint64/ctor`**

-   Fix `@returns` description for the `lo` accessor in `lib/node_modules/@stdlib/number/uint64/ctor/docs/types/index.d.ts` — copy-pasted from `hi`, causing it to read "high word" instead of "low word" (`a8789cc`).

**`ndarray/matrix/ctor`**

-   Fix stray space in compound adjective `array- like` → `array-like` in `ndarray/matrix/ctor/README.md` (`7ff0456`).

**`ndarray/matrix/complex128`**

-   Correct the `@example` for the `(buffer, byteOffset, M, N, options?)` overload in `ndarray/matrix/complex128/docs/types/index.d.ts` — copy-pasted from the shape-based overload and erroneously passed `[ 2, 1 ]` instead of the scalar arguments `2, 1` (`6e71938`).
-   Fix stray space in compound adjective `array- like` → `array-like` in `ndarray/matrix/complex128/README.md` (`56ffe96`).

**`ndarray/matrix/complex64`**

-   Correct the `@example` for the `(buffer, byteOffset, M, N, options?)` overload in `ndarray/matrix/complex64/docs/types/index.d.ts` — copy-pasted from the shape-based overload and erroneously passed `[ 2, 1 ]` instead of the scalar arguments `2, 1` (`117fe75`).
-   Fix stray space in compound adjective `array- like` → `array-like` in `ndarray/matrix/complex64/README.md` (`56ffe96`).

**`ndarray/matrix/float32`**

-   Correct the `@example` for the `(buffer, byteOffset, M, N, options?)` overload in `ndarray/matrix/float32/docs/types/index.d.ts` — copy-pasted from the shape-based overload and erroneously passed `[ 2, 1 ]` instead of the scalar arguments `2, 1` (`d93e3df`).
-   Fix stray space in compound adjective `array- like` → `array-like` in `ndarray/matrix/float32/README.md` (`56ffe96`).

**`ndarray/matrix/float64`**

-   Correct the `@example` for the `(buffer, byteOffset, M, N, options?)` overload in `ndarray/matrix/float64/docs/types/index.d.ts` — copy-pasted from the shape-based overload and erroneously passed `[ 2, 1 ]` instead of the scalar arguments `2, 1` (`af1484d`).
-   Fix stray space in compound adjective `array- like` → `array-like` in `ndarray/matrix/float64/README.md` (`56ffe96`).

**`ndarray/matrix/int32`**

-   Correct the `@example` for the `(buffer, byteOffset, M, N, options?)` overload in `ndarray/matrix/int32/docs/types/index.d.ts` — copy-pasted from the shape-based overload and erroneously passed `[ 2, 1 ]` instead of the scalar arguments `2, 1` (`03d3cb0`).
-   Fix stray space in compound adjective `array- like` → `array-like` in `ndarray/matrix/int32/README.md` (`56ffe96`).

## Related Issues

None.

## Questions

No.

## Other

### Validation

Audited 22 commits merged to `develop` in the last 24 hours via four parallel reviewers (two style-compliance, two correctness-focused bug scans). Each finding was independently re-verified by reading the modified files before inclusion.

Checked:

-   stdlib code style guide compliance (`docs/style-guides/{javascript,c,text}`)
-   Obvious correctness bugs in the introduced code
-   Documentation that contradicts the implementation it documents
-   Typos in identifiers, user-visible strings, and docs

Deliberately excluded (would have required interpretation or out-of-window changes):

-   Subjective preferences and "could be cleaner" suggestions
-   Concerns whose validation needed touching code outside the 24-hour window
-   One reviewer-flagged "alphabetical-ordering violation" in `ndarray/matrix/lib/index.js`: dropped after verifying that stdlib's established convention for typed namespaces (see `ndarray/vector/lib/index.js`) orders type-size digits numerically (Complex64 before Complex128, `vector` between Complex128 and Float32), so the current order is correct.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was generated by a scheduled review routine running on Claude Code. The routine enumerated commits merged to `develop` in the last 24 hours, dispatched four parallel reviewer agents to surface issues, filtered out single-agent findings that could not be independently re-verified by re-reading the diff, and applied only the validated typo fixes listed above. Each fix was re-read after application to confirm it matched the proposed change exactly; no code outside the diff window was touched. Left in draft for human audit.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017WrBiRDyQFC5MxT51h8SAC)_