### PR TITLE
refactor: avoid unnecessary assignment

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of/lib/ndarray.js
@@ -58,8 +58,7 @@ function dlastIndexOf( N, searchElement, x, strideX, offsetX ) {
 		return idx;
 	}
 	// Convert the index from reversed "view" to an index in the original "view":
-	idx = N - 1 - idx;
-	return idx;
+	return N - 1 - idx;
 }
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of/lib/ndarray.js
@@ -58,8 +58,7 @@ function slastIndexOf( N, searchElement, x, strideX, offsetX ) {
 		return idx;
 	}
 	// Convert the index from reversed "view" to an index in the original "view":
-	idx = N - 1 - idx;
-	return idx;
+	return N - 1 - idx;
 }
 
 


### PR DESCRIPTION
## Description

This pull request:

-   Propagates the refactor from 3ceff10 (`refactor: avoid unnecessary assignment`) to sibling `blas/ext/base/*last-index-of` packages, collapsing the redundant `idx = N - 1 - idx; return idx;` sequence into a single `return N - 1 - idx;`. Target packages:
    -   `blas/ext/base/dlast-index-of`
    -   `blas/ext/base/slast-index-of`

## Related Issues

None.

## Questions

No.

## Other

Validation: pattern search scoped to `blas/ext/base/*/lib/ndarray.js`, followed by two independent adversarial passes and a style-consistency check confirming each target is textually identical to the source's pre-refactor shape. Deliberately excluded: the equivalent `src/main.c` sequences in the same packages, since the source commit did not touch C.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by an automated Claude Code routine that propagates recent `develop` fixes to sibling packages with the same defect pattern. Pattern detection, candidate-site validation, and patch generation were AI-assisted; the resulting diff is the verbatim analog of 3ceff10.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_0167guX7631hf8M2hU4v4zb6)_