### PR TITLE
bench: use `isnanf` in `strided/napi/smap`

### DIFF
--- a/lib/node_modules/@stdlib/strided/napi/smap/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/strided/napi/smap/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Float32Array = require( '@stdlib/array/float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -52,12 +52,12 @@ bench( pkg, opts, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		z = addon( len, x, 1, y, 1 );
-		if ( isnan( z[ i%len ] ) ) {
+		if ( isnanf( z[ i%len ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 	}
 	b.toc();
-	if ( isnan( z[ i%len ] ) ) {
+	if ( isnanf( z[ i%len ] ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );


### PR DESCRIPTION
## Description

Normalizes the NaN guard in `@stdlib/strided/napi/smap`'s native benchmark to match the rest of the single-precision NAPI family.

### `strided/napi/smap`

`smap` operates exclusively on `Float32Array` (declared at `benchmark/benchmark.native.js:26,49-50`), but its NaN guard imports `@stdlib/math/base/assert/is-nan` — the double-precision helper. Its four single-precision sibling packages in `@stdlib/strided/napi/` (`smap2`, `smskmap`, `smskmap2`, `cmap`) all use `@stdlib/math/base/assert/is-nanf` in the same benchmark position; `smap` is the sole outlier (4/5 → 80% conformance within the single-precision family). Swap the require and the two call sites to align with the family.

## Related Issues

No.

## Questions

No.

## Other

Detected by a cross-package drift audit over the 15 members of `@stdlib/strided/napi`. The single-precision-family NaN-helper feature has a clear majority (`isnanf` in 4/5 float32-precision packages, i.e. `smap2`/`smskmap`/`smskmap2`/`cmap`); `smap` deviates and its deviation is not justified by any semantic difference from `smap2`. The remainder of the namespace was clean once intentional generic-vs-specialized and unary-vs-binary-vs-nullary splits were accounted for. One sub-threshold observation surfaced (`;` missing from the `STDLIB_STRIDED_NAPI_MODULE_<NAME>(...)` code-fence line in 4 of 14 README / header `@example` blocks — cmap/dmap/smap/zmap) but sits at 10/14 = 71% conformance, below the 75% majority bar; not proposed here.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package drift-detection routine on the `@stdlib/strided/napi` namespace. Structural features were extracted with a script, semantic drift was surfaced by three parallel subagents auditing READMEs, C sources, and JS/TS files, and the sole surviving correction was adversarially verified by a second agent before being applied. A human maintainer will audit before promoting out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kh5zi3rzacKxvFNQrfpN3o)_