### PR TITLE
refactor: rename internal variable

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/median/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/mode/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/median/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/entropy/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/entropy/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var entropy = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = entropy;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/stdev/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/stdev/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var stdev = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = stdev;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/variance/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/variance/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var variance = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = variance;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mode/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/f/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/f/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/mode/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/mode/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/median/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/mode/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/median/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/median/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mode/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/median/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/kurtosis/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/kurtosis/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var kurtosis = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = kurtosis;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/mean/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/mode/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var skewness = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = skewness;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/variance/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/variance/lib/index.js
@@ -35,9 +35,9 @@
 
 // MODULES //
 
-var variance = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = variance;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mean = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mean;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/median/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/median/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var median = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = median;
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mode/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var mode = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = mode;
+module.exports = main;


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between `7dc98086` (2026-06-26 13:30 -0500) and `8433af0a` (2026-06-27 05:54 -0500) to sibling packages with the same underlying defect.

### Pattern: rename `./main.js`-bound variable to `main` in `stats/base/dists/*` index files

Source commit `4a927afa` renamed the local variable bound to `require( './main.js' )` from the stat-function name (`mean`, `median`, `mode`) to the conventional `main` across three `stats/base/dists/bernoulli/*` `lib/index.js` files, with the corresponding `module.exports` update. The identical drift exists in 92 sibling `lib/index.js` files across `stats/base/dists/*`. Each is a pure straight-through index module (single require of `./main.js`, single export, no conditional `builtin`/`polyfill`/`native` fallback), so the rename is a two-line mechanical edit per file with no semantic impact.

- `4a927afa` ([`refactor: rename internal variable`](https://github.com/stdlib-js/stdlib/commit/4a927afaffbf44d28e2ac942fb5b6cfbe1455e35))
  - `@stdlib/stats/base/dists/anglit` (mean, median)
  - `@stdlib/stats/base/dists/arcsine` (mean, median, mode)
  - `@stdlib/stats/base/dists/beta` (mean, median, mode)
  - `@stdlib/stats/base/dists/betaprime` (mean, mode)
  - `@stdlib/stats/base/dists/binomial` (mean, median, mode)
  - `@stdlib/stats/base/dists/bradford` (entropy, mean, median, mode, stdev, variance)
  - `@stdlib/stats/base/dists/cauchy` (median, mode)
  - `@stdlib/stats/base/dists/chi` (mean, mode)
  - `@stdlib/stats/base/dists/cosine` (mean, median, mode)
  - `@stdlib/stats/base/dists/degenerate` (mean, median, mode)
  - `@stdlib/stats/base/dists/discrete-uniform` (mean, median)
  - `@stdlib/stats/base/dists/erlang` (mean, mode)
  - `@stdlib/stats/base/dists/exponential` (mean, median, mode)
  - `@stdlib/stats/base/dists/f` (mean, mode)
  - `@stdlib/stats/base/dists/gamma` (mean, mode)
  - `@stdlib/stats/base/dists/geometric` (mean, median, mode)
  - `@stdlib/stats/base/dists/gumbel` (mean, median, mode)
  - `@stdlib/stats/base/dists/halfnormal` (mean, mode)
  - `@stdlib/stats/base/dists/hypergeometric` (mean, mode)
  - `@stdlib/stats/base/dists/invgamma` (mean, mode)
  - `@stdlib/stats/base/dists/kumaraswamy` (mean, median, mode)
  - `@stdlib/stats/base/dists/laplace` (mean, median, mode)
  - `@stdlib/stats/base/dists/levy` (mean, median, mode)
  - `@stdlib/stats/base/dists/logistic` (mean, median, mode)
  - `@stdlib/stats/base/dists/negative-binomial` (mean, mode)
  - `@stdlib/stats/base/dists/normal` (mean, median, mode)
  - `@stdlib/stats/base/dists/pareto-type1` (median)
  - `@stdlib/stats/base/dists/planck` (mean, median, mode)
  - `@stdlib/stats/base/dists/poisson` (mean, median, mode)
  - `@stdlib/stats/base/dists/rayleigh` (mean, median, mode)
  - `@stdlib/stats/base/dists/triangular` (mean, median, mode)
  - `@stdlib/stats/base/dists/uniform` (mean, median)
  - `@stdlib/stats/base/dists/wald` (kurtosis, mean, mode, skewness, variance)
  - `@stdlib/stats/base/dists/weibull` (mean, median, mode)

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Search scope:** scoped to `lib/node_modules/@stdlib/stats/base/dists/**/lib/index.js`, matching the source commit's namespace. Sibling `lib/index.js` files outside `stats/base/dists` were not searched — the variable-name convention is package-local and the source commit's intent is the dists-specific consistency cleanup.
- **Two independent opus validation passes** confirmed at every candidate site that (a) the file has exactly one `var <varname> = require( './main.js' );` and one matching `module.exports = <varname>;`, (b) the variable is never referenced elsewhere in the file (no property attachment, no `setReadOnly`, no third reference), and (c) the file does not also conditionally require `./builtin.js`, `./polyfill.js`, or `./native.js`. All 92 sites returned `confirmed` from both passes.
- **A sonnet style-consistency pass** verified the existing whitespace and parenthesisation in the require and export lines match the source commit's canonical form across a stratified sample of 12 distributions, so the rename will not look out of place.

Deliberately excluded:

- The `f9377d11` `@example`-block consolidation pattern from `string/base/stickycase`: searched the sibling `string/base/*` namespace and found no other `lib/index.js` with two or more `@example` blocks sharing the same require line — the source fix was a one-off within scope.
- The `7dc98086` `array- like` line-wrap typo, wrong TypeScript example signature, and `@returns` description fixes: zero remaining occurrences after the source commit (typo fully swept), or single-file scope with no sibling structure.
- The `8433af0a` / `8e0d6442` Makefile guards in `tools/make/lib/examples/c.mk` and `tools/make/lib/benchmark/c.mk`: one-off build-script fixes, no sibling Makefile rule with the same skip-when-no-C-files defect.
- Autogenerated namespace-TOC and related-packages docs from the stdlib-bot commits: generator-owned files.
- `feat:` commits adding new APIs: out of scope for this routine.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two opus validation passes plus a sonnet style-consistency pass) before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01M5hEbJgCbSK3g6kidBXTDP)_