### PR TITLE
docs: fix `cosqi`/`sinqi` doctest expected output

### DIFF
--- a/lib/node_modules/@stdlib/fft/base/fftpack/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/docs/types/index.d.ts
@@ -94,7 +94,7 @@ interface Namespace {
 	* // returns <Float64Array>[ ~0.98, ~0.92, ~0.83, ~0.7, ~0.56, ~0.38, ~0.2, ~0.0 ]
 	*
 	* var twiddleFactors = workspace.slice( 2*N, 3*N );
-	* // returns <Float64Array>[ 0, ~0.707, ~0.707, 0, 0, 0, 0, 0 ]
+	* // returns <Float64Array>[ ~0.707, ~0.707, 0, 0, 0, 0, 0, 0 ]
 	*
 	* var factors = workspace.slice( 3*N, ( 3*N ) + 4 );
 	* // returns <Float64Array>[ 8, 2, 2, 4 ]
@@ -186,7 +186,7 @@ interface Namespace {
 	* // returns <Float64Array>[ ~0.98, ~0.92, ~0.83, ~0.7, ~0.56, ~0.38, ~0.2, ~0.0 ]
 	*
 	* var twiddleFactors = workspace.slice( 2*N, 3*N );
-	* // returns <Float64Array>[ 0, ~0.707, ~0.707, 0, 0, 0, 0, 0 ]
+	* // returns <Float64Array>[ ~0.707, ~0.707, 0, 0, 0, 0, 0, 0 ]
 	*
 	* var factors = workspace.slice( 3*N, ( 3*N ) + 4 );
 	* // returns <Float64Array>[ 8, 2, 2, 4 ]


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes two incorrect `@example` "returns" comments in `lib/node_modules/@stdlib/fft/base/fftpack/docs/types/index.d.ts` for the `cosqi` and `sinqi` namespace members.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/28921300699 (job: `Lint Changed Files`, step: `Lint TypeScript declarations files`)

**Symptom:** `stdlib/tsdoc-declarations-doctest` ESLint rule failed with `Expected entries [0,~0.707,~0.707,0,0,0,0,0], but observed [0.7071067811865476,0.7071067811865475,0,0,0,0,0,0]` at lines 97 and 189.

**Root cause:** the `cosqi`/`sinqi` doc examples documented the twiddle-factor slice with a leading `0` before the two `~0.707` entries; the actual runtime output places the two `~0.707` entries first, with no leading zero.

**Fix:** corrected both examples to `[ ~0.707, ~0.707, 0, 0, 0, 0, 0, 0 ]`, verified against the real output of `cosqi`/`sinqi`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI-failure triage and fix routine, based on live GitHub Actions job log analysis and direct execution of the affected code to confirm expected output. The fix was reviewed by three independent automated review passes (correctness, regression scope, style/conventions) before being proposed here; all approved.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDGCZZa3vUhAD1v5Dxkksd)_