### PR TITLE
build(workflows): tolerate GitHub sub-issue cap in `create_sub_issue`

### DIFF
--- a/.github/workflows/scripts/common/create_sub_issue
+++ b/.github/workflows/scripts/common/create_sub_issue
@@ -251,6 +251,12 @@ main() {
 	sub_issue_success=$(echo "$sub_issue_response" | jq -r '.data.addSubIssue.subIssue.number')
 
 	if [ -z "$sub_issue_success" ] || [ "$sub_issue_success" = "null" ]; then
+		# Check whether the parent issue has reached GitHub's maximum number of sub-issues, in which case the child issue was still created successfully and linking is not possible until the parent is replaced or pruned:
+		if echo "$sub_issue_response" | jq -e '.errors // [] | any(.message // "" | test("cannot have more than 100 sub-issues"; "i"))' > /dev/null 2>&1; then
+			echo -e "Warning: parent issue #${parent_issue_number} has reached the maximum number of sub-issues. Child issue #${child_issue_number} was created but could not be linked."
+			print_success
+			exit 0
+		fi
 		echo -e "Failed to create sub-issue relationship. Response: ${sub_issue_response}"
 		exit 1
 	fi


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `.github/workflows/scripts/common/create_sub_issue`, which unconditionally exited with status 1 whenever the `addSubIssue` GraphQL mutation failed for any reason, including GitHub's structural 100-sub-issue-per-parent cap.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/28907996546 (workflow: `lint_random_files`, step: "Create sub-issue for JavaScript lint failures")

**Symptom:** The step has failed on essentially every nightly run for weeks with exit code 1.

**Root cause:** the `addSubIssue` GraphQL mutation returns a `VALIDATION` error — `Parent cannot have more than 100 sub-issues` — because tracking issue #5377 already has exactly 100 linked sub-issues, GitHub's hard cap. The child issue containing the actual lint report is created successfully every time; only the cosmetic parent-linking call fails, which the script treated as fatal.

**Fix:** the script now detects this specific validation message and, only in that case, prints a warning and exits 0 (the lint report was still filed as a standalone issue). Any other error from the mutation (auth, network, a different validation failure) continues to fail the step as before. This does not require replacing tracking issue #5377 — that is a repository/content decision left to a maintainer — it only stops an unrecoverable GitHub-side limit from permanently reddening unrelated nightly CI.

**Validation:** confirmed the jq error-detection expression matches the exact error payload from the failing run and correctly falls through to the original failure path for a normal success response, malformed/empty JSON, and unrelated error messages (tested locally with representative payloads). Reviewed by three independent passes (correctness, regression scope — enumerated all four call sites in `lint_random_files.yml`, style/conventions); all approved.

**Reviewer notes:** one reviewer suggested emitting a GitHub `::warning::` annotation (in addition to the step-log message) so the "sub-issue cap reached" condition is more visible to maintainers going forward; left as a follow-up rather than expanding this fix's scope.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI-failure triage and fix routine, based on live GitHub Actions job log analysis and the GraphQL error payload from the failing run. The fix was reviewed by three independent automated review passes (correctness, regression scope, style/conventions) before being proposed here; all approved.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDGCZZa3vUhAD1v5Dxkksd)_