### PR TITLE
build: fix non-fast-forward push in `publish_coverage_pr`

### DIFF
--- a/.github/workflows/publish_coverage_pr.yml
+++ b/.github/workflows/publish_coverage_pr.yml
@@ -157,8 +157,11 @@ jobs:
         run: |
           cd ./www-test-code-coverage
           BRANCH_NAME="pr-$PR_NUMBER"
-          git fetch origin "$BRANCH_NAME" || true
-          git checkout "$BRANCH_NAME" || git checkout -b "$BRANCH_NAME"
+          if git fetch origin "$BRANCH_NAME"; then
+            git checkout -B "$BRANCH_NAME" FETCH_HEAD
+          else
+            git checkout -b "$BRANCH_NAME"
+          fi
 
           # Remove all directories except .github and .git from branch:
           find . -mindepth 1 -maxdepth 1 -type d -not -name '.github' -not -name '.git' -exec git rm -rf {} + || true


### PR DESCRIPTION
Resolves #{{N/A}}.

## Description

This pull request:

-   Fixes the "Checkout coverage repository branch" step in `.github/workflows/publish_coverage_pr.yml`, which discarded a PR's existing coverage-report branch history on every run, causing the subsequent push to `stdlib-js/www-test-code-coverage` to be rejected as non-fast-forward.

## Related Issues

None.

## Questions

No.

## Other

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/28999588120 (also reproduced on https://github.com/stdlib-js/stdlib/actions/runs/28982083930)

**Symptom:**
```
! [rejected]                pr-13379 -> pr-13379 (fetch first)
error: failed to push some refs to 'https://github.com/stdlib-js/www-test-code-coverage.git'
```

**Root cause:** The step ran `git fetch origin "$BRANCH_NAME" || true` followed by `git checkout "$BRANCH_NAME" || git checkout -b "$BRANCH_NAME"`. Because the repository is freshly checked out each run against only the default branch, the fetch populates `FETCH_HEAD` but never a local or remote-tracking ref for `$BRANCH_NAME`, so the checkout always fell through to creating a new branch from the current default-branch HEAD. This discarded any commits an earlier coverage run for the same PR had already pushed, so the later push was a non-fast-forward relative to the real remote branch and got rejected.

**Fix:** Check out `FETCH_HEAD` when the fetch succeeds (resuming the branch's actual remote history), and only fall back to a fresh branch when the fetch fails (i.e., the first coverage run for a given PR). Subsequent pushes then fast-forward cleanly.

**Validation:** Verified YAML syntax with `python3 -c "import yaml; yaml.safe_load(...)"`. Reviewed by three independent passes (correctness, regression scope, style/conventions); all approved with no blocking findings. Reviewer A additionally confirmed no other explanation fits the observed rejection and that the fallback branch (no local branch pre-exists on a fresh checkout) is safe. Reviewer B confirmed no other workflow has the same anti-pattern and that no other step in this file is affected.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code as part of an automated CI-failure triage and fix routine, based on live GitHub Actions job log analysis. The fix was reviewed by three independent automated review passes before being proposed here; all three approved with no blocking findings.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPufzwGuEE3snDoGcM8ygd)_