### PR TITLE
test: address test failures by increasing `maxBuffer` limit

### DIFF
--- a/lib/node_modules/@stdlib/namespace/test/test.cli.js
+++ b/lib/node_modules/@stdlib/namespace/test/test.cli.js
@@ -191,6 +191,7 @@ tape( 'when invoked with a `-V` flag, the command-line interface prints the vers
 
 tape( 'the command-line interface prints selected fields of the stdlib namespace (comma-separated values)', opts, function test( t ) {
 	var expected;
+	var opts;
 	var cmd;
 
 	cmd = [
@@ -201,7 +202,11 @@ tape( 'the command-line interface prints selected fields of the stdlib namespace
 
 	expected = csv( namespace(), [ 'alias', 'path' ] );
 
-	exec( cmd.join( ' ' ), done );
+	opts = {
+		'maxBuffer': 5000*1024
+	};
+
+	exec( cmd.join( ' ' ), opts, done );
 
 	function done( error, stdout, stderr ) {
 		if ( error ) {
@@ -218,6 +223,7 @@ tape( 'the command-line interface prints selected fields of the stdlib namespace
 
 tape( 'the command-line interface prints the stdlib namespace (newline-delimited JSON)', opts, function test( t ) {
 	var fields;
+	var opts;
 	var cmd;
 	var ns;
 
@@ -228,7 +234,11 @@ tape( 'the command-line interface prints the stdlib namespace (newline-delimited
 	fields = [ 'alias', 'path', 'type', 'related' ];
 	ns = namespace();
 
-	exec( cmd.join( ' ' ), done );
+	opts = {
+		'maxBuffer': 5000*1024
+	};
+
+	exec( cmd.join( ' ' ), opts, done );
 
 	function done( error, stdout, stderr ) {
 		var expected;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `stdout maxBuffer length exceeded` failures in `lib/node_modules/@stdlib/namespace/test/test.cli.js`, which fail every `run_affected_tests` / `run_tests_coverage` run that touches the namespace package.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/28686663068

**Symptom:**

```
Running test: lib/node_modules/@stdlib/namespace/test/test.cli.js
stdout maxBuffer length exceeded
	at:       'done (.../namespace/test/test.cli.js:238:6)'
make: *** [.../tools/make/lib/test/javascript.mk:318: test-javascript-files-min] Error 1
```

**Root cause:** Two tests in `test.cli.js` `exec()` the namespace CLI and capture its full stdout — one as CSV (`--fields alias,path`), one as newline-delimited JSON (all fields, including `related` arrays) — using `child_process.exec` with no explicit `maxBuffer`, so Node's 1 MiB default applies. The stdlib namespace has grown to 3212+ entries, and the full JSON dump now exceeds that default, so `exec()` passes an `error` to its callback instead of `stdout`, which fails the test via `t.fail(error.message)`. This is deterministic and will fail on every run going forward, not intermittent.

**Fix:** Add an explicit `maxBuffer` option (`5000*1024`, ~4.9 MiB) to both `exec()` calls that dump the full namespace. This matches the pre-existing `{'maxBuffer': N*1024}` convention already used across `lib/node_modules/@stdlib/datasets/*/test/test.cli.js` (e.g. `moby-dick`, `cmudict`, `sotu`) for CLI tests with large stdout. The other four `exec()` calls in the same file (`--help`, `-h`, `--version`, `-V`) produce trivial stderr-only output and were left unchanged. No source or CLI behavior changes — test-only.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

**Validation:** Three independent automated reviews (correctness, regression scope, style/conventions) all returned `approve` with no blocking findings.

-   **Correctness:** confirmed both namespace-dumping `exec()` calls are patched, confirmed the other four are trivial and don't need it, and estimated ~5x headroom over current output size (namespace would need to nearly quintuple before recurring).
-   **Regression scope:** confirmed the diff is test-only and minimal (12 insertions / 2 deletions, one file), confirmed raising `maxBuffer` does not mask a correctness bug (both tests still assert stdout content against a locally computed expected value), confirmed no source/CLI/CI files were touched.
-   **Style:** confirmed variable declaration order, quoting, spacing, and the `N*1024` numeric-literal style all match the established sibling convention in `datasets/*/test.cli.js`, and that the local `opts` shadowing of the outer tape `skip` options mirrors the same pattern already used in those files.

**Reviewer notes:** All three reviewers independently flagged the same non-blocking style nit: the new local `var opts` (holding `{maxBuffer}`) shadows the outer, module-scope `var opts` (holding tape's `{skip}` option) within each test callback. This is intentional, harmless (the outer `opts` is already resolved as tape's second argument before the callback body runs), and is the identical pattern already used in `lib/node_modules/@stdlib/datasets/moby-dick/test/test.cli.js` and `.../cmudict/test/test.cli.js`, so no change was made.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Research and understanding

#### Disclosure

This PR was prepared by an automated CI-failure investigation routine (Claude Code). The root cause was identified by reading the failing job logs and namespace source, the fix was implemented to match an existing repo-wide convention, and it was validated by three independent automated reviews (correctness, regression scope, style) before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhBw21LG2PV57r3ZtpN8v5)_