### PR TITLE
chore: add Git note correcting commit message

### DIFF
--- a/docs/git-notes/aa89fb36f12f7e813ddec45082316115185eff89.txt
+++ b/docs/git-notes/aa89fb36f12f7e813ddec45082316115185eff89.txt
@@ -1,0 +1,11 @@
+---
+type: amend-message
+---
+feat: add `stats/incr/nanmmin`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/5849
+Closes: https://github.com/stdlib-js/stdlib/issues/5594
+
+Co-authored-by: Philipp Burckhardt <pburckhardt@outlook.com>
+Co-authored-by: stdlib-bot <noreply@stdlib.io>
+Reviewed-by: Philipp Burckhardt <pburckhardt@outlook.com>


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds a Git note to correct the commit message of a recently merged commit that does not follow the project's Conventional Commits conventions:

-   `aa89fb36f`: subject was `feat(lib): added \`stats/incr/nanmmin\` package` — corrected to `feat: add \`stats/incr/nanmmin\`` (drop the non-standard `(lib)` scope and past-tense/redundant wording; use the imperative `add`).

All original trailers (`PR-URL`, `Closes`, `Co-authored-by`, `Reviewed-by`) are preserved unchanged.

## Related Issues

No.

## Questions

No.

## Other

Git note only; no source changes.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Documentation (including examples)

#### Disclosure

This Git note was authored by Claude Code and reviewed by me.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
