### PR TITLE
feat: add `uint64/base/number2words`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/README.md
@@ -72,8 +72,6 @@ var bool = ( w === out );
 
 <!-- /.usage -->
 
-* * *
-
 <!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="notes">
@@ -85,8 +83,6 @@ var bool = ( w === out );
 </section>
 
 <!-- /.notes -->
-
-* * *
 
 <!-- Package usage examples. -->
 

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/README.md
@@ -1,0 +1,135 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# number2words
+
+> Split a number into the high and low 32-bit words of a 64-bit unsigned integer.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var number2words = require( '@stdlib/number/uint64/base/number2words' );
+```
+
+#### number2words( value )
+
+Splits a number into the high and low 32-bit words of a 64-bit unsigned integer.
+
+```javascript
+var w = number2words( 1234 );
+// returns [ 0, 1234 ]
+```
+
+The function returns an array containing two elements: a higher order word and a lower order word. The lower order word contains the less significant bits, while the higher order word contains the more significant bits.
+
+#### number2words.assign( value, out, stride, offset )
+
+Splits a number into the high and low 32-bit words of a 64-bit unsigned integer and assigns results to a provided output array.
+
+```javascript
+var Uint32Array = require( '@stdlib/array/uint32' );
+
+var out = new Uint32Array( 2 );
+// returns <Uint32Array>[ 0, 0 ]
+
+var w = number2words.assign( 9007199254740991, out, 1, 0 );
+// returns <Uint32Array>[ 2097151, 4294967295 ]
+
+var bool = ( w === out );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+* * *
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   For accurate results, the input value should be an integer in the range \[`0`, `2^53-1`\].
+
+</section>
+
+<!-- /.notes -->
+
+* * *
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+```javascript
+var number2words = require( '@stdlib/number/uint64/base/number2words' );
+
+var w = number2words( 1234 );
+console.log( w );
+// => [ 0, 1234 ]
+
+w = number2words( 0x100000000 );
+console.log( w );
+// => [ 1, 0 ]
+
+w = number2words( 9007199254740991 );
+console.log( w );
+// => [ 2097151, 4294967295 ]
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/benchmark/benchmark.js
@@ -1,0 +1,84 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var isArray = require( '@stdlib/assert/is-array' );
+var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var number2words = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var N;
+	var i;
+	var w;
+
+	N = 100;
+	values = discreteUniform( N, 0, MAX_SAFE_INTEGER );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		w = number2words( values[ i % N ] );
+		if ( typeof w !== 'object' ) {
+			b.fail( 'should return an array' );
+		}
+	}
+	b.toc();
+	if ( !isArray( w ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
+	var values;
+	var out;
+	var N;
+	var i;
+	var w;
+
+	N = 100;
+	values = discreteUniform( N, 0, MAX_SAFE_INTEGER );
+
+	out = new Uint32Array( 2 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		w = number2words.assign( values[ i % N ], out, 1, 0 );
+		if ( typeof w !== 'object' ) {
+			b.fail( 'should return an array' );
+		}
+	}
+	b.toc();
+	if ( w !== out ) {
+		b.fail( 'should return the output array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/repl.txt
@@ -45,7 +45,7 @@
     Returns
     -------
     out: Array|TypedArray|Object
-        High and low words as 32-bit unsigned integers.
+        Output array.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/repl.txt
@@ -1,0 +1,59 @@
+
+{{alias}}( value )
+    Splits a number into the high and low 32-bit words of a 64-bit unsigned
+    integer.
+
+    The function returns an array with two elements: a higher order word and a
+    lower order word, respectively. The lower order word contains the less
+    significant bits, while the higher order word contains the more significant
+    bits.
+
+    Parameters
+    ----------
+    value: NonNegativeInteger
+        Integer value in the range [0, 2^53-1].
+
+    Returns
+    -------
+    out: Array<uinteger32>
+        High and low words as 32-bit unsigned integers.
+
+    Examples
+    --------
+    > var w = {{alias}}( 1234 )
+    [ 0, 1234 ]
+
+
+{{alias}}.assign( value, out, stride, offset )
+    Splits a number into the high and low 32-bit words of a 64-bit unsigned
+    integer and assigns results to a provided output array.
+
+    Parameters
+    ----------
+    value: NonNegativeInteger
+        Integer value in the range [0, 2^53-1].
+
+    out: Array|TypedArray|Object
+        Output array.
+
+    stride: integer
+        Output array stride.
+
+    offset: integer
+        Output array index offset.
+
+    Returns
+    -------
+    out: Array|TypedArray|Object
+        High and low words as 32-bit unsigned integers.
+
+    Examples
+    --------
+    > var out = new {{alias:@stdlib/array/uint32}}( 2 );
+    > var w = {{alias}}.assign( 9007199254740991, out, 1, 0 )
+    <Uint32Array>[ 2097151, 4294967295 ]
+    > var bool = ( w === out )
+    true
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/repl.txt
@@ -10,12 +10,12 @@
 
     Parameters
     ----------
-    value: NonNegativeInteger
+    value: integer
         Integer value in the range [0, 2^53-1].
 
     Returns
     -------
-    out: Array<uinteger32>
+    out: Array<integer>
         High and low words as 32-bit unsigned integers.
 
     Examples
@@ -30,7 +30,7 @@
 
     Parameters
     ----------
-    value: NonNegativeInteger
+    value: integer
         Integer value in the range [0, 2^53-1].
 
     out: Array|TypedArray|Object

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/types/index.d.ts
@@ -1,0 +1,104 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Collection, NumericArray } from '@stdlib/types/array';
+
+/**
+* Interface describing `number2words`.
+*/
+interface NumberToWords {
+	/**
+	* Splits a number into the high and low 32-bit words of a 64-bit unsigned integer.
+	*
+	* @param value - integer value in the range [0, 2^53-1]
+	* @returns high and low words as 32-bit unsigned integers
+	*
+	* @example
+	* var out = number2words( 1234 );
+	* // returns [ 0, 1234 ]
+	*
+	* out = number2words( 0x100000000 );
+	* // returns [ 1, 0 ]
+	*
+	* out = number2words( 9007199254740991 );
+	* // returns [ 2097151, 4294967295 ]
+	*/
+	( value: number ): [ number, number ];
+
+	/**
+	* Splits a number into the high and low 32-bit words of a 64-bit unsigned integer and assigns results to a provided output array.
+	*
+	* @param value - integer value in the range [0, 2^53-1]
+	* @param out - output array
+	* @param stride - stride length
+	* @param offset - starting index
+	* @returns high and low words as 32-bit unsigned integers
+	*
+	* @example
+	* var Uint32Array = require( '@stdlib/array/uint32' );
+	*
+	* var out = new Uint32Array( 2 );
+	* // returns <Uint32Array>[ 0, 0 ]
+	*
+	* var w = number2words.assign( 9007199254740991, out, 1, 0 );
+	* // returns <Uint32Array>[ 2097151, 4294967295 ]
+	*
+	* var bool = ( w === out );
+	* // returns true
+	*/
+	assign<T extends NumericArray | Collection<number>>( value: number, out: T, stride: number, offset: number ): T;
+}
+
+/**
+* Splits a number into the high and low 32-bit words of a 64-bit unsigned integer.
+*
+* @param value - integer value in the range [0, 2^53-1]
+* @returns high and low words as 32-bit unsigned integers
+*
+* @example
+* var out = number2words( 1234 );
+* // returns [ 0, 1234 ]
+*
+* out = number2words( 0x100000000 );
+* // returns [ 1, 0 ]
+*
+* out = number2words( 9007199254740991 );
+* // returns [ 2097151, 4294967295 ]
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+*
+* var out = new Uint32Array( 2 );
+* // returns <Uint32Array>[ 0, 0 ]
+*
+* var w = number2words.assign( 9007199254740991, out, 1, 0 );
+* // returns <Uint32Array>[ 2097151, 4294967295 ]
+*
+* var bool = ( w === out );
+* // returns true
+*/
+declare var number2words: NumberToWords;
+
+
+// EXPORTS //
+
+export = number2words;

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/types/index.d.ts
@@ -51,7 +51,7 @@ interface NumberToWords {
 	* @param out - output array
 	* @param stride - stride length
 	* @param offset - starting index
-	* @returns high and low words as 32-bit unsigned integers
+	* @returns output array
 	*
 	* @example
 	* var Uint32Array = require( '@stdlib/array/uint32' );

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/docs/types/test.ts
@@ -1,0 +1,109 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import number2words = require( './index' );
+
+
+// TESTS //
+
+// The function returns an array...
+{
+	number2words( 1234 ); // $ExpectType [number, number]
+}
+
+// The compiler throws an error if the function is provided an argument that is not a number...
+{
+	number2words( '5' ); // $ExpectError
+	number2words( true ); // $ExpectError
+	number2words( false ); // $ExpectError
+	number2words( null ); // $ExpectError
+	number2words( {} ); // $ExpectError
+	number2words( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	number2words(); // $ExpectError
+	number2words( 1, 2 ); // $ExpectError
+}
+
+// Attached to the main export is an `assign` method which returns an array-like object containing numbers...
+{
+	number2words.assign( 1234, [ 0, 0 ], 1, 0 ); // $ExpectType number[]
+	number2words.assign( 1234, new Uint32Array( 2 ), 1, 0 ); // $ExpectType Uint32Array
+	number2words.assign( 1234, new Float64Array( 2 ), 1, 0 ); // $ExpectType Float64Array
+}
+
+// The compiler throws an error if the `assign` method is provided a first argument which is not a number...
+{
+	const out = [ 0.0, 0.0 ];
+
+	number2words.assign( true, out, 1, 0 ); // $ExpectError
+	number2words.assign( false, out, 1, 0 ); // $ExpectError
+	number2words.assign( '5', out, 1, 0 ); // $ExpectError
+	number2words.assign( null, out, 1, 0 ); // $ExpectError
+	number2words.assign( [], out, 1, 0 ); // $ExpectError
+	number2words.assign( {}, out, 1, 0 ); // $ExpectError
+	number2words.assign( ( x: number ): number => x, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a second argument which is not an array-like object...
+{
+	number2words.assign( 1234, 1, 1, 0 ); // $ExpectError
+	number2words.assign( 1234, true, 1, 0 ); // $ExpectError
+	number2words.assign( 1234, false, 1, 0 ); // $ExpectError
+	number2words.assign( 1234, null, 1, 0 ); // $ExpectError
+	number2words.assign( 1234, {}, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a third argument which is not a number...
+{
+	const out = [ 0.0, 0.0 ];
+
+	number2words.assign( 1234, out, '5', 0 ); // $ExpectError
+	number2words.assign( 1234, out, true, 0 ); // $ExpectError
+	number2words.assign( 1234, out, false, 0 ); // $ExpectError
+	number2words.assign( 1234, out, null, 0 ); // $ExpectError
+	number2words.assign( 1234, out, [], 0 ); // $ExpectError
+	number2words.assign( 1234, out, {}, 0 ); // $ExpectError
+	number2words.assign( 1234, out, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...
+{
+	const out = [ 0.0, 0.0 ];
+
+	number2words.assign( 1234, out, 1, '5' ); // $ExpectError
+	number2words.assign( 1234, out, 1, true ); // $ExpectError
+	number2words.assign( 1234, out, 1, false ); // $ExpectError
+	number2words.assign( 1234, out, 1, null ); // $ExpectError
+	number2words.assign( 1234, out, 1, [] ); // $ExpectError
+	number2words.assign( 1234, out, 1, {} ); // $ExpectError
+	number2words.assign( 1234, out, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided an unsupported number of arguments...
+{
+	const out = [ 0.0, 0.0 ];
+
+	number2words.assign(); // $ExpectError
+	number2words.assign( 1234 ); // $ExpectError
+	number2words.assign( 1234, out ); // $ExpectError
+	number2words.assign( 1234, out, 1 ); // $ExpectError
+	number2words.assign( 1234, out, 1, 0, 1 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/examples/index.js
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var number2words = require( './../lib' );
+
+var w = number2words( 1234 );
+console.log( w );
+// => [ 0, 1234 ]
+
+w = number2words( 0x100000000 );
+console.log( w );
+// => [ 1, 0 ]
+
+w = number2words( 9007199254740991 );
+console.log( w );
+// => [ 2097151, 4294967295 ]

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/assign.js
@@ -32,7 +32,7 @@ var TWO_32 = 0x100000000; // 2^32
 * @param {Collection} out - output array
 * @param {integer} stride - stride length
 * @param {NonNegativeInteger} offset - starting index
-* @returns {Collection} high and low words as 32-bit unsigned integers
+* @returns {Collection} output array
 *
 * @example
 * var Uint32Array = require( '@stdlib/array/uint32' );

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/assign.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// VARIABLES //
+
+var TWO_32 = 0x100000000; // 2^32
+
+
+// MAIN //
+
+/**
+* Splits a number into the high and low 32-bit words of a 64-bit unsigned integer and assigns results to a provided output array.
+*
+* @param {NonNegativeInteger} value - integer value in the range [0, 2^53-1]
+* @param {Collection} out - output array
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - starting index
+* @returns {Collection} high and low words as 32-bit unsigned integers
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+*
+* var out = new Uint32Array( 2 );
+* // returns <Uint32Array>[ 0, 0 ]
+*
+* var w = assign( 9007199254740991, out, 1, 0 );
+* // returns <Uint32Array>[ 2097151, 4294967295 ]
+*
+* var bool = ( w === out );
+* // returns true
+*/
+function assign( value, out, stride, offset ) {
+	out[ offset ] = ( value / TWO_32 ) >>> 0;
+	out[ offset + stride ] = value >>> 0;
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = assign;

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/index.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Split a number into the high and low 32-bit words of a 64-bit unsigned integer.
+*
+* @module @stdlib/number/uint64/base/number2words
+*
+* @example
+* var number2words = require( '@stdlib/number/uint64/base/number2words' );
+*
+* var out = number2words( 1234 );
+* // returns [ 0, 1234 ]
+*
+* out = number2words( 0x100000000 );
+* // returns [ 1, 0 ]
+*
+* out = number2words( 9007199254740991 );
+* // returns [ 2097151, 4294967295 ]
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var assign = require( './assign.js' );
+var main = require( './main.js' );
+
+
+// MAIN //
+
+setReadOnly( main, 'assign', assign );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
@@ -29,7 +29,7 @@ var assign = require( './assign.js' );
 * Splits a number into the high and low 32-bit words of a 64-bit unsigned integer.
 *
 * @param {NonNegativeInteger} value - integer value in the range [0, 2^53-1]
-* @returns {Collection} high and low words as 32-bit unsigned integers
+* @returns {Array<integer>} high and low words as 32-bit unsigned integers
 *
 * @example
 * var out = number2words( 1234 );

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var assign = require( './assign.js' );
+
+
+// MAIN //
+
+/**
+* Splits a number into the high and low 32-bit words of a 64-bit unsigned integer.
+*
+* @param {NonNegativeInteger} value - integer value in the range [0, 2^53-1]
+* @returns {Collection} high and low words as 32-bit unsigned integers
+*
+* @example
+* var out = number2words( 1234 );
+* // returns [ 0, 1234 ]
+*
+* out = number2words( 0x100000000 );
+* // returns [ 1, 0 ]
+*
+* out = number2words( 9007199254740991 );
+* // returns [ 2097151, 4294967295 ]
+*/
+function number2words( value ) {
+	return assign( value, [ 0, 0 ], 1, 0 );
+}
+
+
+// EXPORTS //
+
+module.exports = number2words;

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
@@ -29,7 +29,7 @@ var assign = require( './assign.js' );
 * Splits a number into the high and low 32-bit words of a 64-bit unsigned integer.
 *
 * @param {NonNegativeInteger} value - integer value in the range [0, 2^53-1]
-* @returns {Array<integer>} high and low words as 32-bit unsigned integers
+* @returns {Array<uinteger32>} high and low words as 32-bit unsigned integers
 *
 * @example
 * var out = number2words( 1234 );

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@stdlib/number/uint64/base/number2words",
+  "version": "0.0.0",
+  "description": "Split a number into the high and low 32-bit words of a 64-bit unsigned integer.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "base",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "types",
+    "type",
+    "uint64",
+    "unsigned",
+    "64-bit",
+    "integer",
+    "int",
+    "number",
+    "words",
+    "split",
+    "high",
+    "low"
+  ]
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/test/test.assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/test/test.assign.js
@@ -1,0 +1,157 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var isInteger = require( '@stdlib/math/base/assert/is-integer' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var number2words = require( './../lib/assign.js' );
+
+
+// VARIABLES //
+
+var TWO_32 = 0x100000000; // 2^32
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof number2words, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a two-element numeric array containing integers', function test( t ) {
+	var out;
+	var w;
+
+	out = [ 0, 0 ];
+	w = number2words( 1234, out, 1, 0 );
+
+	t.strictEqual( w, out, 'returns expected value' );
+	t.strictEqual( isInteger( w[0] ), true, 'returns expected value' );
+	t.strictEqual( isInteger( w[1] ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function splits a number into the high and low 32-bit words of a 64-bit unsigned integer', function test( t ) {
+	var values;
+	var out;
+	var w;
+	var x;
+	var i;
+
+	values = [
+		0,
+		1,
+		2,
+		3,
+		4,
+		5,
+		10,
+		99,
+		100,
+		999,
+		1000,
+		999999,
+		1000000,
+		999999999,
+		1000000000,
+		UINT32_MAX,
+		UINT32_MAX + 1,
+		9007199254740881, // Largest prime under 2^53
+		MAX_SAFE_INTEGER - 1,
+		MAX_SAFE_INTEGER
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		out = [ 0, 0 ];
+		w = number2words( values[ i ], out, 1, 0 );
+		t.strictEqual( w, out, 'returns expected value' );
+
+		x = ( w[0] * TWO_32 ) + w[1];
+		t.strictEqual( x, values[ i ], 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function supports providing an output object (array)', function test( t ) {
+	var out;
+	var w;
+
+	out = [ 0, 0 ];
+	w = number2words( 4294967296, out, 1, 0 );
+
+	t.strictEqual( w, out, 'returns expected value' );
+	t.strictEqual( w[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( w[ 1 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing an output object (typed array)', function test( t ) {
+	var out;
+	var w;
+
+	out = new Uint32Array( 2 );
+	w = number2words( 4294967296, out, 1, 0 );
+
+	t.strictEqual( w, out, 'returns expected value' );
+	t.strictEqual( w[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( w[ 1 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a stride', function test( t ) {
+	var out;
+	var val;
+
+	out = new Uint32Array( 4 );
+	val = number2words( 4294967298, out, 2, 0 );
+
+	t.strictEqual( val, out, 'returns expected value' );
+	t.strictEqual( val[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( val[ 1 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 2 ], 2, 'returns expected value' );
+	t.strictEqual( val[ 3 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an offset', function test( t ) {
+	var out;
+	var val;
+
+	out = new Uint32Array( 4 );
+	val = number2words( 4294967298, out, 2, 1 );
+
+	t.strictEqual( val, out, 'returns expected value' );
+	t.strictEqual( val[ 0 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 1 ], 1, 'returns expected value' );
+	t.strictEqual( val[ 2 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 3 ], 2, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/test/test.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var number2words = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof number2words, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is an `assign` method', function test( t ) {
+	t.strictEqual( hasOwnProp( number2words, 'assign' ), true, 'has property' );
+	t.strictEqual( typeof number2words.assign, 'function', 'has method' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/test/test.main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/test/test.main.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isInteger = require( '@stdlib/math/base/assert/is-integer' );
+var number2words = require( './../lib/main.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof number2words, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a two-element numeric array containing integers', function test( t ) {
+	var w = number2words( 1234 );
+
+	t.strictEqual( isInteger( w[0] ), true, 'returns expected value' );
+	t.strictEqual( isInteger( w[1] ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function splits a number into the high and low 32-bit words of a 64-bit unsigned integer', function test( t ) {
+	var w = number2words( 9007199254740991 );
+
+	t.strictEqual( w[ 0 ], 2097151, 'returns expected value' );
+	t.strictEqual( w[ 1 ], 4294967295, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a new package `number/uint64/base/number2words`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

- Is it okay to use specialized number types like `integer`, `NonNegativeInteger`, `uinteger32`, etc. inside repl text and typescript declarations? The repl text guide says to [avoid](https://github.com/stdlib-js/stdlib/blob/develop/docs/contributing/repl_text.md#parameters:~:text=In%20general%2C-,avoid,-specialized%20and/or) `NonNegativeInteger` but isn't it more clear to an end user?

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
