### PR TITLE
chore: align `stats/base/dists/lognormal` log* package descriptions with namespace majority

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/lognormal/logcdf",
   "version": "0.0.0",
-  "description": "Natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution.",
+  "description": "Lognormal distribution logarithm of cumulative distribution function (CDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/lognormal/logpdf",
   "version": "0.0.0",
-  "description": "Natural logarithm of the probability density function (PDF) for a lognormal distribution.",
+  "description": "Lognormal distribution logarithm of probability density function (PDF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

Aligning outliers in `stats/base/dists/lognormal` with namespace majority patterns (random namespace pick, seed `2796326358`).

### Namespace summary

- **Target:** `@stdlib/stats/base/dists/lognormal`
- **Members analyzed:** 14 (`cdf`, `ctor`, `entropy`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `median`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`)
- **Features analyzed:** file tree, `package.json` top-level keys, `package.json` `description`, `package.json` `keywords`, README section sequence, `manifest.json` top-level keys, test/benchmark/examples filenames, public signature sequence, return kind, validation prologue sequence, error construction, JSDoc shape (`@param`/`@returns`/`@throws`/`@example`), dependency set from `lib/main.js` `require` calls, REPL signature and section list, TypeScript declarations shape.
- **Features with clear majority (≥75% conformance):** `package.json` top-level key set (18 keys, 100%); `package.json` `directories` keys (100%); REPL section list `Parameters` / `Returns` / `Examples` / `See Also` (100%); `returnKind` `value` (100%); `mu` `@param` type `number` (100%); JSDoc `@example` presence (100%); `errorConstruction` `none` (13/14 = 92.9% — `ctor` legitimately throws); `sigma` `@param` type `PositiveNumber` (13/14 = 92.9%); `package.json` `description` `"Lognormal distribution {noun}."` form (12/14 = 85.7%); `test/fixtures/julia/REQUIRE` + `runner.jl` (12/14 = 85.7%).
- **Features without clear majority (excluded from drift detection):** native-bindings file group (`manifest.json`, `binding.gyp`, `include.gypi`, `src/**`, `lib/native.js`, `benchmark/c/**`, `benchmark/benchmark.native.js`, `examples/c/**`, `test/test.native.js`) at 10/14 = 71.4%; `gypfile` `package.json` key at 10/14 = 71.4%; `## C APIs` README section / `### Usage` / `### Examples` C subsections at 10/14 = 71.4%; `lib/factory.js` + `test/test.factory.js` at 5/14 = 35.7% (cleanly tied to input-arity packages); `dtsExportShape` (8 `function`, 5 `interface+var`, 1 `class` — split by arity); `returnsTag.type` (6 `NonNegativeNumber`, 6 `number`, 1 `Probability`, 1 `LogNormal` — semantically determined per function); `moduleJsdocSummary` pattern (9 `"Lognormal distribution..."`, 5 `"Evaluate..."` — split by function class); validation-prologue sequence (no single subsequence ≥ 75%, the four function classes — pure stats / `(x|p, mu, sigma)` evaluators / delegating wrappers / constructor — each justify a distinct prologue).

### `stats/base/dists/lognormal/logcdf`

Fixes description drift in `@stdlib/stats/base/dists/lognormal/logcdf` relative to both its namespace and the wider distributions ecosystem. Aligns with the `"Lognormal distribution {noun}."` form used by 12/14 namespace siblings (85.7%) and the `"{Dist} distribution logarithm of cumulative distribution function (CDF)."` template used across `exponential`, `gamma`, `beta`, `gumbel`, `laplace`, `logistic`, `rayleigh`, and `weibull`. Metadata-only change; no source, test, or behavioral changes.

### `stats/base/dists/lognormal/logpdf`

Aligns the `@stdlib/stats/base/dists/lognormal/logpdf` `package.json` description with the ecosystem template `"{Dist} distribution logarithm of probability density function (PDF)."`, used by 7 of 9 sibling distributions checked (`gamma`, `beta`, `gumbel`, `laplace`, `logistic`, `rayleigh`, `weibull`). Also conforms to the within-namespace `"Lognormal distribution {noun}."` form shared by 12/14 siblings (85.7%). Metadata-only change; no source, test, or behavioral modifications.

### Validation

Checked:

- structural feature extraction (file tree, `package.json` shape, README section list, `manifest.json` shape, test/benchmark/example filenames) across all 14 members.
- semantic feature extraction (public signature, validation prologue, error construction, JSDoc shape, dependency set, REPL signature/sections, TypeScript declaration shape, `package.json` `description`/`keywords`) across all 14 members by reading each `lib/main.js`, `lib/index.js`, `lib/factory.js` (where present), `docs/types/index.d.ts`, `docs/repl.txt`, and `package.json` directly.
- three-agent drift validation:
  - opus semantic-review judged each candidate semantic outlier and confirmed both `logcdf` and `logpdf` description deviations are stylistic — inherited from `normal/logcdf`/`logpdf` — with no behavioral basis.
  - opus cross-reference confirmed the verbatim description strings appear only in the respective `package.json` (and `logcdf`'s `lib/index.js` JSDoc, which retains the same `@module` summary across the wider ecosystem). No tests, examples, or sibling-package documentation references them.
  - sonnet structural-review confirmed by reading `exponential`, `gamma`, `laplace`, and `weibull` siblings that the proposed template matches the dominant ecosystem convention.

Deliberately excluded:

- `logcdf` `sigma` `@param` type `NonNegativeNumber` (vs. 13/14 majority `PositiveNumber`). Marked **intentional deviation**: `logcdf` delegates to `normal/logcdf` without a `sigma <= 0.0` NaN guard and documents `logcdf( 2.0, 8.0, 0.0 ) === -Infinity` as supported behavior; changing the annotation to `PositiveNumber` would mis-document the contract, and adding a guard would alter observable behavior.
- `logcdf`/`stdev` empty validation prologue (vs. ~12/14 members with the `isnan(mu) || isnan(sigma) || sigma <= 0.0 → NaN` prologue). Marked **intentional deviation**: `stdev` delegates to `variance` (`sqrt(NaN) === NaN` preserves behavior); `logcdf` delegates to `normal/logcdf`.
- `logcdf` `test/fixtures/r/` (vs. 12/14 with `test/fixtures/julia/`). Marked **intentional deviation**: package uses an R reference toolchain instead of Julia; switching fixture generators is out of scope.
- `ctor` `errorConstruction: format`, optional-parameter signature, `class` TypeScript shape, `## lognormal` / `### Writable Properties` / `### Computed Properties` / `### Methods` README structure, and missing native bindings. Marked **intentional deviation**: a class constructor's documentation and validation surface legitimately differs from value-returning siblings.
- Native-bindings file group (`manifest.json`, `binding.gyp`, `src/`, `lib/native.js`, `benchmark/c/`, `examples/c/`, `test/test.native.js`) at 10/14 = 71.4% — below the 75% threshold and excluded from drift detection. Open PRs #10809, #10881, #10882, #10883 are independently adding C implementations for `cdf`, `logpdf`, `logcdf`, and a second `cdf` PR — no overlap with this run.
- `moduleJsdocSummary` and JSDoc `@returns` description style. Cross-distribution ecosystem still mixes `"{Dist} distribution natural logarithm of..."` (gamma, gumbel, laplace, logistic, rayleigh, weibull) with `"Natural logarithm of... for a {Dist} distribution."` (normal, lognormal, exponential `logpdf`, beta `Evaluate the natural logarithm of...`). No dominant ecosystem template; out of scope for a high-signal correction.
- Keyword arrays — outliers exist but reflect genuine differences in mathematical surface (`bell-shape` on `logcdf`, distinct moment-context terms on summary-statistic packages); none ≥75%-vs-namespace-majority drift.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

Random namespace pick, seed `2796326358`. Eligibility criteria: ≥8 non-autogenerated direct child packages. The chosen namespace had no autogenerated members, so the full membership is in scope.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine: structural and semantic features were extracted from every member of `stats/base/dists/lognormal`, majority patterns were computed at a 75% conformance threshold, and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed each correction was high-signal mechanical drift before any file was edited. All edits are pure `package.json` `description` rewrites; no source, test, or behavioral changes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_016MpvUVp4pvm7okW5UysayX)_