### PR TITLE
style: wrap ternary conditions in parentheses

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmmin/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmin/examples/index.js
@@ -35,5 +35,5 @@ console.log( '\nValue\tMin\n' );
 for ( i = 0; i < 100; i++ ) {
 	v = ( randu() < 0.1 ) ? NaN : randu() * 100.0;
 	m = accumulator( v );
-	console.log( '%s\t%s', isnan( v ) ? 'NaN' : v.toFixed( 4 ), ( m === null ) ? 'null' : m.toFixed( 4 ) );
+	console.log( '%s\t%s', ( isnan( v ) ) ? 'NaN' : v.toFixed( 4 ), ( m === null ) ? 'null' : m.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/incr/nanmrss/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrss/examples/index.js
@@ -38,5 +38,5 @@ for ( i = 0; i < 100; i++ ) {
 	v1 = ( bernoulli( 0.8 ) < 1 ) ? NaN : uniform( 0.0, 100.0 );
 	v2 = ( bernoulli( 0.8 ) < 1 ) ? NaN : uniform( 0.0, 100.0 );
 	rss = accumulator( v1, v2 );
-	console.log( '%s\t%s\t%s', isnan( v1 ) ? 'NaN' : v1.toFixed( 3 ), isnan( v2 ) ? 'NaN' : v2.toFixed( 3 ), ( rss === null ) ? 'null' : rss.toFixed( 3 ) );
+	console.log( '%s\t%s\t%s', ( isnan( v1 ) ) ? 'NaN' : v1.toFixed( 3 ), ( isnan( v2 ) ) ? 'NaN' : v2.toFixed( 3 ), ( rss === null ) ? 'null' : rss.toFixed( 3 ) );
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   wraps the `isnan` ternary conditions in the `@stdlib/stats/incr/nanmmin` and `@stdlib/stats/incr/nanmrss` example files in parentheses to satisfy the `stdlib/ternary-condition-parentheses` lint rule.

These two examples were introduced by the recently merged `stats/incr/nanmmin` and `stats/incr/nanmrss` packages and currently trip the lint rule (`38:25 error parentheses required around ternary conditions`).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Purely a lint fix; no behavior change. Both example scripts run and produce identical output.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)

#### Disclosure

This lint fix was authored by Claude Code and reviewed by me.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
