### PR TITLE
refactor: replace `isProbability` with inline range check in `stats/base/dists/geometric/mgf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/mgf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/mgf/lib/factory.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var constantFunction = require( '@stdlib/utils/constant-function' );
-var isProbability = require( '@stdlib/math/base/assert/is-probability' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var ln = require( '@stdlib/math/base/special/ln' );
@@ -41,7 +40,7 @@ var ln = require( '@stdlib/math/base/special/ln' );
 * // returns ~0.783
 */
 function factory( p ) {
-	if ( !isProbability( p ) ) {
+	if ( isnan( p ) || p < 0.0 || p > 1.0 ) {
 		return constantFunction( NaN );
 	}
 	return mgf;

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/mgf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/mgf/lib/main.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var isProbability = require( '@stdlib/math/base/assert/is-probability' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var ln = require( '@stdlib/math/base/special/ln' );
@@ -67,7 +66,7 @@ var ln = require( '@stdlib/math/base/special/ln' );
 function mgf( t, p ) {
 	var et;
 	var q;
-	if ( isnan( t ) || !isProbability( p ) ) {
+	if ( isnan( t ) || isnan( p ) || p < 0.0 || p > 1.0 ) {
 		return NaN;
 	}
 	q = 1.0 - p;


### PR DESCRIPTION
## Description

Normalizes the probability-range validation in `@stdlib/stats/base/dists/geometric/mgf` (both `lib/main.js` and `lib/factory.js`) from `!isProbability( p )` to the inline form `isnan( p ) || p < 0.0 || p > 1.0` used by every other JS member of the `stats/base/dists/geometric` namespace, and removes the now-unused `@stdlib/math/base/assert/is-probability` require from both files.

Mirrors the identical fix applied to `stats/base/dists/bernoulli/mgf` in merged PR #12292, which called out this package as the direct follow-up: "`stats/base/dists/geometric/mgf` carries the identical `isProbability` drift ... and is a clear follow-up candidate."

### `stats/base/dists/geometric/mgf`

Replaces `!isProbability( p )` with the inline `isnan( p ) || p < 0.0 || p > 1.0` check in both `lib/main.js` and `lib/factory.js`, and drops the unused `@stdlib/math/base/assert/is-probability` import from each file. The inline form is what the other 13 non-`ctor` geometric siblings use (92.9% conformance); `mgf` was the sole outlier. `isProbability( x )` is defined as `!isnan( x ) && x >= 0.0 && x <= 1.0`, so the two forms agree on NaN, ±Infinity, and all finite inputs; every boundary case exercised by `test/test.mgf.js` and `test/test.factory.js` (`NaN`, ±Infinity, `-0.5`, `2.0`, `0.0`, `1.0` for `p`) returns the same value as before. Verified by pre-/post-diff spot check from a Node REPL.

## Related Issues

No.

## Questions

No.

## Other

Total diff: 2 files, 2 insertions, 4 deletions. Cross-run dedup against open PRs and the last 14 days of merged PRs targeting `stats/base/dists/geometric` confirms no overlap.

Sub-signal drift observed and deliberately not applied in this PR (logged for a future maintenance pass):

- `mgf/manifest.json` uses 4-space JSON indentation vs the 2-space indentation used by the 13 other `manifest.json` files in the namespace and mandated by the root `.editorconfig` (`[*.{json,json.txt}] indent_style = space, indent_size = 2`). Whitespace-only; would muddy the semantic focus of this PR.
- `stdev` package uses `test/fixtures/python/` instead of the namespace-standard `test/fixtures/julia/`. **Cascading** — would require regenerating Julia fixtures and rewriting the `tape` loader in `test/test.js` and `test/test.native.js`; out of scope for a mechanical drift PR.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the cross-package drift-detection routine. Structural and semantic features were extracted from every member of `stats/base/dists/geometric`, the majority pattern was computed at a 75% conformance threshold, and three independent validation passes (semantic-review, cross-reference, structural-review) confirmed the single surviving correction was high-signal mechanical drift before any file was edited. The precedent set by merged PR #12292 (identical fix in the sibling `bernoulli/mgf` package) was cross-referenced and the same normalization applied here. A maintainer should audit and promote out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_019nULhDUeBA4bLg6LxAU3VK)_