### PR TITLE
docs: rename link reference label

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mgf/README.md
@@ -20,13 +20,13 @@ limitations under the License.
 
 # Moment-Generating Function
 
-> [Degenerate][degenerate] distribution moment-generating function (MGF).
+> [Degenerate][degenerate-distribution] distribution moment-generating function (MGF).
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
 <section class="intro">
 
-The [moment-generating function][mgf] for a [degenerate][degenerate] random variable is
+The [moment-generating function][mgf] for a [degenerate][degenerate-distribution] random variable is
 
 <!-- <equation class="equation" label="eq:degenerate_mgf" align="center" raw="M_X(t) := e^{\mu t}" alt="Moment-generating function (MGF) of a degenerate distribution."> -->
 
@@ -59,7 +59,7 @@ var mgf = require( '@stdlib/stats/base/dists/degenerate/mgf' );
 
 #### mgf( t, mu )
 
-Evaluates the moment-generating function ([MGF][mgf]) of a [degenerate][degenerate] distribution with parameter `mu` (mean).
+Evaluates the moment-generating function ([MGF][mgf]) of a [degenerate][degenerate-distribution] distribution with parameter `mu` (mean).
 
 ```javascript
 var y = mgf( 1.0, 1.0 );
@@ -81,7 +81,7 @@ y = mgf( 0.0, NaN );
 
 #### mgf.factory( mu )
 
-Returns a function for evaluating the [moment-generating function][mgf] of a [degenerate][degenerate] distribution with parameter `mu` (mean).
+Returns a function for evaluating the [moment-generating function][mgf] of a [degenerate][degenerate-distribution] distribution with parameter `mu` (mean).
 
 ```javascript
 var mymgf = mgf.factory( 10.0 );
@@ -156,7 +156,7 @@ logEachMap( 'x: %0.4f, µ: %0.4f, M_X(t;µ): %0.4f', t, mu, mgf );
 
 #### stdlib_base_dists_degenerate_mgf( t, mu )
 
-Evaluates the moment-generating function ([MGF][mgf]) of a [degenerate][degenerate] distribution with parameter `mu` (mean).
+Evaluates the moment-generating function ([MGF][mgf]) of a [degenerate][degenerate-distribution] distribution with parameter `mu` (mean).
 
 ```c
 double out = stdlib_base_dists_degenerate_mgf( 1.0, 1.0 );
@@ -244,7 +244,7 @@ int main( void ) {
 
 <section class="links">
 
-[degenerate]: https://en.wikipedia.org/wiki/Degenerate_distribution
+[degenerate-distribution]: https://en.wikipedia.org/wiki/Degenerate_distribution
 
 [mgf]: https://en.wikipedia.org/wiki/Moment-generating_function
 


### PR DESCRIPTION
## Description

Renames the `[degenerate]` Markdown link reference label in `stats/base/dists/degenerate/mgf/README.md` to `[degenerate-distribution]` so the label matches the convention used by every other linked README in the namespace.

### Namespace summary

- Member count: 15 packages in `@stdlib/stats/base/dists/degenerate/` (no autogenerated members).
- Features analyzed: file tree, `package.json` shape, README section structure, README link references, test/benchmark/example file naming, public signatures, validation prologue, error construction, JSDoc shape, dependencies.
- Features with a clear majority (≥75%): file-tree skeleton, `package.json` top-level keys, README section structure, public signature shape (per package kind), error-construction pattern, JSDoc shape, README link-reference labels.
- Features excluded (no clear majority): keyword sets (`prob`/`probability` 8/15, `discrete` 7/15, `continuous` 5/15, `parameter` 6/15, `univariate` 7/15), README tagline phrasing (split between function-package and property-package conventions), validation-prologue contents (only `ctor` validates inputs by design).

### `stats/base/dists/degenerate/mgf`

Rename the `[degenerate]` Markdown link reference label to `[degenerate-distribution]`, matching the label used by the other 13 linked READMEs in `@stdlib/stats/base/dists/degenerate/`. Updates the label definition and its five inline references; target URL is unchanged.

## Related Issues

No.

## Questions

No.

## Other

### Validation

- Structural extraction enumerated every file, `package.json` key, README section, and test/benchmark/example name across all 15 packages.
- Semantic extraction ran a per-package agent over `lib/main.js`, `lib/index.js`, and `lib/validate.js` (when present) to capture signatures, validation prologue, error construction, JSDoc shape, and dependencies.
- Three-agent drift validation: opus semantic-review, opus cross-reference (which checks tests/examples/cross-package usage and the broader stdlib convention), and sonnet structural-review. All three confirmed the `mgf` link-reference rename as drift.
- One additional candidate (logpmf description sentence shape) was identified by local majority vote (14/15 within this namespace) but **dropped** after the cross-reference agent observed that the current `logpmf` wording matches the convention used by 6 of 8 `logpmf` packages across the broader `stats/base/dists/*` namespace; changing it would have moved `degenerate/logpmf` away from the ecosystem-wide convention. Logged in the local drift report.

Deliberately excluded:

- Intentional deviations on `ctor` (no native binding, distinct README sections, distinct test-file set) — by design, not drift.
- Keyword sets with no clear majority (no feature reached 12/15 threshold).
- Per-package test, header, and equation-image filenames (named by package, not drift).
- Autogenerated `## See Also` README sections.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a cross-package drift detection routine over the `stats/base/dists/degenerate` namespace. The routine extracted structural and semantic features from every package in the namespace, identified deviations from the local majority pattern, validated each candidate through three independent reviewer agents (semantic, cross-reference, structural), and dropped any candidate flagged as intentional, ecosystem-justified, or test-dependent. Only the high-signal, mechanical, behavior-preserving correction advanced. A human maintainer should audit before promoting this PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6h2erKUL5cXLQ1xwhV7Bp)_