### PR TITLE
build: ensure correct operator precedence when using a dynamic `require` expression

### DIFF
--- a/lib/node_modules/@stdlib/_tools/repl-txt/rules/doctest/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/rules/doctest/lib/main.js
@@ -165,7 +165,7 @@ function main( context ) {
 					return format( 'require(\'%s\')', pkg );
 				}
 				// If an alias does not exist in the global namespace, dynamically `require` a package so that the desired expression can be executed:
-				return format( 'require(\'%s\')', pkg );
+				return format( '(require(\'%s\'))', pkg );
 			}
 			alias = alias.split( '.' );
 			len = alias.length;

--- a/lib/node_modules/@stdlib/repl/help/scripts/build.js
+++ b/lib/node_modules/@stdlib/repl/help/scripts/build.js
@@ -184,7 +184,7 @@ function main() {
 						continue;
 					}
 					// If an alias does not exist in the global namespace, dynamically `require` a package so that the desired expression can be executed in example code:
-					file = replace( file, tmp[ j ], format( 'require(\'%s\')', p ) ); // WARNING: this assumes that `{{alias:}}` placeholders are in examples. If unresolved package identifiers are used in descriptions, this substitution is NOT appropriate. The use of such placeholders in description prose is uncommon, but not unheard of. However, given its relatively rare occurrence, we can likely be confident that this substitution is okay. Ideally, identifiers would be added to the database, so that this workaround is not necessary.
+					file = replace( file, tmp[ j ], format( '(require(\'%s\'))', p ) ); // WARNING: this assumes that `{{alias:}}` placeholders are in examples. If unresolved package identifiers are used in descriptions, this substitution is NOT appropriate. The use of such placeholders in description prose is uncommon, but not unheard of. However, given its relatively rare occurrence, we can likely be confident that this substitution is okay. Ideally, identifiers would be added to the database, so that this workaround is not necessary.
 					debug( 'Inserted a `require` expression for `%s`.', p );
 				} else {
 					file = replace( file, tmp[ j ], a );


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes precedence collision between the `new` keyword and injected `require` statement by wrapping the require statement in parentheses.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
