### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-equal/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-equal/docs/repl.txt
@@ -2,7 +2,8 @@
 {{alias}}( N, x, strideX, y, strideY )
     Returns the index of the first element in a double-precision floating-point
     strided array equal to a corresponding element in another double-precision
-    floating-point strided array
+    floating-point strided array.
+
     The `N` and stride parameters determine which elements in the strided arrays
     are accessed at runtime.
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-equal/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-equal/docs/types/index.d.ts
@@ -103,7 +103,7 @@ interface Routine {
 * var idx = dfirstIndexEqual.ndarray( 4, x, 1, 0, y, 1, 0 );
 * // returns 2
 */
-declare const dfirstIndexEqual: Routine;
+declare var dfirstIndexEqual: Routine;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/sfirst-index-equal/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfirst-index-equal/README.md
@@ -235,7 +235,7 @@ CBLAS_INT stdlib_strided_sfirst_index_equal( const CBLAS_INT N, const float *X, 
 
 #### stdlib_strided_sfirst_index_equal_ndarray( N, \*X, strideX, offsetX, \*Y, strideY, offsetY )
 
-<!-- lint disable maximum-heading-length -->
+<!-- lint enable maximum-heading-length -->
 
 Returns the index of the first element in a single-precision floating-point strided array equal to a corresponding element in another single-precision floating-point strided array using alternative indexing semantics.
 

--- a/lib/node_modules/@stdlib/blas/ext/base/sfirst-index-equal/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfirst-index-equal/docs/repl.txt
@@ -57,7 +57,7 @@
     -1
 
 
-{{alias}}( N, x, strideX, offsetX, y, strideY, offsetY )
+{{alias}}.ndarray( N, x, strideX, offsetX, y, strideY, offsetY )
     Returns the index of the first element in a single-precision floating-point
     strided array equal to a corresponding element in another single-precision
     floating-point strided array using alternative indexing semantics.

--- a/lib/node_modules/@stdlib/types/index.d.ts
+++ b/lib/node_modules/@stdlib/types/index.d.ts
@@ -847,7 +847,7 @@ declare module '@stdlib/types/array' {
 	*     'byteOffset': 0,
 	*     'BYTES_PER_ELEMENT': 8,
 	*     'length': 4,
-	*     'get': ( i: number ): obj.Uint64  => {
+	*     'get': ( i: number ): obj.Uint64 => {
 	*         return {
 	*             'hi': buf[ (2*i) ],
 	*             'lo': buf[ (2*i)+1 ],
@@ -857,7 +857,7 @@ declare module '@stdlib/types/array' {
 	*     },
 	*     'set': ( value: obj.Uint64, i?: number ) => {
 	*         i = ( i ) ? i : 0;
-	*         buf[ (2*i)] = value.hi;
+	*         buf[ (2*i) ] = value.hi;
 	*         buf[ (2*i)+1 ] = value.lo;
 	*     }
 	* };


### PR DESCRIPTION
## Description

Follow-up fixes for commits merged to `develop` between 2026-07-09 12:56 PDT (`669fa61`) and 2026-07-10 02:46 PDT (`ae1746f9`) — 26 first-parent merges, dominated by the new `blas/ext/base/{sfill-equal,sfill-not-equal,dfill-not-equal,dfirst-index-equal,sfirst-index-equal}` packages, the `Uint64Array` type addition, and the `math/base/special/kernel-betainc` C port.

This pull request fixes six isolated, diff-confirmed defects surfaced by a two-track review (style-guide compliance × bug scan, four independent reviewers) of that window.

**`blas/ext/base/dfirst-index-equal`**

-   Fix `declare const dfirstIndexEqual: Routine;` → `declare var` in `blas/ext/base/dfirst-index-equal/docs/types/index.d.ts:106` (from `adf21e7`) — every other package in `@stdlib/blas/ext/base`, including `sfirst-index-equal`, declares the top-level export with `var`; this was the lone `const` outlier in the namespace.
-   `lib/node_modules/@stdlib/blas/ext/base/dfirst-index-equal/docs/repl.txt:5`: the `412de11` docs cleanup dropped the trailing period on the top-level summary and merged it into the following paragraph; restored the period and the blank line, matching the `.ndarray` variant below it.

**`blas/ext/base/sfirst-index-equal`**

-   `ecdd8f1` mis-paired the `<!-- lint disable maximum-heading-length -->` comment in `lib/node_modules/@stdlib/blas/ext/base/sfirst-index-equal/README.md:238` — the closing tag was another `disable`, leaving the rule off for the rest of the file. Changed it to `enable`.
-   Fixed the `.ndarray` help-section heading in `sfirst-index-equal` to actually read `{{alias}}.ndarray(...)` instead of `{{alias}}(...)`, matching the `dfirst-index-equal` convention (`ecdd8f1`, `lib/node_modules/@stdlib/blas/ext/base/sfirst-index-equal/docs/repl.txt:60`).

**`types`**

-   Fix double space before `=>` in the `Uint64ArrayLike` `get` accessor JSDoc example (`lib/node_modules/@stdlib/types/index.d.ts:850`); brings it in line with the single-space convention used elsewhere in the file. Introduced in `ec14192`.
-   `ec14192`: fix missing space before closing bracket in `Uint64ArrayLike` JSDoc example, `buf[ (2*i)] = value.hi;` → `buf[ (2*i) ] = value.hi;`, to match the `docs/style-guides/javascript` array-index spacing rule already followed by the adjacent `Uint64Array` example (`lib/node_modules/@stdlib/types/index.d.ts:860`).

## Related Issues

No.

## Questions

No.

## Other

**Review scope.** The 26 commits in the window were split for review:

-   New `blas/ext/base` packages (`sfill-equal`, `sfill-not-equal`, `dfill-not-equal`, `dfirst-index-equal`, `sfirst-index-equal`) — each cross-checked against sibling `dfill-equal` for template drift, and cross-checked against each other for copy-paste / precision-swap errors.
-   `math/base/special/kernel-betainc` C port (`6512a7a`) — checked line-by-line against `assign.js` for control-flow / branching / special-case parity.
-   `blas/base/dsyr` and `blas/base/ssyr` enum refactors (`5c57284`, `c519b51`) — checked for parity against the pre-existing `dtrmv` `matrix-triangle-resolve-str` pattern.
-   `types` `Uint64Array` addition (`ec14192`), 9 `docs:` commits, namespace / TypeScript declaration updates, `test:` / `bench:` / `chore:` / `build:` fixups — checked for typos, style-guide compliance, and any unintended behavior change in the fix commits themselves.

**Deliberately excluded.** Any concern that required interpretation, a judgment call, or reading files outside the diff to validate was dropped — including a stylistic observation about `STDLIB_CONSTANT_FLOAT32_SMALLEST_NORMAL` being used as the Modified-Lentz "tiny" replacement in a double-precision continued fraction (safe, mirrors the JS reference; only a Boost-idiom preference), and one comment carry-over from the JS source in `kernel-betainc/src/main.c:496` (faithful port of unmodified upstream text). See the local audit report for the full drop list and rationale.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

Opened as a **draft** by an automated commit-review routine. Findings were surfaced by four independent reviewer agents (two style-compliance, two bug-scan) over the last-24h `develop` window, de-duplicated, and re-verified against the working-tree diff before any edit. Each fix is exactly the mechanical change described in its bullet — no scope expansion, no drive-by cleanup. A maintainer should audit before promoting out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSXWvHybe35mis25hMjTH2)_