### PR TITLE
fix: add additional checks for Node.js native add-on detection

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
@@ -24,11 +24,22 @@ var resolve = require( 'path' ).resolve;
 var logger = require( 'debug' );
 var dirname = require( '@stdlib/utils/dirname' );
 var exists = require( '@stdlib/fs/exists' );
+var join = require( '@stdlib/array/base/join' );
 
 
 // VARIABLES //
 
 var debug = logger( 'pkgs:add-ons:resolve' );
+
+var THRESHOLD = 3;
+var FILES = [
+	[ 'src', 'Makefile' ],
+	[ 'binding.gyp' ],
+
+	// WARNING: we assume that a package does NOT have both an `addon.c` AND an `addon.cpp` file!
+	[ 'src', 'addon.c' ],
+	[ 'src', 'addon.cpp' ]
+];
 
 
 // MAIN //
@@ -42,7 +53,9 @@ var debug = logger( 'pkgs:add-ons:resolve' );
 * @returns {void}
 */
 function inspect( files, clbk ) {
+	var counter;
 	var total;
+	var npass;
 	var out;
 	var i;
 
@@ -60,44 +73,25 @@ function inspect( files, clbk ) {
 	function next() {
 		var fpath;
 		var dir;
+		var j;
 
 		i += 1;
 		debug( 'Inspecting package %d of %d: %s', i+1, total, files[ i ] );
 
 		dir = dirname( files[ i ] );
-		fpath = resolve( dir, 'src', 'Makefile' );
-
+		counter = 0;
+		npass = 0;
+		
 		debug( 'Checking for add-on...' );
-		exists( fpath, onExistsMakefile );
+		for ( j = 0; j < FILES.length; j++ ) {
+			debug( 'Checking for add-on file: %s', join( FILES[ j ] ) );
+			fpath = resolve.apply( null, [ dir ].concat( FILES[ j ] ) );
+			exists( fpath, onExists );
+		}
 	}
 
 	/**
-	* Callback invoked upon testing if a `src/Makefile` exists.
-	*
-	* @private
-	* @param {(Error|null)} error - error object
-	* @param {boolean} bool - boolean indicating whether a file exists
-	* @returns {void}
-	*/
-	function onExistsMakefile( error, bool ) {
-		var gpath;
-		var j = i + 1;
-		if ( error ) {
-			debug( 'Encountered an error when testing for add-on: %s (%d of %d). Error: %s', files[ i ], j, total, error.message );
-			return done();
-		}
-		if ( !bool ) {
-			debug( 'Unable to detect add-on.' );
-			return done();
-		}
-		// A `src/Makefile` is also present in WebAssembly-only packages, so additionally require a `binding.gyp` file, which is what `node-gyp` needs to build a native add-on:
-		gpath = resolve( dirname( files[ i ] ), 'binding.gyp' );
-		debug( 'Checking for `binding.gyp`...' );
-		exists( gpath, onExists );
-	}
-
-	/**
-	* Callback invoked upon testing if a `binding.gyp` file exists.
+	* Callback invoked upon testing if a file exists.
 	*
 	* @private
 	* @param {(Error|null)} error - error object
@@ -106,13 +100,23 @@ function inspect( files, clbk ) {
 	*/
 	function onExists( error, bool ) {
 		var j = i + 1;
+
+		counter += 1;
+		debug( 'Finished checking for add-on file (%d of %d).', counter, FILES.length );
 		if ( error ) {
 			debug( 'Encountered an error when testing for add-on: %s (%d of %d). Error: %s', files[ i ], j, total, error.message );
 		} else if ( bool ) {
+			debug( 'Detected add-on file.' );
+			npass += 1;
+		} else {
+			debug( 'Unable to detect add-on file.' );
+		}
+		if ( counter < FILES.length ) {
+			return;
+		}
+		if ( npass >= THRESHOLD ) {
 			debug( 'Detected add-on.' );
 			out.push( dirname( files[ i ] ) );
-		} else {
-			debug( 'Unable to detect add-on.' );
 		}
 		return done();
 	}
@@ -124,8 +128,7 @@ function inspect( files, clbk ) {
 	* @returns {void}
 	*/
 	function done() {
-		var j;
-		j = i + 1;
+		var j = i + 1;
 		if ( j < total ) {
 			debug( 'Inspected %d of %d packages.', j, total );
 			return next();

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
@@ -80,8 +80,8 @@ function inspect( files, clbk ) {
 	* @returns {void}
 	*/
 	function onExistsMakefile( error, bool ) {
-		var j = i + 1;
 		var gpath;
+		var j = i + 1;
 		if ( error ) {
 			debug( 'Encountered an error when testing for add-on: %s (%d of %d). Error: %s', files[ i ], j, total, error.message );
 			return done();

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
@@ -81,7 +81,6 @@ function inspect( files, clbk ) {
 		dir = dirname( files[ i ] );
 		counter = 0;
 		npass = 0;
-		
 		debug( 'Checking for add-on...' );
 		for ( j = 0; j < FILES.length; j++ ) {
 			debug( 'Checking for add-on file: %s', join( FILES[ j ] ) );

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
@@ -68,11 +68,36 @@ function inspect( files, clbk ) {
 		fpath = resolve( dir, 'src', 'Makefile' );
 
 		debug( 'Checking for add-on...' );
-		exists( fpath, onExists );
+		exists( fpath, onExistsMakefile );
 	}
 
 	/**
-	* Callback invoked upon testing if a file exists.
+	* Callback invoked upon testing if a `src/Makefile` exists.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {boolean} bool - boolean indicating whether a file exists
+	* @returns {void}
+	*/
+	function onExistsMakefile( error, bool ) {
+		var j = i + 1;
+		var gpath;
+		if ( error ) {
+			debug( 'Encountered an error when testing for add-on: %s (%d of %d). Error: %s', files[ i ], j, total, error.message );
+			return done();
+		}
+		if ( !bool ) {
+			debug( 'Unable to detect add-on.' );
+			return done();
+		}
+		// A `src/Makefile` is also present in WebAssembly-only packages, so additionally require a `binding.gyp` file, which is what `node-gyp` needs to build a native add-on:
+		gpath = resolve( dirname( files[ i ] ), 'binding.gyp' );
+		debug( 'Checking for `binding.gyp`...' );
+		exists( gpath, onExists );
+	}
+
+	/**
+	* Callback invoked upon testing if a `binding.gyp` file exists.
 	*
 	* @private
 	* @param {(Error|null)} error - error object

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
@@ -117,6 +117,8 @@ function inspect( files, clbk ) {
 		if ( npass >= THRESHOLD ) {
 			debug( 'Detected add-on.' );
 			out.push( dirname( files[ i ] ) );
+		} else {
+			debug( 'Unable to detect add-on.' );
 		}
 		return done();
 	}

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
@@ -48,7 +48,7 @@ var FILES = [
 * Inspects packages for add-ons.
 *
 * @private
-* @param {StringArray} files - list of `package.json` files
+* @param {ArrayLikeObject<string>} files - list of `package.json` files
 * @param {Callback} clbk - callback to invoke upon completion
 * @returns {void}
 */

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/inspect.js
@@ -83,7 +83,7 @@ function inspect( files, clbk ) {
 		npass = 0;
 		debug( 'Checking for add-on...' );
 		for ( j = 0; j < FILES.length; j++ ) {
-			debug( 'Checking for add-on file: %s', join( FILES[ j ] ) );
+			debug( 'Checking for add-on file: %s', join( FILES[ j ], '/' ) );
 			fpath = resolve.apply( null, [ dir ].concat( FILES[ j ] ) );
 			exists( fpath, onExists );
 		}

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/sync.js
@@ -38,12 +38,12 @@ var validate = require( './validate.js' );
 * @param {Options} [options] - function options
 * @param {string} [options.dir] - root directory from which to search for add-ons
 * @param {string} [options.pattern='**\/package.json'] - glob pattern
-* @param {StringArray} [options.ignore] - glob pattern(s) to exclude matches
+* @param {ArrayLikeObject<string>} [options.ignore] - glob pattern(s) to exclude matches
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
 * @throws {Error} `pattern` option must end with `package.json`
 * @throws {Error} unable to parse `package.json` as JSON
-* @returns {(EmptyArray|StringArray)} list of add-ons
+* @returns {(EmptyArray|Array<string>)} list of add-ons
 *
 * @example
 * var pkgs = findAddons();
@@ -83,10 +83,14 @@ function findAddons( options ) {
 	out = [];
 	for ( i = 0; i < files.length; i++ ) {
 		dir = dirname( files[ i ] );
-		fpath = resolve( dir, 'src', 'Makefile' );
-
-		// A `src/Makefile` is also present in WebAssembly-only packages, so additionally require a `binding.gyp` file, which is what `node-gyp` needs to build a native add-on:
-		if ( exists( fpath ) && exists( resolve( dir, 'binding.gyp' ) ) ) {
+		if (
+			exists( resolve( dir, 'src', 'Makefile' ) ) &&
+			exists( resolve( dir, 'binding.gyp' ) ) &&
+			(
+				exists( resolve( dir, 'src', 'addon.c' ) ) ||
+				exists( resolve( dir, 'src', 'addon.cpp' ) )
+			)
+		) {
 			out.push( dir );
 		}
 	}

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/sync.js
@@ -84,7 +84,9 @@ function findAddons( options ) {
 	for ( i = 0; i < files.length; i++ ) {
 		dir = dirname( files[ i ] );
 		fpath = resolve( dir, 'src', 'Makefile' );
-		if ( exists( fpath ) ) {
+
+		// A `src/Makefile` is also present in WebAssembly-only packages, so additionally require a `binding.gyp` file, which is what `node-gyp` needs to build a native add-on:
+		if ( exists( fpath ) && exists( resolve( dir, 'binding.gyp' ) ) ) {
 			out.push( dir );
 		}
 	}

--- a/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/addons/lib/sync.js
@@ -50,7 +50,6 @@ var validate = require( './validate.js' );
 * // returns [...]
 */
 function findAddons( options ) {
-	var fpath;
 	var gopts;
 	var files;
 	var opts;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes native add-on detection in `@stdlib/_tools/pkgs/addons` to also require a `binding.gyp` file, not just `src/Makefile`.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/28557481039

**Symptom:** `random_benchmarks` fails whenever its daily random package sample includes a WebAssembly-only package under `blas/base/wasm/*`, with `gyp: binding.gyp not found`. 24 of the last 30 nightly runs on `develop` failed this way.

**Root cause:** `inspect.js` (async) and `sync.js` classify a package as a native add-on solely by checking for `src/Makefile`. WASM-only packages also ship a `src/Makefile` (used to build `.wasm`/`.wat` artifacts via `wasm2wat`/`wasm2js`), but have no `binding.gyp` anywhere in the package. When `install-node-addons` runs `node-gyp rebuild` against one of these, it fails immediately, aborting the job.

**Fix:** additionally require a `binding.gyp` file — the file `node-gyp` itself needs to build — before classifying a package as a native add-on. Applied to both the async (`inspect.js`) and sync (`sync.js`) detectors, which duplicate the same detection logic and are both part of this package's public API (`findAddons` / `findAddons.sync`).

## Related Issues

> Does this pull request have any related issues?

This pull request has no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation:** confirmed via direct filesystem check that all real native add-on packages (e.g. `math/base/special/abs`) carry `binding.gyp` at the package root alongside `src/Makefile`, and that WASM-only packages (e.g. `blas/base/wasm/scnrm2`) have no `binding.gyp` anywhere. A repo-wide audit (part of review) found zero `binding.gyp` files outside package roots, so this cannot misclassify a legitimate add-on. `node -c` syntax check passed on both files; full package tests could not be run in this environment (third-party dependencies such as `glob`/`tape` are not installed). Three independent agent reviews (correctness, regression scope, style) all approved with no blocking findings.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This pull request was prepared by Claude Code as part of an automated CI-failure investigation routine. Root cause was identified by reading job logs and the add-on detection source, confirmed against real package fixtures on disk, and validated by three independent agent reviews.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbW1MgN7DLHJsHS46xbmv3)_