### PR TITLE
build(workflows): remove stale Node.js version matrix includes in `macos_test_npm_install`

### DIFF
--- a/.github/workflows/macos_test_npm_install.yml
+++ b/.github/workflows/macos_test_npm_install.yml
@@ -84,7 +84,7 @@ jobs:
         BUILD_TASK: ['test-npm-install']
 
         # Define the list of Node.js versions:
-        NODE_VERSION: ['20', '18', '16']
+        NODE_VERSION: ['20', '18', '16'] # ['20', '18', '16', '14', '12', '10', '8', '6', '4', '0.12', '0.10']
 
         # Define the list of operating systems:
         OS: ['macOS-latest']
@@ -103,29 +103,29 @@ jobs:
           - NODE_VERSION: '16'
             NPM_VERSION: '>2.7.0 <10.0.0'
 
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0 <10.0.0'
+          # - NODE_VERSION: '14'
+          #   NPM_VERSION: '>2.7.0 <10.0.0'
 
-          - NODE_VERSION: '12'
-            NPM_VERSION: '>2.7.0 <9.0.0'
+          # - NODE_VERSION: '12'
+          #   NPM_VERSION: '>2.7.0 <9.0.0'
 
-          - NODE_VERSION: '10'
-            NPM_VERSION: '>2.7.0 <7.0.0'
+          # - NODE_VERSION: '10'
+          #   NPM_VERSION: '>2.7.0 <7.0.0'
 
-          - NODE_VERSION: '8'
-            NPM_VERSION: '>2.7.0 <6.0.0'
+          # - NODE_VERSION: '8'
+          #   NPM_VERSION: '>2.7.0 <6.0.0'
 
-          - NODE_VERSION: '6'
-            NPM_VERSION: '>2.7.0 <6.0.0'
+          # - NODE_VERSION: '6'
+          #   NPM_VERSION: '>2.7.0 <6.0.0'
 
-          - NODE_VERSION: '4'
-            NPM_VERSION: '>2.7.0 <6.0.0'
+          # - NODE_VERSION: '4'
+          #   NPM_VERSION: '>2.7.0 <6.0.0'
 
-          - NODE_VERSION: '0.12'
-            NPM_VERSION: '>2.7.0 <4.0.0'
+          # - NODE_VERSION: '0.12'
+          #   NPM_VERSION: '>2.7.0 <4.0.0'
 
-          - NODE_VERSION: '0.10'
-            NPM_VERSION: '>2.7.0 <4.0.0'
+          # - NODE_VERSION: '0.10'
+          #   NPM_VERSION: '>2.7.0 <4.0.0'
 
     # Set defaults:
     defaults:


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes stale `include` entries from the `test_npm_install` job's build matrix in `macos_test_npm_install.yml`.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/28581700913

**Symptom:** `macos_test_npm_install` has failed on every nightly `develop` run for 30+ consecutive days. The run reports overall `conclusion: failure`, but zero `test_npm_install` jobs actually run — only the unrelated `Zulip notification` job executes. Identical failure signature to `linux_test_install` (see #13231).

**Root cause:** `NODE_VERSION` is `['20', '18', '16']`, but `include` still lists entries for `14`, `12`, `10`, `8`, `6`, `4`, `0.12`, `0.10`. None of those values match any base matrix combination, so GitHub Actions adds each as a standalone job configuration containing only the keys given in the `include` entry — missing `OS` and `BUILD_TASK`. `runs-on: ${{ matrix.OS }}` then resolves to an empty string, invalidating the job's entire matrix expansion, so no `test_npm_install` jobs run and the workflow reports failure.

**Fix:** comment out the eight stale `include` entries, identical to the pattern already in use in the sibling `linux_test.yml` and `macos_test.yml` workflows.

## Related Issues

> Does this pull request have any related issues?

This pull request has no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation:** YAML syntax checked with `python3 -c "import yaml; yaml.safe_load(...)"`. Three independent agent reviews (correctness, regression scope, style) all approved with no blocking findings.

**Reviewer notes:** style reviewer noted `macos_test.yml` additionally carries a prose `# Note: ...` line explaining its reduced Node.js version list; this PR follows `linux_test_install.yml`'s leaner inline-comment style instead. Non-blocking.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was prepared by Claude Code as part of an automated CI-failure investigation routine. Root cause was identified from job logs and GitHub Actions matrix semantics, cross-checked against the identical pattern already applied in sibling workflow files, and validated by three independent agent reviews.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbW1MgN7DLHJsHS46xbmv3)_