### PR TITLE
chore: fix copy-paste mistakes

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/README.md
@@ -28,14 +28,14 @@ limitations under the License.
 
 The [mode][mode] for a [beta prime][betaprime-distribution] random variable is
 
-<!-- <equation class="equation" label="eq:betaprime_expectation" align="center" raw="\operatorname{mode}(X) = \begin{cases}\frac{\alpha-1}{\beta+1} & \text{ if } \alpha \ge 1 \\ 0 & \text{ otherwise }\end{cases}" alt="Expected value for a beta prime distribution."> -->
+<!-- <equation class="equation" label="eq:betaprime_mode" align="center" raw="\operatorname{mode}(X) = \begin{cases}\frac{\alpha-1}{\beta+1} & \text{ if } \alpha \ge 1 \\ 0 & \text{ otherwise }\end{cases}" alt="Mode for a beta prime distribution."> -->
 
 ```math
 \mathop{\mathrm{mode}}(X) = \begin{cases}\frac{\alpha-1}{\beta+1} & \text{ if } \alpha \ge 1 \\ 0 & \text{ otherwise }\end{cases}
 ```
 
-<!-- <div class="equation" align="center" data-raw-text="\operatorname{mode}(X) = \begin{cases}\frac{\alpha-1}{\beta+1} &amp; \text{ if } \alpha \ge 1 \\ 0 &amp; \text{ otherwise }\end{cases}" data-equation="eq:betaprime_expectation">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@51534079fef45e990850102147e8945fb023d1d0/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/docs/img/equation_betaprime_expectation.svg" alt="Expected value for a beta prime distribution.">
+<!-- <div class="equation" align="center" data-raw-text="\operatorname{mode}(X) = \begin{cases}\frac{\alpha-1}{\beta+1} &amp; \text{ if } \alpha \ge 1 \\ 0 &amp; \text{ otherwise }\end{cases}" data-equation="eq:betaprime_mode">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@51534079fef45e990850102147e8945fb023d1d0/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/docs/img/equation_betaprime_expectation.svg" alt="Mode for a beta prime distribution.">
     <br>
 </div> -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/docs/types/test.ts
@@ -16,41 +16,41 @@
 * limitations under the License.
 */
 
