### PR TITLE
refactor: use native `instanceof` operator in `plot/components/svg` constructors

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/annotations/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/annotations/lib/main.js
@@ -25,7 +25,6 @@ var logger = require( 'debug' );
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var inherit = require( '@stdlib/utils/inherit' );
 var zeros = require( '@stdlib/array/zeros' );
-var instanceOf = require( '@stdlib/assert/instance-of' );
 var render = require( './render.js' );
 
 
@@ -47,7 +46,7 @@ var debug = logger( 'annotations:main' );
 */
 function Annotations() {
 	var self;
-	if ( !instanceOf( this, Annotations ) ) {
+	if ( !( this instanceof Annotations ) ) {
 		return new Annotations();
 	}
 	self = this;

--- a/lib/node_modules/@stdlib/plot/components/svg/defs/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/defs/lib/main.js
@@ -25,7 +25,6 @@ var logger = require( 'debug' );
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var inherit = require( '@stdlib/utils/inherit' );
 var zeros = require( '@stdlib/array/zeros' );
-var instanceOf = require( '@stdlib/assert/instance-of' );
 var render = require( './render.js' );
 
 
@@ -48,7 +47,7 @@ var debug = logger( 'defs:main' );
 */
 function Defs() {
 	var self;
-	if ( !instanceOf( this, Defs ) ) {
+	if ( !( this instanceof Defs ) ) {
 		return new Defs();
 	}
 	self = this;

--- a/lib/node_modules/@stdlib/plot/components/svg/rug/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/rug/lib/main.js
@@ -30,7 +30,6 @@ var format = require( '@stdlib/string/format' );
 var copy = require( '@stdlib/utils/copy' );
 var merge = require( '@stdlib/utils/merge' );
 var isObject = require( '@stdlib/assert/is-plain-object' );
-var instanceOf = require( '@stdlib/assert/instance-of' );
 var inherit = require( '@stdlib/utils/inherit' );
 var zeros = require( '@stdlib/array/zeros' );
 var isDefined = require( './accessors/is_defined.js' );
@@ -105,7 +104,7 @@ function Rug( options ) {
 	var opts;
 	var key;
 	var i;
-	if ( !instanceOf( this, Rug ) ) {
+	if ( !( this instanceof Rug ) ) {
 		if ( arguments.length ) {
 			return new Rug( options );
 		}


### PR DESCRIPTION
## Description

Replace the `@stdlib/assert/instance-of` helper with the native JavaScript `instanceof` operator in the constructor guard of three `@stdlib/plot/components/svg/*` packages — `annotations`, `defs`, and `rug` — and drop the now-unused `var instanceOf = require( '@stdlib/assert/instance-of' );` imports. `@stdlib/assert/instance-of` returns `value instanceof constructor` verbatim, so behavior is unchanged.

### Namespace summary

-   Members analyzed: 12 packages under `@stdlib/plot/components/svg/*` (`annotations`, `axis`, `background`, `canvas`, `clip-path`, `defs`, `graph`, `marks`, `path`, `rug`, `symbols`, `title`).
-   Features extracted: file tree, `package.json` shape, README section list, `manifest.json` shape, test/benchmark/example file naming, constructor signature, validation prologue, error construction, JSDoc shape, module dependencies.
-   Features with a clear majority (≥75%): constructor guard idiom, `defaults.json` presence, `props/` directory presence, `format`-based error construction, single `@throws` in constructor JSDoc, uniform `package.json` top-level shape, uniform `os`/`engines` fields.
-   Features without a clear majority (excluded from drift analysis): `test/` directory presence (3/12), `benchmark/` directory presence (3/12), `README.md` section list (3/12), prototype inheritance idiom (`inherit` vs manual `Object.create` — 3/12 vs 9/12 splits along the modern/legacy helper axis and reads as intentional rather than drift), `define-read-only-property` vs `define-nonenumerable-read-only-property` (2/12 vs 10/12, same rationale).

### `plot/components/svg/annotations`

`annotations`'s constructor guard in `lib/main.js` now uses the native `instanceof` operator in place of `@stdlib/assert/instance-of`, and the now-dead `instanceOf` import is gone. Nine of twelve `plot/components/svg/*` packages already used the native operator, and stdlib-wide the helper appeared in only three files total — `annotations`, `defs`, and `rug` — against 215+ using `instanceof` directly; this closes out the last of those three. `@stdlib/assert/instance-of` is a straight `value instanceof constructor` wrapper, so behavior is unchanged.

### `plot/components/svg/defs`

Replace `instanceOf( this, Defs )` with `this instanceof Defs` in the `Defs` constructor guard and drop the now-dead `@stdlib/assert/instance-of` import. 9 of 12 sibling packages under `plot/components/svg` already use the native operator, and it is the standard across the project (215+ files vs. 3 using the helper, all in this namespace). `instanceOf` wraps `value instanceof constructor` verbatim, so behavior is unchanged.

### `plot/components/svg/rug`

Replaces `instanceOf( this, Rug )` in `lib/main.js` with the native `this instanceof Rug` check and drops the now-dead `@stdlib/assert/instance-of` require. `rug` was one of only three files stdlib-wide (with `annotations` and `defs`, both in this same `svg` namespace) still pulling in the helper for a constructor guard, against 215+ files using the native operator directly and 9 of 12 `plot/components/svg/*` packages already doing so. `instanceOf` returns `value instanceof constructor` verbatim, so this is a no-op behaviorally.

### Validation

-   Structural extraction over all 12 namespace members (file tree, `package.json` shape, README section list, `manifest.json` shape, test/benchmark/example file naming) followed by an ecosystem-wide grep for the `instanceOf( this, ... )` pattern, which confirmed the three files above are the only stdlib usages of the helper for a constructor guard.
-   Semantic extraction over each package's `lib/main.js` (constructor signature, validation prologue, error construction, JSDoc shape, module dependencies).
-   Three-agent drift validation panel (semantic-review, cross-reference, structural-review) returned `confirmed-drift` for `annotations`, `defs`, and `rug`. The cross-reference agent additionally verified that `test/test.js` in the packages with tests continues to use `@stdlib/assert/instance-of` for boolean assertions unrelated to the constructor guard — that usage is untouched.
-   Deliberately excluded: features without a clear majority in the namespace (`test/` and `benchmark/` presence, README section list, `@stdlib/utils/inherit` vs manual prototype wiring, `define-*read-only-property` variant); the `defaults.json`- and `props/`-absent packages (`annotations`, `defs`) where absence is architectural, not drift; and any change that would touch test expectations, examples, benchmarks, or public signatures.
-   Cross-run dedup: PR #13220 (merged 2026-07-04) fixed a distinct drift in the same namespace (a debug logger prefix in `graph`) and does not overlap with this change; no other open or recently merged PRs target `plot/components/svg`.

## Related Issues

No.

## Questions

No.

## Other

Diff is 3 files × 2 lines removed + 1 line added = 3 insertions / 6 deletions, scoped to `lib/main.js` in each of `annotations`, `defs`, and `rug`. No `package.json`, `README.md`, `test/`, `benchmark/`, or `examples/` files touched. No public signature, JSDoc, or emitted-error message changed.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by an automated cross-package drift-detection routine run under Claude Code. The routine sampled the `@stdlib/plot/components/svg` namespace, extracted structural and semantic features from all 12 packages, identified the native-`instanceof` guard idiom as the majority pattern (9/12 namespace-local, 215+/218 stdlib-wide), and applied the mechanical rewrite to the three outliers. Three independent validation agents (two Opus, one Sonnet) confirmed the deviation as unintentional and the fix as behaviorally identical.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01DjQHdonAV3RJbysAjreTbD)_