### PR TITLE
bench: add missing function documentation and ensure consistency with other benchmarks

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/benchmark/c/benchmark.c
@@ -19,7 +19,6 @@
 #include "stdlib/stats/base/dists/anglit/quantile.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 #include <time.h>
 #include <sys/time.h>
 
@@ -27,19 +26,33 @@
 #define ITERATIONS 1000000
 #define REPEATS 3
 
+/**
+* Prints the TAP version.
+*/
 static void print_version( void ) {
 	printf( "TAP version 13\n" );
 }
 
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
 static void print_summary( int total, int passing ) {
 	printf( "#\n" );
-	printf( "1..%d\n", total );
+	printf( "1..%d\n", total ); // TAP plan
 	printf( "# total %d\n", total );
 	printf( "# pass  %d\n", passing );
 	printf( "#\n" );
 	printf( "# ok\n" );
 }
 
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
 static void print_results( double elapsed ) {
 	double rate = (double)ITERATIONS / elapsed;
 	printf( "  ---\n" );
@@ -49,17 +62,34 @@ static void print_results( double elapsed ) {
 	printf( "  ...\n" );
 }
 
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
 static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
 	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
 }
 
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
+*/
 static double random_uniform( const double min, const double max ) {
 	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
 	return min + ( v*(max-min) );
 }
 
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
 static double benchmark( void ) {
 	double sigma[ 100 ];
 	double mu[ 100 ];
@@ -78,23 +108,27 @@ static double benchmark( void ) {
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_anglit_quantile( p[ i % 100 ], mu[ i % 100 ], sigma[ i % 100 ] );
-		if ( isnan( y ) ) {
+		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - t;
 
-	if ( isnan( y ) ) {
+	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
 	return elapsed;
 }
 
+/**
+* Main execution sequence.
+*/
 int main( void ) {
 	double elapsed;
 	int i;
 
+	// Use the current time to seed the random number generator:
 	srand( time( NULL ) );
 
 	print_version();
@@ -102,7 +136,7 @@ int main( void ) {
 		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
-		printf( "ok %d benchmark finished\n", i + 1 );
+		printf( "ok %d benchmark finished\n", i+1 );
 	}
 	print_summary( REPEATS, REPEATS );
 }


### PR DESCRIPTION
Follow-up fixes for commits merged to `develop` between 2026-06-30 14:47 PDT (`14c51b7f3`) and 2026-07-01 01:30 CDT (`aebd92a2a`).

## Description

Small style follow-ups against the eight commits merged to `develop` in the last 24 hours. Only `stats/base/dists/anglit/quantile` needed changes; the other three new distribution packages (`poisson/entropy` C addition, `lognormal/logpdf` C addition, `log-logistic/pdf`) and the four bot/namespace commits came in clean.

Fixes in this PR:

-   Static helper functions in the anglit `quantile` benchmark lacked the `/** ... */` doc comments every sibling benchmark.c uses. Added matching doc comments to `print_version`, `print_summary`, `print_results`, `tic`, `random_uniform`, `benchmark`, and `main`. (`aebd92a2a`, `lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/benchmark/c/benchmark.c`)
-   `isnan( y )` in `lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/benchmark/c/benchmark.c` broke with the tree's established `y != y` self-comparison idiom for NaN checks, dragging in an unneeded `<math.h>`. Switched both call sites to `y != y` and dropped the include. (`aebd92a2a`, `lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/benchmark/c/benchmark.c`)

## Related Issues

None.

## Questions

No.

## Other

**Validation.** Reviewed all eight commits merged to `develop` in the window with four parallel reviewers (two style, two bug-hunt). Checked for stdlib code style compliance, copy-paste artefacts, math/logic bugs, boundary handling, contract mismatches, wrong constants, and manifest/addon wiring. Findings that were not independently re-verifiable against a sibling reference package, or that would require touching code outside the window's diff, were deliberately excluded. The three sibling C benchmarks added in the same window (`poisson/entropy`, `lognormal/logpdf`, `log-logistic/pdf`) served as the reference for the anglit benchmark fix.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a scheduled routine that audits recent commits to `develop`. The reviewer agents surfaced the two style deviations above; the fixes mirror the doc-comment scaffold and NaN-check idiom already used by the three sibling C benchmarks added in the same window.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_012thbtkeGRK3JW275MTLsoN)_