### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/datasets/cmudict/datapackage.json
+++ b/lib/node_modules/@stdlib/datasets/cmudict/datapackage.json
@@ -92,10 +92,6 @@
     }
   ],
   "keywords": [
-    "stdlib",
-    "datasets",
-    "dataset",
-    "data",
     "words",
     "speech",
     "language",

--- a/lib/node_modules/@stdlib/datasets/stopwords-en/datapackage.json
+++ b/lib/node_modules/@stdlib/datasets/stopwords-en/datapackage.json
@@ -37,5 +37,5 @@
     "english",
     "en"
   ],
-  "license": "CC0 AND PDDL-1.0"
+  "license": "PDDL-1.0 AND CC0-1.0"
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Normalizes two `datapackage.json` outliers in `@stdlib/datasets` so their metadata matches the convention used by the other 55 sibling datasets. Two files change; no code, tests, examples, or benchmarks are touched.

### Namespace summary

-   **Target namespace:** `@stdlib/datasets`
-   **Member count:** 57 (all non-autogenerated)
-   **Features analyzed:** full file tree; `package.json` top-level / `scripts` / `stdlib` key sets; `datapackage.json` top-level shape, `resources` entry shape, `keywords` array, `license` identifier, `sources` shape; `README.md` `##` / `###` heading list; `manifest.json` presence; `test/`, `benchmark/`, `examples/` file naming; `bin/cli` shebang and structure; `etc/cli_opts.json` shape; `docs/repl.txt` placeholder set; `docs/usage.txt` layout; `docs/types/index.d.ts` shape; `lib/index.js` re-export pattern; `lib/main.js` public signature, return kind, validation prologue, error construction, JSDoc shape, and `require` dependency set.
-   **Features with clear majority (≥75% conformance):** `package.json` top-level key set (100%), `directories` value set (100% modulo the `scripts` sub-key which tracks whether a builder script exists), `os` / `engines` / `contributors` / `author` / `homepage` / `bugs` / `repository` / `main` / `types` (100%), file-tree entries `LICENSE`, `README.md`, `benchmark/benchmark.js`, `bin/cli`, `datapackage.json`, `docs/repl.txt`, `docs/types/index.d.ts`, `docs/types/test.ts`, `docs/usage.txt`, `etc/cli_opts.json`, `examples/index.js`, `lib/index.js`, `lib/main.js`, `package.json`, `test/test.cli.js`, `test/test.js` (100%), `bin/cli` shebang `#!/usr/bin/env node` (100%), README `## Usage` / `## Examples` / `## CLI` / `## License` sections (100%), `lib/index.js` `require('./main.js')` + `module.exports = main` pattern (100%), `datapackage.json` top-level key set `{name, version, title, description, resources, sources, keywords, license}` (100%), `datapackage.json` resource entry shape (100%), 40/41 = 98% of PDDL+CC0-licensed datapackages spell the SPDX identifier as `PDDL-1.0 AND CC0-1.0`, and 56/57 = 98% of datapackages omit the four package-manager-oriented keywords (`stdlib`, `datasets`, `dataset`, `data`) that belong in `package.json` rather than `datapackage.json`.
-   **Features without clear majority (excluded from drift detection):** README optional sections `## Notes` (32% at h2, 44% at h3), `## References` (49%), `## See Also` (47%) — all content-dependent (whether the dataset has bibliographic references or documented siblings). `etc/cli_opts.json` `string` key presence (30%) — depends on whether the CLI accepts a `--format` or similar option. `directories.scripts` sub-key (25%) — depends on whether the package carries a builder script under `scripts/`. Copyright year in `lib/main.js` header (82% `2018`, 16% `2019`, 2% `2020`) — reflects when the package first landed, not drift. `datapackage.json` `license` field overall (four distinct values across the namespace) — depends on the underlying data license.

### Per outlier package

#### `@stdlib/datasets/cmudict`

`cmudict/datapackage.json` was the sole outlier carrying the four package-manager-oriented keywords `stdlib`, `datasets`, `dataset`, `data` at the head of its `keywords` array — a set already present verbatim in `cmudict/package.json` and correctly omitted by the other 56 sibling datapackages (98% conformance). The remaining nine content-descriptive keywords (`words`, `speech`, `language`, `nlp`, `spelling`, `pronounciation`, `dictionary`, `english`, `en`) are preserved, and the LICENSE-derived `"license": "BSD-2-Clause"` identifier is untouched.

