### PR TITLE
docs: update descriptions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/include/stdlib/stats/base/dists/levy/entropy.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/include/stdlib/stats/base/dists/levy/entropy.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Returns the differentaial entropy for a Lévy distribution with location `mu` and scale `c`.
+* Returns the differential entropy for a Lévy distribution with location `mu` and scale `c`.
 */
 double stdlib_base_dists_levy_entropy( const double mu, const double c );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/src/main.c
@@ -21,7 +21,7 @@
 #include "stdlib/math/base/special/erfcinv.h"
 
 /**
-* Returns the quantile for a Lévy distribution with location `mu` and scale `c`.
+* Evaluates the quantile function for a Lévy distribution with location parameter `mu` and scale parameter `c` at a probability `p`.
 *
 * @param p   input value
 * @param mu  location parameter


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects two docstring inconsistencies in the C implementation files of the `@stdlib/stats/base/dists/levy` namespace. Both are one-line, docs-only changes; neither affects behavior, tests, examples, or type declarations.

### `@stdlib/stats/base/dists/levy/entropy`

The C header `include/stdlib/stats/base/dists/levy/entropy.h` describes the function as `differentaial entropy` — a plain typo. It is the sole occurrence of the misspelling in the namespace; every other reference to the function (its own `src/main.c`, `lib/main.js`, `lib/native.js`, `docs/repl.txt`, `docs/types/index.d.ts`, `README.md`, the two test files, and the `ctor` package's cross references) spells it `differential`. Fix restores the correct spelling.

### `@stdlib/stats/base/dists/levy/quantile`

The function-level docstring in `src/main.c` read `Returns the quantile for a Lévy distribution with location `` `mu` `` and scale `` `c` ``.`, dropping the "at a probability `p`" clause and the `parameter` qualifiers used everywhere else in the namespace. Four of five sibling `src/main.c` docstrings under `stats/base/dists/levy` (`cdf`, `pdf`, `logcdf`, `logpdf` — 80% conformance) follow the pattern `Evaluates <FUNCTION> for a Lévy distribution with location parameter `` `mu` `` and scale parameter `` `c` `` at [a] value/probability `` `x` ``/`` `p` ``.`; `quantile`'s own header, `lib/main.js`, `lib/native.js`, `docs/repl.txt`, and `docs/types/index.d.ts` also use the "Evaluates the quantile function ... at a probability `p`" phrasing. Rewriting the src docstring to that form aligns it with the package's own header and the sibling C sources.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Total diff is 2 files, 2 lines. Neither commit touches behavior, public signatures, tests, examples, or type declarations. No auto-generated sections (`## See Also`, `repl.txt`, `.d.ts`) are modified.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated cross-package API drift audit of the `@stdlib/stats/base/dists/levy` namespace. Structural features (file tree, `package.json` shape, README section list, manifest shape, test/benchmark/example naming) were extracted from all 12 members. Semantic features (public signature, validation prologue, error construction, JSDoc shape, dependencies) were extracted via per-package sonnet agents from `lib/main.js`, `lib/index.js`, `lib/validate.js`, and `lib/factory.js`. The two candidate corrections above were each independently confirmed as `confirmed-drift` by three parallel reviewer agents (Opus semantic-review, Opus cross-reference, and Sonnet structural-review) before the patches were applied. A maintainer should audit and promote out of draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
