### PR TITLE
style: remove stray spaces

### DIFF
--- a/lib/node_modules/@stdlib/array/base/cuany-by-right/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/cuany-by-right/docs/types/test.ts
@@ -169,21 +169,21 @@ function isPositive( value: number ): boolean {
 	const x = [ false, false, true, false, false ];
 	const y = [ false, null, false, null, false, null, false, null, false, null ];
 
-	cuanyByRight.assign( x, y , '1', 0, isPositive ); // $ExpectError
-	cuanyByRight.assign( x, y , true, 0, isPositive ); // $ExpectError
-	cuanyByRight.assign( x, y , false, 0, isPositive ); // $ExpectError
-	cuanyByRight.assign( x, y , null, 0, isPositive ); // $ExpectError
-	cuanyByRight.assign( x, y , void 0, isPositive ); // $ExpectError
-	cuanyByRight.assign( x, y , {}, 0, isPositive ); // $ExpectError
-	cuanyByRight.assign( x, y , [], 0, isPositive ); // $ExpectError
+	cuanyByRight.assign( x, y, '1', 0, isPositive ); // $ExpectError
+	cuanyByRight.assign( x, y, true, 0, isPositive ); // $ExpectError
+	cuanyByRight.assign( x, y, false, 0, isPositive ); // $ExpectError
+	cuanyByRight.assign( x, y, null, 0, isPositive ); // $ExpectError
+	cuanyByRight.assign( x, y, void 0, isPositive ); // $ExpectError
+	cuanyByRight.assign( x, y, {}, 0, isPositive ); // $ExpectError
+	cuanyByRight.assign( x, y, [], 0, isPositive ); // $ExpectError
 
-	cuanyByRight.assign( x, y , '1', 0, isPositive, {} ); // $ExpectError
-	cuanyByRight.assign( x, y , true, 0, isPositive, {} ); // $ExpectError
-	cuanyByRight.assign( x, y , false, 0, isPositive, {} ); // $ExpectError
-	cuanyByRight.assign( x, y , null, 0, isPositive, {} ); // $ExpectError
-	cuanyByRight.assign( x, y , void 0, isPositive, {} ); // $ExpectError
-	cuanyByRight.assign( x, y , {}, 0, isPositive, {} ); // $ExpectError
-	cuanyByRight.assign( x, y , [], 0, isPositive, {} ); // $ExpectError
+	cuanyByRight.assign( x, y, '1', 0, isPositive, {} ); // $ExpectError
+	cuanyByRight.assign( x, y, true, 0, isPositive, {} ); // $ExpectError
+	cuanyByRight.assign( x, y, false, 0, isPositive, {} ); // $ExpectError
+	cuanyByRight.assign( x, y, null, 0, isPositive, {} ); // $ExpectError
+	cuanyByRight.assign( x, y, void 0, isPositive, {} ); // $ExpectError
+	cuanyByRight.assign( x, y, {}, 0, isPositive, {} ); // $ExpectError
+	cuanyByRight.assign( x, y, [], 0, isPositive, {} ); // $ExpectError
 }
 
 // The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...

--- a/lib/node_modules/@stdlib/array/base/cuany-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/cuany-by/docs/types/test.ts
@@ -169,21 +169,21 @@ function isPositive( value: number ): boolean {
 	const x = [ false, false, true, false, false ];
 	const y = [ false, null, false, null, false, null, false, null, false, null ];
 
-	cuanyBy.assign( x, y , '1', 0, isPositive ); // $ExpectError
-	cuanyBy.assign( x, y , true, 0, isPositive ); // $ExpectError
-	cuanyBy.assign( x, y , false, 0, isPositive ); // $ExpectError
-	cuanyBy.assign( x, y , null, 0, isPositive ); // $ExpectError
-	cuanyBy.assign( x, y , void 0, isPositive ); // $ExpectError
-	cuanyBy.assign( x, y , {}, 0, isPositive ); // $ExpectError
-	cuanyBy.assign( x, y , [], 0, isPositive ); // $ExpectError
+	cuanyBy.assign( x, y, '1', 0, isPositive ); // $ExpectError
+	cuanyBy.assign( x, y, true, 0, isPositive ); // $ExpectError
+	cuanyBy.assign( x, y, false, 0, isPositive ); // $ExpectError
+	cuanyBy.assign( x, y, null, 0, isPositive ); // $ExpectError
+	cuanyBy.assign( x, y, void 0, isPositive ); // $ExpectError
+	cuanyBy.assign( x, y, {}, 0, isPositive ); // $ExpectError
+	cuanyBy.assign( x, y, [], 0, isPositive ); // $ExpectError
 
-	cuanyBy.assign( x, y , '1', 0, isPositive, {} ); // $ExpectError
-	cuanyBy.assign( x, y , true, 0, isPositive, {} ); // $ExpectError
-	cuanyBy.assign( x, y , false, 0, isPositive, {} ); // $ExpectError
-	cuanyBy.assign( x, y , null, 0, isPositive, {} ); // $ExpectError
-	cuanyBy.assign( x, y , void 0, isPositive, {} ); // $ExpectError
-	cuanyBy.assign( x, y , {}, 0, isPositive, {} ); // $ExpectError
-	cuanyBy.assign( x, y , [], 0, isPositive, {} ); // $ExpectError
+	cuanyBy.assign( x, y, '1', 0, isPositive, {} ); // $ExpectError
+	cuanyBy.assign( x, y, true, 0, isPositive, {} ); // $ExpectError
+	cuanyBy.assign( x, y, false, 0, isPositive, {} ); // $ExpectError
+	cuanyBy.assign( x, y, null, 0, isPositive, {} ); // $ExpectError
+	cuanyBy.assign( x, y, void 0, isPositive, {} ); // $ExpectError
+	cuanyBy.assign( x, y, {}, 0, isPositive, {} ); // $ExpectError
+	cuanyBy.assign( x, y, [], 0, isPositive, {} ); // $ExpectError
 }
 
 // The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...

