### PR TITLE
chore: follow-up fixes for commits merged to `develop`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/cgemv/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/cgemv/docs/repl.txt
@@ -43,7 +43,7 @@
     > var cb = new {{alias:@stdlib/complex/float32/ctor}}( 1.0, 0.0 );
     > var beta = {{alias:@stdlib/ndarray/from-scalar}}( cb, opts );
 
-    > var trans = {{alias:@stdlib/ndarray/from-scalar}}( 'no-transpose' );
+    > var trans = {{alias:@stdlib/ndarray/from-scalar}}( {{alias:@stdlib/blas/base/transpose-operation-resolve-enum}}( 'no-transpose' ), { 'dtype': 'int8' } );
 
     > {{alias}}( [ A, x, y, trans, alpha, beta ] );
     > y

--- a/lib/node_modules/@stdlib/blas/base/ndarray/cgemv/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/cgemv/docs/repl.txt
@@ -43,7 +43,7 @@
     > var cb = new {{alias:@stdlib/complex/float32/ctor}}( 1.0, 0.0 );
     > var beta = {{alias:@stdlib/ndarray/from-scalar}}( cb, opts );
 
-    > var trans = {{alias:@stdlib/ndarray/from-scalar}}( {{alias:@stdlib/blas/base/transpose-operation-resolve-enum}}( 'no-transpose' ), { 'dtype': 'int8' } );
+    > var trans = {{alias:@stdlib/ndarray/from-scalar}}( 'no-transpose' );
 
     > {{alias}}( [ A, x, y, trans, alpha, beta ] );
     > y

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-same-value/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-same-value/docs/repl.txt
@@ -49,7 +49,7 @@
     2
 
 
