### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/fs/rename/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/rename/lib/index.js
@@ -28,7 +28,7 @@
 *
 * function done( error ) {
 *     if ( error ) {
-*         throw error;
+*         console.error( error.message );
 *     }
 * }
 *
@@ -39,7 +39,7 @@
 *
 * var err = renameSync( './beep/boop.txt', './beep/foo.txt' );
 * if ( err instanceof Error ) {
-*     throw err;
+*     console.error( err.message );
 * }
 */
 


### PR DESCRIPTION
## Description

This PR fixes an ESLint crash caused by the `stdlib/jsdoc-doctest` rule when linting `@stdlib/fs/rename/lib/index.js`. The `jsdoc-doctest` rule runs JSDoc `@example` code in a VM context. The async `rename()` example used `throw error` in the callback, which, when the rename operation failed with `ENOENT` (file doesn't exist), threw an unhandled exception that crashed the ESLint process.

## Changes

- **`lib/node_modules/@stdlib/fs/rename/lib/index.js`**: Changed `@example` callbacks to use `console.error(error.message)` instead of `throw error`/`throw err`, matching the convention used by similar packages (e.g., `@stdlib/fs/unlink`, `@stdlib/fs/exists`).

This crash blocked ESLint from checking approximately 8 additional JavaScript files in the lint run.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

resolves #13273