### PR TITLE
docs: fix string interpolation and missing JSDoc annotations

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/README.md
@@ -116,7 +116,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %lf, σ: %lf, E(X;µ,σ): %lf', mu, sigma, mean );
+logEachMap( 'µ: %0.4f, σ: %0.4f, E(X;µ,σ): %0.4f', mu, sigma, mean );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %lf, σ: %lf, E(X;µ,σ): %lf', mu, sigma, mean );
+logEachMap( 'µ: %0.4f, σ: %0.4f, E(X;µ,σ): %0.4f', mu, sigma, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/median/README.md
@@ -116,7 +116,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %lf, σ: %lf, Median(X;µ,σ): %lf', mu, sigma, median );
+logEachMap( 'µ: %0.4f, σ: %0.4f, Median(X;µ,σ): %0.4f', mu, sigma, median );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/median/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %lf, σ: %lf, Median(X;µ,σ): %lf', mu, sigma, median );
+logEachMap( 'µ: %0.4f, σ: %0.4f, Median(X;µ,σ): %0.4f', mu, sigma, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/README.md
@@ -129,7 +129,7 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 5.0, opts );
 
-logEachMap( 'p: %lf, µ: %lf, σ: %lf, Q(p;µ,σ): %lf', p, mu, sigma, quantile );
+logEachMap( 'p: %0.4f, µ: %0.4f, σ: %0.4f, Q(p;µ,σ): %0.4f', p, mu, sigma, quantile );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/examples/index.js
@@ -29,4 +29,4 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 5.0, opts );
 
-logEachMap( 'p: %lf, µ: %lf, σ: %lf, Q(p;µ,σ): %lf', p, mu, sigma, quantile );
+logEachMap( 'p: %0.4f, µ: %0.4f, σ: %0.4f, Q(p;µ,σ): %0.4f', p, mu, sigma, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/entropy/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/entropy/lib/native.js
@@ -28,6 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the differential entropy of a Bradford distribution.
 *
+* @private
 * @param {PositiveNumber} c - shape parameter
 * @returns {number} differential entropy
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/lib/native.js
@@ -28,6 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Evaluates the quantile function for a raised cosine distribution with location parameter `mu` and scale parameter `s` at a probability `p`.
 *
+* @private
 * @param {Probability} p - input value
 * @param {number} mu - location parameter
 * @param {NonNegativeNumber} s - scale parameter

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/lib/native.js
@@ -28,6 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Evaluates the probability density function (PDF) for a gamma distribution with shape parameter `alpha` and rate parameter `beta` at a value `x`.
 *
+* @private
 * @param {number} x - input value
 * @param {NonNegativeNumber} alpha - shape parameter
 * @param {PositiveNumber} beta - rate parameter

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/README.md
@@ -117,7 +117,7 @@ var opts = {
 };
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'σ: %lf, E(X;σ): %lf', sigma, mean );
+logEachMap( 'σ: %0.4f, E(X;σ): %0.4f', sigma, mean );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/examples/index.js
@@ -29,4 +29,4 @@ var opts = {
 // Generate positive scale parameters:
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'σ: %lf, E(X;σ): %lf', sigma, mean );
+logEachMap( 'σ: %0.4f, E(X;σ): %0.4f', sigma, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/median/README.md
@@ -28,14 +28,14 @@ limitations under the License.
 
 The [median][median] for a [Lévy][levy-distribution] random variable with location `μ` and scale `c > 0` is
 
-<!-- <equation class="equation" label="eq:levy_expectation" align="center" raw="\operatorname{Median}\left( X \right) = \mu + \frac{c}{2(\operatorname{erfcinv}(1/2))^2}" alt="Mode for a Lévy distribution."> -->
+<!-- <equation class="equation" label="eq:levy_median" align="center" raw="\operatorname{Median}\left( X \right) = \mu + \frac{c}{2(\operatorname{erfcinv}(1/2))^2}" alt="Median for a Lévy distribution."> -->
 
 ```math
 \mathop{\mathrm{Median}}\left( X \right) = \mu + \frac{c}{2(\mathop{\mathrm{erfcinv}}(1/2))^2}
 ```
 
-<!-- <div class="equation" align="center" data-raw-text="\operatorname{Median}\left( X \right) = \mu + \frac{c}{2(\operatorname{erfcinv}(1/2))^2}" data-equation="eq:levy_expectation">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@51534079fef45e990850102147e8945fb023d1d0/lib/node_modules/@stdlib/stats/base/dists/levy/median/docs/img/equation_levy_expectation.svg" alt="Mode for a Lévy distribution.">
+<!-- <div class="equation" align="center" data-raw-text="\operatorname{Median}\left( X \right) = \mu + \frac{c}{2(\operatorname{erfcinv}(1/2))^2}" data-equation="eq:levy_median">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@51534079fef45e990850102147e8945fb023d1d0/lib/node_modules/@stdlib/stats/base/dists/levy/median/docs/img/equation_levy_median.svg" alt="Median for a Lévy distribution.">
     <br>
 </div> -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mode/README.md
@@ -28,14 +28,14 @@ limitations under the License.
 
 The [mode][mode] for a [Lévy][levy-distribution] random variable with location `μ` and scale `c > 0` is
 
-<!-- <equation class="equation" label="eq:levy_expectation" align="center" raw="\operatorname{mode}\left( X \right) = \mu + \frac{c}{3}" alt="Mode for a Lévy distribution."> -->
+<!-- <equation class="equation" label="eq:levy_mode" align="center" raw="\operatorname{mode}\left( X \right) = \mu + \frac{c}{3}" alt="Mode for a Lévy distribution."> -->
 
 ```math
 \mathop{\mathrm{mode}}\left( X \right) = \mu + \frac{c}{3}
 ```
 
-<!-- <div class="equation" align="center" data-raw-text="\operatorname{mode}\left( X \right) = \mu + \frac{c}{3}" data-equation="eq:levy_expectation">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@51534079fef45e990850102147e8945fb023d1d0/lib/node_modules/@stdlib/stats/base/dists/levy/mode/docs/img/equation_levy_expectation.svg" alt="Mode for a Lévy distribution.">
+<!-- <div class="equation" align="center" data-raw-text="\operatorname{mode}\left( X \right) = \mu + \frac{c}{3}" data-equation="eq:levy_mode">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@51534079fef45e990850102147e8945fb023d1d0/lib/node_modules/@stdlib/stats/base/dists/levy/mode/docs/img/equation_levy_mode.svg" alt="Mode for a Lévy distribution.">
     <br>
 </div> -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/lib/native.js
@@ -28,6 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Evaluates the cumulative distribution function (CDF) for a logistic distribution with location parameter `mu` and scale parameter `s` at a value `x`.
 *
+* @private
 * @param {number} x - input value
 * @param {number} mu - location parameter
 * @param {NonNegativeNumber} s - scale parameter

--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/pmf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/pmf/lib/native.js
@@ -28,6 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Evaluates the probability mass function (PMF) for a Poisson distribution with mean parameter `lambda` at a value `x`.
 *
+* @private
 * @param {number} x - input value
 * @param {NonNegativeNumber} lambda - mean parameter
 * @returns {Probability} evaluated PMF

--- a/lib/node_modules/@stdlib/stats/base/dists/signrank/pdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/signrank/pdf/lib/native.js
@@ -28,6 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Evaluates the probability density function (PDF) of the Wilcoxon signed rank test statistic with `n` observations.
 *
+* @private
 * @param {number} x - input value
 * @param {PositiveInteger} n - number of observations
 * @returns {Probability} evaluated PDF


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-07-04 21:17 UTC and 2026-07-05 12:00 UTC to sibling packages that carry the same defects.

### `docs: fix logEachMap format specifier` (source: 4e243797)

The `logEachMap` format string uses stdlib's `format` spec, not C `printf`. `%lf` is not a valid token; `%0.4f` is the intended form. 4e243797 fixed the tukey-lambda/mode example; the same wrong specifier is present in the following sibling distribution READMEs and their `examples/index.js`:

- `stats/base/dists/anglit/mean`
- `stats/base/dists/anglit/median`
- `stats/base/dists/anglit/quantile`
- `stats/base/dists/halfnormal/mean`

Replacement is confined to the `logEachMap` line in each file; the `%lf` tokens inside C `printf` examples elsewhere in each README are untouched.

### `chore: fix copy-pasted equation labels` (source: 6e257ba3)

6e257ba3 corrected a `betaprime/mode/README.md` whose equation `label`, `data-equation`, and image path still read `_expectation` from a mean-package copy-paste. The same three tokens plus a stale `alt` attribute appear in:

- `stats/base/dists/levy/mode` — `label`, `data-equation`, and SVG path corrected to `_mode`.
- `stats/base/dists/levy/median` — same three tokens corrected to `_median`, plus `alt="Mode for a Lévy distribution."` → `"Median for a Lévy distribution."` on both the `<equation>` and the `<img>` element.

### `docs: add missing @private tag` (sources: a1a8d327, 7d1419f8)

Both source commits inserted `* @private` into the JSDoc block of `stats/base/dists/log-logistic/{cdf,quantile}/lib/native.js` because the wrapper is an internal binding, not part of the public API. The same JSDoc block in the following native.js files omits the tag:

- `stats/base/dists/bradford/entropy`
- `stats/base/dists/cosine/quantile`
- `stats/base/dists/gamma/pdf`
- `stats/base/dists/logistic/cdf`
- `stats/base/dists/poisson/pmf`
- `stats/base/dists/signrank/pdf`

Insertion form matches the source commits exactly: one new `* @private` line between the blank comment line following the description and the first `@param`.

## Related Issues

None.

## Questions

None.

## Other

### Validation

- Pattern signatures were derived from the source commits' diffs and searched under `lib/node_modules/@stdlib/stats/base/dists/`.
- Two independent validation passes read each candidate file in full, confirmed the defect was present, and verified the proposed patch is self-contained. Style consistency matches the source commits verbatim.
- Deliberately excluded: `%lf` occurrences inside C `printf` examples (legitimate C format specifiers); README `label="eq:*_expectation"` occurrences in `mean/` packages (label is semantically correct there); autogenerated files (`math/base/special/*/lib/rational_pq.js` — matched `return Infinity` but carry a "generated file" marker, so the fix belongs in the generator).
- Grouping: one commit per source fix pattern to keep the audit trail per-pattern.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine that scans the previous 24 hours of commits merged to `develop`, extracts generalizable fix patterns, locates sibling packages with the same defect, and produces a draft PR for maintainer review. Each candidate site was independently validated by two adversarial review passes before the patch was applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJSVEWQRxpwdjna3LfoqD6)_