### PR TITLE
docs: add source section header

### DIFF
--- a/lib/node_modules/@stdlib/number/uint32/base/identity/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/identity/lib/main.js
@@ -18,6 +18,8 @@
 
 'use strict';
 
+// MAIN //
+
 /**
 * Evaluates the identity function for an unsigned 32-bit integer `x`.
 *


### PR DESCRIPTION
## Description

Inserts the missing `// MAIN //` section marker in `lib/main.js` of `@stdlib/number/uint32/base/identity`. The marker is present in 9/10 (90%) of sibling packages in the namespace; `identity` is the lone omission, despite already carrying the matching `// EXPORTS //` marker further down.

#### `number/uint32/base/identity`

Inserts the missing `// MAIN //` section marker in `lib/main.js`; 9/10 (90%) siblings in `number/uint32/base` already carry it, and the matching `// EXPORTS //` marker was already present. Comment-only diff (2 lines added), mirroring the correction landed in #13009 for `number/float64/base/identity`.

## Related Issues

No.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a scheduled cross-package drift-detection routine over `@stdlib/number/uint32/base`. The routine extracted structural and semantic features across all 10 members; the missing `// MAIN //` marker in `identity/lib/main.js` was the only feature with a clear majority (≥75%) that surfaced an actionable outlier. Three independent validation passes (semantic / cross-reference / structural) returned `confirmed-drift` before the fix was applied. A human maintainer should verify before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01B19cGgoPhbXB3xrWCKoTf4)_