### PR TITLE
fix: add missing index signature to Float16Array class declaration

### DIFF
--- a/lib/node_modules/@stdlib/array/float16/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/float16/docs/types/index.d.ts
@@ -341,6 +341,11 @@ declare class Float16Array implements Float16ArrayInterface {
 	constructor( arg?: number | ArrayLike<number> | ArrayBuffer | Iterable<number>, byteOffset?: number, length?: number );
 
 	/**
+	* Indexed properties.
+	*/
+	[ index: number ]: number;
+
+	/**
 	* Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer indices.
 	*
 	* @param i - element index
@@ -415,11 +420,6 @@ declare class Float16Array implements Float16ArrayInterface {
 	* // returns 10
 	*/
 	readonly length: number;
-
-	/**
-	* Indexed properties.
-	*/
-	[ index: number ]: number;
 
 	/**
 	* Copies a sequence of elements within the array to the position starting at `target`.

--- a/lib/node_modules/@stdlib/array/float16/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/float16/docs/types/index.d.ts
@@ -417,6 +417,11 @@ declare class Float16Array implements Float16ArrayInterface {
 	readonly length: number;
 
 	/**
+	* Indexed properties.
+	*/
+	[ index: number ]: number;
+
+	/**
 	* Copies a sequence of elements within the array to the position starting at `target`.
 	*
 	* @param target - index at which to start copying elements


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `lib/node_modules/@stdlib/array/float16/docs/types/index.d.ts`. Its `Float16Array` class declares `implements Float16ArrayInterface` (imported from `@stdlib/types/array`), but was missing a `[ index: number ]: number` index signature required by that interface (it already correctly declared `buffer`, `byteLength`, `byteOffset`, `BYTES_PER_ELEMENT`, and `length`). Under this repo's pinned `lib: ["es6"]` TypeScript configuration, `@stdlib/types/array`'s `Float16Array` conditional type resolves to its `Float16ArrayFallback` interface (since there is no native `Float16Array` global under `es6` lib), so the class fails to satisfy it, producing `TS2420: Class 'Float16Array' incorrectly implements interface 'Float16ArrayFallback'`. This compile error cascades into a `never` type anywhere a `Float16Array` instance is passed through a generically-typed function, which broke the `lint_changed_files` workflow's "Lint TypeScript declarations test files" step for `@stdlib/array/zero-to-like` and `@stdlib/array/zeros-like` with errors like `Expected type to be: Float16ArrayFallback, got: never`. The same latent break affects `@stdlib/array/zeros` and `@stdlib/array/zero-to`, which reference the identical type but weren't touched by a PR in this failure window. The fix adds the missing index signature, matching the interface's own declaration verbatim.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Found and fixed as part of automated CI-failure triage. Example failing run: https://github.com/stdlib-js/stdlib/actions/runs/28756237389 (job: `lint_changed_files` / "Lint TypeScript declarations test files", package `@stdlib/array/zero-to-like`); the same signature also failed for `@stdlib/array/zeros-like`.

Validation: an initial hypothesis (that the `$ExpectType Float16ArrayFallback` annotations in the consumer test files were simply typos for `Float16Array`) was tried and discarded after a standalone `tsc` run showed the annotations were already correct and the actual resolved type was `never` — a compile-error signal, not a naming mismatch. Root-caused from there to the missing index signature. Verified with a standalone `tsc` invocation (`lib: ["es6"]`, matching this repo's `docs/types/tsconfig.json`) against `@stdlib/array/zero-to-like`'s and `@stdlib/array/zeros-like`'s `docs/types/test.ts`: no error at the Float16-related lines with the fix applied, and the original `TS2420` plus cascading `never` errors reproduce when the fix is reverted. Reviewed by three independent passes (correctness, regression scope, style/conventions); all approved with no blocking findings. This is a declaration-only (`.d.ts`) change with no runtime/JS behavior impact.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI-failure triage and fix routine, based on live GitHub Actions job log analysis. The fix was reviewed by three independent automated review passes before being proposed here.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDRfLqFoviLtaMeRWRWyay)_