### PR TITLE
build(workflows): remove orphaned matrix include entries in nightly install workflows

### DIFF
--- a/.github/workflows/linux_test_install.yml
+++ b/.github/workflows/linux_test_install.yml
@@ -86,7 +86,7 @@ jobs:
         BUILD_TASK: ['test-install']
 
         # Define the list of Node.js versions on which to run this job:
-        NODE_VERSION: ['20', '18', '16'] # ['20', '18', '16', '14', '12', '10', '8', '6', '4', '0.12', '0.10']
+        NODE_VERSION: ['20', '18', '16']
 
         # Define the list of package managers to test:
         PACKAGE_MANAGER: ['npm']
@@ -110,50 +110,6 @@ jobs:
           - NODE_VERSION: '16'
             NPM_VERSION: '>2.7.0 <10.0.0'
             PNPM_VERSION: '6'
-
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0 <10.0.0'
-            PNPM_VERSION: '6'
-
-          - NODE_VERSION: '12'
-            NPM_VERSION: '>2.7.0 <9.0.0'
-            PNPM_VERSION: '6'
-
-          - NODE_VERSION: '10'
-            NPM_VERSION: '>2.7.0 <7.0.0'
-            PNPM_VERSION: '5'
-
-          - NODE_VERSION: '8'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-            PNPM_VERSION: '3'
-
-          - NODE_VERSION: '6'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-            PNPM_VERSION: '2'
-
-          - NODE_VERSION: '4'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-            PNPM_VERSION: '1'
-
-          - NODE_VERSION: '0.12'
-            NPM_VERSION: '>2.7.0 <4.0.0'
-
-          - NODE_VERSION: '0.10'
-            NPM_VERSION: '>2.7.0 <4.0.0'
-
-        # Exclude certain matrix combinations:
-        exclude:
-          - NODE_VERSION: '0.12'
-            PACKAGE_MANAGER: 'pnpm'
-
-          - NODE_VERSION: '0.12'
-            PACKAGE_MANAGER: 'yarn'
-
-          - NODE_VERSION: '0.10'
-            PACKAGE_MANAGER: 'pnpm'
-
-          - NODE_VERSION: '0.10'
-            PACKAGE_MANAGER: 'yarn'
 
     # Set defaults:
     defaults:

--- a/.github/workflows/macos_test_npm_install.yml
+++ b/.github/workflows/macos_test_npm_install.yml
@@ -103,30 +103,6 @@ jobs:
           - NODE_VERSION: '16'
             NPM_VERSION: '>2.7.0 <10.0.0'
 
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0 <10.0.0'
-
-          - NODE_VERSION: '12'
-            NPM_VERSION: '>2.7.0 <9.0.0'
-
-          - NODE_VERSION: '10'
-            NPM_VERSION: '>2.7.0 <7.0.0'
-
-          - NODE_VERSION: '8'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-
-          - NODE_VERSION: '6'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-
-          - NODE_VERSION: '4'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-
-          - NODE_VERSION: '0.12'
-            NPM_VERSION: '>2.7.0 <4.0.0'
-
-          - NODE_VERSION: '0.10'
-            NPM_VERSION: '>2.7.0 <4.0.0'
-
     # Set defaults:
     defaults:
       run:


### PR DESCRIPTION
## Description

This pull request:

-   fixes `macos_test_npm_install` and `linux_test_install`, two nightly scheduled workflows that have failed on **every single run for at least the past 30 days**, each time completing in under 10 seconds with zero billable minutes for the actual test-matrix job — only the downstream `zulip` notification job ever ran.
-   removes orphaned `strategy.matrix.include` entries (Node.js versions 14, 12, 10, 8, 6, 4, 0.12, 0.10) left over after both workflows' active `NODE_VERSION` list was trimmed down to `['20', '18', '16']`, plus the resulting fully-vestigial `exclude` block in `linux_test_install.yml`.

## Related Issues

None.

## Questions

No.

## Other

**Failing runs:**
-   https://github.com/stdlib-js/stdlib/actions/runs/28736742230 (`macos_test_npm_install`)
-   https://github.com/stdlib-js/stdlib/actions/runs/28736806563 (`linux_test_install`)

**Symptom:** both workflows conclude `failure` on every scheduled run, in under 10 seconds, with the jobs API showing zero billable minutes for `test_npm_install`/`test_install` — only the `zulip` notification job (which correctly reports the upstream `failure`) ever executes.

**Root cause:** GitHub Actions' matrix-expansion rules create a *new*, standalone combination from an `include` entry whenever that entry's keys don't match any existing matrix combination — a new combination that only contains the keys given in that entry. Both workflows' `include` lists still had entries for `NODE_VERSION` values (14, 12, 10, 8, 6, 4, 0.12, 0.10) that no longer appear in the active `NODE_VERSION: ['20', '18', '16']` list. Each such entry therefore spawned a combination missing the `OS` key, so `runs-on: ${{ matrix.OS }}` resolved to empty and the job's matrix expansion failed before any runner was allocated — for every one of the intended combinations, not just the orphaned ones. The sibling `windows_test_npm_install` workflow does not have this bug because its `include` entries match its `NODE_VERSION` list exactly.

**Fix:** delete the orphaned `include` entries in both files (and the now fully-vestigial `exclude` block in `linux_test_install.yml`, which referenced only Node versions no longer present anywhere in the matrix), and remove a leftover comment listing the old, wider Node.js version set. Both workflows now cleanly expand to their intended 3 combinations (Node.js 20/18/16), matching the `windows_test_npm_install` convention. No step definitions, other matrix dimensions, secrets, permissions, or the `zulip` job are touched.

**Validation:** confirmed both files remain valid YAML post-edit (parsed with PyYAML) and that every remaining `include` entry's `NODE_VERSION` is now a subset of the active list. Reviewed independently by three agents (correctness, regression scope, style/conventions) — all approved, no blocking findings. One non-blocking nit (a stale comment referencing the old Node version list) was folded in before commit.

**Reviewer notes:** `package.json`'s `engines` field still nominally advertises `>=0.10.0` support — a pre-existing, repo-wide inconsistency with the real 16+ CI target, unrelated to this fix and out of scope here.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated CI-failure investigation routine: it identified that both nightly workflows had been failing on every run for a month, root-caused the matrix-expansion bug, applied the fix, and validated it against three independent review passes before opening this draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTraN5te3bzCDtdidDgVzJ)_