### PR TITLE
docs: update descriptions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/mean/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Mean
 
-> Planck distribution [expected value][expected-value].
+> Planck (discrete exponential) distribution [expected value][expected-value].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/mean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/mean/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/planck/mean",
   "version": "0.0.0",
-  "description": "Planck distribution expected value.",
+  "description": "Planck (discrete exponential) distribution expected value.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/stdev/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Standard Deviation
 
-> Planck distribution [standard deviation][standard-deviation].
+> Planck (discrete exponential) distribution [standard deviation][standard-deviation].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/stdev/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/stdev/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/planck/stdev",
   "version": "0.0.0",
-  "description": "Planck distribution standard deviation.",
+  "description": "Planck (discrete exponential) distribution standard deviation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/variance/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Variance
 
-> Planck distribution [variance][variance].
+> Planck (discrete exponential) distribution [variance][variance].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/variance/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/variance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/planck/variance",
   "version": "0.0.0",
-  "description": "Planck distribution variance.",
+  "description": "Planck (discrete exponential) distribution variance.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

This pull request:

-   adds the `(discrete exponential)` parenthetical to the `package.json` `description` field and the README opening blockquote in three sibling packages under `@stdlib/stats/base/dists/planck` — `mean`, `stdev`, and `variance` — so their outward-facing metadata matches the majority phrasing already used by the other 11 members of the namespace.

### Namespace summary

-   **Members analyzed:** 14 (all direct child packages of `stats/base/dists/planck`; none are autogenerated).
-   **Features analyzed:** file tree, `package.json` shape (top-level, `scripts`, `stdlib`), README section list and order, `manifest.json` shape, `test/`/`benchmark/`/`examples/` filenames; public signature, validation prologue, return kind, error construction, JSDoc shape, and internal dependencies (per-package agent extraction).
-   **Features with a clear majority (≥75%):** `package.json` description phrasing, README opening blockquote phrasing, top-level file layout, `package.json` key set, `manifest.json` key set, README section list, canonical `test.js`/`test.native.js` filenames, `benchmark.js`/`benchmark.native.js`/`c/` layout, `examples/{index.js,c/}` layout, `@param {PositiveNumber} lambda - shape parameter` JSDoc convention, and the shared `isnan(lambda) || lambda <= 0.0 → NaN` validation prologue.
-   **Features excluded — no clear majority:** none material. Bimodal features (e.g. presence of `lib/factory.js` and Python fixture directories) partition cleanly by function shape — parameterized functions (`cdf`, `logcdf`, `logpmf`, `mgf`, `pmf`, `quantile`) versus summary statistics — and are not drift.
-   **Deviations investigated but not corrected:** `mode` lacks `test/fixtures/python/{runner.py,data.json}` because it returns a constant `0.0` for all valid inputs and has no numerical reference to compare against; the extra `## Notes` section in `logcdf` and `logpmf` READMEs (2/14) documents log-domain numerical concerns and is intentional; `pmf`, `logpmf`, and `quantile` omit the `memoryless`/`life-time` keywords in favor of `discrete distribution`, a purposeful taxonomic choice.

### `stats/base/dists/planck/mean`

The `package.json` description and README opening blockquote read "Planck distribution expected value.", omitting the "(discrete exponential)" parenthetical used elsewhere under `stats/base/dists/planck/`. 11 of 14 sibling packages (78.6%) follow the "Planck (discrete exponential) distribution <topic>." pattern; this commit aligns both strings with the majority phrasing. Docs-only; no code or test changes.

### `stats/base/dists/planck/stdev`

Align the `package.json` description and README blockquote with the sibling packages under `stats/base/dists/planck/`, which use the phrasing "Planck (discrete exponential) distribution <topic>." 11 of 14 siblings (78.6%) already conform; this commit adds the missing "(discrete exponential)" parenthetical to both strings. Docs-only; no functional, code, or test changes.

### `stats/base/dists/planck/variance`

Align the `package.json` description and README blockquote with the canonical "Planck (discrete exponential) distribution <topic>." phrasing used by 11 of 14 sibling packages under `stats/base/dists/planck/`. Both strings previously read "Planck distribution variance.", omitting the `(discrete exponential)` parenthetical. Docs-only; no functional changes.

## Related Issues

No.

## Questions

No.

## Other

### Validation

-   **Structural extraction** — file tree, `package.json` / `manifest.json` key sets, README section sequences, and test/benchmark/example filenames were compared across all 14 sibling packages; conformance was tallied per feature at the 75% majority threshold.
-   **Semantic extraction** — public signatures, validation prologues, return kinds, error construction, JSDoc shape, and internal dependencies were extracted directly from `lib/main.js` / `lib/index.js`. No semantic drift found: all packages use the identical `isnan(lambda) || lambda <= 0.0 → NaN` guard, return by value, and neither construct nor throw errors.
-   **Three-agent drift review** ran on the three description outliers. All three agents (semantic, cross-reference, structural) independently returned `confirmed-drift`: the deviation does not track any semantic difference in the underlying distribution, no tests / examples / typings / snapshot files reference the previous description strings, and mechanical insertion of the parenthetical yields grammatical text consistent with the sibling convention.
-   **Deliberately excluded:** intentional deviations tied to the shape of the underlying function (parameterized versus summary statistic), features without a 75% majority, and outliers whose tests or fixtures rely on the deviating behavior.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was drafted by an automated cross-package drift-detection routine running on Claude Code. The routine enumerated all 14 sibling packages under `@stdlib/stats/base/dists/planck`, extracted structural and semantic features, applied a 75% majority-vote threshold, and passed each candidate correction through a three-agent adversarial review (semantic, cross-reference, and structural) before generating the diff. All changes are docs-only and were verified against the sibling convention prior to commit.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3CsUBPTSYZ7ZUjWPXoa9D)_