### PR TITLE
test: fix precision qualifier in test descriptions

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/phi/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/phi/test/test.js
@@ -34,7 +34,7 @@ tape( 'main export is a number', function test( t ) {
 	t.end();
 });
 
-tape( 'export is a double-precision floating-point number equal to 1.6180340051651', function test( t ) {
+tape( 'export is a single-precision floating-point number equal to 1.6180340051651', function test( t ) {
 	t.strictEqual( FLOAT32_PHI, float64ToFloat32( 1.618033988749895 ), 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/constants/float32/pi-squared/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/pi-squared/test/test.js
@@ -37,7 +37,7 @@ tape( 'main export is a number', function test( t ) {
 	t.end();
 });
 
-tape( 'export is a double-precision floating-point number equal to 9.869604110717773', function test( t ) {
+tape( 'export is a single-precision floating-point number equal to 9.869604110717773', function test( t ) {
 	t.strictEqual( FLOAT32_PI_SQUARED, 9.869604110717773, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
## Description

Cross-package drift analysis of `@stdlib/constants/float32` identified two test files whose second `tape` description says `double-precision floating-point number` instead of `single-precision`. Each is a one-word swap; the underlying assertions already verify the correct float32 value.

### `@stdlib/constants/float32/phi`

`test/test.js` line 37 described the export as a `double-precision floating-point number`, while the assertion compares `FLOAT32_PHI` against `float64ToFloat32( 1.618033988749895 )` — a single-precision value. Wording carried over from the float64 sibling test. 30 of 34 float32 packages that use the qualifier in their second `tape` description say `single-precision` (88% conformance); the only `double-precision` instances in the namespace were `phi` and `pi-squared`.

### `@stdlib/constants/float32/pi-squared`

`test/test.js` line 40 described the export as a `double-precision floating-point number`, while the assertion compares `FLOAT32_PI_SQUARED` against the literal `9.869604110717773` — the float32 rounding of π² (the float64 sibling carries `9.869604401089358`). Same shape as `phi`; same 88% conformance fix.

## Related Issues

None.

## Questions

No.

## Other

### Cross-run dedup

- Open PRs against `constants/float32`: #11769, #8981 — neither touches `phi/test/test.js` or `pi-squared/test/test.js`.
- Recently merged drift PRs against the same namespace: #12967 (`chore: update examples and add keyword`, merged 2026-06-21) — did not touch either file or the precision qualifier.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated cross-package API-drift detection run against the `@stdlib/constants/float32` namespace. Drift was identified by extracting structural and semantic features from every package, computing a per-feature majority pattern (≥75% threshold), and filtering candidate corrections through a three-agent validation pass (one opus semantic-review, one opus cross-reference, one sonnet structural-review). A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_0157cSPqrTU4tWtJ2fHr233e)_