### PR TITLE
docs: fix examples to use supported dtypes

### DIFF
--- a/lib/node_modules/@stdlib/array/ones-like/README.md
+++ b/lib/node_modules/@stdlib/array/ones-like/README.md
@@ -108,7 +108,7 @@ var onesLike = require( '@stdlib/array/ones-like' );
 var x = zeros( 4, 'complex128' );
 
 // Get a list of array data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric_and_generic' );
 
 // Generate filled arrays...
 var y;

--- a/lib/node_modules/@stdlib/array/ones-like/examples/index.js
+++ b/lib/node_modules/@stdlib/array/ones-like/examples/index.js
@@ -26,7 +26,7 @@ var onesLike = require( './../lib' );
 var x = zeros( 4, 'complex128' );
 
 // Get a list of array data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric_and_generic' );
 
 // Generate filled arrays...
 var y;


### PR DESCRIPTION
Resolves #{{N/A}}.

## Description

This pull request:

-   Fixes `lib/node_modules/@stdlib/array/ones-like/examples/index.js`, which crashed on the nightly `random_examples` CI run by iterating over a dtype list that includes dtypes `onesLike` doesn't support.

## Related Issues

None.

## Questions

No.

## Other

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/28985865125

**Symptom:** `TypeError: invalid argument. Second argument must be one of the following: ... Value: \`bool\`.` thrown from `onesLike`, crashing the example script.

**Root cause:** The example requested the full, unfiltered dtype list via `dtypes()`, which includes `'bool'`. `onesLike` only accepts `dtypes( 'numeric_and_generic' )` (see `lib/main.js`), so calling it with `'bool'` throws.

**Fix:** Change the example to request `dtypes( 'numeric_and_generic' )`, the same filtered list `onesLike` validates against, so every dtype iterated over is supported.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code as part of an automated CI-failure triage and fix routine, based on live GitHub Actions job log analysis. The fix was reviewed by three independent automated review passes (correctness, regression scope, style/conventions) before being proposed here; all three approved with no blocking findings.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPufzwGuEE3snDoGcM8ygd)_