### PR TITLE
refactor: add `isnan` guards

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var digamma = require( '@stdlib/math/base/special/digamma' );
 var betaln = require( '@stdlib/math/base/special/betaln' );
 
@@ -63,7 +64,12 @@ var betaln = require( '@stdlib/math/base/special/betaln' );
 */
 function entropy( alpha, beta ) {
 	var out;
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	out = betaln( alpha, beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -61,7 +66,12 @@ function kurtosis( alpha, beta ) {
 	var apb;
 	var out;
 
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	axb = alpha * beta;

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/mean/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -56,7 +61,12 @@
 * // returns NaN
 */
 function mean( alpha, beta ) {
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return alpha / ( alpha + beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/median/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/median/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var betaincinv = require( '@stdlib/math/base/special/betaincinv' );
 
 
@@ -61,7 +62,12 @@ var betaincinv = require( '@stdlib/math/base/special/betaincinv' );
 * // returns NaN
 */
 function median( alpha, beta ) {
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return betaincinv( 0.5, alpha, beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/mode/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/mode/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -56,7 +61,12 @@
 * // returns NaN
 */
 function mode( alpha, beta ) {
-	if ( alpha <= 1.0 || beta <= 1.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 1.0 ||
+		isnan( beta ) ||
+		beta <= 1.0
+	) {
 		return NaN;
 	}
 	return ( alpha-1.0 ) / ( alpha+beta-2.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/skewness/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/skewness/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 
 
@@ -63,7 +64,12 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 function skewness( alpha, beta ) {
 	var out;
 	var ab;
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	ab = alpha + beta;

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/stdev/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/stdev/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 
 
@@ -63,7 +64,12 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 function stdev( alpha, beta ) {
 	var apb;
 	var out;
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	apb = alpha + beta;

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/variance/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -58,7 +63,12 @@
 function variance( alpha, beta ) {
 	var apb;
 	var out;
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	apb = alpha + beta;

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -60,7 +65,12 @@
 * // returns NaN
 */
 function mean( alpha, beta ) {
-	if ( alpha <= 0.0 || beta <= 1.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 1.0
+	) {
 		return NaN;
 	}
 	return alpha / ( beta - 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -60,7 +65,12 @@
 * // returns NaN
 */
 function mode( alpha, beta ) {
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	if ( alpha < 1.0 ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/f/kurtosis/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/kurtosis/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 
 
@@ -68,7 +69,12 @@ function kurtosis( d1, d2 ) {
 	var denom;
 	var num;
 
-	if ( d1 <= 0.0 || d2 <= 8.0 ) {
+	if (
+		isnan( d1 ) ||
+		d1 <= 0.0 ||
+		isnan( d2 ) ||
+		d2 <= 8.0
+	) {
 		return NaN;
 	}
 	num = ( d1 * ( ( 5.0*d2 ) - 22.0 ) * ( d1+d2-2.0 ) ) +

--- a/lib/node_modules/@stdlib/stats/base/dists/f/mode/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/mode/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -56,7 +61,12 @@
 * // returns NaN
 */
 function mode( d1, d2 ) {
-	if ( d1 <= 2.0 || d2 <= 0.0 ) {
+	if (
+		isnan( d1 ) ||
+		d1 <= 2.0 ||
+		isnan( d2 ) ||
+		d2 <= 0.0
+	) {
 		return NaN;
 	}
 	return ( ( d1-2.0 ) / d1 ) * ( d2 / ( d2+2.0 ) );

--- a/lib/node_modules/@stdlib/stats/base/dists/f/skewness/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/skewness/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 
 
@@ -66,7 +67,12 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 */
 function skewness( d1, d2 ) {
 	var out;
-	if ( d1 <= 0.0 || d2 <= 6.0 ) {
+	if (
+		isnan( d1 ) ||
+		d1 <= 0.0 ||
+		isnan( d2 ) ||
+		d2 <= 6.0
+	) {
 		return NaN;
 	}
 	out = ( ( 2.0*d1 ) + d2 - 2.0 ) * sqrt( 8.0 * ( d2-4.0 ) );

--- a/lib/node_modules/@stdlib/stats/base/dists/f/stdev/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/stdev/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var SQRT2 = require( '@stdlib/constants/float64/sqrt-two' );
 
@@ -67,7 +68,12 @@ var SQRT2 = require( '@stdlib/constants/float64/sqrt-two' );
 */
 function stdev( d1, d2 ) {
 	var out;
-	if ( d1 <= 0.0 || d2 <= 4.0 ) {
+	if (
+		isnan( d1 ) ||
+		d1 <= 0.0 ||
+		isnan( d2 ) ||
+		d2 <= 4.0
+	) {
 		return NaN;
 	}
 	out = SQRT2 * ( d2 / ( d2-2.0 ) );

--- a/lib/node_modules/@stdlib/stats/base/dists/f/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/variance/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 
 
@@ -66,7 +67,12 @@ var pow = require( '@stdlib/math/base/special/pow' );
 */
 function variance( d1, d2 ) {
 	var out;
-	if ( d1 <= 0.0 || d2 <= 4.0 ) {
+	if (
+		isnan( d1 ) ||
+		d1 <= 0.0 ||
+		isnan( d2 ) ||
+		d2 <= 4.0
+	) {
 		return NaN;
 	}
 	out = 2.0 * d2 * d2 * ( d1 + d2 - 2.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/entropy/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/entropy/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var digamma = require( '@stdlib/math/base/special/digamma' );
 var gammaln = require( '@stdlib/math/base/special/gammaln' );
 var ln = require( '@stdlib/math/base/special/ln' );
@@ -64,7 +65,12 @@ var ln = require( '@stdlib/math/base/special/ln' );
 */
 function entropy( alpha, beta ) {
 	var out;
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	out = alpha - ln( beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/mean/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -56,7 +61,12 @@
 * // returns NaN
 */
 function mean( alpha, beta ) {
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return alpha / beta;

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/mode/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/mode/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -60,7 +65,12 @@
 * // returns NaN
 */
 function mode( alpha, beta ) {
-	if ( alpha < 1.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha < 1.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return ( alpha-1.0 ) / beta;

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/stdev/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/stdev/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 
 
@@ -61,7 +62,12 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 * // returns NaN
 */
 function stdev( alpha, beta ) {
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return sqrt( alpha ) / beta;

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/variance/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -56,7 +61,12 @@
 * // returns NaN
 */
 function variance( alpha, beta ) {
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return alpha / ( beta*beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var digamma = require( '@stdlib/math/base/special/digamma' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
 var ln = require( '@stdlib/math/base/special/ln' );
@@ -64,7 +65,12 @@ var ln = require( '@stdlib/math/base/special/ln' );
 */
 function entropy( alpha, beta ) {
 	var out;
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	out = alpha + ln( beta*gamma( alpha ) );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -56,7 +61,12 @@
 * // returns NaN
 */
 function mean( alpha, beta ) {
-	if ( alpha <= 1.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 1.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return beta / ( alpha - 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
 // MAIN //
 
 /**
@@ -56,7 +61,12 @@
 * // returns NaN
 */
 function mode( alpha, beta ) {
-	if ( alpha <= 0.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 0.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return beta / ( alpha + 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 
 
@@ -61,7 +62,12 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 * // returns NaN
 */
 function stdev( alpha, beta ) {
-	if ( alpha <= 2.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 2.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return beta / ( ( alpha-1.0 ) * sqrt( alpha-2.0 ) );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 
 
@@ -61,7 +62,12 @@ var pow = require( '@stdlib/math/base/special/pow' );
 * // returns NaN
 */
 function variance( alpha, beta ) {
-	if ( alpha <= 2.0 || beta <= 0.0 ) {
+	if (
+		isnan( alpha ) ||
+		alpha <= 2.0 ||
+		isnan( beta ) ||
+		beta <= 0.0
+	) {
 		return NaN;
 	}
 	return ( beta*beta ) / ( pow( alpha-1.0, 2.0 ) * ( alpha-2.0 ) );


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-07-06 15:53 -0700 and 2026-07-07 00:50 -0700 to sibling packages.

### `refactor: add explicit isnan guards` — 2671115d

Propagates the explicit `isnan` guard pattern from 2671115d ("refactor: add explicit `isnan` guards" in `pareto-type1/{mean,median}`) to sibling distribution packages, replacing implicit reliance on `NaN <= 0.0` evaluating to `false` with explicit `isnan( alpha ) || isnan( beta )` rejection. For `betaprime/mode`, the fix is not defensive-only: with the old guard, `mode( 0.5, NaN )` returned `0.0` instead of `NaN`, because the follow-up `alpha < 1.0` branch fired past the failed rejection.

Target packages:

-   `stats/base/dists/gamma/{mean,mode,variance,stdev,entropy}`
-   `stats/base/dists/beta/{mean,median,mode,variance,stdev,skewness,kurtosis,entropy}`
-   `stats/base/dists/f/{mode,variance,stdev,skewness,kurtosis}`
-   `stats/base/dists/invgamma/{mean,mode,variance,stdev,entropy}`
-   `stats/base/dists/betaprime/{mean,mode}`

## Related Issues

No.

## Questions

No.

## Other

**Validation**

-   Pattern search scoped to `lib/node_modules/@stdlib/stats/base/dists/*/{mean,median,mode,variance,stdev,skewness,kurtosis,entropy,mgf}/lib/main.js`.
-   Two independent opus validation agents read each candidate file end-to-end and confirmed the defect present, the fix applies verbatim, and no upstream validator already rejects NaN.
-   Sonnet style-consistency pass confirmed each patch's `isnan` require placement (first in `// MODULES //`), guard-block indentation, parameter-order preservation, and threshold preservation match the source commit and the existing already-fixed sibling files (`t/entropy`, `rayleigh/entropy`, `triangular/entropy`, `weibull/entropy`).
-   Each modified file re-read after patching to confirm exact match with the approved diff.

**Deliberately excluded**

-   Sites where the guard uses `>=` (arcsine, uniform) — 9 files. The pattern signature differs from the source commit and the maintainer intent for `>=` bounds is not established by 2671115d.
-   Sites already delegating to a NaN-safe sibling (e.g. `lognormal/stdev`, `t/stdev`, `chisquare/median`).
-   Sites already guarding with `!isInteger(...)` / `!isNonNegativeInteger(...)` (hypergeometric, discrete-uniform families), which reject NaN inherently.
-   `stats/base/dists/pareto-type1/*` — source of the fix; already covered.
-   All other source commits from the 24h window: grammar-fix propagation (`547176ec`, `9c313057`) had zero remaining unfixed sites in the repo; ternary-parens propagation (`563772fc`) had zero remaining unfixed sites; `dlast-index-of`/`slast-index-of` collapse (`ba80db9c`) — sibling `last-index-of` packages already use `return N - 1 - idx;`; `Float16Array` index-signature fix (`6b88a637`) — pattern does not extend to `Complex64Array`/`Complex128Array`/`BooleanArray` (non-native, no numeric index access).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by an automated stdlib fix-propagation routine: the last 24h of commits merged to `develop` were parsed for propagatable fix patterns; each candidate pattern's structural signature was searched across sibling packages; each candidate site was reviewed by two independent opus validation agents and a sonnet style-consistency agent, with only sites passing all three advancing to the propagation branch. Each patch was hand-verified against the approved diff before commit.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_016y1aWX1is65ZvF8FR8YZE9)_