### PR TITLE
chore: lower `engines.node` floor in two `_tools/github` packages

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/dependents-count/package.json
+++ b/lib/node_modules/@stdlib/_tools/github/dependents-count/package.json
@@ -34,7 +34,7 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=6",
+    "node": ">=0.10.0",
     "npm": ">2.7.0"
   },
   "os": [

--- a/lib/node_modules/@stdlib/_tools/github/dependents/package.json
+++ b/lib/node_modules/@stdlib/_tools/github/dependents/package.json
@@ -34,7 +34,7 @@
   "dependencies": {},
   "devDependencies": {},
   "engines": {
-    "node": ">=6",
+    "node": ">=0.10.0",
     "npm": ">2.7.0"
   },
   "os": [


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Lower `engines.node` from `">=6"` to `">=0.10.0"` in `@stdlib/_tools/github/dependents` and `@stdlib/_tools/github/dependents-count` to match the 91.3% sibling convention in the `@stdlib/_tools/github` namespace (21/23 packages) and the 99.7% stdlib-wide convention (5,741/5,759 `package.json` files). The two packages were added in 2022 with a `">=6"` floor that reflects no actual runtime requirement — their `lib/`, `bin/cli`, and `examples/` are pure ES5 (`var`, function declarations, no template literals, no arrow functions, no destructuring, no `let`/`const`/`class`, no `Map`/`Set`/`Symbol`) and the only Node stdlib APIs they call (`https.request`, `setTimeout`, `Object.create`, `JSON.stringify`, `parseInt`) have been available since Node 0.10.

### Per outlier package

#### `_tools/github/dependents`

`engines.node` lowered to `">=0.10.0"`. The package scrapes GitHub's `network/dependents` HTML view via `https.request` and parses with `cheerio`; nothing in the request pipeline, the validation prologue, or the CLI uses syntax or APIs introduced after Node 0.10.

#### `_tools/github/dependents-count`

`engines.node` lowered to `">=0.10.0"`. The package is structurally the twin of `dependents` (same `defaults.js`, same `resolve.js`-style HTML traversal) and has the same runtime profile; the elevated floor was carried over from `dependents` without justification.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Cross-run dedup: no open PR proposes the same `engines.node` change to either package; PR #12320 (closed 2026-05-27) earlier addressed `@returns` JSDoc drift in the same namespace and did not touch `engines.node`. The full audit trail (per-feature majority computation, dropped candidates and rationale, random seed) is in the local report.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as a scheduled cross-package drift-detection routine targeting `@stdlib/_tools/github`. Structural features (file tree, `package.json` shape, `engines`, `directories`, `keywords`, README headings, `test/`/`benchmark/`/`examples/` filenames) were extracted across all 23 namespace members. `engines.node` surfaced as the only feature with a clean ≥75% majority where the outliers' deviation lacked any source-level justification. Three independent reviewer agents (opus semantic-review, opus cross-reference, sonnet structural-review) classified each correction in parallel before any file was edited; all three returned `confirmed-drift`. Diff is metadata-only — no source, test, behavioral, or documentation change. A maintainer should audit and promote out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQmCqjvVN7SREZPmiMMRfB)_