### PR TITLE
docs: fix signatures

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of/docs/repl.txt
@@ -37,7 +37,7 @@
     1
 
 
-{{alias}}( N, searchElement, x, strideX, offsetX )
+{{alias}}.ndarray( N, searchElement, x, strideX, offsetX )
     Returns the first index of a specified search element in a double-precision
     floating-point strided array using alternative indexing semantics.
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gindex-of/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/gindex-of/docs/repl.txt
@@ -36,7 +36,7 @@
     1
 
 
-{{alias}}( N, searchElement, x, strideX, offsetX )
+{{alias}}.ndarray( N, searchElement, x, strideX, offsetX )
     Returns the first index of a specified search element in a strided array
     using alternative indexing semantics.
 

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of/docs/repl.txt
@@ -37,7 +37,7 @@
     1
 
 
-{{alias}}( N, searchElement, x, strideX, offsetX )
+{{alias}}.ndarray( N, searchElement, x, strideX, offsetX )
     Returns the first index of a specified search element in a single-precision
     floating-point strided array using alternative indexing semantics.
 


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-07-10 12:54 PDT (`e713916`) and 2026-07-11 00:41 PDT (`4da2dcf`) to sibling packages carrying the same defect.

### Pattern: missing `.ndarray` prefix on ndarray-variant REPL signature header

Commit `e713916` corrected the `.ndarray` variant signature header in `blas/ext/base/sfirst-index-equal/docs/repl.txt` — the alternative-indexing section's header line read `{{alias}}( N, ... )` rather than `{{alias}}.ndarray( N, ... )`, so REPL `?` help displayed the wrong signature. The same defect is present in three sibling `blas/ext/base` packages: in each `docs/repl.txt`, the second signature block is documented as the alternative-indexing variant (mentions "alternative indexing semantics", accepts `offsetX`, example calls `{{alias}}.ndarray(...)`), but its header omits the `.ndarray` prefix. Fix is one line per file: prepend `.ndarray` to the header.

-   `e713916` ([`chore: clean-up`](https://github.com/stdlib-js/stdlib/commit/e713916fe28d3fa9bfe95766a1106cf78453e3b4))
    -   `blas/ext/base/gindex-of`
    -   `blas/ext/base/sindex-of`
    -   `blas/ext/base/dindex-of`

## Related Issues

No.

## Questions

No.

## Other

### Validation

-   **Search scope.** `**/docs/repl.txt` files under `lib/node_modules/@stdlib/`, filtered to files that (a) contain both a bare `{{alias}}(` header with no `offset` parameter and a bare `{{alias}}(` header with an `offset` parameter, and (b) contain no `{{alias}}.ndarray(` header. This bounded the candidate set to exactly the three `*index-of` files above.
-   **Two independent Opus validation agents** each read every candidate file in full and confirmed that (a) the flagged header sits above a section whose description explicitly reads "using alternative indexing semantics", accepts an `offsetX` parameter, and whose Examples block already calls `{{alias}}.ndarray(...)`; (b) a distinct main-variant signature (no `offset`) lives at the top of the same file; (c) prepending `.ndarray` is a safe, self-contained one-line edit.
-   **Adaptation pass** confirmed the source patch shape applies verbatim (no per-site tailoring, no cross-file cascade).
-   **Style-consistency pass** confirmed spacing (single space inside parens, comma-space argument separators) and the blank-line separation from the preceding block match the post-fix `sfirst-index-equal` reference exactly.

Deliberately excluded:

-   The `dfirst-index-equal/docs/repl.txt` sentence-terminating period and paragraph-break fix from `e713916`: a repo-wide search for the same signature (description sentence ending without a period, followed by a continuation paragraph on the next line without an intervening blank line) returned no other REPL doc with the same defect.
-   The `sfirst-index-equal/README.md` `<!-- lint disable maximum-heading-length -->` → `enable` correction from `e713916`: candidate READMEs (`blas/ext/base/{gdiff,ddiff,sdiff}`, `blas/base/cgemv`) carry a related but structurally different defect (multiple unclosed `disable` directives, each requiring insertion of a paired `enable` — not a `disable`→`enable` transform). The fix shape is not a direct analog of the source patch and would need adaptive per-site inserts. Logged for a future run.
-   The `dfirst-index-equal/docs/types/index.d.ts` `declare const` → `declare var` change from `e713916`: a repo-wide search for `^declare const \w+: Routine;` in `**/docs/types/index.d.ts` returned zero matches. The source commit closed the last remaining site.
-   `feat:` commits in the window (`sreplicate`/`dreplicate` package additions, `gammaincinv` C implementation, TypeScript declaration updates): not fix patterns.
-   `docs: update namespace table of contents` (`31d535d`, stdlib-bot): generator-owned files.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two Opus validation passes, an adaptation pass, and a style-consistency pass) before commits were applied in the primary worktree. A maintainer should audit and promote out of draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_014QeVZGC9mhxn7aEDkMy7nS)_