### PR TITLE
fix(@stdlib/string/base/atob): guard global `atob` reference to prevent ReferenceError

### DIFF
--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -20,7 +20,7 @@
 
 // MAIN //
 
-var main = ( typeof atob === 'function' ) ? atob : null;
+var main = ( typeof atob === 'function' ) ? atob : null; // eslint-disable-line n/no-unsupported-features/node-builtins
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MAIN //
+
+var main = ( typeof atob === 'function' ) ? atob : null;
+
+
 // EXPORTS //
 
-module.exports = atob;
+module.exports = main;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `lib/node_modules/@stdlib/string/base/atob/lib/global.js`, which re-exported the bare global `atob` identifier directly. On Node.js runtimes that predate the global `atob`/`btoa` (added in Node 16+), referencing an undeclared identifier without a `typeof` guard throws `ReferenceError: atob is not defined` at module-evaluation time. Because `main.js` requires `global.js` at its top level, outside any try/catch, merely requiring the package crashed on Node 12/14. This broke the `linux_test` CI workflow's Node.js v12 and v14 jobs on every scheduled run against `develop`. The fix guards the reference with `typeof atob === 'function'`, matching the identical pattern already used by the sibling `@stdlib/assert/has-atob-support` package.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Found and fixed as part of automated CI-failure triage. Failing run: https://github.com/stdlib-js/stdlib/actions/runs/28785480753 (job: `linux_test`, Node.js v14; also reproduced on Node.js v12 and the macOS Node.js v16 job of the same run).

Validated by reproducing the crash and fix locally via a Node script that deletes `globalThis.atob` and confirms `require()` no longer throws. Reviewed by three independent passes (correctness, regression scope, style/conventions); all approved with no blocking findings.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI-failure triage and fix routine, based on live GitHub Actions job log analysis. The fix was reviewed by three independent automated review passes before being proposed here.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDRfLqFoviLtaMeRWRWyay)_