### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/assert/has-arraybuffer-support/test/test.js
+++ b/lib/node_modules/@stdlib/assert/has-arraybuffer-support/test/test.js
@@ -54,8 +54,8 @@ tape( 'if `ArrayBuffer` is supported, detection result is `true`', function test
 		var out;
 		var i;
 
-		out = []; // we assume evenly divisible
-		for ( i = 0; i < len/8; i++ ) {
+		out = [];
+		for ( i = 0; i < len/8; i++ ) { // we assume `len` is evenly divisible by `8`
 			out.push( 0 );
 		}
 		out.byteLength = len;

--- a/lib/node_modules/@stdlib/assert/has-arraybuffer-support/test/test.js
+++ b/lib/node_modules/@stdlib/assert/has-arraybuffer-support/test/test.js
@@ -54,9 +54,9 @@ tape( 'if `ArrayBuffer` is supported, detection result is `true`', function test
 		var out;
 		var i;
 
-		out = new Array( len/8 ); // we assume evenly divisible
-		for ( i = 0; i < out.length; i++ ) {
-			out[ i ] = 0;
+		out = []; // we assume evenly divisible
+		for ( i = 0; i < len/8; i++ ) {
+			out.push( 0 );
 		}
 		out.byteLength = len;
 		return out;

--- a/lib/node_modules/@stdlib/object/deep-get/examples/index.js
+++ b/lib/node_modules/@stdlib/object/deep-get/examples/index.js
@@ -26,12 +26,12 @@ var keys;
 var val;
 var i;
 
-data = new Array( 100 );
-for ( i = 0; i < data.length; i++ ) {
-	data[ i ] = {
+data = [];
+for ( i = 0; i < 100; i++ ) {
+	data.push({
 		'x': Date.now(),
 		'y': [ randu(), randu(), i ]
-	};
+	});
 }
 
 keys = [ 0, 'y', 2 ];


### PR DESCRIPTION
Resolves #13173

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `stdlib/no-new-array` linting errors in `has-arraybuffer-support/test/test.js` and `deep-get/examples/index.js` by replacing `new Array()` constructors with array literals (`[]`) and `push()`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #13173

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I consulted an AI Coding Assistant to understand the codebase and the contribution guidelines, but the proposed changes were fully authored manually by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
