### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/regexp/basename/lib/index.js
+++ b/lib/node_modules/@stdlib/regexp/basename/lib/index.js
@@ -29,7 +29,7 @@
 *
 * // On a POSIX platform...
 * var base = RE_BASENAME.exec( '/foo/bar/index.js' )[ 1 ];
-* // returns 'index.js'
+* // e.g., returns 'index.js'
 *
 * @example
 * var reBasename = require( '@stdlib/regexp/basename' );

--- a/lib/node_modules/@stdlib/regexp/basename/lib/index.js
+++ b/lib/node_modules/@stdlib/regexp/basename/lib/index.js
@@ -37,7 +37,7 @@
 *
 * // On a Windows platform...
 * var base = RE_BASENAME.exec( 'C:\\foo\\bar\\index.js' )[ 1 ];
-* // returns 'index.js'
+* // e.g., returns 'index.js'
 */
 
 // MODULES //


### PR DESCRIPTION
Resolves #13344.

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes a JSDoc doctest linting failure in `@stdlib/regexp/basename` by updating the `// returns` assertion syntax to the non-assertive `// e.g., returns` syntax for a cross-platform Windows path check.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #13344

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
