### PR TITLE
test: add missing `test.js` scaffolds to `_tools/github/dependents` and `_tools/github/dependents-count`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/dependents-count/package.json
+++ b/lib/node_modules/@stdlib/_tools/github/dependents-count/package.json
@@ -20,7 +20,8 @@
   "directories": {
     "doc": "./docs",
     "example": "./examples",
-    "lib": "./lib"
+    "lib": "./lib",
+    "test": "./test"
   },
   "scripts": {},
   "homepage": "https://github.com/stdlib-js/stdlib",

--- a/lib/node_modules/@stdlib/_tools/github/dependents-count/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/github/dependents-count/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/github/dependents-count/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/github/dependents-count/test/test.js
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var dependentsCount = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dependentsCount, 'function', 'main export is a function' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/_tools/github/dependents/package.json
+++ b/lib/node_modules/@stdlib/_tools/github/dependents/package.json
@@ -20,7 +20,8 @@
   "directories": {
     "doc": "./docs",
     "example": "./examples",
-    "lib": "./lib"
+    "lib": "./lib",
+    "test": "./test"
   },
   "scripts": {},
   "homepage": "https://github.com/stdlib-js/stdlib",

--- a/lib/node_modules/@stdlib/_tools/github/dependents/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/github/dependents/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/_tools/github/dependents/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/github/dependents/test/test.js
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var dependents = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof dependents, 'function', 'main export is a function' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds a minimal `test/test.js` scaffold asserting the main-export shape to `@stdlib/_tools/github/dependents` and `@stdlib/_tools/github/dependents-count`, matching the pattern used by 21 of the 23 sibling packages in `@stdlib/_tools/github` (91% conformance).
-   adds the corresponding `directories.test` entry to each package's `package.json`, matching the same 91% majority.

### Namespace summary

-   Namespace: `@stdlib/_tools/github`
-   Members analyzed: 23 (no autogenerated packages)
-   Features with a clear (≥75%) majority: file tree, `package.json` top-level keys, `engines`, `os`, `directories`, README top-level section sequence, `docs/usage.txt` CLI option set, and the presence of `lib/validate.js`, `test/test.js`, `test/test.main.js`, `test/test.cli.js`, `test/fixtures/opts.js`, and `lib/defaults.json`.
-   Features excluded (no clear majority): error construction (69.6% `format`-only vs 30.4% mixed with a plain static string in `factory.js`), `lib/factory.js` presence (73.9%).

### Per outlier package

#### `@stdlib/_tools/github/dependents`

Package lacked a `test/` directory entirely — the only sibling besides `dependents-count` without one. Added `test/test.js` matching the sibling scaffold used by `create-token`, `delete-token`, and 19 others: `require` the main export, assert it is a function. Also added the `directories.test: "./test"` entry to `package.json` (21 of 23 siblings carry it). No public behavior is altered; no existing tests exist to conflict with.

#### `@stdlib/_tools/github/dependents-count`

Same drift and same fix as `dependents` above. Package exports the main function directly (no `.factory` attached), so the scaffold checks the export shape only, matching the pattern used by other factory-less siblings.

### Validation

Structural feature extraction: file tree, `package.json` shape, README section sequence, `manifest.json` keys, and test/benchmark/examples filenames were captured for all 23 members. Semantic feature extraction: `lib/main.js`, `lib/index.js`, and `lib/validate.js` (where present) were parsed for public signature, return kind, validation prologue predicates, error-construction style, JSDoc shape, and `@stdlib/*` dependencies.

Deliberately excluded:

-   Adding `lib/validate.js` to `fetch-file` — it takes positional arguments (`filepath`, `repos`, `clbk`), not an options object; validation lives inline in `factory.js`. Intentional deviation.
-   Normalizing `is-plain-object` → `is-object` in `create-issue`, `dispatch-workflow`, and `get` — the majority is looser than these three, so applying it would weaken options validation. Intentional deviation.
-   Adding `## Notes` (H2) to `dependents`, `dependents-count`, `set-topics`, `star-repo`, `user-rate-limit` — content is package-specific (rate-limit notes, auth notes), not mechanical.
-   Bumping `engines.node` from `>=6` back to the majority `>=0.10.0` for `dependents` and `dependents-count` — would regress to an older engine constraint.
-   Adding `test/test.main.js`, `test/test.cli.js`, `test/test.validate.js` scaffolds to `dependents` / `dependents-count` — real coverage requires package-specific test cases, out of scope for mechanical drift correction.
-   Normalizing static-string `new Error(...)` in seven factory files to `format(...)` — feature is below the 75% majority threshold (69.6%) and static strings do not benefit from `format`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Full drift-analysis report saved locally at `~/drift-reports/drift-tools-github-2026-07-01.md`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running a scheduled cross-package drift-detection routine that identifies structural deviations across sibling packages in a randomly-selected namespace, then proposes mechanical corrections for a maintainer to review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6G3775t3pyJL1AcmaqWD3)_