### PR TITLE
chore: fix C lint errors

### DIFF
--- a/lib/node_modules/@stdlib/number/float64/base/signbit/README.md
+++ b/lib/node_modules/@stdlib/number/float64/base/signbit/README.md
@@ -147,7 +147,7 @@ int8_t stdlib_base_float64_signbit( const double x );
 #include <inttypes.h>
 
 int main( void ) {
-    double x[] = { 3.14, -3.14, 0.0, -0.0, 4.0, 1.0, -1.0, 1.0e308, -1.0e308 };
+    const double x[] = { 3.14, -3.14, 0.0, -0.0, 4.0, 1.0, -1.0, 1.0e308, -1.0e308 };
 
     int8_t out;
     int i;

--- a/lib/node_modules/@stdlib/number/float64/base/signbit/examples/c/example.c
+++ b/lib/node_modules/@stdlib/number/float64/base/signbit/examples/c/example.c
@@ -22,7 +22,7 @@
 #include <inttypes.h>
 
 int main( void ) {
-	double x[] = { 3.14, -3.14, 0.0, -0.0, 4.0, 1.0, -1.0, 1.0e308, -1.0e308 };
+	const double x[] = { 3.14, -3.14, 0.0, -0.0, 4.0, 1.0, -1.0, 1.0e308, -1.0e308 };
 
 	int8_t out;
 	int i;


### PR DESCRIPTION
Resolves #13275.

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes a C linting style error in `@stdlib/number/float64/base/signbit` by declaring the `x` array as a `const` array in `example.c`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #13275

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
