### PR TITLE
fix(@stdlib/_tools/repl-txt/rules/doctest): guard against null `alias` in `replaceAliases`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/repl-txt/rules/doctest/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/rules/doctest/lib/main.js
@@ -171,7 +171,7 @@ function main( context ) {
 			var o;
 			var i;
 
-			alias = pkg2alias( pkg );
+			alias = pkg2alias( pkg ) || 'ALIAS';
 			alias = alias.split( '.' );
 			len = alias.length;
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes `replaceAliases()` in `@stdlib/_tools/repl-txt/rules/doctest`, which crashed the `lint_changed_files` job with `TypeError: Cannot read properties of null (reading 'split')` whenever a `docs/repl.txt` file references a sibling package via `{{alias:pkg}}` before that package is indexed in the generated `@stdlib/namespace` registry. `pkg2alias()` returns `null` in that case; the call site called `.split('.')` on it directly. Falls back to `'ALIAS'` on a falsy return, matching the identical guard already used a few lines above in the same file at `pkgName = pkg2alias( pkg ) || 'ALIAS';`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Failing run: https://github.com/stdlib-js/stdlib/actions/runs/29372187787 (job: `Lint Changed Files`, step: `Lint REPL help files`). Recurred 4 times on `develop` within a 20-minute window on 2026-07-14, on 4 different commits touching different packages' `docs/repl.txt`.

Root cause: unguarded call to `pkg2alias()`, which returns `null` for packages not yet present in the generated namespace registry.

Note: a prior PR (#13472) proposed this identical one-line fix but was auto-closed on 2026-07-14 without being merged (no review comments; appears to be stale-PR cleanup, not a rejection). The bug was confirmed still present in `develop` source before opening this PR.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code as part of an automated CI-failure triage routine, based on live GitHub Actions job log analysis. The fix was reviewed by three independent automated review passes (correctness, regression scope, style/conventions) before being proposed here; all approved with no blocking findings.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018KjHmY919fVQhqmaebk4Y5)_