### PR TITLE
fix: add missing keywords to dxmy package

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dxmy/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dxmy/package.json
@@ -63,6 +63,8 @@
     "algebra",
     "subroutines",
     "multiply",
+    "multiplication",
+    "hadamard",
     "transform",
     "strided",
     "array",


### PR DESCRIPTION
## Description

Daily automated diff review (2026-06-27) of the 14 commits merged to `develop` in the last 24 hours.

**Review scope:** `dxmy`, `sxmy`, `glast-index-of-falsy` (new packages), namespace TS declaration updates, `ndarray/matrix` doc fixes, build-system guard additions, and miscellaneous housekeeping.

**Finding:** `@stdlib/blas/ext/base/dxmy` is missing the `multiplication` and `hadamard` keywords that the sibling `@stdlib/blas/ext/base/sxmy` package includes. Both packages implement the same element-wise multiplication (Hadamard product) for different floating-point precisions (`float64` vs `float32`), so their keyword sets should be consistent.

**Changes in this PR:**

- `lib/node_modules/@stdlib/blas/ext/base/dxmy/package.json`: add `"multiplication"` and `"hadamard"` keywords between `"multiply"` and `"transform"` to match `sxmy/package.json`.

## Related Issues

No.

## Questions

No.

## Other

**Review results — all other areas clean:**

- `dxmy`/`sxmy` JS and C implementations: loop unrolling, stride/offset logic, return values — correct
- `dxmy`/`sxmy` REPL examples and `// returns` annotations — math verified correct
- `sxmy` has no `float64`/`dxmy` copy-paste leaks
- `glast-index-of-falsy` reversed-stride delegation to `gindexOfFalsy` and `N-1-idx` index conversion — correct; no "truthy" copy-paste leaks
- `blas/ext/base` namespace TS declarations: alphabetical insertion, JSDoc descriptions, return types — correct
- `ndarray/matrix` namespace import ordering (`Complex64` before `Complex128`) — matches established `ndarray/vector` convention
- `number/uint64/ctor` TSDoc fix (`high word` → `low word` for `.lo`) — correct
- Bernoulli `mean`/`median`/`mode` → `main` variable renames — correct
- Makefile C-guard additions — correct

**Validation:** style-guide compliance audit and bug scan across 14 commits; deliberately excluded subjective preferences and any concern requiring context outside the diff window.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code: the 14 commits merged to `develop` in the prior 24h were reviewed by four parallel subagents (two style auditors against `docs/style-guides` and sibling reference packages, two bug hunters), findings cross-verified before applying any change. The single surviving fix — adding the missing `multiplication` and `hadamard` keywords to `dxmy/package.json` to match its `sxmy` sibling — is metadata-only.

* * *

@stdlib-js/reviewers