### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/utils/shift/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/utils/shift/benchmark/benchmark.js
@@ -35,9 +35,9 @@ bench( format( '%s::array', pkg ), function benchmark( b ) {
 	var i;
 
 	len = b.iterations;
-	arr = new Array( len );
+	arr = [];
 	for ( i = 0; i < len; i++ ) {
-		arr[ i ] = i;
+		arr.push( i );
 	}
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -62,9 +62,9 @@ bench( format( '%s::built-in', pkg ), function benchmark( b ) {
 	var i;
 
 	len = b.iterations;
-	arr = new Array( len );
+	arr = [];
 	for ( i = 0; i < len; i++ ) {
-		arr[ i ] = i;
+		arr.push( i );
 	}
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION
Resolves #13224.

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes `stdlib/no-new-array` lint errors in `@stdlib/utils/shift/benchmark/benchmark.js`.
- Replaces the `new Array(len)` constructors with array literals (`[]`) and uses `.push()` to populate the arrays, adhering to the project's style guidelines.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #13224

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I consulted Google Gemini to verify the project's layout conventions and ensure the refactored array logic fully adheres to stdlib coding standards.

***

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md