### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dxdy/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dxdy/package.json
@@ -63,6 +63,8 @@
     "algebra",
     "subroutines",
     "divide",
+    "division",
+    "quotient",
     "transform",
     "strided",
     "array",

--- a/lib/node_modules/@stdlib/number/uint64/base/string2words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/string2words/README.md
@@ -79,7 +79,7 @@ var bool = ( w === out );
 ## Notes
 
 -   The input string must be a valid representation of an unsigned 64-bit integer in the specified radix, containing no whitespace, sign symbols, or leading zeros.
--   If the provided string represents a value greater than `2^64-1` or the radix is invalid, then `0` is assigned to both high and low words.
+-   If the provided string represents a value greater than `2^64-1`, or if the radix is not an integer on the interval `[2, 36]`, the function throws a `RangeError`.
 
 </section>
 

--- a/lib/node_modules/@stdlib/number/uint64/base/string2words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/string2words/README.md
@@ -79,7 +79,7 @@ var bool = ( w === out );
 ## Notes
 
 -   The input string must be a valid representation of an unsigned 64-bit integer in the specified radix, containing no whitespace, sign symbols, or leading zeros.
--   If the provided string represents a value greater than `2^64-1`, or if the radix is not an integer on the interval `[2, 36]`, the function throws a `RangeError`.
+-   If the provided string represents a value greater than `2^64-1` or the radix is not an integer on the interval `[2, 36]`, the function throws a `RangeError`.
 
 </section>
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Applies follow-up fixes for two commits merged to `develop` between 2026-07-13 09:33 UTC and 2026-07-14 07:31 UTC (SHA range `ccb03e301..6208ff550`, 40 first-parent commits).

### Fixes

-   **`blas/ext/base/dxdy` — `chore: align keywords with sibling packages`.** @bb60d76f1: keywords in `lib/node_modules/@stdlib/blas/ext/base/dxdy/package.json` are out of sync with the `sxdy` sibling — missing `"division"` and `"quotient"`. Added both after `"divide"` so all three `?xdy` variants carry the same keyword set.
-   **`number/uint64/base/string2words` — `docs: correct error semantics in notes`.** The README `## Notes` in `lib/node_modules/@stdlib/number/uint64/base/string2words/README.md` (introduced in `edd8fe361`) claimed an out-of-range value or invalid radix yields `0` for both words; `lib/assign.js` actually throws a `RangeError` in both cases, per the `@throws` doc and `test/test.assign.js`. Rewrote the Notes bullet to state the `RangeError` behavior so the README matches the implementation.

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** The 40-commit window was audited along two axes:

-   **Style-guide compliance** against `docs/style-guides/javascript/README.md` and `docs/style-guides/c/README.md`, with each new package diff-compared against an established sibling of similar shape (e.g. `blas/base/ndarray/cgemv` for the new ndarray Level-2 kernels, `blas/ext/base/dfill`/`sfill`/`gfill` for the `?xdy` trio, and `sgd-regression` siblings for the new SGD enum resolvers).
-   **Objective bug scan** across the introduced code (correctness, numeric edge cases at N=0 / negative strides / NaN±0±Inf boundaries, C-source memory/overflow safety in the new `sxdy`/`dxdy` bindings, and doc/test consistency for the `fftpack/cosqi`/`sinqi` fixes). No bugs surfaced.

**Deliberately excluded.** Subjective preferences, style deviations that also exist in the sibling reference packages (pre-existing, not introduced by the window), the `dspr`/`sspr`/`dsyr2`/`ssyr2` enum-refactor cluster's intentional per-package repetition (established stdlib pattern per commit bodies), and cosmetic whitespace differences not codified in the style guide.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by an automated Claude Code routine: the 24-hour `develop` commit window was scanned by four parallel review agents (two style-compliance passes and two bug-focused passes), each finding was independently re-verified against the worktree before being applied, and the two fixes above are the only high-signal issues that survived filtering. A human maintainer will audit before marking ready for review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018vjPsqFDNCPHYDBR7WZbWK)_