### PR TITLE
chore: fix C lint errors (issue #13440)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/every/src/dispatch.c
+++ b/lib/node_modules/@stdlib/ndarray/base/every/src/dispatch.c
@@ -218,7 +218,7 @@ int8_t stdlib_ndarray_every_dispatch( const struct ndarrayEveryDispatchObject *o
 	int64_t ndims;
 	int64_t mab1;
 	int64_t mib1;
-	int64_t *s1;
+	const int64_t *s1;
 	int64_t len;
 	int64_t bp1;
 	int8_t io1;


### PR DESCRIPTION
Resolves #13440 .

## Description

> What is the purpose of this pull request?

This pull request:

-   updates the `s1` stride pointer declaration in `ndarray/base/every/src/dispatch.c` to `const int64_t *`.
-   resolves the `constVariablePointer` C linting warning

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #13440

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
