### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gfirst-index-equal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfirst-index-equal/docs/types/test.ts
@@ -24,8 +24,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The function returns a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual( x.length, x, 1, y, 1 ); // $ExpectType number
 	gfirstIndexEqual( x.length, new AccessorArray( x ), 1, new AccessorArray( y ), 1 ); // $ExpectType number
@@ -33,8 +33,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the function is provided a first argument which is not a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual( '1', x, 1, y, 1 ); // $ExpectError
 	gfirstIndexEqual( true, x, 1, y, 1 ); // $ExpectError
@@ -48,7 +48,7 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the function is provided a second argument which is not a collection...
 {
-	var y = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual( 3, 10, 1, y, 1 ); // $ExpectError
 	gfirstIndexEqual( 3, true, 1, y, 1 ); // $ExpectError
@@ -60,8 +60,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the function is provided a third argument which is not a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual( x.length, x, '1', y, 1 ); // $ExpectError
 	gfirstIndexEqual( x.length, x, true, y, 1 ); // $ExpectError
@@ -75,7 +75,7 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the function is provided a fourth argument which is not a collection...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual( x.length, x, 1, 10, 1 ); // $ExpectError
 	gfirstIndexEqual( x.length, x, 1, true, 1 ); // $ExpectError
@@ -87,8 +87,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the function is provided a fifth argument which is not a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual( x.length, x, 1, y, '1' ); // $ExpectError
 	gfirstIndexEqual( x.length, x, 1, y, true ); // $ExpectError
@@ -102,8 +102,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual(); // $ExpectError
 	gfirstIndexEqual( 3 ); // $ExpectError
@@ -115,8 +115,8 @@ import gfirstIndexEqual = require( './index' );
 
 // Attached to main export is an `ndarray` method which returns a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual.ndarray( x.length, x, 1, 0, y, 1, 0 ); // $ExpectType number
 	gfirstIndexEqual.ndarray( x.length, new AccessorArray( x ), 1, 0, new AccessorArray( y ), 1, 0 ); // $ExpectType number
@@ -124,8 +124,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual.ndarray( '1', x, 1, 0, y, 1, 0 ); // $ExpectError
 	gfirstIndexEqual.ndarray( true, x, 1, 0, y, 1, 0 ); // $ExpectError
@@ -139,7 +139,7 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the `ndarray` method is provided a second argument which is not a collection...
 {
-	var y = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual.ndarray( 3, 10, 1, 0, y, 1, 0 ); // $ExpectError
 	gfirstIndexEqual.ndarray( 3, true, 1, 0, y, 1, 0 ); // $ExpectError
@@ -151,8 +151,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the `ndarray` method is provided a third argument which is not a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual.ndarray( x.length, x, '1', 0, y, 1, 0 ); // $ExpectError
 	gfirstIndexEqual.ndarray( x.length, x, true, 0, y, 1, 0 ); // $ExpectError
@@ -166,8 +166,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual.ndarray( x.length, x, 1, '1', y, 1, 0 ); // $ExpectError
 	gfirstIndexEqual.ndarray( x.length, x, 1, true, y, 1, 0 ); // $ExpectError
@@ -181,7 +181,7 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the `ndarray` method is provided a fifth argument which is not a collection...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual.ndarray( x.length, x, 1, 0, 10, 1, 0 ); // $ExpectError
 	gfirstIndexEqual.ndarray( x.length, x, 1, 0, true, 1, 0 ); // $ExpectError
@@ -193,8 +193,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the `ndarray` method is provided a sixth argument which is not a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual.ndarray( x.length, x, 1, 0, y, '1', 0 ); // $ExpectError
 	gfirstIndexEqual.ndarray( x.length, x, 1, 0, y, true, 0 ); // $ExpectError
@@ -208,8 +208,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the `ndarray` method is provided a seventh argument which is not a number...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual.ndarray( x.length, x, 1, 0, y, 1, '1' ); // $ExpectError
 	gfirstIndexEqual.ndarray( x.length, x, 1, 0, y, 1, true ); // $ExpectError
@@ -223,8 +223,8 @@ import gfirstIndexEqual = require( './index' );
 
 // The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
 {
-	var x = [ 1.0, 2.0, 3.0 ];
-	var y = [ 1.0, 2.0, 3.0 ];
+	const x = [ 1.0, 2.0, 3.0 ];
+	const y = [ 1.0, 2.0, 3.0 ];
 
 	gfirstIndexEqual.ndarray(); // $ExpectError
 	gfirstIndexEqual.ndarray( 3 ); // $ExpectError

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/README.md
@@ -217,7 +217,6 @@ int main( void ) {
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
-
 <section class="related">
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/lib/native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 * @private
 * @param {number} mu - location parameter
 * @param {PositiveNumber} sigma - scale parameter
-* @returns {number} standard deviation
+* @returns {PositiveNumber} standard deviation
 *
 * @example
 * var y = stdev( 0.0, 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/f/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/pdf/test/test.native.js
@@ -236,7 +236,7 @@ tape( 'the function evaluates the pdf for `x` given large parameter `d2` (tested
 	t.end();
 });
 
-tape( 'the function evaluates the pdf for `x` given large `d1` and `d2` (tested against the Boost C++ library', opts, function test( t ) {
+tape( 'the function evaluates the pdf for `x` given large `d1` and `d2` (tested against the Boost C++ library)', opts, function test( t ) {
 	var expected;
 	var d1;
 	var d2;

--- a/lib/node_modules/@stdlib/stats/base/dists/log-logistic/cdf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/log-logistic/cdf/lib/index.js
@@ -30,7 +30,7 @@
 * // returns ~0.667
 *
 * var myCDF = cdf.factory( 1.0, 1.0 );
-* var y = myCDF( 2.0 );
+* y = myCDF( 2.0 );
 * // returns ~0.667
 */
 

--- a/lib/node_modules/@stdlib/stats/base/dists/log-logistic/quantile/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/log-logistic/quantile/lib/index.js
@@ -30,7 +30,7 @@
 * // returns 1.0
 *
 * var myQuantile = quantile.factory( 1.0, 1.0 );
-* var y = myQuantile( 0.5 );
+* y = myQuantile( 0.5 );
 * // returns 1.0
 */
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/lib/native.js
@@ -26,12 +26,12 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution with mean `mu` and standard deviation `sigma` at a value `x`.
+* Evaluates the natural logarithm of the cumulative distribution function (CDF) for a lognormal distribution with location parameter `mu` and scale parameter `sigma` at a value `x`.
 *
 * @private
 * @param {number} x - input value
-* @param {number} mu - mean
-* @param {NonNegativeNumber} sigma - standard deviation
+* @param {number} mu - location parameter
+* @param {NonNegativeNumber} sigma - scale parameter
 * @returns {number} evaluated logCDF
 *
 * @example
@@ -55,7 +55,7 @@ var addon = require( './../src/addon.node' );
 * // returns NaN
 *
 * @example
-* // Negative standard deviation:
+* // Negative scale parameter:
 * var y = logcdf( 2.0, 0.0, -1.0 );
 * // returns NaN
 */

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/src/main.c
@@ -56,7 +56,7 @@ double stdlib_base_dists_lognormal_logcdf( const double x, const double mu, cons
 	}
 	lx = stdlib_base_ln( x );
 	if ( sigma == 0.0 ) {
-		return (lx < mu) ? STDLIB_CONSTANT_FLOAT64_NINF : 0.0;
+		return ( lx < mu ) ? STDLIB_CONSTANT_FLOAT64_NINF : 0.0;
 	}
 	z = ( lx - mu ) / sigma;
 


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-07-04 16:17 CDT and 2026-07-05 16:39 GST (SHAs `d2cee190..2c4aec3f`, 22 first-parent commits).

Grouped by package:

**`blas/ext/base/gfirst-index-equal`**

-   2c4aec3f: replace `var` with `const` throughout `gfirst-index-equal/docs/types/test.ts` — violates `prefer-const` and inconsistent with `gfill-nan`'s `test.ts` added in the same batch.

**`stats/base/dists/log-logistic/cdf`**

-   Fix duplicate `var y` redeclaration in the `@example` block of `log-logistic/cdf/lib/index.js` (e3c68d4f); reassign instead, matching `logistic/cdf`. Would've tripped `stdlib/no-redeclare`.

**`stats/base/dists/log-logistic/quantile`**

-   Fix duplicate `var y` redeclaration in the `@example` block of `log-logistic/quantile/lib/index.js` (85820ddc); reassign instead, matching `logistic/quantile/lib/index.js`.

**`stats/base/dists/anglit/stdev`**

-   f2d84826: fix doc/formatting nits in `stats/base/dists/anglit/stdev` — correct `@returns {number}` to `{PositiveNumber}` in `lib/native.js` to match `main.js` and `anglit/variance/lib/native.js`, and drop the stray extra blank line before `<section class="related">` in `README.md`.

**`stats/base/dists/lognormal/logcdf`**

-   In `native.js`, fix JSDoc for lognormal `logcdf` to call `mu`/`sigma` the location/scale parameters instead of copy-pasted mean/stdev wording; in `src/main.c:59`, add missing interior spaces to the `( lx < mu )` ternary to match the rest of the file (48157fa9).

**`stats/base/dists/f/pdf`**

-   Fix unclosed parenthesis in a tape title in `test/test.native.js` (82d0e4a5) for `stats/base/dists/f/pdf`, matching the neighboring titles at lines 262 and 285.

## Related Issues

No.

## Questions

No.

## Other

**Validation.** The 24h commit window was audited for (a) stdlib style-guide compliance (JS/TS + C/Makefile/README) and (b) objective runtime bugs / logic errors in the introduced code, running four independent reviewers in parallel. Every finding above was re-verified against the actual working-tree source before applying a fix.

Deliberately excluded from this PR:

-   Anything requiring interpretation or judgment (e.g. "consider naming this differently").
-   Style preferences not encoded in a style-guide rule or an existing sibling convention.
-   `betaprime/mode` still references `equation_betaprime_expectation.svg` after the copy-paste rename in `6e257ba3`; fixing this cleanly requires regenerating the SVG asset (out of window) and updating the CDN URL — dropped rather than expanded scope.
-   Auto-generated content (namespace TOC, error-database CSV/JSON, R fixture `data.json`, manifest entries).

Test tolerances, duplicated sibling-package boilerplate, and the intentional `var opts` shadowing in `namespace/test.cli.js` were audited and confirmed deliberate — not flagged.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated review routine (Claude Code) that audits the last 24 hours of commits to `develop` for typos, bugs, and style-guide violations, then applies fixes for validated high-signal issues. Each finding was surfaced by an independent reviewer agent, cross-checked against sibling-package conventions, and re-verified against the working-tree source before an edit was made. A human maintainer will review and promote from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01VN9AwnbPFQkSCCZ961CGmD)_