### PR TITLE
docs: document empty-matrix return value

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/iladlr/lib/iladlr.js
+++ b/lib/node_modules/@stdlib/lapack/base/iladlr/lib/iladlr.js
@@ -33,6 +33,10 @@ var base = require( './base.js' );
 /**
 * Returns the index of the last non-zero row in a matrix `A`.
 *
+* ## Notes
+*
+* -   If provided an empty matrix or a matrix containing only zeros, the function returns `-1` (i.e., an invalid index).
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds a `## Notes` block to the public `iladlr` JSDoc documenting the `-1` return value for empty and all-zero matrices.

### `lapack/base/iladlr`

The public wrapper's JSDoc was the sole member of the `iladl*` family lacking the empty-matrix note. Its sibling `iladlc` documents this behavior inline, and `iladlr`'s own private implementation (`lib/base.js`) carries the identical block. The added note is factually accurate: `base.js` returns `-1` for `M <= 0 || N <= 0` and falls through to `-1` when no non-zero element is encountered. Conformance across the `iladl*` family after this change: 100%.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Sibling reference: `lib/node_modules/@stdlib/lapack/base/iladlc/lib/iladlc.js`. Private impl already documenting the same behavior: `lib/node_modules/@stdlib/lapack/base/iladlr/lib/base.js`. No test, example, or observable behavior changes — JSDoc only.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Drift analysis across the `lapack/base` namespace was performed by Claude Code as part of an automated cross-package audit. The single surviving correction (this JSDoc block) was manually verified against the sibling package and the private implementation before commit.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01W9TdYeFq2d9V5eKAmJFpXd)_