### PR TITLE
chore: update keywords

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/package.json
@@ -63,6 +63,7 @@
     "cumulative distribution",
     "distribution function",
     "discrete",
-    "uniform"
+    "uniform",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/package.json
@@ -67,6 +67,7 @@
     "properties",
     "props",
     "discrete",
-    "uniform"
+    "uniform",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/package.json
@@ -64,6 +64,7 @@
     "discrete",
     "probability",
     "prob",
-    "uniform"
+    "uniform",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/package.json
@@ -64,6 +64,7 @@
     "discrete",
     "probability",
     "prob",
-    "uniform"
+    "uniform",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/package.json
@@ -68,6 +68,7 @@
     "logarithm",
     "log",
     "ln",
-    "natural"
+    "natural",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/package.json
@@ -65,6 +65,7 @@
     "discrete",
     "probability",
     "prob",
-    "uniform"
+    "uniform",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/package.json
@@ -64,6 +64,7 @@
     "discrete",
     "probability",
     "prob",
-    "uniform"
+    "uniform",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/package.json
@@ -62,6 +62,7 @@
     "generating functions",
     "moments",
     "uniform",
-    "discrete"
+    "discrete",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/package.json
@@ -63,6 +63,7 @@
     "discrete",
     "probability",
     "prob",
-    "uniform"
+    "uniform",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/package.json
@@ -67,6 +67,7 @@
     "discrete",
     "probability",
     "prob",
-    "uniform"
+    "uniform",
+    "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/package.json
@@ -65,6 +65,7 @@
     "discrete",
     "probability",
     "prob",
-    "uniform"
+    "uniform",
+    "univariate"
   ]
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds the `univariate` keyword to the `keywords` array of eleven `@stdlib/stats/base/dists/discrete-uniform` sub-packages that were missing it. Only `logpmf`, `pmf`, and `quantile` carried the keyword; the other eleven (`cdf`, `ctor`, `entropy`, `kurtosis`, `logcdf`, `mean`, `median`, `mgf`, `skewness`, `stdev`, `variance`) did not. The keyword is a near-universal ecosystem convention (491/517 = 95% of `stats/base/dists/*/*` packages carry it, including 100% of the sibling `bernoulli`, `poisson`, and continuous `uniform` families), and the namespace's own top-level `package.json` already lists it. No source, tests, TypeScript declarations, or public API are touched.

### Namespace summary

- Members analyzed: 14 (none autogenerated).
- Features extracted: file tree, `package.json` shape (top-level keys, `scripts`, `stdlib`, `keywords`), `manifest.json` shape, README section list, `lib/` / `test/` / `benchmark/` / `examples/` / `docs/` file lists, JSDoc `@example` counts, and per-package semantic features (public signature, validation prologue, error construction, JSDoc shape, dependencies) via direct source inspection of `lib/main.js`, `lib/index.js`, `lib/factory.js`, `lib/native.js`, plus `test/test.js` structure.
- Features with a clear in-namespace majority (≥75%): `package.json` top-level key set, README section list (`## Usage` / `## Examples` / `## C APIs` / `### Usage` / `### Examples`), validation-prologue shape (per API arity), error-construction kind, benchmark / examples / `docs/` file names.
- Feature with an unambiguous **ecosystem-wide** majority that fails the in-namespace threshold: the `univariate` keyword — 3/14 locally (below 75%) but 95% stdlib-wide and 100% across every sibling distribution family checked. This PR corrects it.
- Features without a clear majority (excluded from drift analysis): distribution-specific `keywords` array contents beyond `univariate` (e.g. `probability`, `prob`, `symmetric` — verified as intentional per-package/per-family choices), `@returns` type annotations (`number` / `PositiveNumber` / `Probability` / `integer` vary by mathematical object).

### Per outlier package

Each of the following packages had `"univariate"` appended to the end of its `keywords` array (matching the placement in sibling continuous `uniform`, `bernoulli`, and `poisson` sub-packages). Every diff is a single `+"univariate",` line with a matching comma on the previous line; no other field is touched.

- **`cdf`, `entropy`, `kurtosis`, `mean`, `median`, `skewness`, `stdev`, `variance`** — the eight single-scalar and CDF packages missing the ecosystem-standard `univariate` keyword. Local conformance 3/14 (21%); ecosystem-wide conformance 491/517 (95%).
- **`logcdf`** — same missing keyword; local conformance 3/14; the sibling `logpmf` package already carries it.
- **`mgf`** — same missing keyword; local conformance 3/14; the sibling continuous `uniform/mgf` package already carries it (14/14 in that family).
- **`ctor`** — same missing keyword; the class-based JavaScript wrapper. Sibling `bernoulli/ctor`, `poisson/ctor`, and continuous `uniform/ctor` all carry `univariate`; this one did not.

### Validation

- **Structural extraction:** file tree, `package.json` fields, `manifest.json` shape, README section list, `test/` / `benchmark/` / `examples/` / `docs/` / `lib/` directory listings extracted for each of the 14 members.
- **Semantic extraction:** validation prologues, error-construction kind, JSDoc shape, dependencies, and public signatures compared across single-scalar dists (`entropy`, `kurtosis`, `mean`, `median`, `skewness`, `stdev`, `variance`), factory dists (`cdf`, `logcdf`, `logpmf`, `mgf`, `pmf`, `quantile`), and the class-based `ctor`. All three groupings were internally consistent — no semantic drift found.
- **Adversarial review:** an independent reviewer pass surfaced the `univariate` finding after the primary pass had missed it; the reviewer also verified `.d.ts` shape, C header shape, `benchmark/c/benchmark.c` boilerplate, README heading structure, copyright years, JSDoc `@example` counts, and test tape-block counts — all confirmed to have no drift.
- **Deliberately excluded:**
  - `ctor` lacks the native-addon scaffold (`binding.gyp`, `manifest.json`, `src/`, `include/`, `lib/native.js`) — intentional, since it is a JavaScript class with no C implementation.
  - `skewness` lacks `test/fixtures/julia/` cross-language fixture data — intentional, since the skewness of a discrete uniform distribution is always `0` and does not require numerical verification.
  - `mgf` lacks the `probability` keyword, present in 13/14 in-namespace siblings — excluded because moment-generating-function packages stdlib-wide consistently omit `probability` (20/22 = 91%); the in-namespace majority is itself the outlier.
  - The `symmetric` keyword is present only in `logpmf`, `pmf`, and `quantile` — verified as an intentional narrow convention matching the identical 3-of-14 scoping in the sibling continuous `uniform` family.
  - JSDoc `@returns` type annotations vary by mathematical object and reflect intentional semantic differences.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This is a follow-up drift audit of the same namespace corrected in #12669 (merged 2026-06-07). That PR normalized JSDoc summary phrasing across `mgf` and fixed a typo in `quantile`; this run finds the `univariate` keyword gap missed by the earlier audit. All corrections here are `package.json` metadata only — no source, tests, or declarations.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

A cross-package drift audit of the `@stdlib/stats/base/dists/discrete-uniform` namespace was run using Claude Code. Structural and semantic features were extracted from each of the fourteen non-autogenerated members, the majority pattern was computed per feature, and outliers were validated against sibling packages before any change was applied. An adversarial independent review pass verified the primary findings and surfaced the `univariate` keyword gap that this PR corrects. Each candidate was checked against the ecosystem-wide convention (491/517 = 95% presence) and against sibling distribution families (`bernoulli`, `poisson`, continuous `uniform`, each at 100%) before applying. All proposed changes were reviewed before submitting.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsgmTFJe14SCZgMqW9TZyw)_