### PR TITLE
feat: add float16 dtype support for `array/base/getter`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/getter/README.md
+++ b/lib/node_modules/@stdlib/array/base/getter/README.md
@@ -97,33 +97,37 @@ arr = filled( 2.0, 10, 'float32' );
 v = getter( dtype( arr ) )( arr, 2 );
 // returns 2.0
 
-arr = filled( 3, 10, 'int32' );
+arr = filled( 3.0, 10, 'float16' );
 v = getter( dtype( arr ) )( arr, 2 );
-// returns 3
+// returns 3.0
 
-arr = filled( 4, 10, 'int16' );
+arr = filled( 4, 10, 'int32' );
 v = getter( dtype( arr ) )( arr, 2 );
 // returns 4
 
-arr = filled( 5, 10, 'int8' );
+arr = filled( 5, 10, 'int16' );
 v = getter( dtype( arr ) )( arr, 2 );
 // returns 5
 
-arr = filled( 6, 10, 'uint32' );
+arr = filled( 6, 10, 'int8' );
 v = getter( dtype( arr ) )( arr, 2 );
 // returns 6
 
-arr = filled( 7, 10, 'uint16' );
+arr = filled( 7, 10, 'uint32' );
 v = getter( dtype( arr ) )( arr, 2 );
 // returns 7
 
-arr = filled( 8, 10, 'uint8' );
+arr = filled( 8, 10, 'uint16' );
 v = getter( dtype( arr ) )( arr, 2 );
 // returns 8
 
-arr = filled( 9, 10, 'uint8c' );
+arr = filled( 9, 10, 'uint8' );
 v = getter( dtype( arr ) )( arr, 2 );
 // returns 9
+
+arr = filled( 10, 10, 'uint8c' );
+v = getter( dtype( arr ) )( arr, 2 );
+// returns 10
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/array/base/getter/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/base/getter/benchmark/benchmark.js
@@ -133,6 +133,30 @@ bench( format( '%s:dtype=float32', pkg ), function benchmark( b ) {
 	b.end();
 });
 
