### PR TITLE
style: remove extra space and address lint failures

### DIFF
--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary4d/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary4d/docs/types/test.ts
@@ -52,12 +52,12 @@ type InOutShapes = [ Array<number>, Array<number>, Array<number>, Array<number>,
 	const shapes: InOutShapes = [ [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ] ];
 
 	bquinary4d( [ x, y, z, w, v, out ], shapes, fcn ); // $ExpectType void
-	bquinary4d( [ x[ 0 ], y, z, w, v, out ], [ [ shapes[ 0 ][ 1 ][ 2 ][ 3 ] ], shapes[ 1 ], shapes[ 2 ], shapes [ 3 ], shapes[ 4 ], shapes[ 5 ] ] , fcn ); // $ExpectType void
+	bquinary4d( [ x[ 0 ], y, z, w, v, out ], [ [ shapes[ 0 ][ 1 ][ 2 ][ 3 ] ], shapes[ 1 ], shapes[ 2 ], shapes [ 3 ], shapes[ 4 ], shapes[ 5 ] ], fcn ); // $ExpectType void
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of nested arrays...
 {
-	const shapes: InOutShapes =  [ [ 2, 2, 2, 2 ] , [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ] ];
+	const shapes: InOutShapes =  [ [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ] ];
 
 	bquinary4d( 'abc', shapes, fcn ); // $ExpectError
 	bquinary4d( 3.14, shapes, fcn ); // $ExpectError
@@ -97,7 +97,7 @@ type InOutShapes = [ Array<number>, Array<number>, Array<number>, Array<number>,
 	const v = [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ];
 	const out = [ [ [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] ] ];
 
-	const shapes: InOutShapes = [ [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2 ,2 ] ];
+	const shapes: InOutShapes = [ [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ] ];
 
 	bquinary4d( [ x, y, z, w, v, out ], shapes, 'abc' ); // $ExpectError
 	bquinary4d( [ x, y, z, w, v, out ], shapes, 3.14 ); // $ExpectError
@@ -117,7 +117,7 @@ type InOutShapes = [ Array<number>, Array<number>, Array<number>, Array<number>,
 	const v = [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ];
 	const out = [ [ [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] ] ];
 
-	const shapes: InOutShapes = [ [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2 ,2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ] ];
+	const shapes: InOutShapes = [ [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ], [ 2, 2, 2, 2 ] ];
 
 	bquinary4d(); // $ExpectError
 	bquinary4d( [ x, y, z, w, v, out ] ); // $ExpectError

--- a/lib/node_modules/@stdlib/string/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/docs/types/index.d.ts
@@ -1006,11 +1006,11 @@ interface Namespace {
 	* // returns 'Hello World!'
 	*
 	* @example
-	* var out = ns.replaceAfter( 'beep boop', ' ', 'foo' , 5 );
+	* var out = ns.replaceAfter( 'beep boop', ' ', 'foo', 5 );
 	* // returns 'beep boop'
 	*
 	* @example
-	* var out = ns.replaceAfter( 'beep boop beep baz', 'beep', 'foo' , 5 );
+	* var out = ns.replaceAfter( 'beep boop beep baz', 'beep', 'foo', 5 );
 	* // returns 'beep boop beepfoo'
 	*/
 	replaceAfter: typeof replaceAfter;

--- a/lib/node_modules/@stdlib/string/base/replace-after-last/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/replace-after-last/docs/types/test.ts
@@ -31,18 +31,18 @@ import replaceAfterLast = require( './index' );
 // The compiler throws an error if the function is provided arguments having invalid types...
 {
 	replaceAfterLast( true, 'd', 'foo', 100 ); // $ExpectError
-	replaceAfterLast( false, 'd' , 'foo', 100 ); // $ExpectError
-	replaceAfterLast( 3, 'd' , 'foo', 100 ); // $ExpectError
-	replaceAfterLast( [], 'd' , 'foo', 100 ); // $ExpectError
-	replaceAfterLast( {}, 'd' , 'foo', 100 ); // $ExpectError
+	replaceAfterLast( false, 'd', 'foo', 100 ); // $ExpectError
+	replaceAfterLast( 3, 'd', 'foo', 100 ); // $ExpectError
+	replaceAfterLast( [], 'd', 'foo', 100 ); // $ExpectError
+	replaceAfterLast( {}, 'd', 'foo', 100 ); // $ExpectError
 	replaceAfterLast( ( x: number ): number => x, 'd', 'foo', 100 ); // $ExpectError
 
 	replaceAfterLast( 'abc', true, 'foo', 10 ); // $ExpectError
 	replaceAfterLast( 'abc', false, 'foo', 10 ); // $ExpectError
-	replaceAfterLast( 'abc', 5 , 'foo', 10 ); // $ExpectError
+	replaceAfterLast( 'abc', 5, 'foo', 10 ); // $ExpectError
 	replaceAfterLast( 'abc', [], 'foo', 10 ); // $ExpectError
-	replaceAfterLast( 'abc', {} , 'foo', 10 ); // $ExpectError
-	replaceAfterLast( 'abc', ( x: number ): number => x , 'foo', 10 ); // $ExpectError
+	replaceAfterLast( 'abc', {}, 'foo', 10 ); // $ExpectError
+	replaceAfterLast( 'abc', ( x: number ): number => x, 'foo', 10 ); // $ExpectError
 
 	replaceAfterLast( 'abc', 'd', true, 10 ); // $ExpectError
 	replaceAfterLast( 'abc', 'd', false, 10 ); // $ExpectError

--- a/lib/node_modules/@stdlib/string/base/replace-after/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/replace-after/docs/types/index.d.ts
@@ -49,11 +49,11 @@
 * // returns 'Hello World!'
 *
 * @example
-* var out = replaceAfter( 'beep boop', ' ', 'foo' , 5 );
+* var out = replaceAfter( 'beep boop', ' ', 'foo', 5 );
 * // returns 'beep boop'
 *
 * @example
-* var out = replaceAfter( 'beep boop beep baz', 'beep', 'foo' , 5 );
+* var out = replaceAfter( 'beep boop beep baz', 'beep', 'foo', 5 );
 * // returns 'beep boop beepfoo'
 */
 declare function replaceAfter( str: string,  search: string, replacement: string, fromIndex: number ): string;

--- a/lib/node_modules/@stdlib/string/base/replace-after/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/replace-after/docs/types/test.ts
@@ -32,18 +32,18 @@ import replaceAfter = require( './index' );
 // The compiler throws an error if the function is provided arguments having invalid types...
 {
 	replaceAfter( true, 'd', 'foo', 0 ); // $ExpectError
-	replaceAfter( false, 'd' , 'foo', 0 ); // $ExpectError
-	replaceAfter( 3, 'd' , 'foo', 0 ); // $ExpectError
-	replaceAfter( [], 'd' , 'foo', 0 ); // $ExpectError
-	replaceAfter( {}, 'd' , 'foo', 0 ); // $ExpectError
+	replaceAfter( false, 'd', 'foo', 0 ); // $ExpectError
+	replaceAfter( 3, 'd', 'foo', 0 ); // $ExpectError
+	replaceAfter( [], 'd', 'foo', 0 ); // $ExpectError
+	replaceAfter( {}, 'd', 'foo', 0 ); // $ExpectError
 	replaceAfter( ( x: number ): number => x, 'd', 'foo', 0 ); // $ExpectError
 
 	replaceAfter( 'abc', true, 'foo', 0 ); // $ExpectError
 	replaceAfter( 'abc', false, 'foo', 0 ); // $ExpectError
-	replaceAfter( 'abc', 5 , 'foo', 0 ); // $ExpectError
+	replaceAfter( 'abc', 5, 'foo', 0 ); // $ExpectError
 	replaceAfter( 'abc', [], 'foo', 0 ); // $ExpectError
-	replaceAfter( 'abc', {} , 'foo', 0 ); // $ExpectError
-	replaceAfter( 'abc', ( x: number ): number => x , 'foo', 0 ); // $ExpectError
+	replaceAfter( 'abc', {}, 'foo', 0 ); // $ExpectError
+	replaceAfter( 'abc', ( x: number ): number => x, 'foo', 0 ); // $ExpectError
 
 	replaceAfter( 'abc', 'd', true, 0 ); // $ExpectError
 	replaceAfter( 'abc', 'd', false, 0 ); // $ExpectError

--- a/lib/node_modules/@stdlib/string/base/replace-before-last/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/replace-before-last/docs/types/test.ts
@@ -31,18 +31,18 @@ import replaceBeforeLast = require( './index' );
 // The compiler throws an error if the function is provided arguments having invalid types...
 {
 	replaceBeforeLast( true, 'd', 'foo', 100 ); // $ExpectError
-	replaceBeforeLast( false, 'd' , 'foo', 100 ); // $ExpectError
-	replaceBeforeLast( 3, 'd' , 'foo', 100 ); // $ExpectError
-	replaceBeforeLast( [], 'd' , 'foo', 100 ); // $ExpectError
-	replaceBeforeLast( {}, 'd' , 'foo', 100 ); // $ExpectError
+	replaceBeforeLast( false, 'd', 'foo', 100 ); // $ExpectError
+	replaceBeforeLast( 3, 'd', 'foo', 100 ); // $ExpectError
+	replaceBeforeLast( [], 'd', 'foo', 100 ); // $ExpectError
+	replaceBeforeLast( {}, 'd', 'foo', 100 ); // $ExpectError
 	replaceBeforeLast( ( x: number ): number => x, 'd', 'foo', 100 ); // $ExpectError
 
 	replaceBeforeLast( 'abc', true, 'foo', 10 ); // $ExpectError
 	replaceBeforeLast( 'abc', false, 'foo', 10 ); // $ExpectError
-	replaceBeforeLast( 'abc', 5 , 'foo', 10 ); // $ExpectError
+	replaceBeforeLast( 'abc', 5, 'foo', 10 ); // $ExpectError
 	replaceBeforeLast( 'abc', [], 'foo', 10 ); // $ExpectError
-	replaceBeforeLast( 'abc', {} , 'foo', 10 ); // $ExpectError
-	replaceBeforeLast( 'abc', ( x: number ): number => x , 'foo', 10 ); // $ExpectError
+	replaceBeforeLast( 'abc', {}, 'foo', 10 ); // $ExpectError
+	replaceBeforeLast( 'abc', ( x: number ): number => x, 'foo', 10 ); // $ExpectError
 
 	replaceBeforeLast( 'abc', 'd', true, 10 ); // $ExpectError
 	replaceBeforeLast( 'abc', 'd', false, 10 ); // $ExpectError

--- a/lib/node_modules/@stdlib/string/base/replace-before/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/replace-before/docs/types/test.ts
@@ -31,18 +31,18 @@ import replaceBefore = require( './index' );
 // The compiler throws an error if the function is provided arguments having invalid types...
 {
 	replaceBefore( true, 'd', 'foo', 0 ); // $ExpectError
-	replaceBefore( false, 'd' , 'foo', 0 ); // $ExpectError
-	replaceBefore( 3, 'd' , 'foo', 0 ); // $ExpectError
-	replaceBefore( [], 'd' , 'foo', 0 ); // $ExpectError
-	replaceBefore( {}, 'd' , 'foo', 0 ); // $ExpectError
+	replaceBefore( false, 'd', 'foo', 0 ); // $ExpectError
+	replaceBefore( 3, 'd', 'foo', 0 ); // $ExpectError
+	replaceBefore( [], 'd', 'foo', 0 ); // $ExpectError
+	replaceBefore( {}, 'd', 'foo', 0 ); // $ExpectError
 	replaceBefore( ( x: number ): number => x, 'd', 'foo', 0 ); // $ExpectError
 
 	replaceBefore( 'abc', true, 'foo', 0 ); // $ExpectError
 	replaceBefore( 'abc', false, 'foo', 0 ); // $ExpectError
-	replaceBefore( 'abc', 5 , 'foo', 0 ); // $ExpectError
+	replaceBefore( 'abc', 5, 'foo', 0 ); // $ExpectError
 	replaceBefore( 'abc', [], 'foo', 0 ); // $ExpectError
-	replaceBefore( 'abc', {} , 'foo', 0 ); // $ExpectError
-	replaceBefore( 'abc', ( x: number ): number => x , 'foo', 0 ); // $ExpectError
+	replaceBefore( 'abc', {}, 'foo', 0 ); // $ExpectError
+	replaceBefore( 'abc', ( x: number ): number => x, 'foo', 0 ); // $ExpectError
 
 	replaceBefore( 'abc', 'd', true, 0 ); // $ExpectError
 	replaceBefore( 'abc', 'd', false, 0 ); // $ExpectError

--- a/lib/node_modules/@stdlib/string/replace-before/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/replace-before/docs/types/test.ts
@@ -31,18 +31,18 @@ import replaceBefore = require( './index' );
 // The compiler throws an error if the function is provided arguments having invalid types...
 {
 	replaceBefore( true, 'd', 'foo' ); // $ExpectError
-	replaceBefore( false, 'd' , 'foo' ); // $ExpectError
-	replaceBefore( 3, 'd' , 'foo' ); // $ExpectError
-	replaceBefore( [], 'd' , 'foo' ); // $ExpectError
-	replaceBefore( {}, 'd' , 'foo' ); // $ExpectError
+	replaceBefore( false, 'd', 'foo' ); // $ExpectError
+	replaceBefore( 3, 'd', 'foo' ); // $ExpectError
+	replaceBefore( [], 'd', 'foo' ); // $ExpectError
+	replaceBefore( {}, 'd', 'foo' ); // $ExpectError
 	replaceBefore( ( x: number ): number => x, 'd', 'foo' ); // $ExpectError
 
 	replaceBefore( 'abc', true, 'foo' ); // $ExpectError
 	replaceBefore( 'abc', false, 'foo' ); // $ExpectError
-	replaceBefore( 'abc', 5 , 'foo' ); // $ExpectError
+	replaceBefore( 'abc', 5, 'foo' ); // $ExpectError
 	replaceBefore( 'abc', [], 'foo' ); // $ExpectError
-	replaceBefore( 'abc', {} , 'foo' ); // $ExpectError
-	replaceBefore( 'abc', ( x: number ): number => x , 'foo' ); // $ExpectError
+	replaceBefore( 'abc', {}, 'foo' ); // $ExpectError
+	replaceBefore( 'abc', ( x: number ): number => x, 'foo' ); // $ExpectError
 
 	replaceBefore( 'abc', 'd', true ); // $ExpectError
 	replaceBefore( 'abc', 'd', false ); // $ExpectError

--- a/lib/node_modules/@stdlib/utils/pop/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/utils/pop/benchmark/benchmark.js
@@ -35,9 +35,9 @@ bench( format( '%s::array', pkg ), function benchmark( b ) {
 	var i;
 
 	len = b.iterations;
-	arr = new Array( len );
+	arr = [];
 	for ( i = 0; i < len; i++ ) {
-		arr[ i ] = i;
+		arr.push( i );
 	}
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -62,9 +62,9 @@ bench( format( '%s::built-in', pkg ), function benchmark( b ) {
 	var i;
 
 	len = b.iterations;
-	arr = new Array( len );
+	arr = [];
 	for ( i = 0; i < len; i++ ) {
-		arr[ i ] = i;
+		arr.push( i );
 	}
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Propagates fixes merged to `develop` between 2026-07-03 17:39 UTC and 2026-07-04 06:03 UTC to sibling packages carrying the same defects.

### `style:` — stray space before comma

Sweeps remaining stray space-before-comma occurrences that the prior propagation ([`b71a63d`][b71a63d]) missed. The prior sweep's regex only matched identifiers surrounded by whitespace and skipped adjacent literals, object literals, and closing brackets. All hits are inside JSDoc `@example` blocks in `docs/types/index.d.ts` files or `$ExpectError` argument lists in `docs/types/test.ts`. Purely mechanical whitespace cleanup — no semantic change.

Source commit: [`b71a63d`][b71a63d]

Target packages:

-   `array/base/broadcasted-quinary4d` — `docs/types/test.ts`
-   `string/base` — `docs/types/index.d.ts`
-   `string/base/replace-after` — `docs/types/index.d.ts`, `docs/types/test.ts`
-   `string/base/replace-after-last` — `docs/types/test.ts`
-   `string/base/replace-before` — `docs/types/test.ts`
-   `string/base/replace-before-last` — `docs/types/test.ts`
-   `string/replace-before` — `docs/types/test.ts`

### `chore:` — `stdlib/no-new-array` in `utils/pop` benchmark

Applies the same `new Array( len )` → `[]` + `arr.push( i )` rewrite that [`1cecba9`][1cecba9] landed for `utils/shift/benchmark/benchmark.js` to satisfy the `stdlib/no-new-array` ESLint rule. `utils/pop` is the sibling benchmark with a byte-identical setup block; the lint failure is the same.

Source commit: [`1cecba9`][1cecba9]

Target packages:

-   `utils/pop` — `benchmark/benchmark.js`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Search scope was `docs/types/*.{ts,d.ts}` for the stray-space pattern (repo-wide) and `benchmark/**/*.js` for the `new Array( len )` + indexed-fill pattern (repo-wide). Two independent verifiers read every candidate site in full to confirm the defect against surrounding context; both flagged the same 43 stray-space lines across 8 files and both blocks in `utils/pop/benchmark/benchmark.js` as unambiguous defects with no autogenerated / `eslint-disable` markers on any target file. Sites were deliberately excluded when they would require cross-package changes or interpretation of intent; none reached that bar in this run. The `pkg+'::native'` → `format( '%s::native', pkg )` pattern from [`202e91c`][202e91c] found no valid remaining sites (repo-wide grep for `pkg+'::` returned zero hits — every benchmark already uses `format`). The `Log logistic` → `Log-logistic` typo from [`1fa83d8`][1fa83d8] and the "Planck (discrete exponential)" clarification from [`8975f00`][8975f00] also found no remaining sites — both are fully saturated.

[b71a63d]: https://github.com/stdlib-js/stdlib/commit/b71a63d212d3943412faa229884d0ee56ee429da
[1cecba9]: https://github.com/stdlib-js/stdlib/commit/1cecba96937be3028fe53bf1f93c22859972a129
[202e91c]: https://github.com/stdlib-js/stdlib/commit/202e91c2dcf434f065d94866e076fdb5a7aa36a7
[1fa83d8]: https://github.com/stdlib-js/stdlib/commit/1fa83d83893fb97733d382d860bdb30c172edd53
[8975f00]: https://github.com/stdlib-js/stdlib/commit/8975f00a25cb5ce66c932529659354ae5d8454dd

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was generated by Claude Code as part of a scheduled fix-propagation routine that mirrors recent `develop` fixes to sibling packages carrying the same defect. Each target site was independently verified by two adversarial reviewers before the patch was applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01CjCvFQz1uZR53uKtsknWVf)_