### PR TITLE
docs: update descriptions and comments

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/dfill-nan",
   "version": "0.0.0",
-  "description": "Replace double-precision floating-point strided array elements equal to `NaN` with a specified scalar constant.",
+  "description": "Replace double-precision floating-point strided array elements equal to NaN with a specified scalar constant.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/gfill-nan/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfill-nan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/gfill-nan",
   "version": "0.0.0",
-  "description": "Replace strided array elements equal to `NaN` with a specified scalar constant.",
+  "description": "Replace strided array elements equal to NaN with a specified scalar constant.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/gnancount/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/gnancount/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/gnancount",
   "version": "0.0.0",
-  "description": "Calculate the number of non-`NaN` elements in a strided array.",
+  "description": "Calculate the number of non-NaN elements in a strided array.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansum/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansum/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/dnansum",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansumkbn/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansumkbn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/dnansumkbn",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using an improved Kahan–Babuška algorithm.",
+  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring NaN values and using an improved Kahan–Babuška algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansumkbn2/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansumkbn2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/dnansumkbn2",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using a second-order iterative Kahan–Babuška algorithm.",
+  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring NaN values and using a second-order iterative Kahan–Babuška algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansumors/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansumors/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/dnansumors",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using ordinary recursive summation.",
+  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring NaN values and using ordinary recursive summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansumpw/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansumpw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/dnansumpw",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using pairwise summation.",
+  "description": "Compute the sum of a one-dimensional double-precision floating-point ndarray, ignoring NaN values and using pairwise summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansum/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansum/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/gnansum",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional ndarray, ignoring `NaN` values.",
+  "description": "Compute the sum of a one-dimensional ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansumkbn/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansumkbn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/gnansumkbn",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional ndarray, ignoring `NaN` values and using an improved Kahan–Babuška algorithm.",
+  "description": "Compute the sum of a one-dimensional ndarray, ignoring NaN values and using an improved Kahan–Babuška algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansumkbn2/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansumkbn2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/gnansumkbn2",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional ndarray, ignoring `NaN` values and using a second-order iterative Kahan–Babuška algorithm.",
+  "description": "Compute the sum of a one-dimensional ndarray, ignoring NaN values and using a second-order iterative Kahan–Babuška algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansumors/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansumors/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/gnansumors",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional ndarray, ignoring `NaN` values and using ordinary recursive summation.",
+  "description": "Compute the sum of a one-dimensional ndarray, ignoring NaN values and using ordinary recursive summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansumpw/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gnansumpw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/gnansumpw",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional ndarray, ignoring `NaN` values and using pairwise summation.",
+  "description": "Compute the sum of a one-dimensional ndarray, ignoring NaN values and using pairwise summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansum/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansum/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/snansum",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumkbn/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumkbn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/snansumkbn",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values and using an improved Kahan–Babuška algorithm.",
+  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring NaN values and using an improved Kahan–Babuška algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumkbn2/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumkbn2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/snansumkbn2",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values and using a second-order iterative Kahan–Babuška algorithm.",
+  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring NaN values and using a second-order iterative Kahan–Babuška algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumors/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumors/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/snansumors",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values and using ordinary recursive summation.",
+  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring NaN values and using ordinary recursive summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumpw/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumpw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/ndarray/snansumpw",
   "version": "0.0.0",
-  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values and using pairwise summation.",
+  "description": "Compute the sum of a one-dimensional single-precision floating-point ndarray, ignoring NaN values and using pairwise summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/sfill-nan",
   "version": "0.0.0",
-  "description": "Replace single-precision floating-point strided array elements equal to `NaN` with a specified scalar constant.",
+  "description": "Replace single-precision floating-point strided array elements equal to NaN with a specified scalar constant.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/wasm/dnansumkbn2/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/wasm/dnansumkbn2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/ext/base/wasm/dnansumkbn2",
   "version": "0.0.0",
