### PR TITLE
chore: remove extra space and fix license header

### DIFF
--- a/lib/node_modules/@stdlib/array/base/getter/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/getter/docs/types/test.ts
@@ -71,7 +71,7 @@ import getter = require( './index' );
 
 	const get4 = getter( 'float16' );
 	const x4 = new Float16Array( [ 1, 2, 3, 4 ] );
-	get4( x4 , 2 ); // $ExpectType number | void
+	get4( x4, 2 ); // $ExpectType number | void
 
 	const get5 = getter( 'int32' );
 	const x5 = new Int32Array( [ 1, 2, 3, 4 ] );

--- a/lib/node_modules/@stdlib/array/filled/benchmark/benchmark.length.float16.js
+++ b/lib/node_modules/@stdlib/array/filled/benchmark/benchmark.length.float16.js
@@ -1,5 +1,4 @@
 /**
-/**
 * @license Apache-2.0
 *
 * Copyright (c) 2026 The Stdlib Authors.


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-07-01 20:07 UTC and 2026-07-01 20:07 UTC (SHA range `c81fa285d..c38afb148`).

Two style-guide violations slipped into the float16 dtype rollout and were caught by an automated post-merge audit. Both are one-line, surgical fixes; no runtime behavior changes.

### Fixes

- `lib/node_modules/@stdlib/array/filled/benchmark/benchmark.length.float16.js` — License header had a duplicate `/**` opener from the float16 codegen in c81fa285, breaking the standard single-`/**` shape shared by every `benchmark.length.*.js` sibling; collapsed to one opener. (bf336b2a)
- `lib/node_modules/@stdlib/array/base/getter/docs/types/test.ts` — Fix stray space before comma in float16 `get4( x4 , 2 )` call added in c38afb14; brings it in line with the file's `fn( x, y )` spacing convention. (11675c97)

## Related Issues

None.

## Questions

No.

## Other

### Validation audit

Checked:
- stdlib code style compliance (parallel review, two agents cross-verified each finding against sibling `float32`/`float64` blocks and `benchmark.length.*.js` siblings)
- Obvious runtime bugs in the introduced code (two independent scans over the union diff)
- License-header shape and JS comma-spacing rules from `docs/style-guides`

Deliberately excluded from this PR:
- Anything that would require reading unchanged code outside the diff window to validate (e.g. downstream dispatch, imports)
- Subjective code-organization or naming suggestions
- Speculative concerns (e.g. `-ffast-math` interaction with the `y != y` NaN idiom in the anglit C benchmark) — the `fe3bacee0` C-benchmark cleanup was reviewed in full and matches sibling `stats/base/dists/*/quantile/benchmark/c/benchmark.c` files exactly

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated post-merge audit routine: three commits merged to `develop` in a 24-hour window were reviewed in parallel by four independent agents (two for style-guide compliance, two for bugs); findings that were flagged by ≥2 agents and independently re-verified against the diff were applied here. A human maintainer will audit before promoting the PR out of draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnZSxTaGJxxTUqgNNJtDZD)_