### PR TITLE
fix: wire `blas/ext/base/sany` into parent namespace

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/README.md
@@ -244,6 +244,7 @@ var o = ns;
 -   <span class="signature">[`gxsy( N, x, strideX, y, strideY )`][@stdlib/blas/ext/base/gxsy]</span><span class="delimiter">: </span><span class="description">subtract elements of a strided array `y` from the corresponding elements of a strided array `x` and assign the results to `y`.</span>
 -   <span class="signature">[`gzeroTo( N, x, strideX )`][@stdlib/blas/ext/base/gzero-to]</span><span class="delimiter">: </span><span class="description">fill a strided array with linearly spaced numeric elements which increment by `1` starting from zero.</span>
 -   <span class="signature">[`ndarray`][@stdlib/blas/ext/base/ndarray]</span><span class="delimiter">: </span><span class="description">base ndarray extended BLAS functions.</span>
+-   <span class="signature">[`sany( N, x, strideX )`][@stdlib/blas/ext/base/sany]</span><span class="delimiter">: </span><span class="description">test whether at least one element in a single-precision floating-point strided array is truthy.</span>
 -   <span class="signature">[`sapx( N, alpha, x, strideX )`][@stdlib/blas/ext/base/sapx]</span><span class="delimiter">: </span><span class="description">add a scalar constant to each element in a single-precision floating-point strided array.</span>
 -   <span class="signature">[`sapxsum( N, alpha, x, strideX )`][@stdlib/blas/ext/base/sapxsum]</span><span class="delimiter">: </span><span class="description">add a scalar constant to each single-precision floating-point strided array element and compute the sum.</span>
 -   <span class="signature">[`sapxsumkbn( N, alpha, x, strideX )`][@stdlib/blas/ext/base/sapxsumkbn]</span><span class="delimiter">: </span><span class="description">add a scalar constant to each single-precision floating-point strided array element and compute the sum using an improved Kahan–Babuška algorithm.</span>
@@ -795,6 +796,8 @@ console.log( objectKeys( ns ) );
 [@stdlib/blas/ext/base/gzero-to]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/ext/base/gzero-to
 
 [@stdlib/blas/ext/base/ndarray]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/ext/base/ndarray
+
+[@stdlib/blas/ext/base/sany]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/ext/base/sany
 
 [@stdlib/blas/ext/base/sapx]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/ext/base/sapx
 

--- a/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
@@ -221,6 +221,7 @@ import gxsa = require( '@stdlib/blas/ext/base/gxsa' );
 import gxsy = require( '@stdlib/blas/ext/base/gxsy' );
 import gzeroTo = require( '@stdlib/blas/ext/base/gzero-to' );
 import ndarray = require( '@stdlib/blas/ext/base/ndarray' );
+import sany = require( '@stdlib/blas/ext/base/sany' );
 import sapx = require( '@stdlib/blas/ext/base/sapx' );
 import sapxsum = require( '@stdlib/blas/ext/base/sapxsum' );
 import sapxsumkbn = require( '@stdlib/blas/ext/base/sapxsumkbn' );
