### PR TITLE
docs: rename variable

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/e/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/e/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 -->
 
-# E
+# FLOAT32_E
 
 > The mathematical constant [_e_][e].
 
@@ -27,15 +27,15 @@ limitations under the License.
 ## Usage
 
 ```javascript
-var E = require( '@stdlib/constants/float32/e' );
+var FLOAT32_E = require( '@stdlib/constants/float32/e' );
 ```
 
-#### E
+#### FLOAT32_E
 
 The mathematical constant [_e_][e], also known as Euler's number or Napier's constant. [_e_][e] is the base of the natural logarithm.
 
 ```javascript
-var bool = ( E === 2.7182817459106445 );
+var bool = ( FLOAT32_E === 2.7182817459106445 );
 // returns true
 ```
 
@@ -52,9 +52,9 @@ var bool = ( E === 2.7182817459106445 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var E = require( '@stdlib/constants/float32/e' );
+var FLOAT32_E = require( '@stdlib/constants/float32/e' );
 
-console.log( E );
+console.log( FLOAT32_E );
 // => 2.7182817459106445
 ```
 

--- a/lib/node_modules/@stdlib/constants/float32/e/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/e/docs/types/index.d.ts
@@ -22,12 +22,12 @@
 * Euler's number.
 *
 * @example
-* var e = E;
+* var e = FLOAT32_E;
 * // returns 2.7182817459106445
 */
-declare const E: number;
+declare const FLOAT32_E: number;
 
 
 // EXPORTS //
 
-export = E;
+export = FLOAT32_E;

--- a/lib/node_modules/@stdlib/constants/float32/e/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/e/docs/types/test.ts
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-import E = require( './index' );
+import FLOAT32_E = require( './index' );
 
 
 // TESTS //
@@ -24,5 +24,5 @@ import E = require( './index' );
 // The export is a number...
 {
 	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-	E; // $ExpectType number
+	FLOAT32_E; // $ExpectType number
 }

--- a/lib/node_modules/@stdlib/constants/float32/e/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/e/examples/index.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var E = require( './../lib' );
+var FLOAT32_E = require( './../lib' );
 
-console.log( E );
+console.log( FLOAT32_E );
 // => 2.7182817459106445

--- a/lib/node_modules/@stdlib/constants/float32/e/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/e/lib/index.js
@@ -45,9 +45,9 @@ var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 * @see [OEIS]{@link https://oeis.org/A001113}
 * @see [Wikipedia]{@link https://en.wikipedia.org/wiki/E_(mathematical_constant)}
 */
-var E = float64ToFloat32( 2.718281828459045 );
+var FLOAT32_E = float64ToFloat32( 2.718281828459045 );
 
 
 // EXPORTS //
 
-module.exports = E;
+module.exports = FLOAT32_E;

--- a/lib/node_modules/@stdlib/constants/float32/e/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/e/test/test.js
@@ -21,18 +21,18 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var E = require( './../lib' );
+var FLOAT32_E = require( './../lib' );
 
 
 // TESTS //
 
 tape( 'main export is a number', function test( t ) {
 	t.ok( true, __filename );
-	t.strictEqual( typeof E, 'number', 'main export is a number' );
+	t.strictEqual( typeof FLOAT32_E, 'number', 'main export is a number' );
 	t.end();
 });
 
 tape( 'export is a single-precision floating-point number equal to 2.7182817459106445', function test( t ) {
-	t.strictEqual( E, 2.7182817459106445, 'returns expected value' );
+	t.strictEqual( FLOAT32_E, 2.7182817459106445, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
## Description

Renames the internal identifier `E` -> `FLOAT32_E` in `@stdlib/constants/float32/e` to match the namespace's `FLOAT32_<NAME>` naming convention. Same class of drift and same fix as PR #12432 applied to the sibling `nan` package.

### Namespace summary

-   Namespace: `@stdlib/constants/float32` — 68 packages (all non-autogenerated).
-   Features analyzed: file tree, `package.json` top-level / scripts / stdlib keys, `manifest.json` shape, README section list, and — via per-package agent — the exported constant's identifier across source, TypeScript declarations, examples, tests, and README headings.
-   Features with clear majority (≥75%): all structural features are 100% conformant across the namespace, and the `FLOAT32_<NAME>` identifier convention holds in 65 of 68 packages (95.6%).
-   Features excluded for lack of clear majority: the README `See Also` section (present in 67.6% of packages — below the 75% threshold; also gated as an auto-populated section).

### Outlier

#### `@stdlib/constants/float32/e`

Renamed the exported identifier from `E` to `FLOAT32_E` across `lib/index.js`, `docs/types/index.d.ts`, `docs/types/test.ts`, `examples/index.js`, `test/test.js`, and `README.md` to match the namespace's `FLOAT32_<NAME>` convention (95.6% of siblings already conform). Same drift, same fix as `nan` in #12432. No behavioral change — the `lib/index.js` `@example` line and `namespace/pkg2alias/data.csv` already documented the public alias as `FLOAT32_E`.

## Related Issues

None.

## Questions

No.

## Other

### Validation

-   **Structural extraction:** file trees, `package.json` and `manifest.json` shapes, and README section lists compared across all 68 packages via filesystem walk.
-   **Semantic extraction:** per-package identifier survey across `lib/index.js`, examples, tests, docs, and README to isolate the naming-convention outlier.
-   **Three-agent drift validation:** an opus semantic-review pass confirmed the deviation is a legacy artifact of the package's origin as a copy of `constants/float64/e` (whose namespace convention is unprefixed) and not an intentional preservation of the mathematical symbol; an opus cross-reference pass confirmed no consumer accesses the constant by a property name and no test relies on the local binding name; a sonnet structural pass enumerated the specific line changes required and the tokens that must not be touched (mathematical `_e_` link, `Euler`, `EXPORTS`/`MAIN` banners, URL-encoded `E_%28...%29`, C macro `STDLIB_CONSTANT_FLOAT32_E`, path strings).

Deliberately excluded:

-   `ninf` and `pinf`, which use a local `v` binding in `lib/index.js` for the ArrayBuffer bit-pattern trick but publicly export `FLOAT32_NINF` / `FLOAT32_PINF` — a legitimate implementation shape, not drift.
-   README `See Also` section presence / absence (auto-populated, and below the 75% majority threshold).
-   `@see` link absences in 12 packages — non-mechanical; adding requires domain-specific reference selection.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated cross-package drift-detection run over a randomly-selected stdlib namespace. The namespace `constants/float32` was picked at random; structural and semantic features were extracted across all 68 packages; the sole naming-convention outlier was validated by three independent reviewer agents (two opus, one sonnet) before the identifier rename was applied in the primary worktree. A human will audit and promote the PR out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTbJe6v5Fkekoib4Wg8SaJ)_