### PR TITLE
feat: add `number/uint64/base/get-high-word`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2026 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/README.md
@@ -1,0 +1,100 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2018 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# High Word
+
+> Return an unsigned 32-bit integer corresponding to the high 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var getHighWord = require( '@stdlib/number/uint64/base/get-high-word' );
+```
+
+#### getHighWord( x )
+
+Returns an unsigned 32-bit `integer` corresponding to the high 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
+
+```javascript
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+
+var a = new Uint64( 4294967296 );
+var w = getHighWord( a );
+// returns 1
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var getHighWord = require( '@stdlib/number/uint64/base/get-high-word' );
+
+var a = new Uint64( 4294967296 );
+console.log( getHighWord( a ) );
+// => 1
+
+a = new Uint64( 0xffffffff );
+console.log( getHighWord( a ) );
+// => 0
+
+a = new Uint64( 0x123400005678 );
+console.log( getHighWord( a ) );
+// => 4660
+
+a = new Uint64.of( 1234, 5678 );
+console.log( getHighWord( a ) );
+// => 1234
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/number/uint64/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/uint64/ctor
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/benchmark/benchmark.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/assert/is-nan' ).isPrimitive;
+var bench = require( '@stdlib/bench' );
+var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var pkg = require( './../package.json' ).name;
+var getHighWord = require( './../lib' );
+
+
+// VARIABLES //
+
+var rand = discreteUniform.factory( 0, MAX_SAFE_INTEGER );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var N;
+	var a;
+	var i;
+	var w;
+
+	N = 100;
+	values = [];
+	for ( i = 0; i < N; i++ ) {
+		values.push( new Uint64( rand() ) );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		a = values[ i % N ];
+		w = getHighWord( a );
+		if ( isnan( w ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( w ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/repl.txt
@@ -1,0 +1,25 @@
+
+{{alias}}( x )
+    Returns an unsigned 32-bit integer corresponding to the high 32-bit word of
+    a 64-bit unsigned integer.
+
+    Parameters
+    ----------
+    x: Uint64
+        Input value.
+
+    Returns
+    -------
+    out: integer
+        Higher order word (unsigned 32-bit integer).
+
+    Examples
+    --------
+    > var a = new {{alias:@stdlib/number/uint64/ctor}}( 4294967296 )
+    <Uint64>[ 4294967296n ]
+    > var w = {{alias}}( a )
+    1
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/types/index.d.ts
@@ -1,0 +1,43 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Uint64 } from '@stdlib/types/number';
+
+/**
+* Returns an unsigned 32-bit integer corresponding to the high 32-bit word of a 64-bit unsigned integer.
+*
+* @param a - input value
+* @returns higher order word (unsigned 32-bit integer)
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 4294967296 );
+* var w = getHighWord( a );
+* // returns 1
+*/
+declare function getHighWord( a: Uint64 ): number;
+
+
+// EXPORTS //
+
+export = getHighWord;

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/types/test.ts
@@ -1,0 +1,47 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Uint64 = require( '@stdlib/number/uint64/ctor' );
+import getHighWord = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	const a = new Uint64( 5 );
+	getHighWord( a ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided an argument that is not a 64-bit unsigned integer...
+{
+	getHighWord( 5 ); // $ExpectError
+	getHighWord( '5' ); // $ExpectError
+	getHighWord( true ); // $ExpectError
+	getHighWord( false ); // $ExpectError
+	getHighWord( [] ); // $ExpectError
+	getHighWord( {} ); // $ExpectError
+	getHighWord( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const a = new Uint64( 5 );
+	getHighWord(); // $ExpectError
+	getHighWord( a, a ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/examples/index.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var getHighWord = require( './../lib' );
+
+var a = new Uint64( 4294967296 );
+console.log( getHighWord( a ) );
+// => 1
+
+a = new Uint64( 0xffffffff );
+console.log( getHighWord( a ) );
+// => 0
+
+a = new Uint64( 0x123400005678 );
+console.log( getHighWord( a ) );
+// => 4660
+
+a = new Uint64.of( 1234, 5678 );
+console.log( getHighWord( a ) );
+// => 1234

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/lib/index.js
@@ -1,0 +1,42 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return an unsigned 32-bit integer corresponding to the high 32-bit word of a 64-bit unsigned integer.
+*
+* @module @stdlib/number/uint64/base/get-high-word
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+* var getHighWord = require( '@stdlib/number/uint64/base/get-high-word' );
+*
+* var a = new Uint64( 4294967296 );
+* var w = getHighWord( a );
+* // returns 1
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/lib/main.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Returns an unsigned 32-bit integer corresponding to the high 32-bit word of a 64-bit unsigned integer.
+*
+* @param {Uint64} a - input value
+* @returns {uinteger32} higher order word
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 4294967296 );
+* var w = getHighWord( a );
+* // returns 1
+*/
+function getHighWord( a ) {
+	return a.hi;
+}
+
+
+// EXPORTS //
+
+module.exports = getHighWord;

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/package.json
@@ -14,14 +14,11 @@
     }
   ],
   "main": "./lib",
-  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
-    "include": "./include",
     "lib": "./lib",
-    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@stdlib/number/uint64/base/get-high-word",
+  "version": "0.0.0",
+  "description": "Return an unsigned 32-bit integer corresponding to the high 32-bit word of a 64-bit unsigned integer.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "base",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "types",
+    "type",
+    "uint64",
+    "unsigned",
+    "64-bit",
+    "integer",
+    "int",
+    "high",
+    "word"
+  ]
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/uint64/base/get-high-word/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-high-word/test/test.js
@@ -1,0 +1,83 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var getHighWord = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof getHighWord, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an integer', function test( t ) {
+	var a;
+	var w;
+
+	a = new Uint64( 4294967296 );
+	w = getHighWord( a );
+
+	t.ok( isInteger( w ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the high 32-bit word of a 64-bit unsigned integer', function test( t ) {
+	var values;
+	var a;
+	var v;
+	var w;
+	var i;
+
+	values = [
+		0,
+		1,
+		2,
+		3,
+		4,
+		5,
+		10,
+		99,
+		100,
+		999,
+		1000,
+		999999,
+		1000000,
+		999999999,
+		1000000000,
+		UINT32_MAX
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		v = values[ i ];
+		a = Uint64.of( v, 0 );
+		w = getHighWord( a );
+		t.strictEqual( w, v, 'returns expected value' );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a package for extracting the high 32-bit word of a `Uint64` instance.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
