### PR TITLE
docs: normalize `stats/base/dists/degenerate/logpmf` description to sibling convention

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Mass Function
 
-> Evaluate the natural logarithm of the [probability mass function][pmf] (PMF) for a [degenerate distribution][degenerate-distribution].
+> [Degenerate distribution][degenerate-distribution] logarithm of [probability mass function][pmf] (logPMF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Natural logarithm of the probability mass function (PMF) for a degenerate distribution.
+* Degenerate distribution natural logarithm of probability mass function (logPMF).
 *
 * @module @stdlib/stats/base/dists/degenerate/logpmf
 *

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/degenerate/logpmf",
   "version": "0.0.0",
-  "description": "Natural logarithm of the probability mass function (PMF) for a degenerate distribution.",
+  "description": "Degenerate distribution logarithm of probability mass function (logPMF).",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -62,6 +62,7 @@
     "probability",
     "prob",
     "pmf",
+    "logpmf",
     "degenerate",
     "point mass",
     "logarithm",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request normalizes `stats/base/dists/degenerate/logpmf` documentation and metadata to the noun-phrase convention used by every other package in the namespace.

### Namespace summary

- Members: 15 packages under `stats/base/dists/degenerate` (`cdf`, `ctor`, `entropy`, `logcdf`, `logpdf`, `logpmf`, `mean`, `median`, `mgf`, `mode`, `pdf`, `pmf`, `quantile`, `stdev`, `variance`).
- Analyzed against `ctor` excluded from the doc-shape vote (it is a class constructor, not a numeric routine, and legitimately lacks the C native infrastructure the rest of the namespace shares).
- Features with clear majority (≥75%): `package.json` description form (13/14), `README.md` short-blurb form (13/14), `lib/index.js` `@module` docstring form (13/14), self-name-as-keyword (13/14).
- Features without clear majority (excluded from drift analysis): `docs/repl.txt` acronym convention across the three `log*` variants (mixed — `logcdf` uses `(logCDF)` in some places and `(CDF)` in others), `"discrete"` vs `"continuous"` keyword tagging, presence of `docs/img/equation_*.svg` equation renders.

### `stats/base/dists/degenerate/logpmf`

Four related drift items, one outlier package:

- `package.json` `description` was the sole imperative-form string (`"Natural logarithm of the probability mass function (PMF) for a degenerate distribution."`); 13/14 sibling packages, including the direct analogs `logcdf` and `logpdf`, use the noun-phrase shape `"Degenerate distribution <thing>."`. Normalized to `"Degenerate distribution logarithm of probability mass function (logPMF)."` to match `logpdf` verbatim.
- `README.md` short blurb followed the same imperative shape (13/14 sibling conformance) and used the wrong acronym `(PMF)` where `logpdf`'s blurb uses `(logPDF)`. Rewritten to match.
- `lib/index.js` `@module` docstring on line 22 had the same imperative form; 13/14 sibling `@module` docstrings use `Degenerate distribution ...` noun-phrase.
- `package.json` `keywords` was missing `"logpmf"`; 13/14 sibling packages include their own function name as a keyword, and both `logcdf` and `logpdf` include their `log*` keyword next to the plain `cdf`/`pdf` entry.

### Validation

- Structural extraction across 15 packages (file tree, `package.json` shape, README section list, `manifest.json`, `test`/`benchmark`/`examples` filename sets).
- Semantic extraction across all 14 non-`ctor` packages via inline inspection of `lib/main.js`, `lib/index.js`, `docs/repl.txt`, and `docs/types/index.d.ts`.
- Adversarial verification of the `logpmf` correction against sibling conventions: no test files, benchmarks, or downstream consumers read the drifted strings; no `Do not manually edit` marker guards any of the four edited locations; both direct analogs (`logcdf`, `logpdf`) confirm the target form.
- Explicitly excluded: the `ctor` package's absence of C-native infrastructure (structural but justified — it is a JS class), `main.js` JSDoc acronym form for the three `log*` variants (only two other samples with mixed conventions between them), keyword ordering of `"ln"`/`"natural"` (cosmetic).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Diff is 4 lines across 3 files, no behavior change. `docs:` label is used per the [commit message guide][commit-guide] — the priority order puts `docs` above `chore` when a change mixes README/JSDoc updates with `package.json` metadata.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Drafted by Claude Code as part of an automated cross-package drift-detection routine that extracts structural and semantic features from every package in a randomly-picked namespace, identifies the majority pattern per feature (≥75% threshold), and proposes fixes to outliers. All four corrections here were reviewed against direct sibling analogs before applying.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[commit-guide]: https://github.com/stdlib-js/stdlib/blob/develop/docs/style-guides/git/README.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0148oZdz3y4se4xABUjyyBzZ)_