-  "description": "Compute the sum of double-precision floating-point strided array elements, ignoring `NaN` values and using a second-order iterative Kahan–Babuška algorithm.",
+  "description": "Compute the sum of double-precision floating-point strided array elements, ignoring NaN values and using a second-order iterative Kahan–Babuška algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/random/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/docs/types/index.d.ts
@@ -178,7 +178,7 @@ interface Namespace {
 	beta: typeof beta;
 
 	/**
-	* Generates pseudorandom numbers drawn from a betaprime distribution.
+	* Generates pseudorandom numbers drawn from a beta prime distribution.
 	*
 	* @param shape - output shape
 	* @param alpha - first shape parameter

--- a/lib/node_modules/@stdlib/stats/array/nanstdev/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanstdev/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanstdev",
   "version": "0.0.0",
-  "description": "Calculate the standard deviation of an array ignoring `NaN` values.",
+  "description": "Calculate the standard deviation of an array ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanstdevch/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanstdevch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanstdevch",
   "version": "0.0.0",
-  "description": "Calculate the standard deviation of an array ignoring `NaN` values and using a one-pass trial mean algorithm.",
+  "description": "Calculate the standard deviation of an array ignoring NaN values and using a one-pass trial mean algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanstdevpn/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanstdevpn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanstdevpn",
   "version": "0.0.0",
-  "description": "Calculate the standard deviation of an array ignoring `NaN` values and using a two-pass algorithm.",
+  "description": "Calculate the standard deviation of an array ignoring NaN values and using a two-pass algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanstdevtk/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanstdevtk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanstdevtk",
   "version": "0.0.0",
-  "description": "Calculate the standard deviation of an array ignoring `NaN` values and using a one-pass textbook algorithm.",
+  "description": "Calculate the standard deviation of an array ignoring NaN values and using a one-pass textbook algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanstdevwd/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanstdevwd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanstdevwd",
   "version": "0.0.0",
-  "description": "Calculate the standard deviation of an array ignoring `NaN` values and using Welford's algorithm.",
+  "description": "Calculate the standard deviation of an array ignoring NaN values and using Welford's algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanstdevyc/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanstdevyc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanstdevyc",
   "version": "0.0.0",
-  "description": "Calculate the standard deviation of an array ignoring `NaN` values and using a one-pass algorithm proposed by Youngs and Cramer.",
+  "description": "Calculate the standard deviation of an array ignoring NaN values and using a one-pass algorithm proposed by Youngs and Cramer.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanvariance/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanvariance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanvariance",
   "version": "0.0.0",
-  "description": "Calculate the variance of an array ignoring `NaN` values.",
+  "description": "Calculate the variance of an array ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanvariancech/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanvariancech/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanvariancech",
   "version": "0.0.0",
-  "description": "Calculate the variance of an array ignoring `NaN` values and using a one-pass trial mean algorithm.",
+  "description": "Calculate the variance of an array ignoring NaN values and using a one-pass trial mean algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanvariancepn/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanvariancepn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanvariancepn",
   "version": "0.0.0",
-  "description": "Calculate the variance of an array ignoring `NaN` values and using a two-pass algorithm.",
+  "description": "Calculate the variance of an array ignoring NaN values and using a two-pass algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanvariancetk/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanvariancetk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanvariancetk",
   "version": "0.0.0",
-  "description": "Calculate the variance of an array ignoring `NaN` values and using a one-pass textbook algorithm.",
+  "description": "Calculate the variance of an array ignoring NaN values and using a one-pass textbook algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanvariancewd/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanvariancewd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanvariancewd",
   "version": "0.0.0",
-  "description": "Calculate the variance of an array ignoring `NaN` values and using Welford's algorithm.",
+  "description": "Calculate the variance of an array ignoring NaN values and using Welford's algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/array/nanvarianceyc/package.json
+++ b/lib/node_modules/@stdlib/stats/array/nanvarianceyc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/array/nanvarianceyc",
   "version": "0.0.0",
-  "description": "Calculate the variance of an array ignoring `NaN` values and using a one-pass algorithm proposed by Youngs and Cramer.",
+  "description": "Calculate the variance of an array ignoring NaN values and using a one-pass algorithm proposed by Youngs and Cramer.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/README.md
@@ -72,7 +72,7 @@ The namespace contains the following functions for calculating distribution prop
 
 <!-- </toc> -->
 
-The namespace contains a constructor function for creating a [betaprime][betaprime-distribution] distribution object.
+The namespace contains a constructor function for creating a [beta prime][betaprime-distribution] distribution object.
 
 <!-- <toc pattern="*ctor*"> -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/lib/factory.js
@@ -76,7 +76,7 @@ function factory( alpha, beta ) {
 			return NaN;
 		}
 		if ( x <= 0.0 ) {
-			// Support of the BetaPrime distribution: (0,∞)
+			// Support of the beta prime distribution: (0,∞)
 			return NINF;
 		}
 		out = ( alpha-1.0 ) * ln( x );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/lib/main.js
@@ -90,7 +90,7 @@ function logpdf( x, alpha, beta ) {
 		return NaN;
 	}
 	if ( x <= 0.0 ) {
-		// Support of the BetaPrime distribution: (0,∞)
+		// Support of the beta prime distribution: (0,∞)
 		return NINF;
 	}
 	out = ( alpha-1.0 ) * ln( x );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/src/main.c
@@ -46,7 +46,7 @@ double stdlib_base_dists_betaprime_logpdf( const double x, const double alpha, c
 		return 0.0 / 0.0;
 	}
 	if ( x <= 0.0 ) {
-		// Support of the BetaPrime distribution: (0,∞)
+		// Support of the beta prime distribution: (0,∞)
 		return STDLIB_CONSTANT_FLOAT64_NINF;
 	}
 	out = ( alpha-1.0 ) * stdlib_base_ln( x );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/test/test.js
@@ -33,7 +33,7 @@ tape( 'main export is an object', function test( t ) {
 	t.end();
 });
 
-tape( 'the exported object contains betaprime distribution functions', function test( t ) {
+tape( 'the exported object contains beta prime distribution functions', function test( t ) {
 	var keys = objectKeys( betaprime );
 	t.strictEqual( keys.length > 0, true, 'has keys' );
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmax/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmax/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmax",
   "version": "0.0.0",
-  "description": "Compute the maximum value of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the maximum value of a one-dimensional double-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmaxabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmaxabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmaxabs",
   "version": "0.0.0",
-  "description": "Compute the maximum absolute value of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the maximum absolute value of a one-dimensional double-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmean/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmean",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanors/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanors/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmeanors",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using ordinary recursive summation.",
+  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring NaN values and using ordinary recursive summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanpn/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanpn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmeanpn",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using a two-pass error correction algorithm.",
+  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring NaN values and using a two-pass error correction algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanpw/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanpw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmeanpw",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using pairwise summation.",
+  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring NaN values and using pairwise summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanwd/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanwd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmeanwd",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using Welford's algorithm.",
+  "description": "Compute the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring NaN values and using Welford's algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmin/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmin",
   "version": "0.0.0",
-  "description": "Compute the minimum value of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the minimum value of a one-dimensional double-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanminabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanminabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanminabs",
   "version": "0.0.0",
-  "description": "Compute the minimum value of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the minimum value of a one-dimensional double-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmax/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmskmax",
   "version": "0.0.0",
-  "description": "Compute the maximum value of a double-precision floating-point ndarray according to a mask, ignoring `NaN` values.",
+  "description": "Compute the maximum value of a double-precision floating-point ndarray according to a mask, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmaxabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmaxabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmskmaxabs",
   "version": "0.0.0",
-  "description": "Compute the maximum absolute value of a double-precision floating-point ndarray according to a mask, ignoring `NaN` values.",
+  "description": "Compute the maximum absolute value of a double-precision floating-point ndarray according to a mask, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmin/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskmin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmskmin",
   "version": "0.0.0",
-  "description": "Compute the minimum value of a double-precision floating-point ndarray according to a mask, ignoring `NaN` values.",
+  "description": "Compute the minimum value of a double-precision floating-point ndarray according to a mask, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskminabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmskminabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanmskminabs",
   "version": "0.0.0",
-  "description": "Compute the minimum absolute value of a double-precision floating-point ndarray according to a mask, ignoring `NaN` values.",
+  "description": "Compute the minimum absolute value of a double-precision floating-point ndarray according to a mask, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanrange/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanrange/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanrange",
   "version": "0.0.0",
-  "description": "Compute the range of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the range of a one-dimensional double-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanrangeabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanrangeabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/dnanrangeabs",
   "version": "0.0.0",
-  "description": "Compute the range of absolute values of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the range of absolute values of a one-dimensional double-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanmax/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanmax/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanmax",
   "version": "0.0.0",
-  "description": "Compute the maximum value of a one-dimensional ndarray, ignoring `NaN` values.",
+  "description": "Compute the maximum value of a one-dimensional ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanmaxabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanmaxabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanmaxabs",
   "version": "0.0.0",
-  "description": "Compute the maximum absolute value of a one-dimensional ndarray, ignoring `NaN` values.",
+  "description": "Compute the maximum absolute value of a one-dimensional ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanmean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanmean/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanmean",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional ndarray, ignoring `NaN` values.",
+  "description": "Compute the arithmetic mean of a one-dimensional ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanmeanors/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanmeanors/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanmeanors",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional ndarray, ignoring `NaN` values and using ordinary recursive summation.",
+  "description": "Compute the arithmetic mean of a one-dimensional ndarray, ignoring NaN values and using ordinary recursive summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanmeanpn/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanmeanpn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanmeanpn",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional ndarray, ignoring `NaN` values and using a two-pass error correction algorithm.",
+  "description": "Compute the arithmetic mean of a one-dimensional ndarray, ignoring NaN values and using a two-pass error correction algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanmeanwd/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanmeanwd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanmeanwd",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional ndarray, ignoring `NaN` values and using Welford's algorithm.",
+  "description": "Compute the arithmetic mean of a one-dimensional ndarray, ignoring NaN values and using Welford's algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanmidrange-by/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanmidrange-by/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanmidrange-by",
   "version": "0.0.0",
-  "description": "Calculate the mid-range of a one-dimensional ndarray via a callback function, ignoring `NaN` values.",
+  "description": "Calculate the mid-range of a one-dimensional ndarray via a callback function, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanmin/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanmin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanmin",
   "version": "0.0.0",
-  "description": "Compute the minimum value of a one-dimensional ndarray, ignoring `NaN` values.",
+  "description": "Compute the minimum value of a one-dimensional ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanminabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanminabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanminabs",
   "version": "0.0.0",
-  "description": "Compute the minimum absolute value of a one-dimensional ndarray, ignoring `NaN` values.",
+  "description": "Compute the minimum absolute value of a one-dimensional ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanrange-by/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanrange-by/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanrange-by",
   "version": "0.0.0",
-  "description": "Compute the range of a one-dimensional ndarray via a callback function, ignoring `NaN` values.",
+  "description": "Compute the range of a one-dimensional ndarray via a callback function, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/nanrange/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/nanrange/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/nanrange",
   "version": "0.0.0",
-  "description": "Compute the range of a one-dimensional ndarray, ignoring `NaN` values.",
+  "description": "Compute the range of a one-dimensional ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmax/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmax/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanmax",
   "version": "0.0.0",
-  "description": "Compute the maximum value of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the maximum value of a one-dimensional single-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmaxabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmaxabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanmaxabs",
   "version": "0.0.0",
-  "description": "Compute the maximum absolute value of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the maximum absolute value of a one-dimensional single-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmean/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanmean",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the arithmetic mean of a one-dimensional single-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmeanors/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmeanors/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanmeanors",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values and using ordinary recursive summation.",
+  "description": "Compute the arithmetic mean of a one-dimensional single-precision floating-point ndarray, ignoring NaN values and using ordinary recursive summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmeanpn/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmeanpn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanmeanpn",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values and using a two-pass error correction algorithm.",
+  "description": "Compute the arithmetic mean of a one-dimensional single-precision floating-point ndarray, ignoring NaN values and using a two-pass error correction algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmeanwd/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmeanwd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanmeanwd",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values and using Welford's algorithm.",
+  "description": "Compute the arithmetic mean of a one-dimensional single-precision floating-point ndarray, ignoring NaN values and using Welford's algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmidrange/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmidrange/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanmidrange",
   "version": "0.0.0",
-  "description": "Compute the mid-range of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the mid-range of a one-dimensional single-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanmin/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanmin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanmin",
   "version": "0.0.0",
-  "description": "Compute the minimum value of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the minimum value of a one-dimensional single-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanminabs/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanminabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanminabs",
   "version": "0.0.0",
-  "description": "Compute the minimum absolute value of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the minimum absolute value of a one-dimensional single-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/ndarray/snanrange/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/snanrange/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/ndarray/snanrange",
   "version": "0.0.0",
-  "description": "Compute the range of a one-dimensional single-precision floating-point ndarray, ignoring `NaN` values.",
+  "description": "Compute the range of a one-dimensional single-precision floating-point ndarray, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/incr/nanmmape/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmape/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/incr/nanmmape",
   "version": "0.0.0",
-  "description": "Compute a moving mean absolute percentage error (MAPE) incrementally, ignoring `NaN` values.",
+  "description": "Compute a moving mean absolute percentage error (MAPE) incrementally, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/incr/nanmrange/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrange/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/incr/nanmrange",
   "version": "0.0.0",
-  "description": "Compute a moving range incrementally, ignoring `NaN` values.",
+  "description": "Compute a moving range incrementally, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/incr/nanmvmr/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanmvmr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/incr/nanmvmr",
   "version": "0.0.0",
-  "description": "Compute a moving variance-to-mean ratio (VMR) incrementally, ignoring `NaN` values.",
+  "description": "Compute a moving variance-to-mean ratio (VMR) incrementally, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/incr/nanpcorr2/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanpcorr2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/incr/nanpcorr2",
   "version": "0.0.0",
-  "description": "Compute a squared sample Pearson product-moment correlation coefficient, ignoring `NaN` values.",
+  "description": "Compute a squared sample Pearson product-moment correlation coefficient, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/nanmax/package.json
+++ b/lib/node_modules/@stdlib/stats/nanmax/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/nanmax",
   "version": "0.0.0",
-  "description": "Compute the maximum value along one or more ndarray dimensions, ignoring `NaN` values.",
+  "description": "Compute the maximum value along one or more ndarray dimensions, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/nanmaxabs/package.json
+++ b/lib/node_modules/@stdlib/stats/nanmaxabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/nanmaxabs",
   "version": "0.0.0",
-  "description": "Compute the maximum absolute value along one or more ndarray dimensions, ignoring `NaN` values.",
+  "description": "Compute the maximum absolute value along one or more ndarray dimensions, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/nanmean/package.json
+++ b/lib/node_modules/@stdlib/stats/nanmean/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/nanmean",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean along one or more ndarray dimensions, ignoring `NaN` values.",
+  "description": "Compute the arithmetic mean along one or more ndarray dimensions, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/nanmeanors/package.json
+++ b/lib/node_modules/@stdlib/stats/nanmeanors/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/nanmeanors",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean along one or more ndarray dimensions, ignoring `NaN` values and using ordinary recursive summation.",
+  "description": "Compute the arithmetic mean along one or more ndarray dimensions, ignoring NaN values and using ordinary recursive summation.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/nanmeanpn/package.json
+++ b/lib/node_modules/@stdlib/stats/nanmeanpn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/nanmeanpn",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean along one or more ndarray dimensions, ignoring `NaN` values and using a two-pass error correction algorithm.",
+  "description": "Compute the arithmetic mean along one or more ndarray dimensions, ignoring NaN values and using a two-pass error correction algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/nanmeanwd/package.json
+++ b/lib/node_modules/@stdlib/stats/nanmeanwd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/nanmeanwd",
   "version": "0.0.0",
-  "description": "Compute the arithmetic mean along one or more ndarray dimensions, ignoring `NaN` values and using Welford's algorithm.",
+  "description": "Compute the arithmetic mean along one or more ndarray dimensions, ignoring NaN values and using Welford's algorithm.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/nanmin/package.json
+++ b/lib/node_modules/@stdlib/stats/nanmin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/nanmin",
   "version": "0.0.0",
-  "description": "Compute the minimum value along one or more ndarray dimensions, ignoring `NaN` values.",
+  "description": "Compute the minimum value along one or more ndarray dimensions, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/nanminabs/package.json
+++ b/lib/node_modules/@stdlib/stats/nanminabs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/nanminabs",
   "version": "0.0.0",
-  "description": "Compute the minimum absolute value along one or more ndarray dimensions, ignoring `NaN` values.",
+  "description": "Compute the minimum absolute value along one or more ndarray dimensions, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/nanrange/package.json
+++ b/lib/node_modules/@stdlib/stats/nanrange/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/nanrange",
   "version": "0.0.0",
-  "description": "Compute the range along one or more ndarray dimensions, ignoring `NaN` values.",
+  "description": "Compute the range along one or more ndarray dimensions, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
## Description

Propagating fixes merged to `develop` between 2026-07-12 13:48 UTC and 2026-07-13 09:12 UTC to sibling packages that carried the same defect.

### `docs: update descriptions` (b59aade7)

Source commit rewrote the human-readable descriptor "betaprime" as two words in `random/betaprime`. Sibling packages that reference the beta prime distribution as prose were still spelling it as one word. Applies the same rewrite to JSDoc, C/JS source comments, a test description string, and one namespace-toc link label. Code identifiers, module paths, and the `[betaprime-distribution]` link-def key are unchanged.

Target sites:

-   `lib/node_modules/@stdlib/random/docs/types/index.d.ts`
-   `lib/node_modules/@stdlib/stats/base/dists/betaprime/test/test.js`
-   `lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/lib/factory.js`
-   `lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/lib/main.js`
-   `lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/src/main.c`
-   `lib/node_modules/@stdlib/stats/base/dists/betaprime/README.md`

### `docs: clean-up` (afc9d5b1)

Source commit removed markdown backticks around `NaN` in three `stats/incr/nan*` package.json descriptions. JSON strings are surfaced verbatim on the npm registry and in stdlib REPL/tooling, so the backticks render literally. Extends the same removal to every remaining `package.json` under `lib/node_modules/@stdlib/` whose `description` field wraps `NaN` in backticks. All 81 sites share the identical mechanical transformation.

Target sites: 81 `package.json` files across `stats/`, `stats/base/ndarray/`, `stats/array/`, `stats/incr/`, `blas/ext/base/`, `blas/ext/base/ndarray/`, and `blas/ext/base/wasm/`. Full list is enumerated in the local propagation report.

## Related Issues

No.

## Questions

No.

## Other

### Validation

For each source pattern, sibling packages were located via `rg` scoped to the relevant subdirectories:

-   **Pattern search:** `"betaprime distribution"` text and `[betaprime][…]` markdown link-labels outside the already-fixed `random/betaprime/` package; ``"description": .*`NaN`.*`` in every `package.json` under `lib/node_modules/@stdlib/`.
-   **Two independent validators** (one per candidate site) confirmed the defect is genuinely present and semantically equivalent to the source pattern. Both validators flagged 0 rejections and 0 `needs-human` verdicts across all 87 sites.
-   **Adaptation pass** produced per-site patches for the 6 adaptive Pattern B sites (variable capitalization and prose context). Style-consistency pass rewrote the three `logpdf` comments to `beta prime distribution` (all lowercase) to match the file's own JSDoc convention on nearby lines, rather than the initial `Beta prime distribution` proposal.
-   **Excluded:** three "See Also" cross-links in `random/base/betaprime/README.md`, `random/array/betaprime/README.md`, and `random/strided/betaprime/README.md` are inside `<!-- Do not manually edit this section, as it is automatically populated. -->` blocks — the fix belongs in the generator and will regenerate on the next docs run. Also excluded: 200 additional `package.json` `description` fields that wrap identifiers other than `NaN` in backticks — outside the source commit's pattern.

### Search commit reference

Source commits fall within the range `b59aade7c8f532f93f105ef75c0b165b18dc759a..89717ddc35cff32083cafe5ddf62a6be82d1f7a6` on `develop`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by an automated propagation routine that scans commits merged to `develop` in the preceding 24 hours, specifies each fix's search signature, enumerates sibling packages likely to carry the same defect, runs a four-agent validation (two independent verifiers, one adaptation, one style-consistency check), and applies only the patches all four agents approved. Each commit corresponds to one source fix pattern and is limited to the corresponding validated propagation sites.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01W4tsmdhUM85NwFZ2gAgrbk)_