### PR TITLE
chore: add keywords

### DIFF
--- a/lib/node_modules/@stdlib/regexp/extended-length-path/package.json
+++ b/lib/node_modules/@stdlib/regexp/extended-length-path/package.json
@@ -57,6 +57,7 @@
     "expression",
     "path",
     "test",
+    "match",
     "file",
     "filename",
     "windows",

--- a/lib/node_modules/@stdlib/regexp/regexp/package.json
+++ b/lib/node_modules/@stdlib/regexp/regexp/package.json
@@ -57,6 +57,7 @@
     "expression",
     "string",
     "pattern",
-    "flags"
+    "flags",
+    "match"
   ]
 }


### PR DESCRIPTION
## Description

Adds the missing `match` keyword to `@stdlib/regexp/regexp/package.json` and `@stdlib/regexp/extended-length-path/package.json`. The keyword is present in 23 of 27 sibling packages under `@stdlib/regexp/*` (85.2%); these two were the only regex-producing outliers. The two remaining packages without it — `reviver` and `to-json` — legitimately lack it since neither performs a match: `reviver` deserializes a JSON representation into a `RegExp` instance and `to-json` serializes a `RegExp` in the opposite direction.

### `regexp/regexp`

The package's own JSDoc summary reads "regular expression to parse a regular expression string" — it matches regex-literal syntax. The absent keyword contradicts that description.

### `regexp/extended-length-path`

The package's own `main.js` returns a regular expression that matches extended-length Windows paths. The absent keyword contradicts that description.

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

The change was produced by an automated cross-package drift audit over the 27 non-autogenerated members of `@stdlib/regexp/*`. Three independent reviewer agents (semantic, cross-reference, structural) confirmed both corrections. Total diff is 3 LOC across 2 files.

No other drift corrections survived filtering. Outliers dropped as intentional deviations: `reviver` and `to-json` missing `test/test.main.js` (their `main.js` is the tested function, no separate factory to exercise); `color-hexadecimal` inlining regex constants in `lib/index.js` rather than following the `lib/regexp.js` convention (74.07% sibling conformance — below the 75% majority threshold; three-constant split has no clean sibling analog). Missing `## See Also` sections in five packages were skipped as auto-populated by the package generator.

Only the in-repo consumer of `package.json` `keywords` is the `_tools/search/pkg-index` full-text index (bag-of-words, order-independent), so keyword insertion position is not observable to downstream tooling.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift detection routine over `@stdlib/regexp/*`. Three independent reviewer agents (semantic, cross-reference, structural) confirmed each candidate before the fixes were applied. A maintainer should promote out of draft after review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCbpiq4scMMG4fqFEzwf4v)_