### PR TITLE
docs: fix example

### DIFF
--- a/lib/node_modules/@stdlib/utils/push/lib/push_typed_array.js
+++ b/lib/node_modules/@stdlib/utils/push/lib/push_typed_array.js
@@ -45,7 +45,7 @@ var ceil2 = require( '@stdlib/math/base/special/ceil2' ); // TODO: nextpow2
 * var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
 * // returns <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 *
-* arr = push( arr, 6.0, 7.0 );
+* arr = push( arr, [6.0, 7.0 ] );
 * // returns <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ]
 */
 function push( arr, items ) {

--- a/lib/node_modules/@stdlib/utils/push/lib/push_typed_array.js
+++ b/lib/node_modules/@stdlib/utils/push/lib/push_typed_array.js
@@ -45,7 +45,7 @@ var ceil2 = require( '@stdlib/math/base/special/ceil2' ); // TODO: nextpow2
 * var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
 * // returns <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
 *
-* arr = push( arr, [6.0, 7.0 ] );
+* arr = push( arr, [ 6.0, 7.0 ] );
 * // returns <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ]
 */
 function push( arr, items ) {


### PR DESCRIPTION
Resolves #13366.

## Description
> What is the purpose of this pull request?

This pull request:
-   Fixes a `stdlib/jsdoc-doctest` lint error in `push_typed_array.js` where the JSDoc `@example` block called `push(arr, 6.0, 7.0)` with individual arguments, but the private function's `items` parameter expects a single Array. Updated the example to `push(arr, [ 6.0, 7.0 ])` to match the actual function signature and produce the correct documented output.

## Related Issues
> Does this pull request have any related issues?

This pull request has the following related issues:
-   #13366

## Questions
> Any questions for reviewers of this pull request?

No.

## Other
> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist
> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance
> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Research and understanding

#### Disclosure
> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

I used Claude to help understand the `stdlib/jsdoc-doctest` lint rule and diagnose the root cause of the mismatch (the JSDoc example passed arguments individually instead of as an array). The actual fix was a one-line change I made myself after understanding the issue.

* * *
@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md