### PR TITLE
feat: add `assert/is-int64`

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-int64/README.md
+++ b/lib/node_modules/@stdlib/assert/is-int64/README.md
@@ -1,0 +1,98 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isInt64
+
+> Test if a value is a [64-bit signed integer][@stdlib/number/int64/ctor].
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isInt64 = require( '@stdlib/assert/is-int64' );
+```
+
+#### isInt64( value )
+
+Tests if a value is a [64-bit signed integer][@stdlib/number/int64/ctor].
+
+```javascript
+var Int64 = require( '@stdlib/number/int64/ctor' );
+
+var x = new Int64( 1234 );
+
+var bool = isInt64( x );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Complex128 = require( '@stdlib/complex/float64/ctor' );
+var Int64 = require( '@stdlib/number/int64/ctor' );
+var isInt64 = require( '@stdlib/assert/is-int64' );
+
+console.log( isInt64( new Int64( 1234 ) ) );
+// => true
+
+console.log( isInt64( new Complex128( 3.0, 1.0 ) ) );
+// => false
+
+console.log( isInt64( {} ) );
+// => false
+
+console.log( isInt64( null ) );
+// => false
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/number/int64/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/int64/ctor
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/is-int64/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-int64/benchmark/benchmark.js
@@ -1,0 +1,88 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var Int64 = require( '@stdlib/number/int64/ctor' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var isInt64 = require( './../lib' );
+
+
+// MAIN //
+
+bench( format( '%s::true', pkg ), function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		new Int64( 1234 ),
+		new Int64( 5678 ),
+		new Int64( 9012 ),
+		new Int64( 3456 )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isInt64( values[ i%values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::false', pkg ), function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		[],
+		{}
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isInt64( values[ i%values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-int64/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-int64/docs/repl.txt
@@ -1,0 +1,28 @@
+
+{{alias}}( value )
+    Tests if a value is a 64-bit signed integer.
+
+    Parameters
+    ----------
+    value: any
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether a value is a 64-bit signed integer.
+
+    Examples
+    --------
+    > var bool = {{alias}}( new {{alias:@stdlib/number/int64/ctor}}( 1234 ) )
+    true
+    > bool = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( 3.0, 1.0 ) )
+    false
+    > bool = {{alias}}( 3.14 )
+    false
+    > bool = {{alias}}( {} )
+    false
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/assert/is-int64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-int64/docs/types/index.d.ts
@@ -1,0 +1,44 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Int64 } from '@stdlib/types/number';
+
+/**
+* Tests if a value is a 64-bit signed integer.
+*
+* @param value - value to test
+* @returns boolean indicating if a value is a 64-bit signed integer
+*
+* @example
+* var Int64 = require( '@stdlib/number/int64/ctor' );
+*
+* var x = new Int64( 1234 );
+*
+* var bool = isInt64( x );
+* // returns true
+*/
+declare function isInt64( value: any ): value is Int64;
+
+
+// EXPORTS //
+
+export = isInt64;

--- a/lib/node_modules/@stdlib/assert/is-int64/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-int64/docs/types/test.ts
@@ -1,0 +1,38 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Complex128 = require( '@stdlib/complex/float64/ctor' );
+import Int64 = require( '@stdlib/number/int64/ctor' );
+import isInt64 = require( '@stdlib/assert/is-int64' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isInt64( new Int64( 1234 ) ); // $ExpectType boolean
+	isInt64( new Complex128( 5.0, 3.0 ) ); // $ExpectType boolean
+	isInt64( {} ); // $ExpectType boolean
+	isInt64( 123 ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isInt64(); // $ExpectError
+	isInt64( new Int64( 1234 ), 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/is-int64/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-int64/examples/index.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Complex128 = require( '@stdlib/complex/float64/ctor' );
+var Int64 = require( '@stdlib/number/int64/ctor' );
+var isInt64 = require( './../lib' );
+
+console.log( isInt64( new Int64( 1234 ) ) );
+// => true
+
+console.log( isInt64( new Complex128( 3.0, 1.0 ) ) );
+// => false
+
+console.log( isInt64( {} ) );
+// => false
+
+console.log( isInt64( null ) );
+// => false

--- a/lib/node_modules/@stdlib/assert/is-int64/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-int64/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if a value is a 64-bit signed integer.
+*
+* @module @stdlib/assert/is-int64
+*
+* @example
+* var Int64 = require( '@stdlib/number/int64/ctor' );
+* var isInt64 = require( '@stdlib/assert/is-int64' );
+*
+* var x = new Int64( 1234 );
+*
+* var bool = isInt64( x );
+* // returns true
+*/
+
+// MODULES //
+
+var isInt64 = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = isInt64;

--- a/lib/node_modules/@stdlib/assert/is-int64/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-int64/lib/main.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Int64 = require( '@stdlib/number/int64/ctor' );
+var constructorName = require( '@stdlib/utils/constructor-name' );
+
+
+// MAIN //
+
+/**
+* Tests if a value is a 64-bit signed integer.
+*
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating if a value is a 64-bit signed integer
+*
+* @example
+* var Int64 = require( '@stdlib/number/int64/ctor' );
+*
+* var x = new Int64( 1234 );
+*
+* var bool = isInt64( x );
+* // returns true
+*/
+function isInt64( value ) {
+	return (
+		value instanceof Int64 ||
+		constructorName( value ) === 'Int64'
+	);
+}
+
+
+// EXPORTS //
+
+module.exports = isInt64;

--- a/lib/node_modules/@stdlib/assert/is-int64/package.json
+++ b/lib/node_modules/@stdlib/assert/is-int64/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@stdlib/assert/is-int64",
+  "version": "0.0.0",
+  "description": "Test if a value is a 64-bit signed integer.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "is",
+    "isint64",
+    "int64",
+    "signed",
+    "64-bit",
+    "integer",
+    "type",
+    "check",
+    "test",
+    "validate",
+    "isvalid",
+    "valid"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/is-int64/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-int64/test/test.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Int64 = require( '@stdlib/number/int64/ctor' );
+var Complex128 = require( '@stdlib/complex/float64/ctor' );
+var isInt64 = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isInt64, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a 64-bit signed integer', function test( t ) {
+	t.strictEqual( isInt64( new Int64( 1234 ) ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a 64-bit signed integer', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		'5',
+		null,
+		void 0,
+		NaN,
+		true,
+		[],
+		{},
+		new Complex128( 2.0, 2.0 ),
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( isInt64( values[i] ), false, 'returns false when provided '+values[i] );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds an assertion utility to check if a value is a 64-bit signed integer (`Int64` instance).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
