### PR TITLE
docs: fix string interpolation and update comments

### DIFF
--- a/lib/node_modules/@stdlib/number/int64/ctor/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/int64/ctor/docs/types/test.ts
@@ -39,7 +39,7 @@ import Int64 = require( './index' );
 	x.toString(); // $ExpectType string
 }
 
-// The function returns an instance having a `toJSON` method to serialize an instance as a JSON object....
+// The function returns an instance having a `toJSON` method to serialize an instance as a JSON object...
 {
 	const x = new Int64( 5 ); // $ExpectType Int64
 	x.toJSON(); // $ExpectType SerializedInt64

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
@@ -29,7 +29,7 @@ var assign = require( './assign.js' );
 * Splits a number into the high and low 32-bit words of a 64-bit unsigned integer.
 *
 * @param {NonNegativeInteger} value - integer value in the range [0, 2^53-1]
-* @returns {Array<number>} high and low words as 32-bit unsigned integers
+* @returns {Array<integer>} high and low words as 32-bit unsigned integers
 *
 * @example
 * var out = number2words( 1234 );

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/lib/main.js
@@ -29,7 +29,7 @@ var assign = require( './assign.js' );
 * Splits a number into the high and low 32-bit words of a 64-bit unsigned integer.
 *
 * @param {NonNegativeInteger} value - integer value in the range [0, 2^53-1]
-* @returns {Array<uinteger32>} high and low words as 32-bit unsigned integers
+* @returns {Array<number>} high and low words as 32-bit unsigned integers
 *
 * @example
 * var out = number2words( 1234 );

--- a/lib/node_modules/@stdlib/stats/base/dists/tukey-lambda/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/tukey-lambda/mode/README.md
@@ -99,7 +99,7 @@ var opts = {
 };
 var lambda = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'λ: %lf, mode(X;λ): %lf', lambda, mode );
+logEachMap( 'λ: %0.4f, mode(X;λ): %0.4f', lambda, mode );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/tukey-lambda/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/tukey-lambda/mode/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var lambda = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'λ: %lf, mode(X;λ): %lf', lambda, mode );
+logEachMap( 'λ: %0.4f, mode(X;λ): %0.4f', lambda, mode );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes surfaced by an automated review of the 38 commits merged to `develop` between `c157a0d` (2026-07-03 17:39 -0500) and `8975f00` (2026-07-04 06:03 -0500). Three high-signal issues survived filtering; each is grouped as its own commit by package:

-   **`number/int64/ctor`** — `test.ts` (`docs/types/test.ts`) line 42: stray fourth period on the ellipsis, `....` instead of `...`. Fix the typo. Introduced in `8d10f98b`.
-   **`number/uint64/base/number2words`** — `@returns` tag in `number2words/lib/main.js:32` says `{Array<uinteger32>}`; should be `{Array<number>}` per every other `to-words`/`number2words` package and the package's own `docs/types/index.d.ts`. `uinteger32` doesn't exist anywhere else in stdlib. From `3684ccc6`.
-   **`stats/base/dists/tukey-lambda/mode`** — `%lf` isn't a valid specifier for `@stdlib/string/format`; copy-pasted from the C example in `f52a4633`. Replace with `%0.4f` in `lib/node_modules/@stdlib/stats/base/dists/tukey-lambda/mode/examples/index.js:30` and `README.md:102`, matching every other dist package (e.g. `pareto-type1/mode`).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Four independent reviewer agents audited the union diff (266 files, 13,496 insertions across 38 commits) against `docs/style-guides/` and peer packages:

-   2 style-compliance reviewers (Sonnet) — parallel, independent
-   2 bug hunters (Opus) — parallel, independent, restricted to defects fully visible within the diff window

**Excluded.** Issues that would require behavior changes outside a mechanical typo/JSDoc-convention fix, that only one agent flagged and could not be independently re-verified from the diff, or that fell outside the diff window. One candidate — `stats/base/dists/log-logistic/mean` returning `NaN` for `beta <= 1` where peer packages (`pareto-type1/mean`, `frechet/mean`, `levy/mean`) return `+Infinity` for divergent means — was left off this PR because it crosses from mechanical fix into a behavior change on a newly-added package and warrants maintainer discussion before landing.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Automated review harness authored the fixes. Four independent reviewer agents scanned the 24-hour commit window; findings that only one agent surfaced and could not be independently re-verified from the diff were dropped. Human maintainer to promote from draft after audit.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_012F6MmSer5faPo7mcCUxfQY)_