### PR TITLE
fix: use correct debug logger prefix

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/graph/lib/props/auto-render/set.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/graph/lib/props/auto-render/set.js
@@ -27,7 +27,7 @@ var isValid = require( './../../validators/auto_render.js' );
 
 // VARIABLES //
 
-var debug = logger( 'canvas:set:auto-render' );
+var debug = logger( 'graph:set:auto-render' );
 var CHANGE_EVENT = events( 'autoRender' );
 
 


### PR DESCRIPTION
## Description

This pull request:

-   Corrects a copy-paste bug in `@stdlib/plot/components/svg/graph/lib/props/auto-render/set.js`. The `debug` logger was initialized with the prefix `'canvas:set:auto-render'` — carried over from the sibling `canvas` package — instead of `'graph:set:auto-render'`. As a consequence, debug output from the graph component's auto-render setter was emitted under the wrong namespace and would not surface when a user set `DEBUG=graph:*`.

### `plot/components/svg/graph`

Change the `debug` logger prefix in `lib/props/auto-render/set.js` from `'canvas:set:auto-render'` to `'graph:set:auto-render'`. Every other logger in the `graph` package already uses the `graph:*` prefix, and 7 of 8 sibling packages in `@stdlib/plot/components/svg/*` that expose an auto-render setter prefix their logger with their own package slug (~87% conformance). Behavior is unchanged; only the debug label is corrected.

## Related Issues

No.

## Questions

No.

## Other

Diff is a one-line string change under `lib/props/auto-render/set.js`; no source, test, or documentation depends on the old string.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by an automated drift-detection routine run under Claude Code. The routine sampled the `@stdlib/plot/components/svg` namespace, extracted structural and semantic features from all 12 packages, identified the debug-logger-prefix convention as a majority pattern with a single deviating package, and applied a mechanical one-line fix. Three independent validation agents confirmed the deviation as a copy-paste artifact with no dependents.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_0133zmPQiVdLuvKwhbJJhHG9)_