@@ -6213,6 +6214,36 @@ interface Namespace {
 	* Base ndarray extended BLAS functions.
 	*/
 	ndarray: typeof ndarray;
+
+	/**
+	* Tests whether at least one element in a single-precision floating-point strided array is truthy.
+	*
+	* ## Notes
+	*
+	* -   The function explicitly treats `NaN` values as falsy.
+	*
+	* @param N - number of indexed elements
+	* @param x - input array
+	* @param strideX - stride length
+	* @returns boolean indicating whether at least one element is truthy
+	*
+	* @example
+	* var Float32Array = require( '@stdlib/array/float32' );
+	*
+	* var x = new Float32Array( [ 0.0, 0.0, 1.0, 1.0 ] );
+	*
+	* var v = ns.sany( x.length, x, 1 );
+	* // returns true
+	*
+	* @example
+	* var Float32Array = require( '@stdlib/array/float32' );
+	*
+	* var x = new Float32Array( [ 0.0, 0.0, 1.0, 1.0 ] );
+	*
+	* var v = ns.sany.ndarray( x.length, x, 1, 0 );
+	* // returns true
+	*/
+	sany: typeof sany;
 
 	/**
 	* Adds a scalar constant to each element in a single-precision floating-point strided array.

--- a/lib/node_modules/@stdlib/blas/ext/base/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/lib/index.js
@@ -1846,6 +1846,15 @@ setReadOnly( ns, 'gzeroTo', require( '@stdlib/blas/ext/base/gzero-to' ) );
 setReadOnly( ns, 'ndarray', require( '@stdlib/blas/ext/base/ndarray' ) );
 
 /**
+* @name sany
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/blas/ext/base/sany}
+*/
+setReadOnly( ns, 'sany', require( '@stdlib/blas/ext/base/sany' ) );
+
+/**
 * @name sapx
 * @memberof ns
 * @readonly


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-06-28 17:09 UTC and 2026-06-29 09:22 UTC (`285b7819` → `6e441cc1`).

## Description

> What is the purpose of this pull request?

This pull request:

-   Wires the newly added `@stdlib/blas/ext/base/sany` package into the `blas/ext/base` parent namespace. The package directory landed in `6e441cc` but was never registered in the JS namespace index, the TypeScript declarations, or the README table of contents, so it was unreachable via `require('@stdlib/blas/ext/base')`, missing from the `Namespace` type, and absent from the namespace docs.

Findings (one commit, three additions, all under `lib/node_modules/@stdlib/blas/ext/base/`):

-   **JS namespace registration** (`6e441cc`) — `sany` was not wired into the namespace `lib/index.js` alongside its siblings; `require('@stdlib/blas/ext/base').sany` returned `undefined`. Touches `lib/node_modules/@stdlib/blas/ext/base/lib/index.js`.
-   **TypeScript declarations** (`591dea2`) — Auto-regen pulled in `dany`, `dlastIndexOfFalsy`, and `slastIndexOfFalsy` but dropped `sany`; added the missing import and `Namespace` member. Touches `lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts`.
-   **README table of contents** (`26d85f8`) — TOC regen included the three sibling entries but omitted the `sany` signature line and link reference. Touches `lib/node_modules/@stdlib/blas/ext/base/README.md`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

24h commit window audited (9 commits, `285b7819`..`6e441cc1`):

```
285b7819  chore: fix JavaScript lint errors
f29ec0b8  docs: add source section header
26d85f80  docs: update namespace table of contents
82e40221  docs: update REPL namespace documentation
591dea2e  feat: update `blas/ext/base` TypeScript declarations
e9f75542  docs: update related packages sections
ce4edb12  docs: add examples
7cdcb0a4  chore: fix JavaScript lint errors
6e441cc1  feat: add `blas/ext/base/sany`
```

**Validation:** Style-guide compliance (`docs/style-guides`) and bug-scan reviews were run in parallel; the only surviving high-signal issue was the missing `sany` wiring, independently identified by two reviewers and verified against the in-tree state of `blas/ext/base/lib/index.js`, the namespace TS declarations, and the README TOC. Bot-regenerated REPL data files under `@stdlib/repl/*/data/` are deliberately not touched here — they should follow from the usual regeneration pass once this lands.

**Deliberately excluded:**

-   `repl.txt` trailing-newline diff vs. older siblings (`snansum`, `sapxsum`): the most recent peer `dany/docs/repl.txt` uses the same single-trailing-newline form as `sany`, so this is current convention, not a violation.
-   Anything requiring touching code outside the diff window (e.g., REPL CSV/JSON regeneration).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was drafted by Claude Code as part of an automated 24-hour follow-up review of `develop`. A parallel panel of reviewer agents flagged the missing namespace wiring; the fix and PR body were generated by Claude and are pending human audit (the PR is intentionally left in draft state for a maintainer to promote).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019P9efrLvi3y6DoBNmiNdbx)_