#### `@stdlib/datasets/stopwords-en`

`stopwords-en/datapackage.json` was the sole `PDDL + CC0`-licensed sibling using the non-canonical identifier `CC0 AND PDDL-1.0` — 40 of the 41 packages sharing this license combination (98% conformance among that subset) use the SPDX-canonical `PDDL-1.0 AND CC0-1.0`. The prior value dropped the `-1.0` version qualifier from `CC0` and reversed term order. The LICENSE file explicitly names "Open Data Commons Public Domain Dedication & License 1.0 (PDDL 1.0)" for the database and "Creative Commons Zero v1.0 Universal (CC0 1.0)" for its contents, so the replacement is the SPDX-canonical form of the license the file already documents; `AND` is commutative in SPDX, so the change is semantically equivalent.

### Validation

Checked:

-   Structural feature extraction across all 57 members (file tree, `package.json` shape, `datapackage.json` top-level shape and resource entries, README section list, test/benchmark/example filenames, `bin/cli` shebang, `etc/cli_opts.json` shape, `docs/repl.txt` placeholder set, `docs/types/index.d.ts` shape).
-   Semantic feature extraction across all 57 `lib/main.js` files (public signature, return kind, validation prologue, error construction, JSDoc shape, `require` dependencies). 54/57 datasets are no-argument functions that synchronously read data from disk and rethrow read errors; the 3 options-taking outliers (`cmudict`, `minard-napoleons-march`, `sotu`) have `lib/validate.js`, use `format` for error construction, and were ruled intentional (they filter multi-record datasets by user-supplied criteria).
-   Adversarial verification of both proposed corrections by independent structural-review and cross-reference agents: confirmed both `datapackage.json` deviations are drift (not content-legitimate); confirmed no test, example, benchmark, sibling package, or repository-wide tool reads or asserts on `datapackage.json` keyword or license values; confirmed the pre-commit hook's `package.json` validator explicitly excludes `datapackage.json`; confirmed the only cross-references to `datapackage.json` are per-package `scripts/*.js` builders that populate their own `resources` field.
-   Cross-run dedup: no open or recently-merged PR targets `@stdlib/datasets` with the same fixes (searched open PRs and PRs merged in the last 14 days).

Deliberately excluded:

-   `sotu` missing `lib/browser.js`, `benchmark/benchmark.browser.js`, `test/test.browser.js`, `test/test.main.js` — legitimate architectural difference (multi-file speech corpus; browser support is instead provided via file-specific `browser` field mapping in its `package.json`).
-   `cmudict` `license: "Apache-2.0 and BSD"` in `package.json` — content-legitimate (data is BSD-2-Clause per the LICENSE file; code is Apache-2.0).
-   `anscombes-quartet` and `herndon-venus-semidiameters` carrying `"string": []` in `etc/cli_opts.json` while all 40 sibling CLIs without string options omit the key — below the 75% majority threshold when framed at the whole-field granularity; not batched here because it's a cosmetic no-op rather than a metadata correctness fix.
-   `cmudict` keyword typo `pronounciation` (correct spelling `pronunciation`) — a spelling fix, not majority-vote drift, and out of scope for a drift-detection run.
-   Copyright-year variation in `lib/main.js` headers — reflects package creation date, not drift.
-   Any change to public signatures, tests, benchmarks, examples, or observable behavior.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Random namespace pick, seed `2026-07-11-drift-run`. Eligibility criteria: ≥8 non-autogenerated direct child packages under `lib/node_modules/@stdlib/` and its sub-namespaces (49 candidate namespaces qualified). The chosen namespace had 57 members, none autogenerated. Full per-feature drift report saved locally alongside the run.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running a cross-package drift-detection routine: the namespace (`@stdlib/datasets`) was picked at random (seed `2026-07-11-drift-run`), structural and semantic features were extracted for every member, majority patterns were computed at a 75% conformance threshold, and independent structural-review and cross-reference verification agents confirmed each correction before it was applied. Only two `datapackage.json` files were changed — four keyword removals in `cmudict` and a one-line SPDX identifier normalization in `stopwords-en`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzA1gokGEPY2sFmR1AHgk5)_