-{{alias}}( N, searchElement, x, strideX, offsetX )
+{{alias}}.ndarray( N, searchElement, x, strideX, offsetX )
     Returns the index of the first element in a strided array which has the same
     value as a provided search element using alternative indexing semantics.
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-same-value/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-same-value/test/test.ndarray.js
@@ -122,11 +122,14 @@ tape( 'the function returns `-1` if provided `N` parameter is less than or equal
 
 tape( 'the function returns `-1` if provided `N` parameter is less than or equal to zero (accessors)', function test( t ) {
 	var actual;
+	var x;
 
-	actual = gindexOfSameValue( 0, 2.0, toAccessorArray( [ 1.0, 2.0, 3.0 ] ), 1, 0 );
+	x = toAccessorArray( [ 1.0, 2.0, 3.0 ] );
+
+	actual = gindexOfSameValue( 0, 2.0, x, 1, 0 );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
-	actual = gindexOfSameValue( -1, 2.0, toAccessorArray( [ 1.0, 2.0, 3.0 ] ), 1, 0 );
+	actual = gindexOfSameValue( -1, 2.0, x, 1, 0 );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of-same-value/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of-same-value/test/test.ndarray.js
@@ -83,13 +83,13 @@ tape( 'the function returns the first index of an element which has the same val
 	actual = gindexOfSameValue( x.length, 1.0, x, 1, 0 );
 	t.strictEqual( actual, 0, 'returns expected value' );
 
-	actual = gindexOfSameValue( x.length, 2.0, x, 1, 1 );
+	actual = gindexOfSameValue( x.length-1, 2.0, x, 1, 1 );
 	t.strictEqual( actual, 1, 'returns expected value' );
 
-	actual = gindexOfSameValue( x.length, 3.0, x, 1, 2 );
+	actual = gindexOfSameValue( x.length-2, 3.0, x, 1, 2 );
 	t.strictEqual( actual, 2, 'returns expected value' );
 
-	actual = gindexOfSameValue( x.length, 4.0, x, 1, 2 );
+	actual = gindexOfSameValue( x.length-2, 4.0, x, 1, 2 );
 	t.strictEqual( actual, -1, 'returns expected value' );
 
 	// Negative stride...

--- a/lib/node_modules/@stdlib/stats/incr/nanpcorr2/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/nanpcorr2/docs/repl.txt
@@ -27,14 +27,16 @@
     null
     > r2 = accumulator( 2.0, 1.0 )
     0.0
+    > r2 = accumulator( 1.0, 90.0 )
+    1.0
     > r2 = accumulator( -5.0, NaN )
-    ~0.0
+    ~1.0
     > r2 = accumulator( NaN, NaN )
-    ~0.0
+    ~1.0
     > r2 = accumulator( NaN, -8.0 )
-    ~0.0
+    ~1.0
     > r2 = accumulator()
-    ~0.0
+    ~1.0
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/stats/incr/nanpcorr2/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanpcorr2/docs/types/index.d.ts
@@ -55,17 +55,20 @@ declare function incrnanpcorr2( meanx: number, meany: number ): accumulator;
 * r2 = accumulator( 2.0, 1.0 );
 * // returns 0.0
 *
+* r2 = accumulator( 1.0, 90.0 );
+* // returns 1.0
+*
 * r2 = accumulator( -5.0, NaN );
-* // returns ~0.0
+* // returns ~1.0
 *
 * r2 = accumulator( NaN, NaN );
-* // returns ~0.0
+* // returns ~1.0
 *
 * r2 = accumulator( NaN, 8.0 );
-* // returns ~0.0
+* // returns ~1.0
 *
 * r2 = accumulator();
-* // returns ~0.0
+* // returns ~1.0
 */
 declare function incrnanpcorr2(): accumulator;
 

--- a/lib/node_modules/@stdlib/stats/incr/nanpcorr2/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanpcorr2/lib/main.js
@@ -44,17 +44,20 @@ var incrpcorr2 = require( '@stdlib/stats/incr/pcorr2' );
 * r2 = accumulator( 2.0, 1.0 );
 * // returns 0.0
 *
+* r2 = accumulator( 1.0, 90.0 );
+* // returns 1.0
+*
 * r2 = accumulator( -5.0, NaN );
-* // returns ~0.0
+* // returns ~1.0
 *
 * r2 = accumulator( NaN, NaN );
-* // returns ~0.0
+* // returns ~1.0
 *
 * r2 = accumulator( NaN, 8.0 );
-* // returns ~0.0
+* // returns ~1.0
 *
 * r2 = accumulator();
-* // returns ~0.0
+* // returns ~1.0
 *
 * @example
 * var accumulator = incrnanpcorr2( 2.0, -3.0 );


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between `5de852b` (2026-07-05 13:52 -0500) and `be45b3657` (2026-07-06 03:54 -0700). A 24-hour code-review sweep across the 41 commits in that window surfaced three high-signal fixes on this branch, grouped into two package commits (+ one lint cleanup):

-   **`blas/ext/base/gindex-of-same-value`** — Fix missing `.ndarray` suffix in the second signature header of `blas/ext/base/gindex-of-same-value/docs/repl.txt` (line 52); header didn't match the documented ndarray method, unlike sibling packages. Introduced in 0cf99ac9.
-   **`blas/ext/base/gindex-of-same-value`** — Fix out-of-bounds reads in the accessors `test.ndarray.js` for `gindex-of-same-value` (0cf99ac9): the `offsetX=1`/`2` cases still used `N = x.length` instead of `x.length-1`/`x.length-2` like the non-accessor block above, walking past the 6-element array; tests only passed because the match preceded the overrun.
-   **`stats/incr/nanpcorr2`** — Fix nanpcorr2 example in 6570c4f: `lib/main.js` never fed a second `(x, y)` pair before the NaN calls, so the accumulator stayed pinned at 0.0 instead of demonstrating NaN-skipping at ~1.0. Same bug duplicated in `docs/types/index.d.ts` and `docs/repl.txt`; all three now insert `accumulator( 1.0, 90.0 )` to match the README.

## Related Issues

None.

## Questions

No.

## Other

**Validation.** The review checked (1) stdlib style-guide compliance for every touched package against a sibling reference package, and (2) objective bugs surfaceable from the diff alone (wrong loop bounds, swapped arguments, copy-paste leftovers, wrong return values, broken assertions, mismatched signatures, doc examples that don't match code). Excluded, deliberately: subjective preferences, "might be" concerns, anything requiring interpretation, and anything that would require touching code outside the window's diff to validate. Five candidate findings that failed those bars were dropped — most notably a suggestion to override commit `dbaac4d3`'s (Reines) deliberate widening of the alt-hypothesis ndarray type on the `dztest`/`dztest2`/`sztest`/`sztest2` type declarations, and a cgemv REPL fix that would have required registering a new REPL alias for `@stdlib/blas/base/transpose-operation-resolve-enum` (out of scope).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by a scheduled Claude Code review routine that swept the last 24h of commits on `develop`, ran four parallel reviewer agents (two style-guide, two bug-hunt), merged and de-duplicated their findings against a high-signal filter, and applied the surviving fixes. A human maintainer will audit before promoting from draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
