### PR TITLE
docs: add link

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> [Cauchy][cauchy-distribution] distribution natural logarithm of probability density function (logPDF).
+> [Cauchy][cauchy-distribution] distribution natural logarithm of [probability density function][pdf] (logPDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Cauchy][cauchy-distribution] distribution probability density function (PDF).
+> [Cauchy][cauchy-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 


### PR DESCRIPTION
## Description

Link the term `probability density function` to the `[pdf]` reference in the opening blockquote of both `stats/base/dists/cauchy/pdf/README.md` and `stats/base/dists/cauchy/logpdf/README.md`. Every other non-`ctor` sibling in the `cauchy` namespace already wraps its mathematical term in a reference-style link on that line (`[cumulative distribution function][cdf]`, `[differential entropy][entropy]`, `[median][median]`, `[mode][mode]`, `[quantile function][quantile-function]`). The `[pdf]:` reference is already defined at the bottom of both files, so the link resolves without further changes. Conformance on this line goes from 6/8 to 8/8; the "natural logarithm of" phrasing in `logpdf` (from 8d60f4105, propagated via #12736) is preserved.

### `@stdlib/stats/base/dists/cauchy/pdf`

Fixed the drift in `pdf`'s README: line 23's opening blockquote referenced "probability density function" as plain text instead of the `[probability density function][pdf]` link every other non-`ctor` sibling uses there, even though the `[pdf]:` reference definition already existed at the bottom of the file. One-line change, brings the `cauchy` namespace from 6/8 to 8/8 conformance on this pattern. No behavioral, test, or signature changes.

### `@stdlib/stats/base/dists/cauchy/logpdf`

Fixed the `logpdf` README to link `probability density function` to the `[pdf]` reference, matching the pattern used by 6 of the other 7 non-`ctor` siblings in `@stdlib/stats/base/dists/cauchy`. The `[pdf]` anchor was already defined at the bottom of the file, so this is a pure markup fix — no behavioral, test, or signature changes. Namespace conformance on this line goes from 6/8 to 8/8.

## Related Issues

None.

## Questions

None.

## Other

Single conformance percentage: 6/8 non-`ctor` sibling packages already reference-link the mathematical term in the opening blockquote (75%); `pdf` and `logpdf` were the two outliers.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package drift-detection sweep. The routine extracted structural and semantic features from every package in `stats/base/dists/cauchy/`, computed a per-feature majority pattern, and validated each candidate correction through a structural-review agent (confirmed the linked form is the file's own established convention and the un-linked blockquote is the outlier) and a cross-reference agent (confirmed no test, example, `docs/types/*`, or generated file depends on the current wording) before any edit. The single correction is a pure Markdown link addition; no behavior, signatures, or tests changed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSEUGcmc1vEm4UpvJvuSuZ)_