### PR TITLE
chore: fix JavaScript lint errors (issue #13209)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/modules/pkg-deps/lib/to_array.js
+++ b/lib/node_modules/@stdlib/_tools/modules/pkg-deps/lib/to_array.js
@@ -37,12 +37,12 @@ function toArray( results ) {
 	var out;
 	var i;
 	files = objectKeys( results );
-	out = new Array( files.length );
+	out = [];
 	for ( i = 0; i < files.length; i++ ) {
-		out[ i ] = {
+		out.push({
 			'file': files[ i ],
 			'deps': results[ files[ i ] ]
-		};
+		});
 	}
 	return out;
 }

--- a/lib/node_modules/@stdlib/blas/base/dsymv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dsymv/test/test.ndarray.js
@@ -37,7 +37,6 @@ var rxpyp = require( './fixtures/row_major_xpyp.json' );
 var rxnyp = require( './fixtures/row_major_xnyp.json' );
 var rxpyn = require( './fixtures/row_major_xpyn.json' );
 var rxnyn = require( './fixtures/row_major_xnyn.json' );
-
 var cxoyt = require( './fixtures/column_major_xoyt.json' );
 var cxpyp = require( './fixtures/column_major_xpyp.json' );
 var cxnyp = require( './fixtures/column_major_xnyp.json' );


### PR DESCRIPTION
resolves #13209

## What
Fixes the two ESLint failures reported in the automated JavaScript lint workflow run (https://github.com/stdlib-js/stdlib/actions/runs/28484773514):

1. `lib/node_modules/@stdlib/_tools/modules/pkg-deps/lib/to_array.js` (line 40) — replaced `out = new Array( files.length );` plus indexed assignment with an array literal (`out = [];`) and `out.push(...)`, per the `stdlib/no-new-array` rule.
2. `lib/node_modules/@stdlib/blas/base/dsymv/test/test.ndarray.js` (line 40) — removed the blank line between the row-major and column-major `require()` statements in the FIXTURES block, per the `stdlib/no-empty-lines-between-requires` rule.

## Why
Both changes are minimal, behavior-preserving fixes that address the exact lint errors and rule violations reported by the workflow, with no functional changes to either file.

This PR was opened by an automated OSS contribution bot.