--- a/lib/node_modules/@stdlib/array/base/cuany/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/cuany/docs/types/index.d.ts
@@ -33,7 +33,7 @@ interface CuAny {
 	* @returns output array
 	*
 	* @example
-	* var x = [ false, false , true, false , false ];
+	* var x = [ false, false, true, false, false ];
 	*
 	* var y = cuany( x );
 	* // returns [ false, false, true, true, true ];

--- a/lib/node_modules/@stdlib/array/base/cuany/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/cuany/docs/types/test.ts
@@ -81,13 +81,13 @@ import cuany = require( './index' );
 	const x = [ false, false, true, false, false ];
 	const y = [ false, null, false, null, false, null, false, null, false, null ];
 
-	cuany.assign( x, y , '1', 0 ); // $ExpectError
-	cuany.assign( x, y , true, 0 ); // $ExpectError
-	cuany.assign( x, y , false, 0 ); // $ExpectError
-	cuany.assign( x, y , null, 0 ); // $ExpectError
-	cuany.assign( x, y , void 0, 0 ); // $ExpectError
-	cuany.assign( x, y , {}, 0 ); // $ExpectError
-	cuany.assign( x, y , [], 0 ); // $ExpectError
+	cuany.assign( x, y, '1', 0 ); // $ExpectError
+	cuany.assign( x, y, true, 0 ); // $ExpectError
+	cuany.assign( x, y, false, 0 ); // $ExpectError
+	cuany.assign( x, y, null, 0 ); // $ExpectError
+	cuany.assign( x, y, void 0, 0 ); // $ExpectError
+	cuany.assign( x, y, {}, 0 ); // $ExpectError
+	cuany.assign( x, y, [], 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...

--- a/lib/node_modules/@stdlib/array/base/cuevery/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/cuevery/docs/types/test.ts
@@ -81,13 +81,13 @@ import cuevery = require( './index' );
 	const x = [ false, false, true, false, false ];
 	const y = [ false, null, false, null, false, null, false, null, false, null ];
 
-	cuevery.assign( x, y , '1', 0 ); // $ExpectError
-	cuevery.assign( x, y , true, 0 ); // $ExpectError
-	cuevery.assign( x, y , false, 0 ); // $ExpectError
-	cuevery.assign( x, y , null, 0 ); // $ExpectError
-	cuevery.assign( x, y , void 0, 0 ); // $ExpectError
-	cuevery.assign( x, y , {}, 0 ); // $ExpectError
-	cuevery.assign( x, y , [], 0 ); // $ExpectError
+	cuevery.assign( x, y, '1', 0 ); // $ExpectError
+	cuevery.assign( x, y, true, 0 ); // $ExpectError
+	cuevery.assign( x, y, false, 0 ); // $ExpectError
+	cuevery.assign( x, y, null, 0 ); // $ExpectError
+	cuevery.assign( x, y, void 0, 0 ); // $ExpectError
+	cuevery.assign( x, y, {}, 0 ); // $ExpectError
+	cuevery.assign( x, y, [], 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...

--- a/lib/node_modules/@stdlib/array/base/cunone/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/cunone/docs/types/test.ts
@@ -81,13 +81,13 @@ import cunone = require( './index' );
 	const x = [ false, false, true, false, false ];
 	const y = [ false, null, false, null, false, null, false, null, false, null ];
 
-	cunone.assign( x, y , '1', 0 ); // $ExpectError
-	cunone.assign( x, y , true, 0 ); // $ExpectError
-	cunone.assign( x, y , false, 0 ); // $ExpectError
-	cunone.assign( x, y , null, 0 ); // $ExpectError
-	cunone.assign( x, y , void 0, 0 ); // $ExpectError
-	cunone.assign( x, y , {}, 0 ); // $ExpectError
-	cunone.assign( x, y , [], 0 ); // $ExpectError
+	cunone.assign( x, y, '1', 0 ); // $ExpectError
+	cunone.assign( x, y, true, 0 ); // $ExpectError
+	cunone.assign( x, y, false, 0 ); // $ExpectError
+	cunone.assign( x, y, null, 0 ); // $ExpectError
+	cunone.assign( x, y, void 0, 0 ); // $ExpectError
+	cunone.assign( x, y, {}, 0 ); // $ExpectError
+	cunone.assign( x, y, [], 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -498,9 +498,9 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	*
 	* var arr = new Complex128Array( 3 );
 	*
-	* arr.set( [ 1.0 , 1.0 ], 0 );
-	* arr.set( [ 2.0 , 2.0 ], 1 );
-	* arr.set( [ 3.0 , 3.0 ], 2 );
+	* arr.set( [ 1.0, 1.0 ], 0 );
+	* arr.set( [ 2.0, 2.0 ], 1 );
+	* arr.set( [ 3.0, 3.0 ], 2 );
 	*
 	* var bool = arr.every( predicate );
 	* // returns true
@@ -1006,9 +1006,9 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	*
 	* var arr = new Complex128Array( 3 );
 	*
-	* arr.set( [ 1.0 , -1.0 ], 0 );
-	* arr.set( [ 2.0 , 2.0 ], 1 );
-	* arr.set( [ 3.0 , -3.0 ], 2 );
+	* arr.set( [ 1.0, -1.0 ], 0 );
+	* arr.set( [ 2.0, 2.0 ], 1 );
+	* arr.set( [ 3.0, -3.0 ], 2 );
 	*
 	* var bool = arr.some( predicate );
 	* // returns true

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -498,9 +498,9 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	*
 	* var arr = new Complex64Array( 3 );
 	*
-	* arr.set( [ 1.0 , 1.0 ], 0 );
-	* arr.set( [ 2.0 , 2.0 ], 1 );
-	* arr.set( [ 3.0 , 3.0 ], 2 );
+	* arr.set( [ 1.0, 1.0 ], 0 );
+	* arr.set( [ 2.0, 2.0 ], 1 );
+	* arr.set( [ 3.0, 3.0 ], 2 );
 	*
 	* var bool = arr.every( predicate );
 	* // returns true
@@ -1020,9 +1020,9 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	*
 	* var arr = new Complex64Array( 3 );
 	*
-	* arr.set( [ 1.0 , -1.0 ], 0 );
-	* arr.set( [ 2.0 , 2.0 ], 1 );
-	* arr.set( [ 3.0 , -3.0 ], 2 );
+	* arr.set( [ 1.0, -1.0 ], 0 );
+	* arr.set( [ 2.0, 2.0 ], 1 );
+	* arr.set( [ 3.0, -3.0 ], 2 );
 	*
 	* var bool = arr.some( predicate );
 	* // returns true

--- a/lib/node_modules/@stdlib/math/base/special/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/docs/types/index.d.ts
@@ -5129,11 +5129,11 @@ interface Namespace {
 	*
 	* @example
 	* var out = ns.frexp( Infinity );
-	* // returns [ Infinity , 0 ]
+	* // returns [ Infinity, 0 ]
 	*
 	* @example
 	* var out = ns.frexp( -Infinity );
-	* // returns [ -Infinity , 0 ]
+	* // returns [ -Infinity, 0 ]
 	*/
 	frexp: typeof frexp;
 
@@ -5167,11 +5167,11 @@ interface Namespace {
 	*
 	* @example
 	* var out = ns.frexpf( Infinity );
-	* // returns [ Infinity , 0 ]
+	* // returns [ Infinity, 0 ]
 	*
 	* @example
 	* var out = ns.frexpf( -Infinity );
-	* // returns [ -Infinity , 0 ]
+	* // returns [ -Infinity, 0 ]
 	*/
 	frexpf: typeof frexpf;
 

--- a/lib/node_modules/@stdlib/math/base/special/frexp/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/frexp/docs/types/index.d.ts
@@ -56,11 +56,11 @@ interface Frexp {
 	*
 	* @example
 	* var out = frexp( Infinity );
-	* // returns [ Infinity , 0 ]
+	* // returns [ Infinity, 0 ]
 	*
 	* @example
 	* var out = frexp( -Infinity );
-	* // returns [ -Infinity , 0 ]
+	* // returns [ -Infinity, 0 ]
 	*/
 	( x: number ): [ number, number ];
 
@@ -123,11 +123,11 @@ interface Frexp {
 *
 * @example
 * var out = frexp( Infinity );
-* // returns [ Infinity , 0 ]
+* // returns [ Infinity, 0 ]
 *
 * @example
 * var out = frexp( -Infinity );
-* // returns [ -Infinity , 0 ]
+* // returns [ -Infinity, 0 ]
 */
 declare var frexp: Frexp;
 

--- a/lib/node_modules/@stdlib/math/base/special/frexpf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/frexpf/docs/types/index.d.ts
@@ -56,11 +56,11 @@ interface Frexpf {
 	*
 	* @example
 	* var out = frexpf( Infinity );
-	* // returns [ Infinity , 0 ]
+	* // returns [ Infinity, 0 ]
 	*
 	* @example
 	* var out = frexpf( -Infinity );
-	* // returns [ -Infinity , 0 ]
+	* // returns [ -Infinity, 0 ]
 	*/
 	( x: number ): [ number, number ];
 
@@ -123,11 +123,11 @@ interface Frexpf {
 *
 * @example
 * var out = frexpf( Infinity );
-* // returns [ Infinity , 0 ]
+* // returns [ Infinity, 0 ]
 *
 * @example
 * var out = frexpf( -Infinity );
-* // returns [ -Infinity , 0 ]
+* // returns [ -Infinity, 0 ]
 */
 declare var frexpf: Frexpf;
 

--- a/lib/node_modules/@stdlib/object/any-own-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/object/any-own-by/docs/types/test.ts
@@ -46,12 +46,12 @@ const obj = {
 
 // The compiler throws an error if the function is provided a second argument which is not a function...
 {
-	anyOwnBy( obj , 2 ); // $ExpectError
-	anyOwnBy( obj , false ); // $ExpectError
-	anyOwnBy( obj , true ); // $ExpectError
-	anyOwnBy( obj , 'abc' ); // $ExpectError
-	anyOwnBy( obj , {} ); // $ExpectError
-	anyOwnBy( obj , [] ); // $ExpectError
+	anyOwnBy( obj, 2 ); // $ExpectError
+	anyOwnBy( obj, false ); // $ExpectError
+	anyOwnBy( obj, true ); // $ExpectError
+	anyOwnBy( obj, 'abc' ); // $ExpectError
+	anyOwnBy( obj, {} ); // $ExpectError
+	anyOwnBy( obj, [] ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an invalid number of arguments...

--- a/lib/node_modules/@stdlib/object/every-own-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/object/every-own-by/docs/types/test.ts
@@ -46,12 +46,12 @@ var obj = {
 
 // The compiler throws an error if the function is provided a second argument which is not a function...
 {
-	everyOwnBy( obj , 2 ); // $ExpectError
-	everyOwnBy( obj , false ); // $ExpectError
-	everyOwnBy( obj , true ); // $ExpectError
-	everyOwnBy( obj , 'abc' ); // $ExpectError
-	everyOwnBy( obj , {} ); // $ExpectError
-	everyOwnBy( obj , [] ); // $ExpectError
+	everyOwnBy( obj, 2 ); // $ExpectError
+	everyOwnBy( obj, false ); // $ExpectError
+	everyOwnBy( obj, true ); // $ExpectError
+	everyOwnBy( obj, 'abc' ); // $ExpectError
+	everyOwnBy( obj, {} ); // $ExpectError
+	everyOwnBy( obj, [] ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an invalid number of arguments...

--- a/lib/node_modules/@stdlib/object/none-own-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/object/none-own-by/docs/types/test.ts
@@ -45,12 +45,12 @@ const obj = {
 
 // The compiler throws an error if the function is provided a second argument which is not a function...
 {
-	noneOwnBy( obj , 2 ); // $ExpectError
-	noneOwnBy( obj , false ); // $ExpectError
-	noneOwnBy( obj , true ); // $ExpectError
-	noneOwnBy( obj , 'abc' ); // $ExpectError
-	noneOwnBy( obj , {} ); // $ExpectError
-	noneOwnBy( obj , [] ); // $ExpectError
+	noneOwnBy( obj, 2 ); // $ExpectError
+	noneOwnBy( obj, false ); // $ExpectError
+	noneOwnBy( obj, true ); // $ExpectError
+	noneOwnBy( obj, 'abc' ); // $ExpectError
+	noneOwnBy( obj, {} ); // $ExpectError
+	noneOwnBy( obj, [] ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an invalid number of arguments...

--- a/lib/node_modules/@stdlib/utils/papply-right/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/papply-right/docs/types/test.ts
@@ -24,7 +24,7 @@ import papplyRight = require( './index' );
 // The function returns a partially applied function...
 {
 	papplyRight( ( x: number, y: number ): number => x + y, 3 ); // $ExpectType Closure
-	papplyRight( ( x: number, y: number, z: number ): number => x + y + z , 3, 4 ); // $ExpectType Closure
+	papplyRight( ( x: number, y: number, z: number ): number => x + y + z, 3, 4 ); // $ExpectType Closure
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a function...

--- a/lib/node_modules/@stdlib/utils/papply/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/papply/docs/types/test.ts
@@ -24,7 +24,7 @@ import papply = require( './index' );
 // The function returns a partially applied function...
 {
 	papply( ( x: number, y: number ): number => x + y, 3 ); // $ExpectType Closure
-	papply( ( x: number, y: number, z: number ): number => x + y + z , 3, 4 ); // $ExpectType Closure
+	papply( ( x: number, y: number, z: number ): number => x + y + z, 3, 4 ); // $ExpectType Closure
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a function...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Propagates fixes merged to `develop` between 2026-07-02 13:19 UTC and 2026-07-03 00:00 UTC to sibling packages carrying the same defects.

### `chore:` — stray space before comma

Removes stray space-before-comma occurrences across sibling packages, matching the fix in [7fbca26][7fbca26] which corrected a single such typo in `array/base/getter/docs/types/test.ts`. The same defect appears in argument lists inside `docs/types/test.ts` files and in JSDoc `@example` blocks inside `docs/types/index.d.ts` files. Purely mechanical whitespace cleanup — no semantic change; aligns with the repo-wide `comma-spacing` convention.

Source commit: [`7fbca26`][7fbca26]

Target packages:

-   `object/any-own-by` — `docs/types/test.ts`
-   `object/none-own-by` — `docs/types/test.ts`
-   `object/every-own-by` — `docs/types/test.ts`
-   `utils/papply` — `docs/types/test.ts`
-   `utils/papply-right` — `docs/types/test.ts`
-   `array/base/cuany` — `docs/types/test.ts`, `docs/types/index.d.ts`
-   `array/base/cuany-by` — `docs/types/test.ts`
-   `array/base/cuany-by-right` — `docs/types/test.ts`
-   `array/base/cuevery` — `docs/types/test.ts`
-   `array/base/cunone` — `docs/types/test.ts`
-   `math/base/special` — `docs/types/index.d.ts`
-   `math/base/special/frexp` — `docs/types/index.d.ts`
-   `math/base/special/frexpf` — `docs/types/index.d.ts`
-   `array/complex64` — `docs/types/index.d.ts`
-   `array/complex128` — `docs/types/index.d.ts`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Search scope was `.ts` files under `lib/node_modules/@stdlib` matching stray-space-before-comma. Two independent verifiers read every candidate line in full to confirm the defect against surrounding context; both flagged the same 94 lines across 16 files as unambiguous typos with no autogenerated / do-not-edit markers on any target file. Sites were deliberately excluded when they would require cross-package changes or interpretation of intent; none reached that bar in this run. The C-benchmark `isnan( y )` → `y != y` pattern from [`5dee19d`][5dee19d] found no valid remaining sites (all sibling `stats/base/dists/*` benchmarks already use the self-comparison idiom; the two remaining `isnan` sites benchmark the `isnan` function itself and cannot be rewritten). The duplicate `/**` header pattern from `7fbca26` also found no other occurrences repo-wide.

[7fbca26]: https://github.com/stdlib-js/stdlib/commit/7fbca26c260e75cc31902488cf09f43163a58c17
[5dee19d]: https://github.com/stdlib-js/stdlib/commit/5dee19dbe000c3512c48f5546478b66a41a2a062

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was generated by Claude Code as part of a scheduled fix-propagation routine that mirrors recent `develop` fixes to sibling packages carrying the same defect. Each target site was independently verified by two adversarial reviewers before the patch was applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01T9HTxgkCA6v7PYseig742g)_