### PR TITLE
bench: use consistent assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/entropy/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/entropy/benchmark/c/benchmark.c
@@ -20,7 +20,6 @@
 #include "stdlib/constants/float64/eps.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 #include <time.h>
 #include <sys/time.h>
 
@@ -106,14 +105,14 @@ static double benchmark( void ) {
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_chi_entropy( k[ i % 100 ] );
-		if ( isnan( y ) ) {
+		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - start;
 
-	if ( isnan( y ) ) {
+	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
 	return elapsed;

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/kurtosis/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/kurtosis/benchmark/c/benchmark.c
@@ -20,7 +20,6 @@
 #include "stdlib/constants/float64/eps.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 #include <time.h>
 #include <sys/time.h>
 
@@ -106,14 +105,14 @@ static double benchmark( void ) {
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_chisquare_kurtosis( k[ i % 100 ] );
-		if ( isnan( y ) ) {
+		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - start;
 
-	if ( isnan( y ) ) {
+	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
 	return elapsed;

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/mgf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/mgf/benchmark/c/benchmark.c
@@ -17,7 +17,6 @@
 */
 
 #include "stdlib/stats/base/dists/chisquare/mgf.h"
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -107,14 +106,14 @@ static double benchmark( void ) {
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_chisquare_mgf( t[ i % 100 ], k[ i % 100 ] );
-		if ( isnan( y ) ) {
+		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - start;
 
-	if ( isnan( y ) ) {
+	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
 	return elapsed;

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
@@ -20,7 +20,6 @@
 #include "stdlib/math/base/special/ceil.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 #include <time.h>
 #include <sys/time.h>
 
@@ -108,14 +107,14 @@ static double benchmark( void ) {
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_degenerate_logpmf( x[ i % 100 ], mu[ i % 100 ] );
-		if ( isnan( y ) ) {
+		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - start;
 
-	if ( isnan( y ) ) {
+	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
 	return elapsed;

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/benchmark/c/benchmark.c
@@ -19,7 +19,6 @@
 #include "stdlib/stats/base/dists/degenerate/pdf.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 #include <time.h>
 #include <sys/time.h>
 
@@ -107,14 +106,14 @@ static double benchmark( void ) {
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_degenerate_pdf( x[ i % 100 ], mu[ i % 100 ] );
-		if ( isnan( y ) ) {
+		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - start;
 
-	if ( isnan( y ) ) {
+	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
 	return elapsed;

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/benchmark/c/benchmark.c
@@ -20,7 +20,6 @@
 #include "stdlib/math/base/special/ceil.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 #include <time.h>
 #include <sys/time.h>
 
@@ -108,14 +107,14 @@ static double benchmark( void ) {
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_degenerate_pmf( x[ i % 100 ], mu[ i % 100 ] );
-		if ( isnan( y ) ) {
+		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - start;
 
-	if ( isnan( y ) ) {
+	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
 	return elapsed;

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/benchmark/c/benchmark.c
@@ -19,7 +19,6 @@
 #include "stdlib/stats/base/dists/degenerate/quantile.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 #include <time.h>
 #include <sys/time.h>
 
@@ -107,14 +106,14 @@ static double benchmark( void ) {
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_degenerate_quantile( p[ i % 100 ], mu[ i % 100 ] );
-		if ( isnan( y ) ) {
+		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - start;
 
-	if ( isnan( y ) ) {
+	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
 	return elapsed;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/mgf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/mgf/benchmark/c/benchmark.c
@@ -19,7 +19,6 @@
 #include "stdlib/stats/base/dists/planck/mgf.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 #include <time.h>
 #include <sys/time.h>
 
@@ -107,13 +106,13 @@ static double benchmark( void ) {
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_planck_mgf( t[ i%100 ], lambda[ i%100 ] );
-		if ( isnan( y ) ) {
+		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - start;
-	if ( isnan( y ) ) {
+	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
 	return elapsed;


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between `fe3bacee0` (2026-07-01 12:58 -0700) and `c38afb148` (2026-07-01 13:07 -0700) to sibling packages with the same underlying defect.

### Pattern: adopt `y != y` NaN check and drop unneeded `<math.h>` in C benchmarks

Source commit `fe3bacee0` reworked `stats/base/dists/anglit/quantile/benchmark/c/benchmark.c` to match sibling style. Among those changes, both `if ( isnan( y ) )` sites inside `static double benchmark( void )` were switched to the tree's canonical `y != y` self-comparison idiom, and the now-unneeded `#include <math.h>` was dropped. The identical pair of defects (unnecessary `<math.h>` include; `isnan( y )` NaN check inconsistent with sibling benchmarks) exists in every listed target, and `<math.h>` carries no other symbol into any of them. Fix applies verbatim per file: one include line deleted, two `isnan( y )` occurrences swapped for `y != y`.

- `fe3bacee0` ([`bench: add missing function documentation and ensure consistency with other benchmarks`](https://github.com/stdlib-js/stdlib/commit/fe3bacee0706a1562d6654c859ce2644dc69ba56))
  - `@stdlib/stats/base/dists/chi/entropy`
  - `@stdlib/stats/base/dists/chisquare/kurtosis`
  - `@stdlib/stats/base/dists/chisquare/mgf`
  - `@stdlib/stats/base/dists/degenerate/logpmf`
  - `@stdlib/stats/base/dists/degenerate/pdf`
  - `@stdlib/stats/base/dists/degenerate/pmf`
  - `@stdlib/stats/base/dists/degenerate/quantile`
  - `@stdlib/stats/base/dists/planck/mgf`

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Search scope:** all `lib/node_modules/@stdlib/**/benchmark/c/benchmark.c` matching `isnan( y )`; eight sites returned, all under `stats/base/dists/*`.
- **Two independent opus validation passes** confirmed at every candidate site that (a) `#include <math.h>` is present on its own line and carries no other symbol into the file (stdlib headers like `stdlib/math/base/special/ceil.h` are unrelated), (b) exactly two `if ( isnan( y ) )` occurrences exist, both inside `static double benchmark( void )` — one inside the ITERATIONS loop, one after — and (c) `y` is declared `double` and assigned by the loop's first iteration before the check, so `y != y` is semantically equivalent to `isnan( y )` in all reachable states.
- **A sonnet style-consistency pass** verified the mechanical patch preserves the include block's contiguous layout and the `if ( ... )` single-space padding at both call sites.

Deliberately excluded:

- The remaining stylistic changes from `fe3bacee0` (JSDoc scaffolding for static helpers, `/** Main execution sequence. */` before `int main`, inline `// TAP plan` / `// Use the current time to seed the random number generator:` comments, `i + 1` → `i+1`): every candidate site already carries most of these, and the missing subsets differ per file. Applying them here would drift into "while we're here" cleanup beyond the propagatable core.
- The two `feat:` commits from the window (`c81fa285` `array/filled` float16, `c38afb148` `array/base/getter` float16): feature additions, not defect propagations.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two opus validation passes plus a sonnet style-consistency pass) before commits were applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JimWkASpu9ZpkGKX8okXMb)_