### PR TITLE
build(workflows): remove stale Node.js version matrix includes in `linux_test_install`

### DIFF
--- a/.github/workflows/linux_test_install.yml
+++ b/.github/workflows/linux_test_install.yml
@@ -111,35 +111,35 @@ jobs:
             NPM_VERSION: '>2.7.0 <10.0.0'
             PNPM_VERSION: '6'
 
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0 <10.0.0'
-            PNPM_VERSION: '6'
+          # - NODE_VERSION: '14'
+          #   NPM_VERSION: '>2.7.0 <10.0.0'
+          #   PNPM_VERSION: '6'
 
-          - NODE_VERSION: '12'
-            NPM_VERSION: '>2.7.0 <9.0.0'
-            PNPM_VERSION: '6'
+          # - NODE_VERSION: '12'
+          #   NPM_VERSION: '>2.7.0 <9.0.0'
+          #   PNPM_VERSION: '6'
 
-          - NODE_VERSION: '10'
-            NPM_VERSION: '>2.7.0 <7.0.0'
-            PNPM_VERSION: '5'
+          # - NODE_VERSION: '10'
+          #   NPM_VERSION: '>2.7.0 <7.0.0'
+          #   PNPM_VERSION: '5'
 
-          - NODE_VERSION: '8'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-            PNPM_VERSION: '3'
+          # - NODE_VERSION: '8'
+          #   NPM_VERSION: '>2.7.0 <6.0.0'
+          #   PNPM_VERSION: '3'
 
-          - NODE_VERSION: '6'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-            PNPM_VERSION: '2'
+          # - NODE_VERSION: '6'
+          #   NPM_VERSION: '>2.7.0 <6.0.0'
+          #   PNPM_VERSION: '2'
 
-          - NODE_VERSION: '4'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-            PNPM_VERSION: '1'
+          # - NODE_VERSION: '4'
+          #   NPM_VERSION: '>2.7.0 <6.0.0'
+          #   PNPM_VERSION: '1'
 
-          - NODE_VERSION: '0.12'
-            NPM_VERSION: '>2.7.0 <4.0.0'
+          # - NODE_VERSION: '0.12'
+          #   NPM_VERSION: '>2.7.0 <4.0.0'
 
-          - NODE_VERSION: '0.10'
-            NPM_VERSION: '>2.7.0 <4.0.0'
+          # - NODE_VERSION: '0.10'
+          #   NPM_VERSION: '>2.7.0 <4.0.0'
 
         # Exclude certain matrix combinations:
         exclude:


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes stale `include` entries from the `test_install` job's build matrix in `linux_test_install.yml`.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/28581985462

**Symptom:** `linux_test_install` has failed on every nightly `develop` run for 30+ consecutive days. The run reports overall `conclusion: failure`, but zero `test_install` jobs actually run — only the unrelated `Zulip notification` job executes.

**Root cause:** `NODE_VERSION` was trimmed to `['20', '18', '16']`, but `include` still lists entries for `14`, `12`, `10`, `8`, `6`, `4`, `0.12`, `0.10`. None of those values match any base matrix combination, so GitHub Actions adds each as a standalone job configuration containing only the keys given in the `include` entry — missing `OS`, `BUILD_TASK`, and `PACKAGE_MANAGER`. `runs-on: ${{ matrix.OS }}` then resolves to an empty string, invalidating the job's entire matrix expansion, so no `test_install` jobs run and the workflow reports failure.

**Fix:** comment out the eight stale `include` entries, identical to the pattern already in use in the sibling `linux_test.yml` and `macos_test.yml` workflows.

## Related Issues

> Does this pull request have any related issues?

This pull request has no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation:** YAML syntax checked with `python3 -c "import yaml; yaml.safe_load(...)"`. Three independent agent reviews (correctness, regression scope, style) all approved with no blocking findings, confirming the remaining `include` entries all match existing base combinations and that the comment style matches `linux_test.yml`/`macos_test.yml` character-for-character.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was prepared by Claude Code as part of an automated CI-failure investigation routine. Root cause was identified from job logs and GitHub Actions matrix semantics, cross-checked against the identical pattern already applied in sibling workflow files, and validated by three independent agent reviews.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbW1MgN7DLHJsHS46xbmv3)_