### PR TITLE
fix(@stdlib/_tools/repl-txt/rules/doctest): guard against null `alias` in `replaceAliases`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/repl-txt/rules/doctest/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/rules/doctest/lib/main.js
@@ -171,7 +171,7 @@ function main( context ) {
 			var o;
 			var i;
 
-			alias = pkg2alias( pkg );
+			alias = pkg2alias( pkg ) || 'ALIAS';
 			alias = alias.split( '.' );
 			len = alias.length;
 


### PR DESCRIPTION
## Description

This pull request:

-   Fixes `replaceAliases()` in `@stdlib/_tools/repl-txt/rules/doctest`, which crashed the `lint_changed_files` job with `TypeError: Cannot read properties of null (reading 'split')` whenever a `docs/repl.txt` file references a sibling package via `{{alias:pkg}}` before that package is indexed in the generated `@stdlib/namespace` registry (e.g. two sibling packages added in the same commit). `pkg2alias()` returns `null` in that case; the call site called `.split('.')` on it directly. Falls back to `'ALIAS'` on a falsy return, matching the identical guard already used earlier in the same file at `pkgName = pkg2alias( pkg ) || 'ALIAS';`.

## Related Issues

None.

## Questions

No.

## Other

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/29314039197 (job: `Lint Changed Files`, step: `Lint REPL help files`)

**Symptom:** `TypeError: Cannot read properties of null (reading 'split')` at `lib/node_modules/@stdlib/_tools/repl-txt/rules/doctest/lib/main.js:175`.

**Root cause:** unguarded call to `pkg2alias()`, which returns `null` for packages not yet present in the generated namespace registry.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code as part of an automated CI-failure triage routine: identified the failing job from Actions logs, traced the root cause to the unguarded `pkg2alias()` call, and validated the fix against the existing guard pattern in the same file. Reviewed by three independent passes (correctness, regression scope, style/conventions); all approved with no blocking findings.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018BUs6YZkMPWhDc9oHbJx3A)_