### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ccopy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ccopy/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -75,12 +75,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			ccopy( x.length, x, 1, y, 1 );
-			if ( isnan( viewY[ i%(len*2) ] ) ) {
+			if ( isnanf( viewY[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( viewY[ i%(len*2) ] ) ) {
+		if ( isnanf( viewY[ i%(len*2) ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/ccopy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/ccopy/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -80,12 +80,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			ccopy( x.length, x, 1, y, 1 );
-			if ( isnan( viewY[ i%(len*2) ] ) ) {
+			if ( isnanf( viewY[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( viewY[ i%(len*2) ] ) ) {
+		if ( isnanf( viewY[ i%(len*2) ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/ccopy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/ccopy/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -75,12 +75,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			ccopy( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( viewY[ i%(len*2) ] ) ) {
+			if ( isnanf( viewY[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( viewY[ i%(len*2) ] ) ) {
+		if ( isnanf( viewY[ i%(len*2) ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/ccopy/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/ccopy/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -80,12 +80,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			ccopy( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( viewY[ i%(len*2) ] ) ) {
+			if ( isnanf( viewY[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( viewY[ i%(len*2) ] ) ) {
+		if ( isnanf( viewY[ i%(len*2) ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/cswap/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/cswap/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -75,12 +75,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			cswap( x.length, x, 1, y, 1 );
-			if ( isnan( viewY[ i%(len*2) ] ) ) {
+			if ( isnanf( viewY[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( viewY[ i%(len*2) ] ) ) {
+		if ( isnanf( viewY[ i%(len*2) ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/cswap/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/cswap/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -80,12 +80,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			cswap( x.length, x, 1, y, 1 );
-			if ( isnan( viewY[ i%(len*2) ] ) ) {
+			if ( isnanf( viewY[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( viewY[ i%(len*2) ] ) ) {
+		if ( isnanf( viewY[ i%(len*2) ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/cswap/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/cswap/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -75,12 +75,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			cswap( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( viewY[ i%(len*2) ] ) ) {
+			if ( isnanf( viewY[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( viewY[ i%(len*2) ] ) ) {
+		if ( isnanf( viewY[ i%(len*2) ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/cswap/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/cswap/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
@@ -80,12 +80,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			cswap( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( viewY[ i%(len*2) ] ) ) {
+			if ( isnanf( viewY[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( viewY[ i%(len*2) ] ) ) {
+		if ( isnanf( viewY[ i%(len*2) ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/diagonal-types/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/diagonal-types/test/test.js
@@ -66,7 +66,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/blas/base/layouts/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/layouts/test/test.js
@@ -66,7 +66,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/blas/base/matrix-orientations/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/matrix-orientations/test/test.js
@@ -66,7 +66,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/blas/base/matrix-triangles/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/matrix-triangles/test/test.js
@@ -66,7 +66,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/blas/base/operation-sides/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/operation-sides/test/test.js
@@ -66,7 +66,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/blas/base/transpose-operations/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/transpose-operations/test/test.js
@@ -68,7 +68,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/ml/base/kmeans/algorithms/test/test.js
+++ b/lib/node_modules/@stdlib/ml/base/kmeans/algorithms/test/test.js
@@ -66,7 +66,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/ml/base/sgd-classification/learning-rates/test/test.js
+++ b/lib/node_modules/@stdlib/ml/base/sgd-classification/learning-rates/test/test.js
@@ -70,7 +70,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/casting-modes/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/casting-modes/test/test.js
@@ -74,7 +74,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/orders/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/orders/test/test.js
@@ -66,7 +66,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/ztest/alternatives/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/ztest/alternatives/test/test.js
@@ -68,7 +68,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < o.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, o[ i ] ), true, 'has property `' + o[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ o[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ o[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/strided/base/cmap/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/strided/base/cmap/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/base/uniform' ).factory;
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var cidentityf = require( '@stdlib/complex/float32/base/identity' );
 var real = require( '@stdlib/complex/float32/real' );
@@ -69,12 +69,12 @@ function createBenchmark( len ) {
 		for ( i = 0; i < b.iterations; i++ ) {
 			out = cmap( x.length, x, 1, y, 1, cidentityf );
 			v = out.get( i%len );
-			if ( isnan( real( v ) ) || isnan( imag( v ) ) ) {
+			if ( isnanf( real( v ) ) || isnanf( imag( v ) ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( real( v ) ) || isnan( imag( v ) ) ) {
+		if ( isnanf( real( v ) ) || isnanf( imag( v ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/strided/base/cmap/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/strided/base/cmap/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/base/uniform' ).factory;
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var cidentityf = require( '@stdlib/complex/float32/base/identity' );
 var real = require( '@stdlib/complex/float32/real' );
@@ -69,12 +69,12 @@ function createBenchmark( len ) {
 		for ( i = 0; i < b.iterations; i++ ) {
 			out = cmap( x.length, x, 1, 0, y, 1, 0, cidentityf );
 			v = out.get( i%len );
-			if ( isnan( real( v ) ) || isnan( imag( v ) ) ) {
+			if ( isnanf( real( v ) ) || isnanf( imag( v ) ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( real( v ) ) || isnan( imag( v ) ) ) {
+		if ( isnanf( real( v ) ) || isnanf( imag( v ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/strided/base/mskunary/benchmark/benchmark.accessors.js
+++ b/lib/node_modules/@stdlib/strided/base/mskunary/benchmark/benchmark.accessors.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
 var bernoulli = require( '@stdlib/random/base/bernoulli' ).factory;
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var cidentityf = require( '@stdlib/complex/float32/base/identity' );
 var filledarray = require( '@stdlib/array/filled' );
@@ -82,13 +82,13 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			mskunary( arrays, shape, strides, cidentityf );
-			if ( isnan( ybuf[ i%(len*2) ] ) ) {
+			if ( isnanf( ybuf[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
 		v = arrays[ 2 ].get( i%len );
-		if ( isnan( realf( v ) ) || isnan( imagf( v ) ) ) {
+		if ( isnanf( realf( v ) ) || isnanf( imagf( v ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/strided/base/mskunary/benchmark/benchmark.ndarray.accessors.js
+++ b/lib/node_modules/@stdlib/strided/base/mskunary/benchmark/benchmark.ndarray.accessors.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
 var bernoulli = require( '@stdlib/random/base/bernoulli' ).factory;
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var cidentityf = require( '@stdlib/complex/float32/base/identity' );
 var filledarray = require( '@stdlib/array/filled' );
@@ -84,13 +84,13 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			mskunary( arrays, shape, strides, offsets, cidentityf );
-			if ( isnan( ybuf[ i%(len*2) ] ) ) {
+			if ( isnanf( ybuf[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
 		v = arrays[ 2 ].get( i%len );
-		if ( isnan( realf( v ) ) || isnan( imagf( v ) ) ) {
+		if ( isnanf( realf( v ) ) || isnanf( imagf( v ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/strided/base/nullary/benchmark/benchmark.accessors.js
+++ b/lib/node_modules/@stdlib/strided/base/nullary/benchmark/benchmark.accessors.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var constantFunction = require( '@stdlib/utils/constant-function' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
@@ -75,13 +75,13 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			nullary( arrays, shape, strides, f );
-			if ( isnan( xbuf[ i%(len*2) ] ) ) {
+			if ( isnanf( xbuf[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
 		v = arrays[ 0 ].get( i%len );
-		if ( isnan( realf( v ) ) || isnan( imagf( v ) ) ) {
+		if ( isnanf( realf( v ) ) || isnanf( imagf( v ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/strided/base/nullary/benchmark/benchmark.ndarray.accessors.js
+++ b/lib/node_modules/@stdlib/strided/base/nullary/benchmark/benchmark.ndarray.accessors.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var constantFunction = require( '@stdlib/utils/constant-function' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
@@ -77,13 +77,13 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			nullary( arrays, shape, strides, offsets, f );
-			if ( isnan( xbuf[ i%(len*2) ] ) ) {
+			if ( isnanf( xbuf[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
 		v = arrays[ 0 ].get( i%len );
-		if ( isnan( realf( v ) ) || isnan( imagf( v ) ) ) {
+		if ( isnanf( realf( v ) ) || isnanf( imagf( v ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/strided/base/smap/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/strided/base/smap/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var identityf = require( '@stdlib/number/float32/base/identity' );
 var Float32Array = require( '@stdlib/array/float32' );
@@ -65,12 +65,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = smap( x.length, x, 1, y, 1, identityf );
-			if ( isnan( z[ i%len ] ) ) {
+			if ( isnanf( z[ i%len ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%len ] ) ) {
+		if ( isnanf( z[ i%len ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/strided/base/smap/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/strided/base/smap/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var identityf = require( '@stdlib/number/float32/base/identity' );
 var Float32Array = require( '@stdlib/array/float32' );
@@ -65,12 +65,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = smap( x.length, x, 1, 0, y, 1, 0, identityf );
-			if ( isnan( z[ i%len ] ) ) {
+			if ( isnanf( z[ i%len ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%len ] ) ) {
+		if ( isnanf( z[ i%len ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/strided/base/unary/benchmark/benchmark.accessors.js
+++ b/lib/node_modules/@stdlib/strided/base/unary/benchmark/benchmark.accessors.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var cidentityf = require( '@stdlib/complex/float32/base/identity' );
 var filledarray = require( '@stdlib/array/filled' );
@@ -78,13 +78,13 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			unary( arrays, shape, strides, cidentityf );
-			if ( isnan( ybuf[ i%(len*2) ] ) ) {
+			if ( isnanf( ybuf[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
 		v = arrays[ 1 ].get( i%len );
-		if ( isnan( realf( v ) ) || isnan( imagf( v ) ) ) {
+		if ( isnanf( realf( v ) ) || isnanf( imagf( v ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/strided/base/unary/benchmark/benchmark.ndarray.accessors.js
+++ b/lib/node_modules/@stdlib/strided/base/unary/benchmark/benchmark.ndarray.accessors.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var cidentityf = require( '@stdlib/complex/float32/base/identity' );
 var filledarray = require( '@stdlib/array/filled' );
@@ -80,13 +80,13 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			unary( arrays, shape, strides, offsets, cidentityf );
-			if ( isnan( ybuf[ i%(len*2) ] ) ) {
+			if ( isnanf( ybuf[ i%(len*2) ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
 		v = arrays[ 1 ].get( i%len );
-		if ( isnan( realf( v ) ) || isnan( imagf( v ) ) ) {
+		if ( isnanf( realf( v ) ) || isnanf( imagf( v ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-07-08 13:12 UTC and 2026-07-09 13:12 UTC to sibling packages that exhibit the same defect.

### `chore`: bracket spacing

Propagates the fix from `9757a36a` (chore: clean-up), applying `obj[ o[i] ]` → `obj[ o[ i ] ]` in enum-key tape test loops to restore stdlib's inner-spacing convention on every `[ ... ]` accessor. Same one-line pattern, mechanically applied across the remaining packages that missed the original clean-up.

- `@stdlib/blas/base/diagonal-types`
- `@stdlib/blas/base/layouts`
- `@stdlib/blas/base/matrix-orientations`
- `@stdlib/blas/base/matrix-triangles`
- `@stdlib/blas/base/operation-sides`
- `@stdlib/blas/base/transpose-operations`
- `@stdlib/ml/base/kmeans/algorithms`
- `@stdlib/ml/base/sgd-classification/learning-rates`
- `@stdlib/ndarray/casting-modes`
- `@stdlib/ndarray/orders`
- `@stdlib/stats/base/ztest/alternatives`

### `bench`: isnanf on single-precision benchmarks

Propagates the fix from `49456e6b` ("bench: use `isnanf` in `strided/napi/smap`"): benchmarks operating on `Float32Array`/`Complex64Array` data must check for NaN with `is-nanf` (single-precision), not `is-nan` (double-precision). Each file gets the require path, local variable name, and every call site renamed from `isnan`/`is-nan` to `isnanf`/`is-nanf`; 18 benchmark files across 7 packages.

- `@stdlib/blas/base/ccopy` — 4 benchmark files
- `@stdlib/blas/base/cswap` — 4 benchmark files
- `@stdlib/strided/base/cmap` — 2 benchmark files
- `@stdlib/strided/base/mskunary` — 2 accessor benchmark files
- `@stdlib/strided/base/nullary` — 2 accessor benchmark files
- `@stdlib/strided/base/smap` — 2 benchmark files
- `@stdlib/strided/base/unary` — 2 accessor benchmark files

## Related Issues

None.

## Questions

None.

## Other

### Validation

Candidate sites were located by pattern search scoped to `lib/node_modules/@stdlib/` (bracket spacing: literal grep for `obj[ o[i] ]`; isnanf: benchmarks requiring `is-nan` while operating on `Float32Array` or `Complex64Array`). Every surviving site was independently verified by two validators reading each file in full; the isnanf candidate list dropped from 32 → 18 after that pass.

Sites deliberately excluded from the isnanf propagation:

- `blas/ext/base/cindex-of-column` and `blas/ext/base/clast-index-of-row` — `isnan` argument is the integer index return value, not an f32 element access. Rejected by both validators.
- `blas/gdot/benchmark.float32.js`, `blas/gswap/benchmark.float32.js`, and `stats/base/sdsnanmean` (four files) — argument is a scalar return from a routine whose accumulator is double-precision. Both validators marked these as `needs-human` / `rejected`; propagation would not match the source pattern verbatim.

The source commits `f449b5c1` (docs: update related packages sections) and `262f2dc2` (docs: update namespace table of contents) are bot-generated and were skipped: they are not fix patterns. `7eb19700` (fix: rename enum) was skipped because the sole sibling (`ml/base/sgd-classification/learning-rates`) already conforms to the new enum-naming convention. `2fc0cf41` (docs: fix example in `utils/push`) is confined to a single private helper's docstring; no sibling packages exhibit the defect.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by an automated propagation routine driven by Claude Code (Anthropic). Source commits were categorised, propagation targets were located by ripgrep, and each target was independently verified by two model validators reading each file in full before any patch was applied. All propagations are mechanical (verbatim substitutions matching the source commit's fix). No new tests or benchmarks were authored; only the specified rename/spacing changes were applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01TTYjacxNZccuEGs32UAbWC)_