### PR TITLE
bench: add missing native benchmark

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/benchmark/benchmark.native.js
@@ -1,0 +1,62 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var log1pmx = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( log1pmx instanceof Error )
+};
+
+
+// MAIN //
+
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = uniform( 100, -1.0, 99.0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = log1pmx( x[ i%x.length ] );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Adds the missing `benchmark/benchmark.native.js` to `@stdlib/math/base/special/log1pmx` so its N-API addon has the same JS-level benchmark surface as its 342 siblings in `@stdlib/math/base/special`.

### Namespace summary

- **Namespace:** `@stdlib/math/base/special`
- **Members analyzed:** 357 packages, none autogenerated.
- **Native subset:** 343 packages ship a native N-API addon (`binding.gyp` + `src/addon.c` + `lib/native.js`); 14 are pure-JS by design.
- **Features with a clear majority (≥75%):** the shared file tree (`README.md`, `lib/index.js`, `lib/main.js`, `docs/repl.txt`, `docs/types/{index.d.ts,test.ts}`, `test/test.js`, `benchmark/benchmark.js`, `examples/index.js`, `package.json`), the standard `package.json` key set, and the H2 section list (`Usage`, `Examples`, `C APIs` for native packages). Among the 343 native packages, `benchmark/benchmark.native.js` and `test/test.native.js` are each present at 342/343.
- **Features excluded (no clear majority):** the `stdlib` `package.json` sub-key set (only 249/357 packages carry a `__stdlib__` block, below the 75% cutoff — likely a build-time addition, deliberately not touched here); the H2 `See Also` section (237/357, generator-owned per the routine's auto-populated gate).

### `math/base/special/log1pmx`

`log1pmx` is the sole native package in the namespace missing `benchmark/benchmark.native.js` — 342 of 343 native siblings (99.7%) carry it, including the immediate sibling `log1p`. The package already ships a functional N-API addon (`binding.gyp`, `src/{addon.c,main.c}`, `lib/native.js`), so the gap is a bookkeeping oversight from when the package was added, not an intentional deviation. The new file mirrors `log1p/benchmark/benchmark.native.js` verbatim in structure — loads the addon via `tryRequire('./../lib/native.js')`, skips cleanly when the addon isn't built, and reuses the JS benchmark's `uniform( 100, -1.0, 99.0 )` input distribution so JS and native numbers are comparable. No other file in the package changes, and nothing in `test/`, `examples/`, `README.md`, or `docs/repl.txt` — nor anywhere else in the repo — references or depends on the file's absence.

## Related Issues

None.

## Questions

No.

## Other

### Validation

- **Structural extraction** over all 357 members — file trees, `package.json` key sets, `manifest.json` key sets, and README H2/H3 section lists — computed the majority pattern per feature at the routine's 75% threshold.
- **Semantic extraction** via per-package agents was skipped for this run because structural drift alone surfaced a clear, single-file correction; the namespace is dense enough (357 members) that a per-package semantic pass would have burned rate limits for no gain against the specific finding already in hand.
- **Three-agent drift validation** (opus semantic-review, opus cross-reference, sonnet structural-review) each independently returned `confirmed-drift` for the `log1pmx` finding.
- **Cross-run dedup** against open PRs on the namespace: PR #9491 modifies `log1pmx/test/test.js` (adding special-value tests) and PR #12467 revises TSDoc across `math/base/special`; neither touches `benchmark/benchmark.native.js` in `log1pmx` and neither collides at the file level.

**Deliberately excluded:**
- `log1pmx/test/test.native.js` (also missing, 342/343 conformance). Adding it would mirror `test/test.js`, which PR #9491 is actively extending; landing a `test.native.js` derived from today's `test.js` would silently omit the special-value tests once #9491 merges. Deferred until #9491 lands.
- `cfloor/benchmark/c/native/{Makefile,benchmark.c}` (native package, 340/343 conformance for this pair). `cfloor`'s existing `benchmark/c/benchmark.c` is a raw-C reference (calls `floor()` on `creal(z)`/`cimag(z)`); adding a stdlib-impl native benchmark would require writing ~140 lines of C that construct `stdlib_complex128_t` inputs and format `Complex128` outputs — beyond the routine's mechanical-fix criterion.
- `hyp2f1/benchmark/c/native/{Makefile,benchmark.c}` and `sqrtpif/benchmark/c/native/{Makefile,benchmark.c}` (same 340/343 conformance). Both packages have `benchmark/c/benchmark.c` files that already `#include "stdlib/math/base/special/*.h"` and call `stdlib_base_*` — content-wise they belong under `benchmark/c/native/`. The correction is a directory move plus Makefile CFLAGS rework, not a pure file addition, so it needs a human call on whether to move or duplicate; dropped from this run.
- The `fast` sub-namespace parent (single-outlier missing `lib/main.js`, `benchmark/benchmark.js`, `docs/repl.txt`). It is a namespace package, not a leaf; deviation is intentional.
- Autogenerated `## See Also` sections (237/357), per the routine's auto-populated gate.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as a cross-package drift audit of `@stdlib/math/base/special`. Structural features (file trees, `package.json` shape, README sections, manifest shape) were extracted for all 357 members; majority patterns were computed at the routine's 75% threshold; the single surviving outlier finding was independently validated by three reviewer agents (opus semantic-review, opus cross-reference, sonnet structural-review). A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01XBKt5NuGngNmdvsfKXfTeZ)_