### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/string/num2words/package.json
+++ b/lib/node_modules/@stdlib/string/num2words/package.json
@@ -52,6 +52,7 @@
     "windows"
   ],
   "keywords": [
+    "stdlib",
     "stdstring",
     "utilities",
     "utility",

--- a/lib/node_modules/@stdlib/string/to-well-formed/package.json
+++ b/lib/node_modules/@stdlib/string/to-well-formed/package.json
@@ -50,7 +50,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdstring",
     "string",
+    "str",
     "well-formed",
     "surrogate",
     "lone-surrogate",
@@ -62,7 +64,9 @@
     "sanitization",
     "conversion",
     "transform",
+    "utilities",
     "utility",
-    "utils"
+    "utils",
+    "util"
   ]
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds five missing generic `keywords` entries across two `@stdlib/string/*` `package.json` files so their sibling-shared metadata cluster is complete.

### Namespace summary

-   **Target**: `@stdlib/string` (58 direct child packages; 56 leaf packages + 2 namespace aggregators `base` and `tools`, which are excluded from the semantic vote because they have no `lib/main.js`).
-   **Features analyzed**: file tree presence, `package.json` top-level key set, `keywords` array membership, `directories`/`scripts`/`stdlib` key sets, README section presence and order, `test/` / `benchmark/` / `examples/` file naming, `manifest.json` shape, plus semantic-shape grep across `lib/main.js` covering error-construction (`format` usage), JSDoc `@example` / `@returns` / `@throws` / `@param` presence, and copyright-year distribution.
-   **Features with clear majority (≥75%)**: `test/test.js`, `examples/index.js`, `lib/index.js`, `README.md`, `package.json`, `docs/types/index.d.ts`, `docs/types/test.ts` (all 100%); `benchmark/benchmark.js`, `lib/main.js`, `docs/repl.txt` (96.6% — missing only from the two aggregators); every `package.json` top-level key (`author`, `bin`, `bugs`, `contributors`, `dependencies`, `description`, `devDependencies`, `directories`, `engines`, `homepage`, `keywords`, `license`, `main`, `name`, `os`, `repository`, `scripts`, `types`, `version`) at 84.5–100%; README sections `Usage` (100%), `Examples` (100%), `Notes` (77.6%), `CLI` (84.5%); `bin`-field presence (84.5%, perfectly correlated with the `CLI` README section — not drift); `keywords` values `utility`/`utils`/`string` (100%), `stdlib`/`stdstring`/`utilities`/`util`/`str` (98.3%); semantic: 55/56 leaves use `@stdlib/string/format` for error construction (100% except `format` itself); 100% carry `@example`, `@returns`, `@throws` JSDoc tags; 0% use string concatenation or template literals in `throw new *Error(...)`.
-   **Features without clear majority (excluded from drift analysis)**: README section ordering (plurality 29% — no ≥75% sequence); README `See Also` (70.7% — also generator-owned per pre-validation gate); `lib/validate.js` presence (5.2% — only 3 packages use a separate validation module); `manifest.json` presence (0%); `binding.gyp`/`src/*.c`/`.npmignore` presence (0%); `scripts` and `stdlib` `package.json` subkey sets (empty across the namespace); JSDoc `@example` count per file (bimodal, no ≥75% mode).

### `string/num2words`

Fixes `keywords[0]` in `lib/node_modules/@stdlib/string/num2words/package.json` from missing to `"stdlib"`, matching the shared metadata template used across the namespace. Prior to this, 57/58 (98.3%) `@stdlib/string/*` packages carried `"stdlib"` as their first keyword; `num2words` already had every other cluster keyword (`stdstring`, `utilities`, `utility`, `utils`, `util`, `string`, `str`) but this one. One-line diff, brings conformance to 58/58.

### `string/to-well-formed`

Correction adds `stdstring`, `utilities`, `util`, and `str` to `to-well-formed`'s keyword list — each keyword sits at 57/58 (98.3%) across `@stdlib/string/*`, and `to-well-formed` was the lone outlier despite already carrying the cluster's siblings (`stdlib`, `string`, `utility`, `utils`). No semantic basis for the omission; insertions land next to their existing cluster-mates, no reordering.

### Validation

Three independent agents reviewed the candidate corrections:

-   **Semantic-review (opus)** — classified both candidates as `confirmed-drift`. Both target packages are ordinary leaf string utilities; the missing keywords apply generically and the omissions are asymmetric relative to already-present cluster-mates. No mathematical/semantic shape difference justifies the deviations.
-   **Cross-reference (opus)** — confirmed no test assertion, example output, README, `docs/repl.txt`, `docs/types/index.d.ts`, or `docs/types/test.ts` under either outlier inspects the `keywords` array; grep for the specific added keywords returns no matches inside the target packages; parent `string/README.md` references the outliers only as signature links, with no keyword contract; no keyword lint policy in `.github/PULL_REQUEST_TEMPLATE.md`.
-   **Structural-review (sonnet)** — confirmed both corrections; the recommended `num2words` insertion position (`stdlib` at index 0) is unambiguous across all reference packages, and the four `to-well-formed` insertions are placed minimal-diff next to each keyword's cluster-mate without reordering the pre-existing sequence.

### Excluded from this run

-   README section ordering, `Notes` section content, `See Also` links — either below the 75% majority threshold, or generator-owned and covered by pre-validation gate 7a.
-   `docs/repl.txt` presence gap in aggregator packages `base` / `tools` — generator-owned artifact per pre-validation gate 7a.
-   `benchmark/benchmark.js` / `lib/main.js` presence gap in aggregator packages — inapplicable per pre-validation gate 7b (namespace aggregators legitimately lack a benchmarkable single function).
-   `bin`-field / `CLI` README section absence in 9 packages — presence is perfectly correlated (packages either have a CLI or don't), reflecting an intentional design difference, not drift.
-   The `bin` key in `code-point-at/package.json` is `"from-code-point": "./bin/cli"`, which mismatches the package's documented CLI command name (`code-point-at`). This looks like a copy-paste bug but a fix would change the installed executable's name — a public behavior change — so it is flagged as `needs-human` and not touched here.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

This PR is the output of an automated cross-package API drift detection routine over the `@stdlib/string` namespace. Namespace was picked uniformly at random from eligible (≥8 direct child packages) namespaces. Detailed per-feature majority pattern, conformance percentages, outlier list, and validation-agent verdicts are in the local drift report (not committed to the repo). PR is intentionally left in **draft** state pending maintainer audit.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code running an automated cross-package drift-detection routine: namespace selection, structural feature extraction (Python over `package.json`, README, and file trees), semantic-shape extraction (targeted grep over `lib/main.js` covering error-construction, JSDoc tags, throws/returns), three-agent drift validation (opus semantic-review + opus cross-reference + sonnet structural-review), and patch application. Corrections are strictly additive metadata (`keywords` array entries) — no runtime, signature, or test behavior is touched. PR is left in draft for human audit before promotion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPC5mN5gZTUxwsDdD8rfkD)_