### PR TITLE
fix: return 0 for constant input in `incr/skewness` and `incr/kurtosis`

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/kurtosis/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/kurtosis/lib/main.js
@@ -95,6 +95,10 @@ function incrkurtosis() {
 			if ( N < 4 ) {
 				return ( isnan( M4 ) ) ? NaN : null;
 			}
+			// When all provided values are equal, `M2` is zero, and the excess kurtosis is, by convention, zero:
+			if ( M2 === 0.0 ) {
+				return 0.0;
+			}
 			// Calculate the population excess kurtosis:
 			g2 = (( N*M4 ) / ( M2*M2 )) - 3.0;
 
@@ -121,6 +125,10 @@ function incrkurtosis() {
 		mean += deltaN;
 		if ( N < 4 ) {
 			return ( isnan( M4 ) ) ? NaN : null;
+		}
+		// When all provided values are equal, `M2` is zero, and the excess kurtosis is, by convention, zero:
+		if ( M2 === 0.0 ) {
+			return 0.0;
 		}
 		// Calculate the population excess kurtosis:
 		g2 = (N*M4 / ( M2*M2 )) - 3.0;

--- a/lib/node_modules/@stdlib/stats/incr/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/kurtosis/test/test.js
@@ -132,3 +132,17 @@ tape( 'if provided a `NaN`, the accumulator function returns `NaN` for all futur
 	t.strictEqual( isnan( acc() ), true, 'returns expected value' );
 	t.end();
 });
+
+tape( 'if provided all equal values, the accumulator function returns `0`', function test( t ) {
+	var kurtosis;
+	var acc;
+	var i;
+
+	acc = incrkurtosis();
+	for ( i = 0; i < 100; i++ ) {
+		kurtosis = acc( 10.0 );
+	}
+	t.strictEqual( kurtosis, 0.0, 'returns expected value' );
+	t.strictEqual( acc(), 0.0, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/skewness/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/skewness/lib/main.js
@@ -93,6 +93,10 @@ function incrskewness() {
 			if ( N < 3 ) {
 				return ( isnan( M3 ) ) ? NaN : null;
 			}
+			// When all provided values are equal, `M2` is zero, and the skewness is, by convention, zero:
+			if ( M2 === 0.0 ) {
+				return 0.0;
+			}
 			// Calculate the population skewness:
 			g1 = sqrt( N )*M3 / pow( M2, 1.5 );
 
@@ -112,6 +116,10 @@ function incrskewness() {
 		mean += deltaN;
 		if ( N < 3 ) {
 			return ( isnan( M3 ) ) ? NaN : null;
+		}
+		// When all provided values are equal, `M2` is zero, and the skewness is, by convention, zero:
+		if ( M2 === 0.0 ) {
+			return 0.0;
 		}
 		// Calculate the population skewness:
 		g1 = sqrt( N )*M3 / pow( M2, 1.5 );

--- a/lib/node_modules/@stdlib/stats/incr/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/skewness/test/test.js
@@ -133,3 +133,17 @@ tape( 'if provided a `NaN`, the accumulator function returns `NaN` for all futur
 	t.strictEqual( isnan( acc() ), true, 'returns expected value' );
 	t.end();
 });
+
+tape( 'if provided all equal values, the accumulator function returns `0`', function test( t ) {
+	var skewness;
+	var acc;
+	var i;
+
+	acc = incrskewness();
+	for ( i = 0; i < 100; i++ ) {
+		skewness = acc( 10.0 );
+	}
+	t.strictEqual( skewness, 0.0, 'returns expected value' );
+	t.strictEqual( acc(), 0.0, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #287.

-   Fixes `@stdlib/stats/incr/skewness` and `@stdlib/stats/incr/kurtosis` returning `NaN` instead of `0` when every value is equal.

The accumulators divide by a power of the second central moment `M2`. For constant input `M2` is exactly `0`, so it's a `0/0` division (`NaN`). The expected value for a constant data set is `0` (same as the pandas reference in the issue). The fix guards a zero `M2` in both accumulators, in the running-update and no-argument query paths. These two are the only `stats/incr` packages doing this division; `incr/nanskewness` wraps skewness and inherits it, `incr/summary` still passes.

## Related Issues
-   #287

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)