### PR TITLE
refactor: rename internal variable

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request renames the `lib/index.js` local variable that holds the `require( './main.js' )` result from the function name to `main` in three outlier packages under `@stdlib/stats/base/dists/bernoulli`. Purely internal rename; no source, signature, JSDoc, test, or behavioral change.

### Namespace summary

- **Target:** `@stdlib/stats/base/dists/bernoulli`
- **Members analyzed:** 13 (`cdf`, `ctor`, `entropy`, `kurtosis`, `mean`, `median`, `mgf`, `mode`, `pmf`, `quantile`, `skewness`, `stdev`, `variance`)
- **Features with a clear majority (≥75%):** file tree (12/13 outside `ctor`, which is a constructor class and legitimately omits the native-binding cluster), `package.json` top-level shape, `directories`, `manifest.json` keys (`confs` / `fields` / `options`), `binding.gyp` / `include.gypi` / `src/main.c` / `src/addon.c` / `lib/native.js` / `examples/c/` / `benchmark/c/` presence, the 10 shared keywords (`stdlib`, `stdmath`, `statistics`, `stats`, `distribution`, `dist`, `bernoulli`, `binomial`, `discrete`, `univariate`), README `## Usage` / `## Examples` / `## C APIs` / `### Usage` / `### Examples` section sequence, `lib/main.js` validation prologue (`isnan(p) || p < 0.0 || p > 1.0 → NaN`), `lib/main.js` error construction (no errors thrown — all surface invalid input as `NaN`), JSDoc `@param {Probability} p - success probability` convention, and the `var main = require( './main.js' )` `lib/index.js` entry-point convention (10/13 = 77% within bernoulli; 412/507 = 81% across `@stdlib/stats/base/dists`).
- **Features without a clear majority (excluded):** `lib/factory.js` presence (4/13, tracks whether the function takes a non-distribution argument — `cdf`, `mgf`, `pmf`, `quantile`); `test/fixtures/julia/data.json` (7/13, only the closed-form summary stats carry it); `## Notes` README section (1/13 — `mode/README.md` has it because `p = 0.5` legitimately needs a tie-break note); `factory.js` validation-prologue style (2 single-line vs. 2 stacked, no majority either way); `'parameter'` keyword (8/13, tracks the summary-stat sub-cluster). Surfaced but intentionally deviating: `ctor` (constructor class, no native binding); `stdev` (delegates validation to `variance`; uses Python fixtures instead of Julia — porting the reference data is not mechanical and is out of scope).

### `@stdlib/stats/base/dists/bernoulli/mean`

Renames the `lib/index.js` local-variable holding `require( './main.js' )` from `mean` to `main` to match the namespace majority (10/13 = 77%) and the wider ecosystem (412/507 = 81% across `@stdlib/stats/base/dists`). The `module.exports` reference is updated correspondingly. JSDoc `@example` block — which intentionally uses `var mean = require( '@stdlib/stats/base/dists/bernoulli/mean' );` to model consumer code — is left untouched.

### `@stdlib/stats/base/dists/bernoulli/median`

Same rename, applied to `lib/index.js` of `@stdlib/stats/base/dists/bernoulli/median`. The variable in `MODULES` and the value passed to `module.exports` switch from `median` to `main`; the JSDoc `@example` block keeps the consumer-facing `var median = require( '@stdlib/stats/base/dists/bernoulli/median' );` form.

### `@stdlib/stats/base/dists/bernoulli/mode`

Same rename, applied to `lib/index.js` of `@stdlib/stats/base/dists/bernoulli/mode`. Variable in `MODULES` and `module.exports` switch from `mode` to `main`; consumer-facing `@example` block is untouched.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Checked:

- **Structural feature extraction** across all 13 members: file tree, `package.json` shape (top-level keys, `scripts`, `directories`, `keywords`, `stdlib`), `manifest.json` keys, README `##` / `###` heading set and sequence, `lib/`, `src/`, `test/`, `benchmark/`, `examples/`, `docs/`, `binding.gyp`, `include.gypi`, Makefile EOF conventions.
- **Semantic feature extraction** across all 13 `lib/main.js`, `lib/index.js`, and `lib/factory.js` (where present) files: public signature, return kind, validation prologue, error construction style, JSDoc tag set, `require()`-derived dependencies. Performed by direct file inspection rather than per-package agents — the namespace has 13 members and every `lib/main.js` follows the same `isnan(p) || p < 0.0 || p > 1.0 → NaN` prologue with no thrown errors, so the agent layer would not surface additional drift.
- **Three-agent drift validation** on the surviving correction. The `lib/index.js` variable name is a purely structural feature; Agent 1 (semantic-review) skipped per policy. Agent 2 (cross-reference): tests import via `require( './../lib' )` and consume only `module.exports`; no test, example, or sibling package code references the local variable name. Agent 3 (structural-review): confirmed `main` as the convention via 77% within-namespace and 81% wider-`stats/base/dists` conformance.
- **Cross-run dedup:** searched open PRs (`is:open bernoulli`) and PRs merged in the last 14 days (`is:merged bernoulli merged:>2026-06-13`); none touch the three `lib/index.js` files modified here.

Deliberately excluded:

- **`ctor`'s missing native-binding cluster** (`binding.gyp`, `src/`, `include/`, `manifest.json`, `lib/native.js`, `examples/c/`, `benchmark/c/`, `test/test.native.js`, `## C APIs` README section). `ctor` is the distribution constructor class, not a math function; it has no C analog. Intentional deviation, not drift.
- **`stdev`'s Python vs. Julia test fixtures.** All 11 other summary-stat packages use `test/fixtures/julia/`; `stdev` uses `test/fixtures/python/`. Porting the reference data requires re-generating it via Julia and rewriting the test loader — not a mechanical edit. Flagged for a future routine.
- **`stdev`'s missing validation prologue.** `stdev/lib/main.js` is `sqrt( variance( p ) )` and inherits NaN propagation from `variance`. Intentional delegation, not drift.
- **`lib/factory.js` presence** (4/13). Tracks whether the function takes a non-distribution argument (`cdf`, `mgf`, `pmf`, `quantile`); not a drift-correctable feature.
- **`mode`'s `## Notes` README section.** `mode(0.5)` is a legitimate tie between `0` and `1`; the implementation returns `0` and the note documents that. Intentional content, not drift.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine. The target namespace `@stdlib/stats/base/dists/bernoulli` was selected by uniform-random pick over the 123 eligible directories (≥8 direct child packages with `package.json` under `lib/node_modules/@stdlib/`). Structural and semantic features were extracted from all 13 members, majority patterns were computed at the 75% conformance threshold, and the surviving correction was validated against the namespace, the wider `stats/base/dists` ecosystem, and open/recent PRs before any file was edited. Each rename is a two-line in-file substitution; no source behavior, JSDoc, test, or generator output is touched.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1SW3qj8nEeCmScrpDfNMc)_