### PR TITLE
fix(@stdlib/string/base/atob): guard against missing global `atob`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -20,7 +20,7 @@
 
 // MAIN //
 
-var main = ( typeof atob === 'function' ) ? atob : null;
+var main = ( typeof atob === 'function' ) ? atob : null; // eslint-disable-line n/no-unsupported-features/node-builtins
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MAIN //
+
+var main = ( typeof atob === 'function' ) ? atob : null;
+
+
 // EXPORTS //
 
-module.exports = atob;
+module.exports = main;


### PR DESCRIPTION
## Description

This pull request:

-   fixes a `ReferenceError: atob is not defined` in `@stdlib/string/base/atob` on Node.js versions lacking the global `atob` (<16). `lib/global.js` bare-referenced `atob`, which throws at module-load time. Since `lib/index.js` requires `./main.js` (and transitively `./global.js`) unconditionally before running its `hasAtobSupport()` feature detection, this crashed `require('@stdlib/string/base/atob')` outright on Node.js <16, not just in tests.
-   guards the reference with `typeof atob === 'function'`, which does not throw on an undeclared identifier, matching the existing pattern in `@stdlib/assert/has-atob-support/lib/atob.js`. On unsupported platforms, the module now resolves to `null`, and the existing try/catch in `main.js` plus the `hasAtobSupport()` check in `index.js` handle the rest as originally intended.

## Related Issues

None.

## Questions

No.

## Other

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/28736797063 (`linux_test`, jobs "Node.js v12" and "Node.js v14")

**Symptom:** `ReferenceError: atob is not defined` at `lib/node_modules/@stdlib/string/base/atob/lib/global.js:23:18`, thrown from `test/test.main.js` on `require`, before tape's `skip` option ever takes effect.

**Root cause:** bare (unguarded) reference to the global `atob` in `global.js`, executed unconditionally at module load via `index.js` → `main.js` → `global.js`, regardless of the package's own `hasAtobSupport()` feature detection.

**Validation:** confirmed via manual `node -e` runs that (1) requiring `lib/main.js` with `globalThis.atob` deleted no longer throws and now returns `null` on invocation, (2) requiring `lib/index.js` in the same simulated environment correctly falls back to the polyfill and returns the correct decoded string, (3) normal behavior on a Node.js version with native `atob` is unchanged. A full `node_modules` install was not available in this environment to run the package's `tape` suite directly. Reviewed independently by three agents (correctness, regression scope, style/conventions) — all approved, no blocking findings.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated CI-failure investigation routine: it identified the failing nightly job, root-caused the `ReferenceError`, applied the fix, and validated it against three independent review passes before opening this draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTraN5te3bzCDtdidDgVzJ)_