### PR TITLE
chore: clean `complex/float64/base/identity` package.json metadata

### DIFF
--- a/lib/node_modules/@stdlib/complex/float64/base/identity/package.json
+++ b/lib/node_modules/@stdlib/complex/float64/base/identity/package.json
@@ -62,7 +62,7 @@
     "dbl",
     "float64",
     "complex",
-    "cmplx"
-  ],
-  "__stdlib__": {}
+    "cmplx",
+    "number"
+  ]
 }


### PR DESCRIPTION
Resolves #N/A.

## Description

> What is the purpose of this pull request?

This pull request:

-   Removes the empty `"__stdlib__": {}` field from `@stdlib/complex/float64/base/identity`'s `package.json` and appends the missing `"number"` keyword.

### `@stdlib/complex/float64/base/identity`

Two package-metadata deviations within the `@stdlib/complex/float64/base/*` namespace, both `identity`-only outliers (9/10 sibling conformance):

-   `package.json` carried `"__stdlib__": {}`, an empty object no consumer keys on. Sibling packages (`add`, `add3`, `div`, `mul`, `mul-add`, `neg`, `scale`, `sub`, plus the `assert` aggregator) do not declare the field. Removed.
-   The `keywords` array was missing `"number"`, which every other sibling carries alongside the same `math`/`stdmath`/`mathematics`/`complex`/`cmplx` set. Appended to match.

No source, tests, REPL fixtures, type declarations, or generated `## See Also` content are touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a cross-package API-drift detection routine: features were extracted from every package under `@stdlib/complex/float64/base/`, majority patterns were computed at a 75% threshold, the `identity` outlier was confirmed by a structural-review pass and an independent cross-reference pass (verifying no test, REPL doc, or `__stdlib__` consumer relies on either deviation), and the two corrections were applied mechanically to `package.json` only.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoXBFcoHLxDAC8vwRmJ6rn)_