### PR TITLE
chore: add keywords

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-constantcase/package.json
+++ b/lib/node_modules/@stdlib/assert/is-constantcase/package.json
@@ -51,5 +51,21 @@
     "win32",
     "windows"
   ],
-  "keywords": []
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "is",
+    "isconstantcase",
+    "constantcase",
+    "string",
+    "valid",
+    "validate",
+    "test"
+  ]
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Populates the empty `keywords` array in `lib/node_modules/@stdlib/assert/is-constantcase/package.json`.

### Namespace summary

Ran a majority-vote drift audit across `@stdlib/assert`:

-   **Members analyzed:** 343 packages.
-   **Features with clear majority (≥75%):** file-tree presence of `lib/index.js`, `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, `README.md`, `test/`, `examples/`, `benchmark/`; `package.json` keyword set (universal `stdlib`/`utilities`/`utility`/`utils`/`util`); `main` path; error-construction via `@stdlib/string/format`; JSDoc `@example` presence.
-   **Features excluded (no clear majority):** `bin` (23%), `browser` (3%), the `stdlib` `package.json` sub-key (variable across packages).

### Per outlier package

#### `assert/is-constantcase`

The `keywords` array in `assert/is-constantcase/package.json` was empty, making the package the sole outlier among 343 packages in `@stdlib/assert` (99.7% conformance). Populated with the 15-item list shared by every sibling `is-<name>case` package (`is-camelcase`, `is-snakecase`, `is-kebabcase`, `is-pascalcase`, `is-uppercase`, `is-lowercase`), substituting `isconstantcase` and `constantcase` for the package-specific slugs.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Structural features were extracted from the file tree, `package.json`, `manifest.json`, and README section headings across all 343 members. Semantic features (error construction, JSDoc shape, validation prologue, dependency graph) were extracted from `lib/main.js` and `lib/index.js`. Every candidate correction passed three independent reviews (semantic-review, cross-reference, structural-review). Deliberately excluded from this PR: (a) outliers whose deviation reflects a genuine structural difference (e.g. `is-<T>-array` packages that inline logic in `lib/index.js` without a separate `lib/main.js`; environment-detection packages such as `is-browser`/`is-darwin`/`is-node` lacking `benchmark/` since they return constants; `napi` and `tools` as internal utilities); (b) features without a clear majority; (c) `has-*-support` packages lacking `assert`/`assertion` keywords, which reflect the feature-detection subclass rather than value-type assertion.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by a scheduled cross-package API drift-detection routine driven by Claude Code. Structural and semantic features were extracted per package, a majority pattern computed at a 75% threshold, and the surviving outlier correction was validated by three independent review passes before being applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01UVPhMaMfEYxMk9GNMYp5uU)_