### PR TITLE
feat: add `number/uint64/base/bigint2words`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/README.md
@@ -1,0 +1,135 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# bigint2words
+
+> Split a bigint into the high and low 32-bit words of a 64-bit unsigned integer.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var bigint2words = require( '@stdlib/number/uint64/base/bigint2words' );
+```
+
+#### bigint2words( value )
+
+Splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer.
+
+```javascript
+var BigInt = require( '@stdlib/bigint/ctor' );
+
+var w = bigint2words( BigInt( 1234 ) );
+// returns [ 0, 1234 ]
+```
+
+The function returns an array containing two elements: a higher order word and a lower order word. The lower order word contains the less significant bits, while the higher order word contains the more significant bits.
+
+#### bigint2words.assign( value, out, stride, offset )
+
+Splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer and assigns results to a provided output array.
+
+```javascript
+var Uint32Array = require( '@stdlib/array/uint32' );
+var BigInt = require( '@stdlib/bigint/ctor' );
+
+var out = new Uint32Array( 2 );
+// returns <Uint32Array>[ 0, 0 ]
+
+var w = bigint2words.assign( BigInt( '18446744073709551615' ), out, 1, 0 );
+// returns <Uint32Array>[ 4294967295, 4294967295 ]
+
+var bool = ( w === out );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   For accurate results, the input value should be an integer in the range \[`0`, `2^64-1`\].
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+```javascript
+var BigInt = require( '@stdlib/bigint/ctor' );
+var bigint2words = require( '@stdlib/number/uint64/base/bigint2words' );
+
+var w = bigint2words( BigInt( 1234 ) );
+console.log( w );
+// => [ 0, 1234 ]
+
+w = bigint2words( BigInt( 0x100000000 ) );
+console.log( w );
+// => [ 1, 0 ]
+
+w = bigint2words( BigInt( '18446744073709551615' ) );
+console.log( w );
+// => [ 4294967295, 4294967295 ]
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/benchmark/benchmark.js
@@ -35,7 +35,9 @@ var bigint2words = require( './../lib' );
 // VARIABLES //
 
 var TWO_32 = 0x100000000; // 2^32
-var HAS_BIGINT = hasBigIntSupport();
+var opts = {
+	'skip': !hasBigIntSupport()
+};
 var options = {
 	'dtype': 'uint32'
 };
@@ -43,18 +45,13 @@ var options = {
 
 // MAIN //
 
-bench( pkg, function benchmark( b ) {
+bench( pkg, opts, function benchmark( b ) {
 	var values;
 	var N;
 	var a;
 	var i;
 	var w;
 	var x;
-
-	if ( !HAS_BIGINT ) {
-		b.end();
-		return;
-	}
 
 	N = 100;
 	x = discreteUniform( N, 0, UINT32_MAX, options );
@@ -79,7 +76,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s:assign', pkg ), function benchmark( b ) {
+bench( format( '%s:assign', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var N;
@@ -87,11 +84,6 @@ bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var i;
 	var w;
 	var x;
-
-	if ( !HAS_BIGINT ) {
-		b.end();
-		return;
-	}
 
 	N = 100;
 	x = discreteUniform( N, 0, UINT32_MAX, options );

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/benchmark/benchmark.js
@@ -1,0 +1,119 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var isArray = require( '@stdlib/assert/is-array' );
+var hasBigIntSupport = require( '@stdlib/assert/has-bigint-support' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var BigInt = require( '@stdlib/bigint/ctor' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var bigint2words = require( './../lib' );
+
+
+// VARIABLES //
+
+var TWO_32 = 0x100000000; // 2^32
+var HAS_BIGINT = hasBigIntSupport();
+var options = {
+	'dtype': 'uint32'
+};
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var N;
+	var a;
+	var i;
+	var w;
+	var x;
+
+	if ( !HAS_BIGINT ) {
+		b.end();
+		return;
+	}
+
+	N = 100;
+	x = discreteUniform( N, 0, UINT32_MAX, options );
+	values = [];
+	for ( i = 0; i < N; i++ ) {
+		a = ( BigInt( x[ i ] ) * BigInt( TWO_32 ) ) + BigInt( x[ (i+1)%N ] );
+		values.push( a );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		w = bigint2words( values[ i % N ] );
+		if ( typeof w !== 'object' ) {
+			b.fail( 'should return an array' );
+		}
+	}
+	b.toc();
+	if ( !isArray( w ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
+	var values;
+	var out;
+	var N;
+	var a;
+	var i;
+	var w;
+	var x;
+
+	if ( !HAS_BIGINT ) {
+		b.end();
+		return;
+	}
+
+	N = 100;
+	x = discreteUniform( N, 0, UINT32_MAX, options );
+	values = [];
+	for ( i = 0; i < N; i++ ) {
+		a = ( BigInt( x[ i ] ) * BigInt( TWO_32 ) ) + BigInt( x[ (i+1)%N ] );
+		values.push( a );
+	}
+
+	out = new Uint32Array( 2 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		w = bigint2words.assign( values[ i % N ], out, 1, 0 );
+		if ( typeof w !== 'object' ) {
+			b.fail( 'should return an array' );
+		}
+	}
+	b.toc();
+	if ( w !== out ) {
+		b.fail( 'should return the output array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/docs/repl.txt
@@ -1,0 +1,59 @@
+
+{{alias}}( value )
+    Splits a bigint into the high and low 32-bit words of a 64-bit unsigned
+    integer.
+
+    The function returns an array with two elements: a higher order word and a
+    lower order word, respectively. The lower order word contains the less
+    significant bits, while the higher order word contains the more significant
+    bits.
+
+    Parameters
+    ----------
+    value: bigint
+        Integer value in the range [0, 2^64-1].
+
+    Returns
+    -------
+    out: Array<integer>
+        High and low words as 32-bit unsigned integers.
+
+    Examples
+    --------
+    > var w = {{alias}}( {{alias:@stdlib/bigint/ctor}}( 1234 ) )
+    [ 0, 1234 ]
+
+
+{{alias}}.assign( value, out, stride, offset )
+    Splits a bigint into the high and low 32-bit words of a 64-bit unsigned
+    integer and assigns results to a provided output array.
+
+    Parameters
+    ----------
+    value: bigint
+        Integer value in the range [0, 2^64-1].
+
+    out: Array|TypedArray|Object
+        Output array.
+
+    stride: integer
+        Output array stride.
+
+    offset: integer
+        Output array index offset.
+
+    Returns
+    -------
+    out: Array|TypedArray|Object
+        Output array.
+
+    Examples
+    --------
+    > var out = new {{alias:@stdlib/array/uint32}}( 2 );
+    > var w = {{alias}}.assign( {{alias:@stdlib/bigint/ctor}}( '18446744073709551615' ), out, 1, 0 )
+    <Uint32Array>[ 4294967295, 4294967295 ]
+    > var bool = ( w === out )
+    true
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/docs/types/index.d.ts
@@ -1,0 +1,110 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Collection, NumericArray } from '@stdlib/types/array';
+
+/**
+* Interface describing `bigint2words`.
+*/
+interface BigIntToWords {
+	/**
+	* Splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer.
+	*
+	* @param value - integer value in the range [0, 2^64-1]
+	* @returns high and low words as 32-bit unsigned integers
+	*
+	* @example
+	* var BigInt = require( '@stdlib/bigint/ctor' );
+	*
+	* var out = bigint2words( BigInt( 1234 ) );
+	* // returns [ 0, 1234 ]
+	*
+	* out = bigint2words( BigInt( 0x100000000 ) );
+	* // returns [ 1, 0 ]
+	*
+	* out = bigint2words( BigInt( '18446744073709551615' ) );
+	* // returns [ 4294967295, 4294967295 ]
+	*/
+	( value: bigint ): [ number, number ];
+
+	/**
+	* Splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer and assigns results to a provided output array.
+	*
+	* @param value - integer value in the range [0, 2^64-1]
+	* @param out - output array
+	* @param stride - stride length
+	* @param offset - starting index
+	* @returns output array
+	*
+	* @example
+	* var Uint32Array = require( '@stdlib/array/uint32' );
+	* var BigInt = require( '@stdlib/bigint/ctor' );
+	*
+	* var out = new Uint32Array( 2 );
+	* // returns <Uint32Array>[ 0, 0 ]
+	*
+	* var w = bigint2words.assign( BigInt( '18446744073709551615' ), out, 1, 0 );
+	* // returns <Uint32Array>[ 4294967295, 4294967295 ]
+	*
+	* var bool = ( w === out );
+	* // returns true
+	*/
+	assign<T extends NumericArray | Collection<number>>( value: bigint, out: T, stride: number, offset: number ): T;
+}
+
+/**
+* Splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer.
+*
+* @param value - integer value in the range [0, 2^64-1]
+* @returns high and low words as 32-bit unsigned integers
+*
+* @example
+* var BigInt = require( '@stdlib/bigint/ctor' );
+*
+* var out = bigint2words( BigInt( 1234 ) );
+* // returns [ 0, 1234 ]
+*
+* out = bigint2words( BigInt( 0x100000000 ) );
+* // returns [ 1, 0 ]
+*
+* out = bigint2words( BigInt( '18446744073709551615' ) );
+* // returns [ 4294967295, 4294967295 ]
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+* var BigInt = require( '@stdlib/bigint/ctor' );
+*
+* var out = new Uint32Array( 2 );
+* // returns <Uint32Array>[ 0, 0 ]
+*
+* var w = bigint2words.assign( BigInt( '18446744073709551615' ), out, 1, 0 );
+* // returns <Uint32Array>[ 4294967295, 4294967295 ]
+*
+* var bool = ( w === out );
+* // returns true
+*/
+declare var bigint2words: BigIntToWords;
+
+
+// EXPORTS //
+
+export = bigint2words;

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/docs/types/test.ts
@@ -1,0 +1,111 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import bigint2words = require( './index' );
+
+
+// TESTS //
+
+// The function returns an array...
+{
+	bigint2words( 1234n ); // $ExpectType [number, number]
+}
+
+// The compiler throws an error if the function is provided an argument that is not a bigint...
+{
+	bigint2words( 5 ); // $ExpectError
+	bigint2words( '5' ); // $ExpectError
+	bigint2words( true ); // $ExpectError
+	bigint2words( false ); // $ExpectError
+	bigint2words( null ); // $ExpectError
+	bigint2words( {} ); // $ExpectError
+	bigint2words( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	bigint2words(); // $ExpectError
+	bigint2words( 1n,  2n ); // $ExpectError
+}
+
+// Attached to the main export is an `assign` method which returns an array-like object containing numbers...
+{
+	bigint2words.assign( 1234n,  [ 0, 0 ], 1, 0 ); // $ExpectType number[]
+	bigint2words.assign( 1234n,  new Uint32Array( 2 ), 1, 0 ); // $ExpectType Uint32Array
+	bigint2words.assign( 1234n,  new Float64Array( 2 ), 1, 0 ); // $ExpectType Float64Array
+}
+
+// The compiler throws an error if the `assign` method is provided a first argument which is not a bigint...
+{
+	const out = [ 0.0, 0.0 ];
+
+	bigint2words.assign( 5, out, 1, 0 ); // $ExpectError
+	bigint2words.assign( '5', out, 1, 0 ); // $ExpectError
+	bigint2words.assign( true, out, 1, 0 ); // $ExpectError
+	bigint2words.assign( false, out, 1, 0 ); // $ExpectError
+	bigint2words.assign( null, out, 1, 0 ); // $ExpectError
+	bigint2words.assign( [], out, 1, 0 ); // $ExpectError
+	bigint2words.assign( {}, out, 1, 0 ); // $ExpectError
+	bigint2words.assign( ( x: number ): number => x, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a second argument which is not an array-like object...
+{
+	bigint2words.assign( 1234n,  1, 1, 0 ); // $ExpectError
+	bigint2words.assign( 1234n,  true, 1, 0 ); // $ExpectError
+	bigint2words.assign( 1234n,  false, 1, 0 ); // $ExpectError
+	bigint2words.assign( 1234n,  null, 1, 0 ); // $ExpectError
+	bigint2words.assign( 1234n,  {}, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a third argument which is not a number...
+{
+	const out = [ 0.0, 0.0 ];
+
+	bigint2words.assign( 1234n, out, '5', 0 ); // $ExpectError
+	bigint2words.assign( 1234n, out, true, 0 ); // $ExpectError
+	bigint2words.assign( 1234n, out, false, 0 ); // $ExpectError
+	bigint2words.assign( 1234n, out, null, 0 ); // $ExpectError
+	bigint2words.assign( 1234n, out, [], 0 ); // $ExpectError
+	bigint2words.assign( 1234n, out, {}, 0 ); // $ExpectError
+	bigint2words.assign( 1234n, out, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...
+{
+	const out = [ 0.0, 0.0 ];
+
+	bigint2words.assign( 1234n, out, 1, '5' ); // $ExpectError
+	bigint2words.assign( 1234n, out, 1, true ); // $ExpectError
+	bigint2words.assign( 1234n, out, 1, false ); // $ExpectError
+	bigint2words.assign( 1234n, out, 1, null ); // $ExpectError
+	bigint2words.assign( 1234n, out, 1, [] ); // $ExpectError
+	bigint2words.assign( 1234n, out, 1, {} ); // $ExpectError
+	bigint2words.assign( 1234n, out, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided an unsupported number of arguments...
+{
+	const out = [ 0.0, 0.0 ];
+
+	bigint2words.assign(); // $ExpectError
+	bigint2words.assign( 1234n ); // $ExpectError
+	bigint2words.assign( 1234n, out ); // $ExpectError
+	bigint2words.assign( 1234n, out, 1 ); // $ExpectError
+	bigint2words.assign( 1234n, out, 1, 0, 1 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/examples/index.js
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var BigInt = require( '@stdlib/bigint/ctor' );
+var bigint2words = require( './../lib' );
+
+var w = bigint2words( BigInt( 1234 ) );
+console.log( w );
+// => [ 0, 1234 ]
+
+w = bigint2words( BigInt( 0x100000000 ) );
+console.log( w );
+// => [ 1, 0 ]
+
+w = bigint2words( BigInt( '18446744073709551615' ) );
+console.log( w );
+// => [ 4294967295, 4294967295 ]

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/lib/assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/lib/assign.js
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var BigInt = require( '@stdlib/bigint/ctor' );
+var Number = require( '@stdlib/number/ctor' );
+
+
+// MAIN //
+
+/**
+* Splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer and assigns results to a provided output array.
+*
+* @param {bigint} value - integer value in the range [0, 2^64-1]
+* @param {Collection} out - output array
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - starting index
+* @returns {Collection} output array
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+* var BigInt = require( '@stdlib/bigint/ctor' );
+*
+* var out = new Uint32Array( 2 );
+* // returns <Uint32Array>[ 0, 0 ]
+*
+* var w = assign( BigInt( '18446744073709551615' ), out, 1, 0 );
+* // returns <Uint32Array>[ 4294967295, 4294967295 ]
+*
+* var bool = ( w === out );
+* // returns true
+*/
+function assign( value, out, stride, offset ) {
+	var v = BigInt.asUintN( 64, value );
+	out[ offset ] = Number( v >> BigInt( 32 ) ) >>> 0;
+	out[ offset + stride ] = Number( v & BigInt( 0xffffffff ) ) >>> 0;
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = assign;

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/lib/index.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Split a bigint into the high and low 32-bit words of a 64-bit unsigned integer.
+*
+* @module @stdlib/number/uint64/base/bigint2words
+*
+* @example
+* var BigInt = require( '@stdlib/bigint/ctor' );
+* var bigint2words = require( '@stdlib/number/uint64/base/bigint2words' );
+*
+* var out = bigint2words( BigInt( 1234 ) );
+* // returns [ 0, 1234 ]
+*
+* out = bigint2words( BigInt( 0x100000000 ) );
+* // returns [ 1, 0 ]
+*
+* out = bigint2words( BigInt( '18446744073709551615' ) );
+* // returns [ 4294967295, 4294967295 ]
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var assign = require( './assign.js' );
+var main = require( './main.js' );
+
+
+// MAIN //
+
+setReadOnly( main, 'assign', assign );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/lib/main.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var assign = require( './assign.js' );
+
+
+// MAIN //
+
+/**
+* Splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer.
+*
+* @param {bigint} value - integer value in the range [0, 2^64-1]
+* @returns {Array<integer>} high and low words as 32-bit unsigned integers
+*
+* @example
+* var BigInt = require( '@stdlib/bigint/ctor' );
+*
+* var out = bigint2words( BigInt( 1234 ) );
+* // returns [ 0, 1234 ]
+*
+* out = bigint2words( BigInt( 0x100000000 ) );
+* // returns [ 1, 0 ]
+*
+* out = bigint2words( BigInt( '18446744073709551615' ) );
+* // returns [ 4294967295, 4294967295 ]
+*/
+function bigint2words( value ) {
+	return assign( value, [ 0, 0 ], 1, 0 );
+}
+
+
+// EXPORTS //
+
+module.exports = bigint2words;

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@stdlib/number/uint64/base/bigint2words",
+  "version": "0.0.0",
+  "description": "Split a bigint into the high and low 32-bit words of a 64-bit unsigned integer.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "base",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "types",
+    "type",
+    "uint64",
+    "unsigned",
+    "64-bit",
+    "integer",
+    "int",
+    "bigint",
+    "words",
+    "split",
+    "high",
+    "low"
+  ]
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.assign.js
@@ -1,0 +1,203 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var hasBigIntSupport = require( '@stdlib/assert/has-bigint-support' );
+var BigInt = require( '@stdlib/bigint/ctor' );
+var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var bigint2words = require( './../lib/assign.js' );
+
+
+// VARIABLES //
+
+var TWO_32 = 0x100000000; // 2^32
+var HAS_BIGINT = hasBigIntSupport();
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof bigint2words, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a two-element numeric array containing integers', function test( t ) {
+	var out;
+	var w;
+
+	if ( !HAS_BIGINT ) {
+		t.end();
+		return;
+	}
+
+	out = [ 0, 0 ];
+	w = bigint2words( BigInt( 1234 ), out, 1, 0 );
+
+	t.strictEqual( w, out, 'returns expected value' );
+	t.strictEqual( isInteger( w[0] ), true, 'returns expected value' );
+	t.strictEqual( isInteger( w[1] ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer', function test( t ) {
+	var values;
+	var out;
+	var w;
+	var x;
+	var i;
+
+	if ( !HAS_BIGINT ) {
+		t.end();
+		return;
+	}
+
+	values = [
+		0,
+		1,
+		2,
+		3,
+		4,
+		5,
+		10,
+		99,
+		100,
+		999,
+		1000,
+		999999,
+		1000000,
+		999999999,
+		1000000000,
+		UINT32_MAX,
+		UINT32_MAX + 1,
+		9007199254740881, // Largest prime under 2^53
+		MAX_SAFE_INTEGER - 1,
+		MAX_SAFE_INTEGER,
+		'9007199254740992', // MAX_SAFE_INTEGER + 1
+		'9999999999999999',
+		'10000000000000000',
+		'99999999999999999',
+		'100000000000000000',
+		'999999999999999999',
+		'1000000000000000000',
+		'9223372036854775783', // Largest prime under 2^63
+		'9999999999999999999',
+		'10000000000000000000',
+		'18446744073709551557', // Largest prime under 2^64
+		'18446744073709551615' // 2^64 - 1
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		values[ i ] = BigInt( values[ i ] ); // Convert values to BigInt
+		out = [ 0, 0 ];
+		w = bigint2words( values[ i ], out, 1, 0 );
+		t.strictEqual( w, out, 'returns expected value' );
+
+		x = ( BigInt( w[0] ) * BigInt( TWO_32 ) ) + BigInt( w[1] ); // Create BigInt from words
+		t.strictEqual( x, values[ i ], 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function supports providing an output object (array)', function test( t ) {
+	var out;
+	var w;
+
+	if ( !HAS_BIGINT ) {
+		t.end();
+		return;
+	}
+
+	out = [ 0, 0 ];
+	w = bigint2words( BigInt( 4294967296 ), out, 1, 0 );
+
+	t.strictEqual( w, out, 'returns expected value' );
+	t.strictEqual( w[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( w[ 1 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing an output object (typed array)', function test( t ) {
+	var out;
+	var w;
+
+	if ( !HAS_BIGINT ) {
+		t.end();
+		return;
+	}
+
+	out = new Uint32Array( 2 );
+	w = bigint2words( BigInt( 4294967296 ), out, 1, 0 );
+
+	t.strictEqual( w, out, 'returns expected value' );
+	t.strictEqual( w[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( w[ 1 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a stride', function test( t ) {
+	var out;
+	var val;
+
+	if ( !HAS_BIGINT ) {
+		t.end();
+		return;
+	}
+
+	out = new Uint32Array( 4 );
+	val = bigint2words( BigInt( 4294967298 ), out, 2, 0 );
+
+	t.strictEqual( val, out, 'returns expected value' );
+	t.strictEqual( val[ 0 ], 1, 'returns expected value' );
+	t.strictEqual( val[ 1 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 2 ], 2, 'returns expected value' );
+	t.strictEqual( val[ 3 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an offset', function test( t ) {
+	var out;
+	var val;
+
+	if ( !HAS_BIGINT ) {
+		t.end();
+		return;
+	}
+
+	out = new Uint32Array( 4 );
+	val = bigint2words( BigInt( 4294967298 ), out, 2, 1 );
+
+	t.strictEqual( val, out, 'returns expected value' );
+	t.strictEqual( val[ 0 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 1 ], 1, 'returns expected value' );
+	t.strictEqual( val[ 2 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 3 ], 2, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.assign.js
@@ -33,7 +33,9 @@ var bigint2words = require( './../lib/assign.js' );
 // VARIABLES //
 
 var TWO_32 = 0x100000000; // 2^32
-var HAS_BIGINT = hasBigIntSupport();
+var opts = {
+	'skip': !hasBigIntSupport()
+};
 
 
 // TESTS //
@@ -44,14 +46,9 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function returns a two-element numeric array containing integers', function test( t ) {
+tape( 'the function returns a two-element numeric array containing integers', opts, function test( t ) {
 	var out;
 	var w;
-
-	if ( !HAS_BIGINT ) {
-		t.end();
-		return;
-	}
 
 	out = [ 0, 0 ];
 	w = bigint2words( BigInt( 1234 ), out, 1, 0 );
@@ -63,17 +60,12 @@ tape( 'the function returns a two-element numeric array containing integers', fu
 	t.end();
 });
 
-tape( 'the function splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer', function test( t ) {
+tape( 'the function splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer', opts, function test( t ) {
 	var values;
 	var out;
 	var w;
 	var x;
 	var i;
-
-	if ( !HAS_BIGINT ) {
-		t.end();
-		return;
-	}
 
 	values = [
 		0,
@@ -122,14 +114,9 @@ tape( 'the function splits a bigint into the high and low 32-bit words of a 64-b
 	t.end();
 });
 
-tape( 'the function supports providing an output object (array)', function test( t ) {
+tape( 'the function supports providing an output object (array)', opts, function test( t ) {
 	var out;
 	var w;
-
-	if ( !HAS_BIGINT ) {
-		t.end();
-		return;
-	}
 
 	out = [ 0, 0 ];
 	w = bigint2words( BigInt( 4294967296 ), out, 1, 0 );
@@ -141,14 +128,9 @@ tape( 'the function supports providing an output object (array)', function test(
 	t.end();
 });
 
-tape( 'the function supports providing an output object (typed array)', function test( t ) {
+tape( 'the function supports providing an output object (typed array)', opts, function test( t ) {
 	var out;
 	var w;
-
-	if ( !HAS_BIGINT ) {
-		t.end();
-		return;
-	}
 
 	out = new Uint32Array( 2 );
 	w = bigint2words( BigInt( 4294967296 ), out, 1, 0 );
@@ -160,14 +142,9 @@ tape( 'the function supports providing an output object (typed array)', function
 	t.end();
 });
 
-tape( 'the function supports specifying a stride', function test( t ) {
+tape( 'the function supports specifying a stride', opts, function test( t ) {
 	var out;
 	var val;
-
-	if ( !HAS_BIGINT ) {
-		t.end();
-		return;
-	}
 
 	out = new Uint32Array( 4 );
 	val = bigint2words( BigInt( 4294967298 ), out, 2, 0 );
@@ -181,14 +158,9 @@ tape( 'the function supports specifying a stride', function test( t ) {
 	t.end();
 });
 
-tape( 'the function supports specifying an offset', function test( t ) {
+tape( 'the function supports specifying an offset', opts, function test( t ) {
 	var out;
 	var val;
-
-	if ( !HAS_BIGINT ) {
-		t.end();
-		return;
-	}
 
 	out = new Uint32Array( 4 );
 	val = bigint2words( BigInt( 4294967298 ), out, 2, 1 );

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var bigint2words = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof bigint2words, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is an `assign` method', function test( t ) {
+	t.strictEqual( hasOwnProp( bigint2words, 'assign' ), true, 'has property' );
+	t.strictEqual( typeof bigint2words.assign, 'function', 'has method' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.main.js
@@ -1,0 +1,73 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var hasBigIntSupport = require( '@stdlib/assert/has-bigint-support' );
+var BigInt = require( '@stdlib/bigint/ctor' );
+var bigint2words = require( './../lib/main.js' );
+
+
+// VARIABLES //
+
+var HAS_BIGINT = hasBigIntSupport();
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof bigint2words, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a two-element numeric array containing integers', function test( t ) {
+	var w;
+
+	if ( !HAS_BIGINT ) {
+		t.end();
+		return;
+	}
+
+	w = bigint2words( BigInt( 1234 ) );
+
+	t.strictEqual( isInteger( w[0] ), true, 'returns expected value' );
+	t.strictEqual( isInteger( w[1] ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer', function test( t ) {
+	var w;
+
+	if ( !HAS_BIGINT ) {
+		t.end();
+		return;
+	}
+
+	w = bigint2words( BigInt( '18446744073709551615' ) );
+
+	t.strictEqual( w[ 0 ], 4294967295, 'returns expected value' );
+	t.strictEqual( w[ 1 ], 4294967295, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/bigint2words/test/test.main.js
@@ -29,7 +29,9 @@ var bigint2words = require( './../lib/main.js' );
 
 // VARIABLES //
 
-var HAS_BIGINT = hasBigIntSupport();
+var opts = {
+	'skip': hasBigIntSupport()
+};
 
 
 // TESTS //
@@ -40,13 +42,8 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function returns a two-element numeric array containing integers', function test( t ) {
+tape( 'the function returns a two-element numeric array containing integers', opts, function test( t ) {
 	var w;
-
-	if ( !HAS_BIGINT ) {
-		t.end();
-		return;
-	}
 
 	w = bigint2words( BigInt( 1234 ) );
 
@@ -56,13 +53,8 @@ tape( 'the function returns a two-element numeric array containing integers', fu
 	t.end();
 });
 
-tape( 'the function splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer', function test( t ) {
+tape( 'the function splits a bigint into the high and low 32-bit words of a 64-bit unsigned integer', opts, function test( t ) {
 	var w;
-
-	if ( !HAS_BIGINT ) {
-		t.end();
-		return;
-	}
 
 	w = bigint2words( BigInt( '18446744073709551615' ) );
 


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a new package for splitting BigInt values into high and low 32-bit words of a 64-bit unsigned integer.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
