### PR TITLE
chore: propagate recent `develop` fixes to sibling packages (2026-07-10)

### DIFF
--- a/lib/node_modules/@stdlib/array/byte-orders/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/byte-orders/benchmark/benchmark.js
@@ -35,8 +35,8 @@ bench( pkg, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		out = byteOrders();
-		if ( out.length !== 2 ) {
-			b.fail( 'should return an array of length 2' );
+		if ( out.length < 2 ) {
+			b.fail( 'should return an array of strings' );
 		}
 	}
 	b.toc();

--- a/lib/node_modules/@stdlib/blas/base/layouts/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/layouts/benchmark/benchmark.js
@@ -35,8 +35,8 @@ bench( pkg, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		out = layouts();
-		if ( out.length !== 2 ) {
-			b.fail( 'should return an array of length 2' );
+		if ( out.length < 2 ) {
+			b.fail( 'should return an array of strings' );
 		}
 	}
 	b.toc();

--- a/lib/node_modules/@stdlib/blas/base/sasum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/sasum/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -62,12 +62,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			y = sasum( x.length, x, 1 );
-			if ( isnan( y ) ) {
+			if ( isnanf( y ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( y ) ) {
+		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sasum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sasum/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var format = require( '@stdlib/string/format' );
@@ -67,12 +67,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			y = sasum( x.length, x, 1 );
-			if ( isnan( y ) ) {
+			if ( isnanf( y ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( y ) ) {
+		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sasum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sasum/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -62,12 +62,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			y = sasum( x.length, x, 1, 0 );
-			if ( isnan( y ) ) {
+			if ( isnanf( y ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( y ) ) {
+		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sasum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sasum/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var format = require( '@stdlib/string/format' );
@@ -67,12 +67,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			y = sasum( x.length, x, 1, 0 );
-			if ( isnan( y ) ) {
+			if ( isnanf( y ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( y ) ) {
+		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/saxpy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/saxpy/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = saxpy( x.length, 5.0, x, 1, y, 1 );
-			if ( isnan( z[ i%z.length ] ) ) {
+			if ( isnanf( z[ i%z.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%z.length ] ) ) {
+		if ( isnanf( z[ i%z.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/saxpy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/saxpy/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -68,12 +68,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = saxpy( x.length, 5.0, x, 1, y, 1 );
-			if ( isnan( z[ i%z.length ] ) ) {
+			if ( isnanf( z[ i%z.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%z.length ] ) ) {
+		if ( isnanf( z[ i%z.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/saxpy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/saxpy/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = saxpy( x.length, 5.0, x, 1, 0, y, 1, 0 );
-			if ( isnan( z[ i%z.length ] ) ) {
+			if ( isnanf( z[ i%z.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%z.length ] ) ) {
+		if ( isnanf( z[ i%z.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/saxpy/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/saxpy/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -68,12 +68,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = saxpy( x.length, 5.0, x, 1, 0, y, 1, 0 );
-			if ( isnan( z[ i%z.length ] ) ) {
+			if ( isnanf( z[ i%z.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%z.length ] ) ) {
+		if ( isnanf( z[ i%z.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/scabs1/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/scabs1/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var pkg = require( './../package.json' ).name;
 var scabs1 = require( './../lib' );
@@ -43,12 +43,12 @@ bench( pkg, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = scabs1( values[ i%values.length ] );
-		if ( isnan( y ) ) {
+		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnanf( y ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/scabs1/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/scabs1/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var format = require( '@stdlib/string/format' );
@@ -53,12 +53,12 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = scabs1( values[ i%values.length ] );
-		if ( isnan( y ) ) {
+		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnanf( y ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/scopy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/scopy/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -66,12 +66,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = scopy( x.length, x, 1, y, 1 );
-			if ( isnan( z[ i%x.length ] ) ) {
+			if ( isnanf( z[ i%x.length ] ) ) {
 				b.fail( 'something went wrong' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%x.length ] ) ) {
+		if ( isnanf( z[ i%x.length ] ) ) {
 			b.fail( 'something went wrong' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/scopy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/scopy/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -71,12 +71,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = scopy( x.length, x, 1, y, 1 );
-			if ( isnan( z[ i%x.length ] ) ) {
+			if ( isnanf( z[ i%x.length ] ) ) {
 				b.fail( 'something went wrong' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%x.length ] ) ) {
+		if ( isnanf( z[ i%x.length ] ) ) {
 			b.fail( 'something went wrong' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/scopy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/scopy/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -66,12 +66,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = scopy( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( z[ i%x.length ] ) ) {
+			if ( isnanf( z[ i%x.length ] ) ) {
 				b.fail( 'something went wrong' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%x.length ] ) ) {
+		if ( isnanf( z[ i%x.length ] ) ) {
 			b.fail( 'something went wrong' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/scopy/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/scopy/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -71,12 +71,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = scopy( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( z[ i%x.length ] ) ) {
+			if ( isnanf( z[ i%x.length ] ) ) {
 				b.fail( 'something went wrong' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%x.length ] ) ) {
+		if ( isnanf( z[ i%x.length ] ) ) {
 			b.fail( 'something went wrong' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sdot/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/sdot/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = sdot( x.length, x, 1, y, 1 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sdot/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sdot/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -68,12 +68,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = sdot( x.length, x, 1, y, 1 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sdot/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sdot/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = sdot( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sdot/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sdot/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -68,12 +68,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = sdot( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sdsdot/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/sdsdot/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = sdsdot( x.length, 0.0, x, 1, y, 1 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sdsdot/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sdsdot/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -68,12 +68,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = sdsdot( x.length, 0.0, x, 1, y, 1 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sdsdot/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sdsdot/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = sdsdot( x.length, 0.0, x, 1, 0, y, 1, 0 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sdsdot/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sdsdot/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -68,12 +68,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = sdsdot( x.length, 0.0, x, 1, 0, y, 1, 0 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/snrm2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/snrm2/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -62,12 +62,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = snrm2( x.length, x, 1 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/snrm2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/snrm2/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var format = require( '@stdlib/string/format' );
@@ -67,12 +67,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = snrm2( x.length, x, 1 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/snrm2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/snrm2/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -62,12 +62,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = snrm2( x.length, x, 1, 0 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/snrm2/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/snrm2/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var format = require( '@stdlib/string/format' );
@@ -67,12 +67,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			d = snrm2( x.length, x, 1, 0 );
-			if ( isnan( d ) ) {
+			if ( isnanf( d ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( d ) ) {
+		if ( isnanf( d ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sscal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/sscal/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -62,12 +62,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			y = sscal( x.length, 1.01, x, 1 );
-			if ( isnan( y[ i%x.length ] ) ) {
+			if ( isnanf( y[ i%x.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( y[ i%x.length ] ) ) {
+		if ( isnanf( y[ i%x.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sscal/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sscal/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var format = require( '@stdlib/string/format' );
@@ -67,12 +67,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			y = sscal( x.length, 1.01, x, 1 );
-			if ( isnan( y[ i%x.length ] ) ) {
+			if ( isnanf( y[ i%x.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( y[ i%x.length ] ) ) {
+		if ( isnanf( y[ i%x.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sscal/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sscal/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -62,12 +62,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			y = sscal( x.length, 1.01, x, 1, 0 );
-			if ( isnan( y[ i%x.length ] ) ) {
+			if ( isnanf( y[ i%x.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( y[ i%x.length ] ) ) {
+		if ( isnanf( y[ i%x.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sscal/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sscal/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var format = require( '@stdlib/string/format' );
@@ -67,12 +67,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			y = sscal( x.length, 1.01, x, 1, 0 );
-			if ( isnan( y[ i%x.length ] ) ) {
+			if ( isnanf( y[ i%x.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( y[ i%x.length ] ) ) {
+		if ( isnanf( y[ i%x.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sswap/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/sswap/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = sswap( x.length, x, 1, y, 1 );
-			if ( isnan( z[ i%x.length ] ) ) {
+			if ( isnanf( z[ i%x.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%x.length ] ) ) {
+		if ( isnanf( z[ i%x.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sswap/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sswap/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var format = require( '@stdlib/string/format' );
@@ -68,12 +68,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = sswap( x.length, x, 1, y, 1 );
-			if ( isnan( z[ i%x.length ] ) ) {
+			if ( isnanf( z[ i%x.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%x.length ] ) ) {
+		if ( isnanf( z[ i%x.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sswap/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/sswap/benchmark/benchmark.ndarray.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = sswap( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( z[ i%x.length ] ) ) {
+			if ( isnanf( z[ i%x.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%x.length ] ) ) {
+		if ( isnanf( z[ i%x.length ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/base/sswap/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/sswap/benchmark/benchmark.ndarray.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var format = require( '@stdlib/string/format' );
@@ -68,12 +68,12 @@ function createBenchmark( len ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = sswap( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( z[ i%x.length ] ) ) {
+			if ( isnanf( z[ i%x.length ] ) ) {
 				b.fail( 'something went wrong' );
 			}
 		}
 		b.toc();
-		if ( isnan( z[ i%x.length ] ) ) {
+		if ( isnanf( z[ i%x.length ] ) ) {
 			b.fail( 'something went wrong' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var zeros = require( '@stdlib/array/zeros' );
 var pow = require( '@stdlib/math/base/special/pow' );
@@ -81,12 +81,12 @@ function createBenchmark( order, N ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = cindexOfColumn( order, N, N, A, N, x, 1, workspace, 1 );
-			if ( isnan( z ) ) {
+			if ( isnanf( z ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z ) ) {
+		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var zeros = require( '@stdlib/array/zeros' );
 var pow = require( '@stdlib/math/base/special/pow' );
@@ -86,12 +86,12 @@ function createBenchmark( order, N ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = cindexOfColumn( order, N, N, A, N, x, 1, workspace, 1 );
-			if ( isnan( z ) ) {
+			if ( isnanf( z ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z ) ) {
+		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/benchmark/benchmark.ndarray.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -92,12 +92,12 @@ function createBenchmark( order, N ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = cindexOfColumn( N, N, A, sa1, sa2, 0, x, 1, 0, workspace, 1, 0 );
-			if ( isnan( z ) ) {
+			if ( isnanf( z ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z ) ) {
+		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/benchmark/benchmark.ndarray.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -97,12 +97,12 @@ function createBenchmark( order, N ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = cindexOfColumn( N, N, A, sa1, sa2, 0, x, 1, 0, workspace, 1, 0 );
-			if ( isnan( z ) ) {
+			if ( isnanf( z ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z ) ) {
+		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var zeros = require( '@stdlib/array/zeros' );
 var pow = require( '@stdlib/math/base/special/pow' );
@@ -81,12 +81,12 @@ function createBenchmark( order, N ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = clastIndexOfRow( order, N, N, A, N, x, 1, workspace, 1 );
-			if ( isnan( z ) ) {
+			if ( isnanf( z ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z ) ) {
+		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var zeros = require( '@stdlib/array/zeros' );
 var pow = require( '@stdlib/math/base/special/pow' );
@@ -86,12 +86,12 @@ function createBenchmark( order, N ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = clastIndexOfRow( order, N, N, A, N, x, 1, workspace, 1 );
-			if ( isnan( z ) ) {
+			if ( isnanf( z ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z ) ) {
+		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/benchmark/benchmark.ndarray.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -92,12 +92,12 @@ function createBenchmark( order, N ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = clastIndexOfRow( N, N, A, sa1, sa2, 0, x, 1, 0, workspace, 1, 0 );
-			if ( isnan( z ) ) {
+			if ( isnanf( z ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z ) ) {
+		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/benchmark/benchmark.ndarray.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
@@ -97,12 +97,12 @@ function createBenchmark( order, N ) {
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = clastIndexOfRow( N, N, A, sa1, sa2, 0, x, 1, 0, workspace, 1, 0 );
-			if ( isnan( z ) ) {
+			if ( isnanf( z ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( z ) ) {
+		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/README.md
@@ -80,7 +80,7 @@ dfillNotEqual( 3, 0.0, 5.0, x1, 2 );
 
 #### dfillNotEqual.ndarray( N, searchElement, alpha, x, strideX, offsetX )
 
-Replaces strided array elements not equal to a provided search element with a specified scalar constant using alternative indexing semantics.
+Replaces double-precision floating-point strided array elements not equal to a provided search element with a specified scalar constant using alternative indexing semantics.
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/test/test.dfill_not_equal.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/test/test.dfill_not_equal.js
@@ -23,7 +23,7 @@
 var tape = require( 'tape' );
 var isSameFloat64Array = require( '@stdlib/assert/is-same-float64array' );
 var Float64Array = require( '@stdlib/array/float64' );
-var dfillNotEqual = require( './../lib' );
+var dfillNotEqual = require( './../lib/dfill_not_equal.js' );
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/test/test.sfill_not_equal.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/test/test.sfill_not_equal.js
@@ -23,7 +23,7 @@
 var tape = require( 'tape' );
 var isSameFloat32Array = require( '@stdlib/assert/is-same-float32array' );
 var Float32Array = require( '@stdlib/array/float32' );
-var sfillNotEqual = require( './../lib' );
+var sfillNotEqual = require( './../lib/sfill_not_equal.js' );
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/ndarray/base/dtype-enums/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/dtype-enums/test/test.js
@@ -68,7 +68,7 @@ tape( 'the function returns an object mapping dtypes to enumeration constants', 
 
 	for ( i = 0; i < DTYPES.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, DTYPES[ i ] ), true, 'has property `' + DTYPES[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ DTYPES[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ DTYPES[ i ] ] ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/ndarray/index-modes/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/index-modes/test/test.js
@@ -70,7 +70,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 	];
 	for ( i = 0; i < m.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, m[ i ] ), true, 'has property `' + m[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ m[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ m[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/input-casting-policies/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/input-casting-policies/test/test.js
@@ -68,7 +68,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 
 	for ( i = 0; i < POLICIES.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, POLICIES[ i ] ), true, 'has property `' + POLICIES[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ POLICIES[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ POLICIES[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -77,7 +77,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 tape( 'attached to the main function are policy enumeration constants', function test( t ) {
 	var i;
 	for ( i = 0; i < POLICIES.length; i++ ) {
-		t.strictEqual( isNonNegativeInteger( policies[ POLICIES[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( policies[ POLICIES[ i ] ] ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/ndarray/orders/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/orders/benchmark/benchmark.js
@@ -35,8 +35,8 @@ bench( pkg, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		out = orders();
-		if ( out.length !== 2 ) {
-			b.fail( 'should return an array of length 2' );
+		if ( out.length < 2 ) {
+			b.fail( 'should return an array of strings' );
 		}
 	}
 	b.toc();

--- a/lib/node_modules/@stdlib/ndarray/output-dtype-policies/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/output-dtype-policies/test/test.js
@@ -93,7 +93,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 
 	for ( i = 0; i < POLICIES.length; i++ ) {
 		t.strictEqual( hasOwnProp( obj, POLICIES[ i ] ), true, 'has property `' + POLICIES[ i ] + '`' );
-		t.strictEqual( isNonNegativeInteger( obj[ POLICIES[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( obj[ POLICIES[ i ] ] ), true, 'returns expected value' );
 	}
 
 	t.end();
@@ -102,7 +102,7 @@ tape( 'attached to the main function is an `enum` method to return an object map
 tape( 'attached to the main function are policy enumeration constants', function test( t ) {
 	var i;
 	for ( i = 0; i < POLICIES.length; i++ ) {
-		t.strictEqual( isNonNegativeInteger( policies[ POLICIES[i] ] ), true, 'returns expected value' );
+		t.strictEqual( isNonNegativeInteger( policies[ POLICIES[ i ] ] ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> [Beta][beta-distribution] distribution logarithm of probability density function (PDF).
+> [Beta][beta-distribution] distribution logarithm of [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Beta][beta-distribution] distribution probability density function (PDF).
+> [Beta][beta-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> [Beta prime][betaprime-distribution] distribution logarithm of probability density function (PDF).
+> [Beta prime][betaprime-distribution] distribution logarithm of [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Beta prime][betaprime-distribution] distribution probability density function (PDF).
+> [Beta prime][betaprime-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Mass Function
 
-> Evaluate the natural logarithm of the probability mass function (PMF) for a [binomial][binomial-distribution] distribution.
+> Evaluate the natural logarithm of the [probability mass function][pmf] (PMF) for a [binomial][binomial-distribution] distribution.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Mass Function
 
-> [Binomial][binomial-distribution] distribution probability mass function (PMF).
+> [Binomial][binomial-distribution] distribution [probability mass function][pmf] (PMF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> Evaluate the natural logarithm of the probability density function (PDF) for an [Erlang][erlang-distribution] distribution.
+> Evaluate the natural logarithm of the [probability density function][pdf] (PDF) for an [Erlang][erlang-distribution] distribution.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Erlang][erlang-distribution] distribution probability density function (PDF).
+> [Erlang][erlang-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> Evaluate the natural logarithm of the probability density function (PDF) for an [exponential][exponential-distribution] distribution.
+> Evaluate the natural logarithm of the [probability density function][pdf] (PDF) for an [exponential][exponential-distribution] distribution.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Exponential][exponential-distribution] distribution probability density function (PDF).
+> [Exponential][exponential-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/f/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [F][f-distribution] distribution probability density function (PDF).
+> [F][f-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> [Gamma][gamma-distribution] distribution natural logarithm of probability density function (PDF).
+> [Gamma][gamma-distribution] distribution natural logarithm of [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Gamma][gamma-distribution] distribution probability density function (PDF).
+> [Gamma][gamma-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> Evaluate the natural logarithm of the probability density function (PDF) for an [inverse gamma][inverse-gamma] distribution.
+> Evaluate the natural logarithm of the [probability density function][pdf] (PDF) for an [inverse gamma][inverse-gamma] distribution.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Inverse gamma][inverse-gamma] distribution probability density function (PDF).
+> [Inverse gamma][inverse-gamma] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> [Laplace][laplace-distribution] distribution natural logarithm of probability density function (PDF).
+> [Laplace][laplace-distribution] distribution natural logarithm of [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Laplace][laplace-distribution] distribution probability density function (PDF).
+> [Laplace][laplace-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> Evaluate the natural logarithm of the probability density function (PDF) for a [lognormal][lognormal-distribution] distribution.
+> Evaluate the natural logarithm of the [probability density function][pdf] (PDF) for a [lognormal][lognormal-distribution] distribution.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Lognormal][lognormal-distribution] distribution probability density function (PDF).
+> [Lognormal][lognormal-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> Evaluate the natural logarithm of the probability density function (PDF) for a [normal][normal-distribution] distribution.
+> Evaluate the natural logarithm of the [probability density function][pdf] (PDF) for a [normal][normal-distribution] distribution.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Normal][normal-distribution] distribution probability density function (PDF).
+> [Normal][normal-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Pareto (Type I)][pareto-distribution] distribution probability density function (PDF).
+> [Pareto (Type I)][pareto-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Rayleigh][rayleigh-distribution] distribution probability density function (PDF).
+> [Rayleigh][rayleigh-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/t/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/logpdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Logarithm of Probability Density Function
 
-> Evaluate the natural logarithm of the probability density function (PDF) for a [Student's t][t-distribution] distribution.
+> Evaluate the natural logarithm of the [probability density function][pdf] (PDF) for a [Student's t][t-distribution] distribution.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Student's t][t-distribution] distribution probability density function (PDF).
+> [Student's t][t-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Truncated normal][truncated-normal-distribution] distribution probability density function (PDF).
+> [Truncated normal][truncated-normal-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Wald][wald-distribution] distribution probability density function (PDF).
+> [Wald][wald-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Probability Density Function
 
-> [Weibull][weibull-distribution] distribution probability density function (PDF).
+> [Weibull][weibull-distribution] distribution [probability density function][pdf] (PDF).
 
 <section class="intro">
 


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-07-09 14:56 PDT (`669fa61`) and 2026-07-10 02:46 PDT (`ae1746f9`) to sibling packages carrying the same defect.

### Pattern: bracketed `probability {density,mass} function` link in distribution READMEs

Commit `2180fed` wrapped "probability density function" in `[…][pdf]` on the top-level blockquote of `stats/base/dists/cauchy/{pdf,logpdf}/README.md`. The same defect is present in 28 sibling READMEs: the blockquote quotes the phrase as plain text while the file already defines the `[pdf]:` (or `[pmf]:`) link-reference at the bottom.

-   `2180fed` ([`docs: add link`](https://github.com/stdlib-js/stdlib/commit/2180fed844c032e1dd39b8465fa44d934b3d94fc))
    -   `stats/base/dists/{beta,betaprime,erlang,exponential,gamma,invgamma,laplace,lognormal,normal,t}/{pdf,logpdf}`
    -   `stats/base/dists/{f,pareto-type1,rayleigh,truncated-normal,wald,weibull}/pdf`
    -   `stats/base/dists/binomial/{pmf,logpmf}`

### Pattern: test require path in single-function test file

Commit `3109ac2` corrected the require path in `blas/ext/base/dfirst-index-equal/test/test.dfirst_index_equal.js` from the `./../lib` Routine wrapper to the specific `./../lib/dfirst_index_equal.js` implementation — the `test.<name>.js` test targets the main function, not the `.ndarray` variant, so it must bind the specific implementation. The two other newly added `blas/ext/base` packages with a matching `test.<snake_case>.js` file carry the same defect.

-   `3109ac2` ([`test: fix require path`](https://github.com/stdlib-js/stdlib/commit/3109ac28df00b595456cab2dd3dfd1c4a9529ecf))
    -   `blas/ext/base/dfill-not-equal`
    -   `blas/ext/base/sfill-not-equal`

### Pattern: `.ndarray` description missing precision qualifier

Commit `412de11` rewrote `blas/ext/base/dfirst-index-equal`'s descriptions to specify "double-precision floating-point strided array" instead of the generic "strided array". Sibling package `blas/ext/base/dfill-not-equal` has this correction applied everywhere except the `.ndarray` variant description in `README.md:83` — every other description in that package (main-form README block, JSDoc in `lib/**`, `docs/repl.txt`, `docs/types/index.d.ts`, C header + `src/main.c`, `package.json`) already reads "double-precision floating-point strided array elements".

-   `412de11` ([`docs: fix descriptions`](https://github.com/stdlib-js/stdlib/commit/412de11c9b73aedaadb0c8ffac231d2d76696d60))
    -   `blas/ext/base/dfill-not-equal` (`README.md` `.ndarray` description only)

### Pattern: brittle exact-length assertion in niladic enum benchmarks

Commit `d32732a` replaced `if ( out.length !== 3 ) { b.fail( 'should return an array of length 3' ) }` in `ndarray/index-modes/benchmark/benchmark.js` with `if ( out.length < 2 ) { b.fail( 'should return an array of strings' ) }` so the benchmark keeps passing when new index modes are added. Three sibling enum-listing benchmarks carry the same brittle exact-length pattern.

-   `d32732a` ([`bench: fix assertion`](https://github.com/stdlib-js/stdlib/commit/d32732aad13ce518c74ce6c7ec1982d7b994e071))
    -   `ndarray/orders`
    -   `blas/base/layouts`
    -   `array/byte-orders`

### Pattern: `isnan` → `isnanf` in single-precision and complex64 benchmarks

Commit `945328a` swapped `isnan` for `isnanf` in benchmarks operating on Float32 / Complex64 data across `blas/base/{ccopy,cswap}` and `strided/base/{cmap,smap,mskunary,nullary,unary}`. Direct siblings in `blas/base` (`s*` single-precision routines) and `blas/ext/base` (`c*` complex64 routines) still bind `isnan` from `@stdlib/math/base/assert/is-nan` despite operating on Float32 values via `'dtype': 'float32'` random arrays or `Complex64Array` views.

-   `945328a` ([`chore: clean-up`](https://github.com/stdlib-js/stdlib/commit/945328aa14e710f4b828b8fa303173c660c77817))
    -   `blas/base/{sasum,saxpy,scopy,sdot,sdsdot,snrm2,sscal,sswap}` (all 4 benchmark variants each)
    -   `blas/base/scabs1` (`benchmark.js`, `benchmark.native.js`)
    -   `blas/ext/base/{cindex-of-column,clast-index-of-row}` (all 4 benchmark variants each)

### Pattern: bracket spacing in `enum()`-mapping test assertions

Commit `945328a` also fixed `obj[ o[i] ]` → `obj[ o[ i ] ]` (missing spaces inside the inner index bracket, per `docs/style-guides/javascript`) across eleven enum-mapping tests. Four sibling `enum()`-mapping test files still carry the same style violation.

-   `945328a` ([`chore: clean-up`](https://github.com/stdlib-js/stdlib/commit/945328aa14e710f4b828b8fa303173c660c77817))
    -   `ndarray/input-casting-policies` (2 occurrences)
    -   `ndarray/output-dtype-policies` (2 occurrences)
    -   `ndarray/base/dtype-enums` (1 occurrence)
    -   `ndarray/index-modes` (1 occurrence)

## Related Issues

No.

## Questions

No.

## Other

### Validation

-   **Search scope.** Per source pattern: for `2180fed`, `stats/base/dists/*/{pdf,logpdf,pmf,logpmf}/README.md`; for `3109ac2`, `blas/ext/base/*/test/test.<snake_case>.js` files with a matching sibling `lib/<snake_case>.js`; for `412de11`, the newly added `blas/ext/base/{dfill-equal,dfill-not-equal,sfill-equal,sfill-not-equal,sfirst-index-equal}` sibling packages, every description-carrying file (README, docs/repl.txt, docs/types/index.d.ts, include header, `lib/**`, `src/main.c`, `package.json`); for `d32732a`, `**/benchmark/benchmark.js` files matching the niladic enum-listing + hardcoded-length-check idiom; for `945328a` (isnan→isnanf), all `benchmark/benchmark*.js` under `blas/base`, `blas/ext/base`, `strided/base` binding `isnan` and operating on Float32 or Complex64 data; for `945328a` (spacing), all `**/test/test.js` matching the `enum()`-mapping idiom (`hasOwnProp( obj, o[ i ] )` + `isNonNegativeInteger( obj[ o[i] ] )`).
-   **Two independent Opus validation agents** and a style-consistency pass confirmed the defect at each candidate site by reading each file in full, cross-checking the surrounding package's convention, and rejecting sites where semantics or intent differed. Search agents that read every candidate file already ruled out sites where the fix was previously applied or the pattern didn't hold.
-   **Style-consistency.** Every patch reproduces the source commit's exact mechanical shape — no naming, message, or JSDoc drift; where the source commit's message on the same line was reused (e.g. `'should return an array of strings'`), the propagation carries the same string.

Deliberately excluded:

-   The 96 additional `blas/ext/base/{sapx*,sdsapxsum*,sdssum*,sdsnansum*,ssum*,snansum*,ssumkbn*,ssumors*,ssumpw*,sxsy,snancount,sapxsumors,sapxsumpw,sapxsumkbn2}` benchmarks matching the `isnan`→`isnanf` pattern. Same defect and same mechanical shape, but well outside the source commit's direct sibling scope (which was limited to `blas/base` complex64 and `strided/base` benchmarks); batching them into a separate propagation round keeps this PR's scope tight and makes the isnan-typing sweep easier to review as its own change. Logged for the next run.
-   `e7884bb7` (`docs: fix example` — missing `.ndarray` qualifier in `dfill-equal/docs/types/index.d.ts`): repo-wide regex sweep (validated against the pre-fix commit) confirmed zero recurrences elsewhere in `blas/ext/base`.
-   `2ad0b70` (`docs: document empty-matrix return value` in `lapack/base/iladlr/lib/iladlr.js`): the only sibling ila-prefixed LAPACK routine, `iladlc`, already carries the same `## Notes` block (added incidentally in `a18ec63` one day earlier). No other `ila*` routines exist in `lapack/base`.
-   Cauchy sibling READMEs that already applied the bracketed `[…][pdf]`/`[…][pmf]` link (46 files) — not the same defect.
-   The `5488831` (`style: fix line wrapping`, `dfirst-index-equal/docs/repl.txt`) and `ae1746f`/`442d4f0` (`docs: fix heading` for `sspr`/`dspr`) source commits: neither pattern recurs at any sibling site. For the spr heading, the two sibling packed BLAS routines in-tree (`sspmv`/`dspmv`) already show `order` in their `.ndarray` heading; the non-packed `s{yr,ymv,yr2}` and `d{syr,syr2}` variants take strides (`sa1,sa2`) instead of `order`, so the fix doesn't propagate to them.
-   The `array/{full-like,empty-like,nans-like,zeros-like}` docs (source `669fa61`, "docs: fix examples to use supported dtypes"): `zeros-like` and `nans-like` already scope their `dtypes(...)` call correctly; `full-like` and `empty-like` skip dtype validation entirely and empirically iterate every dtype without error. No genuine bug propagation target.
-   `refactor: add support for enums` (`5c57284`, `c519b51`) and every `feat:` commit in the window: not fix patterns.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents before commits were applied in the primary worktree. A maintainer should audit and promote out of draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0187eVejnzwAVY9vVQMgv3XD)_