### PR TITLE
build(workflows): remove orphaned matrix `include` entries in nightly install tests

### DIFF
--- a/.github/workflows/linux_test_install.yml
+++ b/.github/workflows/linux_test_install.yml
@@ -111,36 +111,6 @@ jobs:
             NPM_VERSION: '>2.7.0 <10.0.0'
             PNPM_VERSION: '6'
 
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0 <10.0.0'
-            PNPM_VERSION: '6'
-
-          - NODE_VERSION: '12'
-            NPM_VERSION: '>2.7.0 <9.0.0'
-            PNPM_VERSION: '6'
-
-          - NODE_VERSION: '10'
-            NPM_VERSION: '>2.7.0 <7.0.0'
-            PNPM_VERSION: '5'
-
-          - NODE_VERSION: '8'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-            PNPM_VERSION: '3'
-
-          - NODE_VERSION: '6'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-            PNPM_VERSION: '2'
-
-          - NODE_VERSION: '4'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-            PNPM_VERSION: '1'
-
-          - NODE_VERSION: '0.12'
-            NPM_VERSION: '>2.7.0 <4.0.0'
-
-          - NODE_VERSION: '0.10'
-            NPM_VERSION: '>2.7.0 <4.0.0'
-
         # Exclude certain matrix combinations:
         exclude:
           - NODE_VERSION: '0.12'

--- a/.github/workflows/macos_test_npm_install.yml
+++ b/.github/workflows/macos_test_npm_install.yml
@@ -103,30 +103,6 @@ jobs:
           - NODE_VERSION: '16'
             NPM_VERSION: '>2.7.0 <10.0.0'
 
-          - NODE_VERSION: '14'
-            NPM_VERSION: '>2.7.0 <10.0.0'
-
-          - NODE_VERSION: '12'
-            NPM_VERSION: '>2.7.0 <9.0.0'
-
-          - NODE_VERSION: '10'
-            NPM_VERSION: '>2.7.0 <7.0.0'
-
-          - NODE_VERSION: '8'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-
-          - NODE_VERSION: '6'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-
-          - NODE_VERSION: '4'
-            NPM_VERSION: '>2.7.0 <6.0.0'
-
-          - NODE_VERSION: '0.12'
-            NPM_VERSION: '>2.7.0 <4.0.0'
-
-          - NODE_VERSION: '0.10'
-            NPM_VERSION: '>2.7.0 <4.0.0'
-
     # Set defaults:
     defaults:
       run:


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes the nightly `linux_test_install` and `macos_test_npm_install` workflows, which have failed on every scheduled run for the past month on `develop`. Root cause: `strategy.matrix.include` in both YAML files still listed entries for `NODE_VERSION` values (`14`, `12`, `10`, `8`, `6`, `4`, `0.12`, `0.10`) that no longer exist in the trimmed base `matrix.NODE_VERSION: ['20', '18', '16']` list. GitHub Actions treats any `include` entry with no matching base combination as a new job using only the keys given in that entry, leaving `matrix.OS` undefined; `runs-on: ${{ matrix.OS }}` then evaluates to `''` and the run fails before any job executes.
-   Removes the orphaned `include` entries from both files so every remaining entry matches an existing `NODE_VERSION`/`OS` combination.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Failing runs: https://github.com/stdlib-js/stdlib/actions/runs/29241867217 and https://github.com/stdlib-js/stdlib/actions/runs/29241447715.

Symptom: `Error when evaluating 'runs-on' for job 'test_install'/'test_npm_install': Unexpected value ''`.

Validation: YAML syntax checked with Python's `yaml.safe_load`; matrix expansion traced by hand for both files, confirming no orphan combinations remain after the fix. Reviewed in three passes: correctness (checked all matrix-using workflows for the same bug pattern; found none elsewhere), regression scope (`NODE_VERSION` 20/18/16 legs and the `zulip` notification job untouched, no downstream references to the removed legs), and style/conventions (checked against `docs/style-guides/git/README.md`).

Note: sibling workflows (`linux_test.yml`, `macos_test.yml`, etc.) handle the same trimmed-matrix situation by commenting out stale entries rather than deleting them. This PR deletes the orphaned entries outright since they were live, not commented, and were the actual cause of the failure.

Note: the `exclude:` block in `linux_test_install.yml` referencing `NODE_VERSION` `0.12`/`0.10` is now fully vestigial. Pre-existing, not touched by this PR — flagging for a maintainer as a possible follow-up cleanup.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, investigating a GitHub Actions run failure and proposing a minimal fix to the affected workflow YAML files.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0145gijagWF8iq5hNHRSnnkq)_