-import stdev = require( './index' );
+import variance = require( './index' );
 
 
 // TESTS //
 
 // The function returns a number...
 {
-	stdev( 8, 5 ); // $ExpectType number
+	variance( 8, 5 ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided values other than two numbers...
 {
-	stdev( true, 3 ); // $ExpectError
-	stdev( false, 2 ); // $ExpectError
-	stdev( '5', 1 ); // $ExpectError
-	stdev( [], 1 ); // $ExpectError
-	stdev( {}, 2 ); // $ExpectError
-	stdev( ( x: number ): number => x, 2 ); // $ExpectError
+	variance( true, 3 ); // $ExpectError
+	variance( false, 2 ); // $ExpectError
+	variance( '5', 1 ); // $ExpectError
+	variance( [], 1 ); // $ExpectError
+	variance( {}, 2 ); // $ExpectError
+	variance( ( x: number ): number => x, 2 ); // $ExpectError
 
-	stdev( 9, true ); // $ExpectError
-	stdev( 9, false ); // $ExpectError
-	stdev( 5, '5' ); // $ExpectError
-	stdev( 8, [] ); // $ExpectError
-	stdev( 9, {} ); // $ExpectError
-	stdev( 8, ( x: number ): number => x ); // $ExpectError
+	variance( 9, true ); // $ExpectError
+	variance( 9, false ); // $ExpectError
+	variance( 5, '5' ); // $ExpectError
+	variance( 8, [] ); // $ExpectError
+	variance( 9, {} ); // $ExpectError
+	variance( 8, ( x: number ): number => x ); // $ExpectError
 
-	stdev( [], true ); // $ExpectError
-	stdev( {}, false ); // $ExpectError
-	stdev( false, '5' ); // $ExpectError
-	stdev( {}, [] ); // $ExpectError
-	stdev( '5', ( x: number ): number => x ); // $ExpectError
+	variance( [], true ); // $ExpectError
+	variance( {}, false ); // $ExpectError
+	variance( false, '5' ); // $ExpectError
+	variance( {}, [] ); // $ExpectError
+	variance( '5', ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided insufficient arguments...
 {
-	stdev(); // $ExpectError
-	stdev( 3 ); // $ExpectError
+	variance(); // $ExpectError
+	variance( 3 ); // $ExpectError
 }


### PR DESCRIPTION
## Description

Corrects copy-paste-derived identifiers in two `@stdlib/stats/base/dists/betaprime` sibling packages surfaced by a cross-package majority-vote audit of the namespace's twelve members. Both fixes are docs-only, mechanical renames; no observable behavior changes and no test expectations move.

**Namespace summary:** 12 members audited (`cdf`, `ctor`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`). Structural pass (file tree, `package.json`, `manifest.json`, README section shape, keywords, benchmarks/tests/examples layout) and semantic pass (public signatures, validation prologues, error construction, JSDoc, dependencies) yielded high uniformity within the C-implementation and no-C sub-groups. Two features had a ≥75% majority with a single-package outlier and a mechanical fix; other candidate drifts (e.g. explicit `isnan` on shape parameters in moment functions, `Notes` section presence in READMEs, package.json `gypfile` presence) fell below threshold or tracked with legitimate structural differences and were dropped.

### `@stdlib/stats/base/dists/betaprime/mode`

Rename the equation `label`, `data-equation`, and `alt` identifiers from `eq:betaprime_expectation` / "Expected value for a beta prime distribution." to `eq:betaprime_mode` / "Mode for a beta prime distribution." — leftovers copy-pasted from `mean/README.md`. Rendered SVG and raw LaTeX are unchanged; this only aligns the identifiers with the sibling packages, ten of eleven of which already name the label after their own function.

### `@stdlib/stats/base/dists/betaprime/variance`

Rename the local binding in `docs/types/test.ts` from `stdev` to `variance` at the import and all twenty call sites; the file was a byte-identical copy of the sibling `stdev` package's test with the alias never renamed. Behavior is unchanged — the import still resolves `./index` to variance's declaration and dtslint asserts the same surface — but the fixture now matches the package under test and aligns with the convention used in ten of the eleven sibling `betaprime` distribution packages.

## Related Issues

None.

## Questions

No.

## Other

**Validation.** Structural features were extracted for every member; semantic features (public signature, validation prologue, error construction, JSDoc shape, dependencies) were extracted via a per-package pass over `lib/main.js` and adjacent sources. Both surviving corrections were then independently reviewed for (a) whether the deviation might reflect a legitimate semantic difference between the outlier and its siblings and (b) whether tests or examples rely on the deviating identifier — both came back confirmed as unintentional copy-paste artifacts with no downstream dependence. Deliberately excluded: outlier structural features that track with C-implementation status (e.g. `gypfile`, `manifest.json`, `docs/img/`, `src/`, `include.gypi`), features without a clear namespace-wide majority (README `Notes` section, moment-function `isnan` prologues), and the misnamed `mode/docs/img/equation_betaprime_expectation.svg` file itself (rename would break the CDN URL pinned to a historical commit hash; the metadata correction here is safe and self-contained).

The pinned CDN URL in `mode/README.md` is intentionally left unchanged: it references the current filename at a historical stdlib commit and continues to resolve to the correctly-rendered mode SVG. A future filename rename can be paired with a coordinated CDN commit-hash bump.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code as part of a scheduled cross-package drift-detection routine. The namespace was picked uniformly at random; drift was surfaced by a majority-vote analysis of structural and semantic features across the twelve `betaprime` sibling packages; only mechanical fixes with a clear ≥75%-conformance majority and no behavior impact were retained. Independent verification passes confirmed both fixes as unintentional copy-paste from the neighboring sibling.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ha7jz8N6XHpKzwf7yPrED9)_