### PR TITLE
docs: update descriptions

### DIFF
--- a/lib/node_modules/@stdlib/string/base/replace-after-last/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/replace-after-last/lib/main.js
@@ -27,7 +27,7 @@
 * @param {string} search - search string
 * @param {string} replacement - replacement string
 * @param {integer} fromIndex - index from which to start searching
-* @returns {string} string
+* @returns {string} output string
 *
 * @example
 * var str = 'beep boop';

--- a/lib/node_modules/@stdlib/string/base/replace-before-last/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/replace-before-last/lib/main.js
@@ -27,7 +27,7 @@
 * @param {string} search - search string
 * @param {string} replacement - replacement string
 * @param {integer} fromIndex - index from which to start searching
-* @returns {string} string
+* @returns {string} output string
 *
 * @example
 * var str = 'beep boop';

--- a/lib/node_modules/@stdlib/string/base/replace-before/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/replace-before/lib/main.js
@@ -27,7 +27,7 @@
 * @param {string} search - search string
 * @param {string} replacement - replacement string
 * @param {integer} fromIndex - index at which to start the search
-* @returns {string} string
+* @returns {string} output string
 *
 * @example
 * var out = replaceBefore( 'beep boop', ' ', 'foo', 0 );

--- a/lib/node_modules/@stdlib/string/base/right-trim/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/right-trim/lib/main.js
@@ -26,7 +26,7 @@ var builtin = require( './builtin.js' );
 // MAIN //
 
 /**
-* Trims whitespace from the end of a string.
+* Trims whitespace characters from the end of a string.
 *
 * @param {string} str - input string
 * @returns {string} trimmed string

--- a/lib/node_modules/@stdlib/string/base/right-trim/lib/polyfill.js
+++ b/lib/node_modules/@stdlib/string/base/right-trim/lib/polyfill.js
@@ -32,7 +32,7 @@ var RE = /[\u0020\f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u30
 // MAIN //
 
 /**
-* Trims whitespace from the end of a string.
+* Trims whitespace characters from the end of a string.
 *
 * @private
 * @param {string} str - input string


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Aligns four JSDoc description lines in `@stdlib/string/base` outlier packages so they match both their sibling packages' phrasing and each package's own TypeScript declaration.

### Namespace summary

Ran a majority-vote drift audit across `@stdlib/string/base`:

-   **Members analyzed:** 60 packages.
-   **Features with clear majority (≥75%):** file-tree presence of `lib/main.js`, `benchmark/benchmark.js`, `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, `examples/index.js`, `test/test.js`; `package.json` shape (topKeys, `engines`, `repository`, `bugs`, `homepage`, `os`, `main`, `license`, `directories`); README `## Usage` and `## Examples` sections; `require( 'tape' )` import style; `## Usage` subheading level (`####`); JSDoc `@example` presence; `hasExample`, `paramTags` conventions.
-   **Features excluded (no clear majority):** `## Notes` README section (present in 27% of packages), `browser` `package.json` field (present in 3% — `atob`, `base64-to-uint8array` — kept because they legitimately need browser polyfills), `throws`/error-construction (59/60 packages don't validate inputs; `format-interpolate` uses concatenation because it *is* the format function).

### Per outlier package

#### `string/base/right-trim`

The JSDoc description in `lib/main.js` and `lib/polyfill.js` read `Trims whitespace from the end of a string.`, dropping the word "characters". Sibling packages `string/base/left-trim` and `string/base/trim` both include "characters" ("Trims whitespace characters from the beginning of a string.", "Trims whitespace characters from the beginning and end of a string."), and `right-trim`'s own `docs/types/index.d.ts` line 22 already reads "Trims whitespace characters from the end of a string.". Adds "characters" to both source files to match.

#### `string/base/replace-before`

The `@returns` description in `lib/main.js` read `@returns {string} string`. Sibling `string/base/replace-after` uses `@returns {string} output string`, and `replace-before`'s own `docs/types/index.d.ts` line 33 already reads `@returns output string`. Changes the JSDoc to `output string` to match.

#### `string/base/replace-after-last`

The `@returns` description in `lib/main.js` read `@returns {string} string`. The sibling `replace-after` first-occurrence variant uses `output string`, and `replace-after-last`'s own `docs/types/index.d.ts` line 34 already reads `output string`. Aligned to `output string`.

#### `string/base/replace-before-last`

The `@returns` description in `lib/main.js` read `@returns {string} string`. The sibling `replace-before` first-occurrence variant uses `output string`, and `replace-before-last`'s own `docs/types/index.d.ts` line 34 already reads `output string`. Aligned to `output string`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Structural features were extracted from the file tree, `package.json`, `manifest.json`, README section headings, and test/benchmark/example filenames across all 60 members. Semantic features (public signature, validation prologue, error construction, JSDoc shape, dependency graph) were extracted from `lib/main.js` and cross-referenced against `docs/types/index.d.ts`. Every candidate correction passed three independent review passes (semantic-review, cross-reference, structural-review). Deliberately excluded from this PR: (a) the `## See Also` README section (auto-populated by the package generator; 11 packages missing it drops at the pre-validation gate); (b) `distances`, a namespace aggregator whose deviations (missing `lib/main.js`, `benchmark/`, `docs/repl.txt`, several keywords) all reflect its role and are not drift; (c) the `browser` field on `atob` and `base64-to-uint8array` (removing it would change bundler behavior — behavior-changing removals drop at the pre-validation gate); (d) `format-interpolate`'s concatenation-based error construction (the package *is* the `format` implementation, so the "normalize to `format`" majority pattern is circular here); (e) `starts-with(str, search, position)` vs. `ends-with(str, search, len)` parameter naming (semantically distinct — an offset index vs. a substring length — not drift). Total diff: 5 lines across 5 files in 4 packages.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by a scheduled cross-package API drift-detection routine driven by Claude Code. Structural and semantic features were extracted per package, a majority pattern computed at a 75% threshold, and the surviving outlier corrections were validated by three independent review passes before being applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01C3yJ9vSceHAPZJLe7nUkAQ)_