### PR TITLE
build(workflows): fetch update_pr_copyright_years script from base repo

### DIFF
--- a/.github/workflows/update_pr_copyright_years.yml
+++ b/.github/workflows/update_pr_copyright_years.yml
@@ -120,7 +120,13 @@ jobs:
           FILES: ${{ steps.added-files.outputs.files }}
         run: |
           files="$FILES"
-          . "$GITHUB_WORKSPACE/.github/workflows/scripts/update_pr_copyright_years/run" "$files"
+
+          # Fetch the script from the base repository at the ref this workflow is running from, as the checked out PR branch (potentially an external fork) may not contain it:
+          script="$(mktemp)"
+          curl -sf "https://raw.githubusercontent.com/stdlib-js/stdlib/${{ github.sha }}/.github/workflows/scripts/update_pr_copyright_years/run" -o "$script"
+          chmod +x "$script"
+
+          "$script" "$files"
 
       # Disable Git hooks:
       - name: 'Disable Git hooks'


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `.github/workflows/update_pr_copyright_years.yml`, a reusable workflow invoked by `/stdlib update-copyright-years` (`slash_commands.yml`) and by the `bot: Update Copyright Years` label (`label_commands.yml`). The workflow's "Checkout repository" step checks out the PR's own branch/repository (from GitHub API PR details) into `$GITHUB_WORKSPACE`, and the following step then sourced the copyright-years tooling script from that same checkout: `. "$GITHUB_WORKSPACE/.github/workflows/scripts/update_pr_copyright_years/run"`. If the PR's branch predates that script's addition to `develop`, or is a stale/unrebased fork, the script isn't present there, and the step fails with `No such file or directory`. This has failed repeatedly and recurringly across unrelated PRs (three times on 2026-07-05 alone, plus bursts on 2026-06-26 and 2026-06-17). The fix fetches the script from the base repository at `${{ github.sha }}` (the workflow's own commit, never the PR's, and not attacker-influenced the way the PR checkout is) into a temp file and executes it, instead of trusting the checked-out PR branch for internal CI tooling.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Found and fixed as part of automated CI-failure triage. Example failing run: https://github.com/stdlib-js/stdlib/actions/runs/28750106733 (job: `Update Copyright Years`, via `slash_commands.yml`).

Validated by simulating the fixed step outside any repository checkout (`curl` the script from a `develop` SHA into `/tmp`, `chmod +x`, run it against a test file) and confirming the copyright year updates correctly with no "No such file" error. Reviewed by three independent passes (correctness, regression scope, style/conventions); all approved with no blocking findings. Reviewer B noted the reusable workflow has two callers (`slash_commands.yml` and `label_commands.yml`, not just the former) — both hit the identical failure mode and both benefit from this fix.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI-failure triage and fix routine, based on live GitHub Actions job log analysis. The fix was reviewed by three independent automated review passes before being proposed here.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDRfLqFoviLtaMeRWRWyay)_