### PR TITLE
docs: add Git note

### DIFF
--- a/docs/git-notes/ef6a8d06633359aa718f4aef91a1a257782748b2.txt
+++ b/docs/git-notes/ef6a8d06633359aa718f4aef91a1a257782748b2.txt
@@ -1,0 +1,12 @@
+---
+type: amend-message
+---
+feat: add C implementation for `stats/base/dists/frechet/pdf`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/10843
+Closes: https://github.com/stdlib-js/stdlib/issues/3612
+
+Co-authored-by: Philipp Burckhardt <pburckhardt@outlook.com>
+Co-authored-by: stdlib-bot <noreply@stdlib.io>
+Reviewed-by: Philipp Burckhardt <pburckhardt@outlook.com>
+Signed-off-by: Philipp Burckhardt <pburckhardt@outlook.com>


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds Git notes under `docs/git-notes/` proposing amended commit messages for commits merged to `develop` in the last 24 hours whose subject lines deviate from established repository conventions. This is output from a scheduled commit-message audit routine; no source code, tests, or behavior are changed.

- `ef6a8d0`: wrong scope in subject — original read `` feat: add C implementation for `frechet/pdf` `` but the change touches `lib/node_modules/@stdlib/stats/base/dists/frechet/pdf/`; every other "add C implementation for" commit in the repo's history (e.g. `stats/base/dists/lognormal/logcdf`, `stats/base/dists/f/pdf`, `stats/base/dists/lognormal/cdf`, `stats/base/dists/chisquare/pdf`) uses the full package-path scope. Corrected subject: `` feat: add C implementation for `stats/base/dists/frechet/pdf` ``.

All other commits from the last 24 hours were audited (subject/body spelling, `PR-URL`/`Closes`/`Ref` accuracy verified against GitHub, trailer well-formedness) and found correct — no note was added for them.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Per the audit routine's guardrails, this PR only adds new files under `docs/git-notes/`; it does not rewrite history on `develop` or touch any existing file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

This PR was generated by Claude Code running a scheduled commit-message audit routine: it reviewed all no-merge commits landed on `develop` in the last 24 hours, verified each `PR-URL`/`Closes`/`Ref` trailer against the actual GitHub PR/issue, and cross-checked subject-line scope conventions against prior commit history before proposing the single correction above.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0157PVuS1NEFHg1nRcrWqjiJ)_