### PR TITLE
docs: add notes section

### DIFF
--- a/lib/node_modules/@stdlib/os/platform/README.md
+++ b/lib/node_modules/@stdlib/os/platform/README.md
@@ -43,6 +43,22 @@ console.log( PLATFORM );
 
 <!-- /.usage -->
 
+<section class="notes">
+
+## Notes
+
+-   The following values are possible:
+
+    -   `'win32'`
+    -   `'darwin'`
+    -   `'linux'`
+    -   `'freebsd'`
+    -   `'sunos'`
+
+</section>
+
+<!-- /.notes -->
+
 <section class="examples">
 
 ## Examples


### PR DESCRIPTION
## Description

This pull request:

-   Adds a `## Notes` section to `@stdlib/os/platform/README.md` documenting the enumerated possible platform values (`'win32'`, `'darwin'`, `'linux'`, `'freebsd'`, `'sunos'`), placed between `## Usage` and `## Examples` to match sibling packages.

### Namespace summary

-   Namespace: `@stdlib/os` — 8 members (arch, byte-order, configdir, float-word-order, homedir, num-cpus, platform, tmpdir).
-   Features analyzed: file tree, `package.json` shape, README section list and order, `manifest.json` presence, `test/`/`benchmark/`/`examples/` file naming, public signature, return kind, validation prologue, error construction, JSDoc shape, dependencies.
-   Features with a clear ≥75% majority: 9 (all core files, all 19 `package.json` top-level keys, `returnKind`, JSDoc `@example`, README `Usage`/`Examples`/`CLI` sections, README `See Also`, README `Notes`).
-   Features excluded for no clear majority: `browser` key (3/8), `benchmark/benchmark.js` presence (3/8), `manifest.json` presence (2/8, native-only), `publicSignature` (constants vs. functions split), `validationPrologue` and `errorConstruction` (only `configdir` has non-trivial values), README `C APIs` section (2/8, native-only).

### Per outlier package

#### `@stdlib/os/platform`

Six of the eight `@stdlib/os` packages ship a `## Notes` section in the README (~75% conformance); `platform` is one of two outliers. Its own `docs/types/index.d.ts` already documents the enumerated possible values under a `## Notes` heading, and the two sibling value-returning constants that share the same shape — `byte-order` and `float-word-order` — mirror that enumeration into the README in a `<section class="notes">` block between Usage and Examples. This commit ports the same list into `platform/README.md`, matching the sibling pattern exactly. No behavior change; docs only.

### Validation

-   Structural extraction over the 8 members: file tree, `package.json` shape, README section list, `manifest.json`, and `test/`/`benchmark/`/`examples/` file naming.
-   Semantic extraction via per-package agents: public signature, return kind, validation prologue, error construction, JSDoc shape, and `require()` dependencies.
-   Three-agent drift validation on the one advancing correction: semantic-review (confirmed drift — d.ts already documents the enumeration), cross-reference (confirmed drift — no test/example/lint depends on README shape), structural-review (confirmed drift — pattern matches sibling constants).
-   Deliberately excluded: README `See Also` outlier in `num-cpus` (auto-populated section — gated); README `Notes` outlier in `tmpdir` (would require original content, not a mechanical mirror); `dts` `Notes` outlier in `tmpdir` (no equivalent source content).

## Related Issues

No.

## Questions

No.

## Other

Change is 16 additions, one file. Diff scope confined to inserting the new `<section class="notes">` block; no surrounding lines were touched, no other package was modified.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by a scheduled cross-package drift-detection routine driven by Claude Code. The routine surveyed structural and semantic features across every package in the `@stdlib/os` namespace, identified the majority pattern per feature, ran a three-agent adversarial validation over the one advancing outlier, and applied a single mechanical correction (mirroring the value enumeration already present in `platform/docs/types/index.d.ts` into a new README Notes section, following the pattern used by `byte-order` and `float-word-order`).

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0198HEDowpnrW923x2MqUtpJ)_