+bench( format( '%s:dtype=float16', pkg ), function benchmark( b ) {
+	var arr;
+	var get;
+	var i;
+	var v;
+
+	arr = filledBy( 100, 'float16', rand );
+	get = getter( dtype( arr ) );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = get( arr, i%arr.length );
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( v ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
 bench( format( '%s:dtype=int32', pkg ), function benchmark( b ) {
 	var arr;
 	var get;

--- a/lib/node_modules/@stdlib/array/base/getter/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/getter/docs/types/index.d.ts
@@ -41,6 +41,15 @@ type GetFloat64 = ( arr: Float64Array, idx: number ) => number | void;
 type GetFloat32 = ( arr: Float32Array, idx: number ) => number | void;
 
 /**
+* Returns an element from a `Float16Array`.
+*
+* @param arr - input array
+* @param idx - element index
+* @returns element value
+*/
+type GetFloat16 = ( arr: Float16Array, idx: number ) => number | void;
+
+/**
 * Returns an element from an `Int32Array`.
 *
 * @param arr - input array
@@ -154,6 +163,23 @@ declare function getter( dtype: 'float64' ): GetFloat64;
 * // returns 3.0
 */
 declare function getter( dtype: 'float32' ): GetFloat32;
+
+/**
+* Returns an accessor function for retrieving an element from a `Float16Array`.
+*
+* @param dtype - data type
+* @returns accessor function
+*
+* @example
+* var Float16Array = require( '@stdlib/array/float16' );
+*
+* var arr = new Float16Array( [ 1, 2, 3, 4 ] );
+*
+* var get = getter( 'float16' );
+* var v = get( arr, 2 );
+* // returns 3.0
+*/
+declare function getter( dtype: 'float16' ): GetFloat16;
 
 /**
 * Returns an accessor function for retrieving an element from an `Int32Array`.

--- a/lib/node_modules/@stdlib/array/base/getter/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/getter/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Collection } from '@stdlib/types/array';
+import { Collection, Float16Array } from '@stdlib/types/array';
 
 /**
 * Returns an element from a `Float64Array`.

--- a/lib/node_modules/@stdlib/array/base/getter/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/getter/docs/types/test.ts
@@ -16,6 +16,7 @@
 * limitations under the License.
 */
 
+import Float16Array = require( '@stdlib/array/float16' );
 import getter = require( './index' );
 
 

--- a/lib/node_modules/@stdlib/array/base/getter/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/getter/docs/types/test.ts
@@ -25,6 +25,7 @@ import getter = require( './index' );
 {
 	getter( 'float64' ); // $ExpectType GetFloat64
 	getter( 'float32' ); // $ExpectType GetFloat32
+	getter( 'float16' ); // $ExpectType GetFloat16
 	getter( 'int32' ); // $ExpectType GetInt32
 	getter( 'int16' ); // $ExpectType GetInt16
 	getter( 'int8' ); // $ExpectType GetInt8
@@ -67,37 +68,41 @@ import getter = require( './index' );
 	const x3 = new Float32Array( [ 1, 2, 3, 4 ] );
 	get3( x3, 2 ); // $ExpectType number | void
 
-	const get4 = getter( 'int32' );
-	const x4 = new Int32Array( [ 1, 2, 3, 4 ] );
-	get4( x4, 2 ); // $ExpectType number | void
+	const get4 = getter( 'float16' );
+	const x4 = new Float16Array( [ 1, 2, 3, 4 ] );
+	get4( x4 , 2 ); // $ExpectType number | void
 
-	const get5 = getter( 'int16' );
-	const x5 = new Int16Array( [ 1, 2, 3, 4 ] );
+	const get5 = getter( 'int32' );
+	const x5 = new Int32Array( [ 1, 2, 3, 4 ] );
 	get5( x5, 2 ); // $ExpectType number | void
 
-	const get6 = getter( 'int8' );
-	const x6 = new Int8Array( [ 1, 2, 3, 4 ] );
+	const get6 = getter( 'int16' );
+	const x6 = new Int16Array( [ 1, 2, 3, 4 ] );
 	get6( x6, 2 ); // $ExpectType number | void
 
-	const get7 = getter( 'uint32' );
-	const x7 = new Uint32Array( [ 1, 2, 3, 4 ] );
+	const get7 = getter( 'int8' );
+	const x7 = new Int8Array( [ 1, 2, 3, 4 ] );
 	get7( x7, 2 ); // $ExpectType number | void
 
-	const get8 = getter( 'uint16' );
-	const x8 = new Uint16Array( [ 1, 2, 3, 4 ] );
+	const get8 = getter( 'uint32' );
+	const x8 = new Uint32Array( [ 1, 2, 3, 4 ] );
 	get8( x8, 2 ); // $ExpectType number | void
 
-	const get9 = getter( 'uint8' );
-	const x9 = new Uint8Array( [ 1, 2, 3, 4 ] );
+	const get9 = getter( 'uint16' );
+	const x9 = new Uint16Array( [ 1, 2, 3, 4 ] );
 	get9( x9, 2 ); // $ExpectType number | void
 
-	const get10 = getter( 'uint8c' );
-	const x10 = new Uint8ClampedArray( [ 1, 2, 3, 4 ] );
+	const get10 = getter( 'uint8' );
+	const x10 = new Uint8Array( [ 1, 2, 3, 4 ] );
 	get10( x10, 2 ); // $ExpectType number | void
 
-	const get11 = getter( 'foo' );
-	const x11 = [ 1, 2, 3, 4 ];
-	get11( x11, 2 ); // $ExpectType unknown
+	const get11 = getter( 'uint8c' );
+	const x11 = new Uint8ClampedArray( [ 1, 2, 3, 4 ] );
+	get11( x11, 2 ); // $ExpectType number | void
+
+	const get12 = getter( 'foo' );
+	const x12 = [ 1, 2, 3, 4 ];
+	get12( x12, 2 ); // $ExpectType unknown
 }
 
 // The compiler throws an error if the returned function is provided a first argument which is not a collection...
@@ -123,61 +128,68 @@ import getter = require( './index' );
 	get3( null, 2 ); // $ExpectError
 	get3( {}, 2 ); // $ExpectError
 
-	const get4 = getter( 'int32' );
+	const get4 = getter( 'float16' );
 	get4( 5, 2 ); // $ExpectError
 	get4( true, 2 ); // $ExpectError
 	get4( false, 2 ); // $ExpectError
 	get4( null, 2 ); // $ExpectError
 	get4( {}, 2 ); // $ExpectError
 
-	const get5 = getter( 'int16' );
+	const get5 = getter( 'int32' );
 	get5( 5, 2 ); // $ExpectError
 	get5( true, 2 ); // $ExpectError
 	get5( false, 2 ); // $ExpectError
 	get5( null, 2 ); // $ExpectError
 	get5( {}, 2 ); // $ExpectError
 
-	const get6 = getter( 'int8' );
+	const get6 = getter( 'int16' );
 	get6( 5, 2 ); // $ExpectError
 	get6( true, 2 ); // $ExpectError
 	get6( false, 2 ); // $ExpectError
 	get6( null, 2 ); // $ExpectError
 	get6( {}, 2 ); // $ExpectError
 
-	const get7 = getter( 'uint32' );
+	const get7 = getter( 'int8' );
 	get7( 5, 2 ); // $ExpectError
 	get7( true, 2 ); // $ExpectError
 	get7( false, 2 ); // $ExpectError
 	get7( null, 2 ); // $ExpectError
 	get7( {}, 2 ); // $ExpectError
 
-	const get8 = getter( 'uint16' );
+	const get8 = getter( 'uint32' );
 	get8( 5, 2 ); // $ExpectError
 	get8( true, 2 ); // $ExpectError
 	get8( false, 2 ); // $ExpectError
 	get8( null, 2 ); // $ExpectError
 	get8( {}, 2 ); // $ExpectError
 
-	const get9 = getter( 'uint8' );
+	const get9 = getter( 'uint16' );
 	get9( 5, 2 ); // $ExpectError
 	get9( true, 2 ); // $ExpectError
 	get9( false, 2 ); // $ExpectError
 	get9( null, 2 ); // $ExpectError
 	get9( {}, 2 ); // $ExpectError
 
-	const get10 = getter( 'uint8c' );
+	const get10 = getter( 'uint8' );
 	get10( 5, 2 ); // $ExpectError
 	get10( true, 2 ); // $ExpectError
 	get10( false, 2 ); // $ExpectError
 	get10( null, 2 ); // $ExpectError
 	get10( {}, 2 ); // $ExpectError
 
-	const get11 = getter( 'foo' );
+	const get11 = getter( 'uint8c' );
 	get11( 5, 2 ); // $ExpectError
 	get11( true, 2 ); // $ExpectError
 	get11( false, 2 ); // $ExpectError
 	get11( null, 2 ); // $ExpectError
 	get11( {}, 2 ); // $ExpectError
+
+	const get12 = getter( 'foo' );
+	get12( 5, 2 ); // $ExpectError
+	get12( true, 2 ); // $ExpectError
+	get12( false, 2 ); // $ExpectError
+	get12( null, 2 ); // $ExpectError
+	get12( {}, 2 ); // $ExpectError
 }
 
 // The compiler throws an error if the returned function is provided a second argument which is not a number...
@@ -203,61 +215,68 @@ import getter = require( './index' );
 	get3( new Float32Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
 	get3( new Float32Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
 
-	const get4 = getter( 'int32' );
-	get4( new Int32Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
-	get4( new Int32Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
-	get4( new Int32Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
-	get4( new Int32Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
-	get4( new Int32Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
+	const get4 = getter( 'float16' );
+	get4( new Float16Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
+	get4( new Float16Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
+	get4( new Float16Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
+	get4( new Float16Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
+	get4( new Float16Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
 
-	const get5 = getter( 'int16' );
-	get5( new Int16Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
-	get5( new Int16Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
-	get5( new Int16Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
-	get5( new Int16Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
-	get5( new Int16Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
+	const get5 = getter( 'int32' );
+	get5( new Int32Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
+	get5( new Int32Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
+	get5( new Int32Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
+	get5( new Int32Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
+	get5( new Int32Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
 
-	const get6 = getter( 'int8' );
-	get6( new Int8Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
-	get6( new Int8Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
-	get6( new Int8Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
-	get6( new Int8Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
-	get6( new Int8Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
+	const get6 = getter( 'int16' );
+	get6( new Int16Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
+	get6( new Int16Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
+	get6( new Int16Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
+	get6( new Int16Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
+	get6( new Int16Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
 
-	const get7 = getter( 'uint32' );
-	get7( new Uint32Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
-	get7( new Uint32Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
-	get7( new Uint32Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
-	get7( new Uint32Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
-	get7( new Uint32Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
+	const get7 = getter( 'int8' );
+	get7( new Int8Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
+	get7( new Int8Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
+	get7( new Int8Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
+	get7( new Int8Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
+	get7( new Int8Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
 
-	const get8 = getter( 'uint16' );
-	get8( new Uint16Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
-	get8( new Uint16Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
-	get8( new Uint16Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
-	get8( new Uint16Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
-	get8( new Uint16Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
+	const get8 = getter( 'uint32' );
+	get8( new Uint32Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
+	get8( new Uint32Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
+	get8( new Uint32Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
+	get8( new Uint32Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
+	get8( new Uint32Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
 
-	const get9 = getter( 'uint8' );
-	get9( new Uint8Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
-	get9( new Uint8Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
-	get9( new Uint8Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
-	get9( new Uint8Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
-	get9( new Uint8Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
+	const get9 = getter( 'uint16' );
+	get9( new Uint16Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
+	get9( new Uint16Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
+	get9( new Uint16Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
+	get9( new Uint16Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
+	get9( new Uint16Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
 
-	const get10 = getter( 'uint8c' );
-	get10( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
-	get10( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
-	get10( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
-	get10( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
-	get10( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
+	const get10 = getter( 'uint8' );
+	get10( new Uint8Array( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
+	get10( new Uint8Array( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
+	get10( new Uint8Array( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
+	get10( new Uint8Array( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
+	get10( new Uint8Array( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
 
-	const get11 = getter( 'foo' );
-	get11( [ 1, 2, 3, 4 ], '5' ); // $ExpectError
-	get11( [ 1, 2, 3, 4 ], true ); // $ExpectError
-	get11( [ 1, 2, 3, 4 ], false ); // $ExpectError
-	get11( [ 1, 2, 3, 4 ], null ); // $ExpectError
-	get11( [ 1, 2, 3, 4 ], {} ); // $ExpectError
+	const get11 = getter( 'uint8c' );
+	get11( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), '5' ); // $ExpectError
+	get11( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), true ); // $ExpectError
+	get11( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), false ); // $ExpectError
+	get11( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), null ); // $ExpectError
+	get11( new Uint8ClampedArray( [ 1, 2, 3, 4 ] ), {} ); // $ExpectError
+
+	const get12 = getter( 'foo' );
+	get12( [ 1, 2, 3, 4 ], '5' ); // $ExpectError
+	get12( [ 1, 2, 3, 4 ], true ); // $ExpectError
+	get12( [ 1, 2, 3, 4 ], false ); // $ExpectError
+	get12( [ 1, 2, 3, 4 ], null ); // $ExpectError
+	get12( [ 1, 2, 3, 4 ], {} ); // $ExpectError
 }
 
 // The compiler throws an error if the returned function is provided an unsupported number of arguments...
@@ -277,43 +296,48 @@ import getter = require( './index' );
 	get3( new Float32Array( [] ) ); // $ExpectError
 	get3( new Float32Array( [] ), 1, 2 ); // $ExpectError
 
-	const get4 = getter( 'int32' );
+	const get4 = getter( 'float16' );
 	get4(); // $ExpectError
-	get4( new Int32Array( [] ) ); // $ExpectError
-	get4( new Int32Array( [] ), 1, 2 ); // $ExpectError
+	get4( new Float16Array( [] ) ); // $ExpectError
+	get4( new Float16Array( [] ), 1, 2 ); // $ExpectError
 
-	const get5 = getter( 'int16' );
+	const get5 = getter( 'int32' );
 	get5(); // $ExpectError
-	get5( new Int16Array( [] ) ); // $ExpectError
-	get5( new Int16Array( [] ), 1, 2 ); // $ExpectError
+	get5( new Int32Array( [] ) ); // $ExpectError
+	get5( new Int32Array( [] ), 1, 2 ); // $ExpectError
 
-	const get6 = getter( 'int8' );
+	const get6 = getter( 'int16' );
 	get6(); // $ExpectError
-	get6( new Int8Array( [] ) ); // $ExpectError
-	get6( new Int8Array( [] ), 1, 2 ); // $ExpectError
+	get6( new Int16Array( [] ) ); // $ExpectError
+	get6( new Int16Array( [] ), 1, 2 ); // $ExpectError
 
-	const get7 = getter( 'uint32' );
+	const get7 = getter( 'int8' );
 	get7(); // $ExpectError
-	get7( new Uint32Array( [] ) ); // $ExpectError
-	get7( new Uint32Array( [] ), 1, 2 ); // $ExpectError
+	get7( new Int8Array( [] ) ); // $ExpectError
+	get7( new Int8Array( [] ), 1, 2 ); // $ExpectError
 
-	const get8 = getter( 'uint16' );
+	const get8 = getter( 'uint32' );
 	get8(); // $ExpectError
-	get8( new Uint16Array( [] ) ); // $ExpectError
-	get8( new Uint16Array( [] ), 1, 2 ); // $ExpectError
+	get8( new Uint32Array( [] ) ); // $ExpectError
+	get8( new Uint32Array( [] ), 1, 2 ); // $ExpectError
 
-	const get9 = getter( 'uint8' );
+	const get9 = getter( 'uint16' );
 	get9(); // $ExpectError
-	get9( new Uint8Array( [] ) ); // $ExpectError
-	get9( new Uint8Array( [] ), 1, 2 ); // $ExpectError
+	get9( new Uint16Array( [] ) ); // $ExpectError
+	get9( new Uint16Array( [] ), 1, 2 ); // $ExpectError
 
-	const get10 = getter( 'uint8c' );
+	const get10 = getter( 'uint8' );
 	get10(); // $ExpectError
-	get10( new Uint8ClampedArray( [] ) ); // $ExpectError
-	get10( new Uint8ClampedArray( [] ), 1, 2 ); // $ExpectError
+	get10( new Uint8Array( [] ) ); // $ExpectError
+	get10( new Uint8Array( [] ), 1, 2 ); // $ExpectError
 
-	const get11 = getter( 'foo' );
+	const get11 = getter( 'uint8c' );
 	get11(); // $ExpectError
-	get11( [] ); // $ExpectError
-	get11( [], 1, 2 ); // $ExpectError
+	get11( new Uint8ClampedArray( [] ) ); // $ExpectError
+	get11( new Uint8ClampedArray( [] ), 1, 2 ); // $ExpectError
+
+	const get12 = getter( 'foo' );
+	get12(); // $ExpectError
+	get12( [] ); // $ExpectError
+	get12( [], 1, 2 ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/array/base/getter/examples/index.js
+++ b/lib/node_modules/@stdlib/array/base/getter/examples/index.js
@@ -30,30 +30,34 @@ arr = filled( 2.0, 10, 'float32' );
 v = getter( dtype( arr ) )( arr, 2 );
 console.log( 'v: %d', v );
 
-arr = filled( 3, 10, 'int32' );
+arr = filled( 3.0, 10, 'float16' );
 v = getter( dtype( arr ) )( arr, 2 );
 console.log( 'v: %d', v );
 
-arr = filled( 4, 10, 'int16' );
+arr = filled( 4, 10, 'int32' );
 v = getter( dtype( arr ) )( arr, 2 );
 console.log( 'v: %d', v );
 
-arr = filled( 5, 10, 'int8' );
+arr = filled( 5, 10, 'int16' );
 v = getter( dtype( arr ) )( arr, 2 );
 console.log( 'v: %d', v );
 
-arr = filled( 6, 10, 'uint32' );
+arr = filled( 6, 10, 'int8' );
 v = getter( dtype( arr ) )( arr, 2 );
 console.log( 'v: %d', v );
 
-arr = filled( 7, 10, 'uint16' );
+arr = filled( 7, 10, 'uint32' );
 v = getter( dtype( arr ) )( arr, 2 );
 console.log( 'v: %d', v );
 
-arr = filled( 8, 10, 'uint8' );
+arr = filled( 8, 10, 'uint16' );
 v = getter( dtype( arr ) )( arr, 2 );
 console.log( 'v: %d', v );
 
-arr = filled( 9, 10, 'uint8c' );
+arr = filled( 9, 10, 'uint8' );
+v = getter( dtype( arr ) )( arr, 2 );
+console.log( 'v: %d', v );
+
+arr = filled( 10, 10, 'uint8c' );
 v = getter( dtype( arr ) )( arr, 2 );
 console.log( 'v: %d', v );

--- a/lib/node_modules/@stdlib/array/base/getter/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/getter/lib/main.js
@@ -23,6 +23,7 @@
 var GETTERS = {
 	'float64': getFloat64,
 	'float32': getFloat32,
+	'float16': getFloat16,
 	'int32': getInt32,
 	'int16': getInt16,
 	'int8': getInt8,
@@ -74,6 +75,26 @@ function getFloat64( arr, idx ) {
 * // returns 3.0
 */
 function getFloat32( arr, idx ) {
+	return arr[ idx ];
+}
+
+/**
+* Returns an element from a `Float16Array`.
+*
+* @private
+* @param {Float16Array} arr - input array
+* @param {NonNegativeInteger} idx - element index
+* @returns {number} element value
+*
+* @example
+* var Float16Array = require( '@stdlib/array/float16' );
+*
+* var arr = new Float16Array( [ 1, 2, 3, 4 ] );
+*
+* var v = getFloat16( arr, 2 );
+* // returns 3.0
+*/
+function getFloat16( arr, idx ) {
 	return arr[ idx ];
 }
 


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-   feat: add float16 dtype support for array/base/getter

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
