### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/streams/node/transform/lib/index.js
+++ b/lib/node_modules/@stdlib/streams/node/transform/lib/index.js
@@ -43,7 +43,7 @@
 * stream.write( '3' );
 *
 * stream.end();
-* // => '1\n2\n3\n'
+* // e.g., => '1\n2\n3\n'
 *
 * @example
 * var transformStream = require( '@stdlib/streams/node/transform' );
@@ -95,7 +95,7 @@
 * s1.write( {'value': 'c'} );
 *
 * s1.end();
-* // => '{"value":"a"}\n{"value":"b"}\n{"value":"c"}\n'
+* // e.g., => '{"value":"a"}\n{"value":"b"}\n{"value":"c"}\n'
 *
 * @example
 * var stdout = require( '@stdlib/streams/node/stdout' );
@@ -120,7 +120,7 @@
 * stream.write( '3' );
 *
 * stream.end();
-* // => '1\n2\n3\n'
+* // e.g., => '1\n2\n3\n'
 */
 
 // MODULES //


### PR DESCRIPTION
Resolves #13238.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a JSDoc doctest linting failure in `@stdlib/streams/node/transform` by updating the `// =>` assertion syntax to the non-assertive `// e.g., =>` syntax for console outputs, as `stream.end()` returns `undefined`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #13238

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
