### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-typedef-typos/lib/edit_distance.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-typedef-typos/lib/edit_distance.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var ndarray = require( '@stdlib/ndarray/array' );
+var zeros = require( '@stdlib/ndarray/zeros' );
 var minn = require( '@stdlib/math/base/special/minn' );
 
 
@@ -31,7 +31,7 @@ var minn = require( '@stdlib/math/base/special/minn' );
 *
 * ## Notes
 *
-* -   the edit distance between two strings is the number of insertions, deletions, character substitutions, as well as transpositions of adjacent characters to convert one of the strings into the other.
+* -   The edit distance between two strings is the number of insertions, deletions, character substitutions, as well as transpositions of adjacent characters to convert one of the strings into the other.
 *
 * [damerau-levenshtein]: https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
 *
@@ -56,9 +56,7 @@ function editDistance( word1, word2 ) {
 	n = word2.length;
 
 	// FIXME: all of the following needs to be cleaned up. There may be an opportunity for a `blas/ext/base` implementation of edit distance; however, we need to think carefully about this as the following doesn't take into account grapheme clusters.
-	d = ndarray({
-		'shape': [ m+1, n+1 ]
-	});
+	d = zeros( [ m+1, n+1 ] );
 	for ( i = 0; i <= m; i++ ) {
 		d.set( i, 0, i );
 	}

--- a/lib/node_modules/@stdlib/_tools/repl-txt/rules/interface-spacing/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/rules/interface-spacing/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var format = require( '@stdlib/string/format' );
+
+
 // VARIABLES //
 
 var DEFAULT_SPACING = 2;
@@ -52,7 +57,7 @@ function main( context ) {
 				elem = interfaces[ i ];
 				emptyLines = elem.start - end - 1;
 				if ( emptyLines !== spacing ) {
-					context.report( 'Interface documentation sections must be separated by `' + spacing + '` empty lines. Encountered: `'+ emptyLines+'`.', interfaces[ i ] );
+					context.report( format( 'Interface documentation sections must be separated by `%s` empty lines. Encountered: `%s`.', spacing, emptyLines ), interfaces[ i ] );
 				}
 				end = elem.end;
 			}

--- a/lib/node_modules/@stdlib/_tools/repl-txt/rules/section-heading-style/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/rules/section-heading-style/lib/main.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var isCapitalized = require( '@stdlib/assert/is-capitalized' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -59,10 +60,10 @@ function main( context ) {
 	*/
 	function sectionStyle( section ) {
 		if ( !isCapitalized( section.title ) ) {
-			context.report( 'Section title "'+section.title+'" should be capitalized', section );
+			context.report( format( 'Section title "%s" should be capitalized', section.title ), section );
 		}
 		if ( countHyphens( section.rawTitle ) !== section.title.length ) {
-			context.report( 'Number of hyphens in the line following "'+section.title+'" must match the length of the title', section );
+			context.report( format( 'Number of hyphens in the line following "%s" must match the length of the title', section.title ), section );
 		}
 	}
 	return {

--- a/lib/node_modules/@stdlib/_tools/repl-txt/rules/section-order/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/rules/section-order/lib/main.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var indexOf = require( '@stdlib/utils/index-of' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -61,7 +62,7 @@ function main( context ) {
 			section = sections[ i ];
 			idx = indexOf( order, section.title );
 			if ( last !== void 0 && idx < last ) {
-				context.report( 'Sections have to be arranged in the following order: '+order.join( ', ' ), section );
+				context.report( format( 'Sections have to be arranged in the following order: %s', order.join( ', ' ) ), section );
 			}
 			last = idx;
 		}

--- a/lib/node_modules/@stdlib/_tools/repl-txt/rules/whitelisted-sections/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/rules/whitelisted-sections/lib/main.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var indexOf = require( '@stdlib/utils/index-of' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -54,7 +55,7 @@ function main( context ) {
 
 		idx = indexOf( SECTIONS, section.title );
 		if ( idx === -1 ) {
-			context.report( 'Only use one of the following section header titles: '+SECTIONS.join( '\n' ), section );
+			context.report( format( 'Only use one of the following section header titles: %s', SECTIONS.join( '\n' ) ), section );
 		}
 	}
 	return {

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/README.md
@@ -116,7 +116,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, E(X;µ,σ): %0.4f', mu, sigma, mean );
+logEachMap( 'μ: %0.4f, σ: %0.4f, E(X;μ,σ): %0.4f', mu, sigma, mean );
 ```
 
 </section>
@@ -205,7 +205,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_anglit_mean( mu, sigma );
-        printf( "µ: %lf, σ: %lf, E(X;µ,σ): %lf\n", mu, sigma, y );
+        printf( "μ: %lf, σ: %lf, E(X;μ,σ): %lf\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_anglit_mean( mu, sigma );
-		printf( "µ: %lf, σ: %lf, E(X;µ,σ): %lf\n", mu, sigma, y );
+		printf( "μ: %lf, σ: %lf, E(X;μ,σ): %lf\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, E(X;µ,σ): %0.4f', mu, sigma, mean );
+logEachMap( 'μ: %0.4f, σ: %0.4f, E(X;μ,σ): %0.4f', mu, sigma, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/median/README.md
@@ -116,7 +116,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Median(X;µ,σ): %0.4f', mu, sigma, median );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Median(X;μ,σ): %0.4f', mu, sigma, median );
 ```
 
 </section>
@@ -205,7 +205,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_anglit_median( mu, sigma );
-        printf( "µ: %lf, σ: %lf, Median(X;µ,σ): %lf\n", mu, sigma, y );
+        printf( "μ: %lf, σ: %lf, Median(X;μ,σ): %lf\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/median/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_anglit_median( mu, sigma );
-		printf( "µ: %lf, σ: %lf, Median(X;µ,σ): %lf\n", mu, sigma, y );
+		printf( "μ: %lf, σ: %lf, Median(X;μ,σ): %lf\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/median/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Median(X;µ,σ): %0.4f', mu, sigma, median );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Median(X;μ,σ): %0.4f', mu, sigma, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/README.md
@@ -129,7 +129,7 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 5.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, σ: %0.4f, Q(p;µ,σ): %0.4f', p, mu, sigma, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, σ: %0.4f, Q(p;μ,σ): %0.4f', p, mu, sigma, quantile );
 ```
 
 </section>
@@ -221,7 +221,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.0, 5.0 );
         y = stdlib_base_dists_anglit_quantile( p, mu, sigma );
-        printf( "p: %lf, µ: %lf, σ: %lf, Q(p;µ,σ): %lf\n", p, mu, sigma, y );
+        printf( "p: %lf, μ: %lf, σ: %lf, Q(p;μ,σ): %lf\n", p, mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.0, 5.0 );
 		y = stdlib_base_dists_anglit_quantile( p, mu, sigma );
-		printf( "p: %lf, µ: %lf, σ: %lf, Q(p;µ,σ): %lf\n", p, mu, sigma, y );
+		printf( "p: %lf, μ: %lf, σ: %lf, Q(p;μ,σ): %lf\n", p, mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/examples/index.js
@@ -29,4 +29,4 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 5.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, σ: %0.4f, Q(p;µ,σ): %0.4f', p, mu, sigma, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, σ: %0.4f, Q(p;μ,σ): %0.4f', p, mu, sigma, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/README.md
@@ -113,7 +113,7 @@ var opts = {
 var mu = uniform( 10, -50.0, 50.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, SD(X;µ,σ): %0.4f', mu, sigma, stdev );
+logEachMap( 'μ: %0.4f, σ: %0.4f, SD(X;μ,σ): %0.4f', mu, sigma, stdev );
 ```
 
 </section>
@@ -202,7 +202,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_anglit_stdev( mu, sigma );
-        printf( "µ: %lf, σ: %lf, SD(X;µ,σ): %lf\n", mu, sigma, y );
+        printf( "μ: %lf, σ: %lf, SD(X;μ,σ): %lf\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_anglit_stdev( mu, sigma );
-		printf( "µ: %lf, σ: %lf, SD(X;µ,σ): %lf\n", mu, sigma, y );
+		printf( "μ: %lf, σ: %lf, SD(X;μ,σ): %lf\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var sigma = uniform( 10, 0.1, 20.0, opts );
 var mu = uniform( 10, -50.0, 50.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, SD(X;µ,σ): %0.4f', mu, sigma, stdev );
+logEachMap( 'μ: %0.4f, σ: %0.4f, SD(X;μ,σ): %0.4f', mu, sigma, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/README.md
@@ -116,7 +116,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Var(X;µ,σ): %0.4f', mu, sigma, variance );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Var(X;μ,σ): %0.4f', mu, sigma, variance );
 ```
 
 </section>
@@ -205,7 +205,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_anglit_variance( mu, sigma );
-        printf( "µ: %lf, σ: %lf, Var(X;µ,σ): %lf\n", mu, sigma, y );
+        printf( "μ: %lf, σ: %lf, Var(X;μ,σ): %lf\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_anglit_variance( mu, sigma );
-		printf( "µ: %lf, σ: %lf, Var(X;µ,σ): %lf\n", mu, sigma, y );
+		printf( "μ: %lf, σ: %lf, Var(X;μ,σ): %lf\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.1, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Var(X;µ,σ): %0.4f', mu, sigma, variance );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Var(X;μ,σ): %0.4f', mu, sigma, variance );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/README.md
@@ -140,7 +140,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, F(x;µ,s): %0.4f', x, mu, s, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, F(x;μ,s): %0.4f', x, mu, s, cdf );
 ```
 
 </section>
@@ -233,7 +233,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_cdf( x, mu, s );
-        printf( "x: %lf, µ: %lf, s: %lf, F(x;µ,s): %lf\n", x, mu, s, y );
+        printf( "x: %lf, μ: %lf, s: %lf, F(x;μ,s): %lf\n", x, mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_cdf( x, mu, s );
-		printf( "x: %lf, µ: %lf, s: %lf, F(x;µ,s): %lf\n", x, mu, s, y );
+		printf( "x: %lf, μ: %lf, s: %lf, F(x;μ,s): %lf\n", x, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, F(x;µ,s): %0.4f', x, mu, s, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, F(x;μ,s): %0.4f', x, mu, s, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Kurt(X;µ,s): %0.4f', mu, s, kurtosis );
+logEachMap( 'μ: %0.4f, s: %0.4f, Kurt(X;μ,s): %0.4f', mu, s, kurtosis );
 ```
 
 </section>
@@ -211,7 +211,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_kurtosis( mu, s );
-        printf( "µ: %lf, s: %lf, Kurt(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, Kurt(X;μ,s): %lf\n", mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_kurtosis( mu, s );
-		printf( "µ: %lf, s: %lf, Kurt(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, Kurt(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Kurt(X;µ,s): %0.4f', mu, s, kurtosis );
+logEachMap( 'μ: %0.4f, s: %0.4f, Kurt(X;μ,s): %0.4f', mu, s, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/README.md
@@ -150,7 +150,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, ln(F(x;µ,s)): %0.4f', x, mu, s, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, ln(F(x;μ,s)): %0.4f', x, mu, s, logcdf );
 ```
 
 </section>
@@ -243,7 +243,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_logcdf( x, mu, s );
-        printf( "x: %lf, µ: %lf, s: %lf, ln(F(x;µ,s)): %lf\n", x, mu, s, y );
+        printf( "x: %lf, μ: %lf, s: %lf, ln(F(x;μ,s)): %lf\n", x, mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_logcdf( x, mu, s );
-		printf( "x: %lf, µ: %lf, s: %lf, ln(F(x;µ,s)): %lf\n", x, mu, s, y );
+		printf( "x: %lf, μ: %lf, s: %lf, ln(F(x;μ,s)): %lf\n", x, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, ln(F(x;µ,s)): %0.4f', x, mu, s, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, ln(F(x;μ,s)): %0.4f', x, mu, s, logcdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/README.md
@@ -141,7 +141,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, ln(f(x;µ,s)): %0.4f', x, mu, s, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, ln(f(x;μ,s)): %0.4f', x, mu, s, logpdf );
 ```
 
 </section>
@@ -234,7 +234,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_logpdf( x, mu, s );
-        printf( "x: %lf, µ: %lf, s: %lf, ln(f(x;µ,s)): %lf\n", x, mu, s, y );
+        printf( "x: %lf, μ: %lf, s: %lf, ln(f(x;μ,s)): %lf\n", x, mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_logpdf( x, mu, s );
-		printf( "x: %lf, µ: %lf, s: %lf, ln(f(x;µ,s)): %lf\n", x, mu, s, y );
+		printf( "x: %lf, μ: %lf, s: %lf, ln(f(x;μ,s)): %lf\n", x, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, ln(f(x;µ,s)): %0.4f', x, mu, s, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, ln(f(x;μ,s)): %0.4f', x, mu, s, logpdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, E(X;µ,s): %0.4f', mu, s, mean );
+logEachMap( 'μ: %0.4f, s: %0.4f, E(X;μ,s): %0.4f', mu, s, mean );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_cosine_mean( mu, s );
-        printf( "µ: %lf, s: %lf, E(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, E(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_cosine_mean( mu, s );
-		printf( "µ: %lf, s: %lf, E(X;µ,s): %lf\n", mu , s , y );
+		printf( "μ: %lf, s: %lf, E(X;μ,s): %lf\n", mu , s , y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, E(X;µ,s): %0.4f', mu, s, mean );
+logEachMap( 'μ: %0.4f, s: %0.4f, E(X;μ,s): %0.4f', mu, s, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/median/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Median(X;µ,s): %0.4f', mu, s, median );
+logEachMap( 'μ: %0.4f, s: %0.4f, Median(X;μ,s): %0.4f', mu, s, median );
 ```
 
 </section>
@@ -211,7 +211,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_median( mu, s );
-        printf( "µ: %lf, s: %lf, Median(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, Median(X;μ,s): %lf\n", mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/median/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_median( mu, s );
-		printf( "µ: %lf, s: %lf, Median(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, Median(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/median/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Median(X;µ,s): %0.4f', mu, s, median );
+logEachMap( 'μ: %0.4f, s: %0.4f, Median(X;μ,s): %0.4f', mu, s, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/README.md
@@ -124,7 +124,7 @@ var t = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, M_X(t;µ,s): %0.4f', t, mu, s, mgf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, M_X(t;μ,s): %0.4f', t, mu, s, mgf );
 ```
 
 </section>
@@ -217,7 +217,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_mgf( t, mu, s );
-        printf( "t: %lf, µ: %lf, s: %lf, M_X(t;µ,s): %lf\n", t, mu, s, y );
+        printf( "t: %lf, μ: %lf, s: %lf, M_X(t;μ,s): %lf\n", t, mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_mgf( t, mu, s );
-		printf( "t: %lf, µ: %lf, s: %lf, M_X(t;µ,s): %lf\n", t, mu, s, y );
+		printf( "t: %lf, μ: %lf, s: %lf, M_X(t;μ,s): %lf\n", t, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/examples/index.js
@@ -29,4 +29,4 @@ var t = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, M_X(t;µ,s): %0.4f', t, mu, s, mgf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, M_X(t;μ,s): %0.4f', t, mu, s, mgf );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, mode(X;µ,s): %0.4f', mu, s, mode );
+logEachMap( 'μ: %0.4f, s: %0.4f, mode(X;μ,s): %0.4f', mu, s, mode );
 ```
 
 </section>
@@ -211,7 +211,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_mode( mu, s );
-        printf( "µ: %lf, s: %lf, mode(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, mode(X;μ,s): %lf\n", mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_mode( mu, s );
-		printf( "µ: %lf, s: %lf, mode(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, mode(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, mode(X;µ,s): %0.4f', mu, s, mode );
+logEachMap( 'μ: %0.4f, s: %0.4f, mode(X;μ,s): %0.4f', mu, s, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/README.md
@@ -131,7 +131,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, f(x;µ,s): %0.4f', x, mu, s, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, f(x;μ,s): %0.4f', x, mu, s, pdf );
 ```
 
 </section>
@@ -224,7 +224,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_pdf( x, mu, s );
-        printf( "x: %lf, µ: %lf, s: %lf, f(x;µ,s): %lf\n", x, mu, s, y );
+        printf( "x: %lf, μ: %lf, s: %lf, f(x;μ,s): %lf\n", x, mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_pdf( x, mu, s );
-		printf( "x: %lf, µ: %lf, s: %lf, f(x;µ,s): %lf\n", x, mu, s, y );
+		printf( "x: %lf, μ: %lf, s: %lf, f(x;μ,s): %lf\n", x, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, f(x;µ,s): %0.4f', x, mu, s, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, f(x;μ,s): %0.4f', x, mu, s, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/README.md
@@ -124,7 +124,7 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, s: %0.4f, Q(p;µ,s): %0.4f', p, mu, s, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, s: %0.4f, Q(p;μ,s): %0.4f', p, mu, s, quantile );
 ```
 
 </section>
@@ -217,7 +217,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_quantile( p, mu, s );
-        printf( "p: %.4f, µ: %.4f, s: %.4f, Q(p;µ,s): %.4f\n", p, mu, s, y );
+        printf( "p: %.4f, μ: %.4f, s: %.4f, Q(p;μ,s): %.4f\n", p, mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_quantile( p, mu, s );
-		printf( "p:%.4f, µ: %.4f, s: %.4f, Q(p;µ,s): %.4f\n", p, mu, s, y );
+		printf( "p:%.4f, μ: %.4f, s: %.4f, Q(p;μ,s): %.4f\n", p, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/examples/index.js
@@ -30,4 +30,4 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, EPS, 10.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, s: %0.4f, Q(p;µ,s): %0.4f', p, mu, s, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, s: %0.4f, Q(p;μ,s): %0.4f', p, mu, s, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, skew(X;µ,s): %0.4f', mu, s, skewness );
+logEachMap( 'μ: %0.4f, s: %0.4f, skew(X;μ,s): %0.4f', mu, s, skewness );
 ```
 
 </section>
@@ -211,7 +211,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_skewness( mu, s );
-        printf( "µ: %lf, s: %lf, Skew(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, Skew(X;μ,s): %lf\n", mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_skewness( mu, s );
-		printf( "µ: %lf, s: %lf, skew(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, skew(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, skew(X;µ,s): %0.4f', mu, s, skewness );
+logEachMap( 'μ: %0.4f, s: %0.4f, skew(X;μ,s): %0.4f', mu, s, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, SD(X;µ,s): %0.4f', mu, s, stdev );
+logEachMap( 'μ: %0.4f, s: %0.4f, SD(X;μ,s): %0.4f', mu, s, stdev );
 ```
 
 </section>
@@ -211,7 +211,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_cosine_stdev( mu, s );
-        printf( "µ: %lf, s: %lf, SD(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, SD(X;μ,s): %lf\n", mu, s, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		s = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_cosine_stdev( mu, s );
-		printf( "µ: %lf, s: %lf, SD(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, SD(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, SD(X;µ,s): %0.4f', mu, s, stdev );
+logEachMap( 'μ: %0.4f, s: %0.4f, SD(X;μ,s): %0.4f', mu, s, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Var(X;µ,s): %0.4f', mu, s, variance );
+logEachMap( 'μ: %0.4f, s: %0.4f, Var(X;μ,s): %0.4f', mu, s, variance );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_cosine_variance( mu, s );
-        printf( "µ: %lf, s: %lf, Var(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, Var(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_cosine_variance( mu, s );
-		printf( "µ: %lf, s: %lf, Var(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, Var(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Var(X;µ,s): %0.4f', mu, s, variance );
+logEachMap( 'μ: %0.4f, s: %0.4f, Var(X;μ,s): %0.4f', mu, s, variance );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/cdf/README.md
@@ -39,7 +39,7 @@ F(x;\mu)={\begin{cases}1, & x \geq \mu,\\0,& x < \mu.\end{cases}}
 
 <!-- </equation> -->
 
-where `µ` is the constant value of the distribution.
+where `μ` is the constant value of the distribution.
 
 </section>
 
@@ -103,7 +103,7 @@ var opts = {
 var x = discreteUniform( 10, 0, 10, opts );
 var mu = discreteUniform( 10, 0, 10, opts );
 
-logEachMap( 'x: %d, µ: %d, F(x;µ): %0.4f', x, mu, cdf );
+logEachMap( 'x: %d, μ: %d, F(x;μ): %0.4f', x, mu, cdf );
 ```
 
 </section>
@@ -193,7 +193,7 @@ int main( void ) {
         x = stdlib_base_round( random_uniform( 0.0, 10.0 ) );
         mu = stdlib_base_round( random_uniform( 0.0, 10.0 ) );
         y = stdlib_base_dists_degenerate_cdf( x, mu );
-        printf( "x: %lf, µ: %lf, F(x;µ): %lf\n", x, mu, y );
+        printf( "x: %lf, μ: %lf, F(x;μ): %lf\n", x, mu, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/cdf/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		x = stdlib_base_round( random_uniform( 0.0, 10.0 ) );
 		mu = stdlib_base_round( random_uniform( 0.0, 10.0 ) );
 		y = stdlib_base_dists_degenerate_cdf( x, mu );
-		printf( "x: %lf, µ: %lf, F(x;µ): %lf\n", x, mu, y );
+		printf( "x: %lf, μ: %lf, F(x;μ): %lf\n", x, mu, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/cdf/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var x = discreteUniform( 10, 0, 10, opts );
 var mu = discreteUniform( 10, 0, 10, opts );
 
-logEachMap( 'x: %d, µ: %d, F(x;µ): %0.4f', x, mu, cdf );
+logEachMap( 'x: %d, μ: %d, F(x;μ): %0.4f', x, mu, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/entropy/README.md
@@ -102,7 +102,7 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, H(X;µ): %0.4f', mu, entropy );
+logEachMap( 'μ: %0.4f, H(X;μ): %0.4f', mu, entropy );
 ```
 
 </section>
@@ -188,7 +188,7 @@ int main( void ) {
     for ( i = 0; i < 10; i++ ) {
         mu = random_uniform( 0.0, 1.0 );
         y = stdlib_base_dists_degenerate_entropy( mu );
-        printf( "µ: %lf, H(X;µ): %lf\n", mu, y );
+        printf( "μ: %lf, H(X;μ): %lf\n", mu, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/entropy/examples/c/example.c
@@ -33,6 +33,6 @@ int main( void ) {
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( 0.0, 1.0 );
 		y = stdlib_base_dists_degenerate_entropy( mu );
-		printf( "µ: %lf, H(X;µ): %lf\n", mu, y );
+		printf( "μ: %lf, H(X;μ): %lf\n", mu, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/entropy/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, H(X;µ): %0.4f', mu, entropy );
+logEachMap( 'μ: %0.4f, H(X;μ): %0.4f', mu, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logcdf/README.md
@@ -39,7 +39,7 @@ F(x;\mu) = {\begin{cases}1, & x \geq \mu,\\0, & x < \mu.\end{cases}}
 
 <!-- </equation> -->
 
-where `µ` is the constant value of the distribution.
+where `μ` is the constant value of the distribution.
 
 </section>
 
@@ -103,7 +103,7 @@ var opts = {
 var x = discreteUniform( 10, 0, 10, opts );
 var mu = discreteUniform( 10, 0, 10, opts );
 
-logEachMap( 'x: %d, µ: %d, ln(F(x;µ)): %0.4f', x, mu, logcdf );
+logEachMap( 'x: %d, μ: %d, ln(F(x;μ)): %0.4f', x, mu, logcdf );
 ```
 
 </section>
@@ -193,7 +193,7 @@ int main( void ) {
         x = stdlib_base_round( random_uniform( 0.0, 10.0 ) );
         mu = stdlib_base_round( random_uniform( 0.0, 10.0 ) );
         y = stdlib_base_dists_degenerate_logcdf( x, mu );
-        printf( "x: %lf, µ: %lf, ln(F(x;µ)): %lf\n", x, mu, y );
+        printf( "x: %lf, μ: %lf, ln(F(x;μ)): %lf\n", x, mu, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logcdf/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		x = stdlib_base_round( random_uniform( 0.0, 10.0 ) );
 		mu = stdlib_base_round( random_uniform( 0.0, 10.0 ) );
 		y = stdlib_base_dists_degenerate_logcdf( x, mu );
-		printf( "x: %lf, µ: %lf, ln(F(x;µ)): %lf\n", x, mu, y );
+		printf( "x: %lf, μ: %lf, ln(F(x;μ)): %lf\n", x, mu, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logcdf/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var x = discreteUniform( 10, 0, 10, opts );
 var mu = discreteUniform( 10, 0, 10, opts );
 
-logEachMap( 'x: %d, µ: %d, ln(F(x;µ)): %0.4f', x, mu, logcdf );
+logEachMap( 'x: %d, μ: %d, ln(F(x;μ)): %0.4f', x, mu, logcdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/README.md
@@ -116,7 +116,7 @@ var opts = {
 var x = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %d, µ: %d, ln(f(x;µ)): %0.4f', x, mu, logpdf );
+logEachMap( 'x: %d, μ: %d, ln(f(x;μ)): %0.4f', x, mu, logpdf );
 ```
 
 </section>
@@ -205,7 +205,7 @@ int main( void ) {
         x = random_uniform( 0.0, 5.0 );
         mu = random_uniform( 0.0, 5.0 );
         y = stdlib_base_dists_degenerate_logpdf( x, mu );
-        printf( "x: %lf, µ: %lf, ln(f(x;µ)): %lf\n", x, mu, y );
+        printf( "x: %lf, μ: %lf, ln(f(x;μ)): %lf\n", x, mu, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		x = random_uniform( 0.0, 5.0 );
 		mu = random_uniform( 0.0, 5.0 );
 		y = stdlib_base_dists_degenerate_logpdf( x, mu );
-		printf( "x: %lf, µ: %lf, ln(f(x;µ)): %lf\n", x, mu, y );
+		printf( "x: %lf, μ: %lf, ln(f(x;μ)): %lf\n", x, mu, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var x = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %d, µ: %d, ln(f(x;µ)): %0.4f', x, mu, logpdf );
+logEachMap( 'x: %d, μ: %d, ln(f(x;μ)): %0.4f', x, mu, logpdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
@@ -86,7 +86,7 @@ var opts = {
 var x = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %d, µ: %d, ln(P(X=x;µ)): %0.4f', x, mu, logpmf );
+logEachMap( 'x: %d, μ: %d, ln(P(X=x;μ)): %0.4f', x, mu, logpmf );
 ```
 
 </section>
@@ -176,7 +176,7 @@ int main( void ) {
         x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         result = stdlib_base_dists_degenerate_logpmf( x, mu );
-        printf( "x: %lf, µ: %lf, ln(P(X=x;µ)): %lf \n", x, mu, result );
+        printf( "x: %lf, μ: %lf, ln(P(X=x;μ)): %lf \n", x, mu, result );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		result = stdlib_base_dists_degenerate_logpmf( x, mu );
-		printf( "x: %lf, µ: %lf, ln(P(X=x;µ)): %lf \n", x, mu, result );
+		printf( "x: %lf, μ: %lf, ln(P(X=x;μ)): %lf \n", x, mu, result );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var x = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %d, µ: %d, ln(P(X=x;µ)): %0.4f', x, mu, logpmf );
+logEachMap( 'x: %d, μ: %d, ln(P(X=x;μ)): %0.4f', x, mu, logpmf );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/README.md
@@ -99,7 +99,7 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, E(X;µ): %0.4f', mu, mean );
+logEachMap( 'μ: %0.4f, E(X;μ): %0.4f', mu, mean );
 ```
 
 </section>
@@ -185,7 +185,7 @@ int main( void ) {
     for ( i = 0; i < 25; i++ ) {
         mu = random_uniform( 0.0, 1.0 );
         v = stdlib_base_dists_degenerate_mean( mu );
-        printf( "µ: %lf, E(X;µ): %lf\n", mu, v );
+        printf( "μ: %lf, E(X;μ): %lf\n", mu, v );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/examples/c/example.c
@@ -33,6 +33,6 @@ int main( void ) {
 	for ( i = 0; i < 25; i++ ) {
 		mu = random_uniform( 0.0, 1.0 );
 		v = stdlib_base_dists_degenerate_mean( mu );
-		printf( "µ: %lf, E(X;µ): %lf\n", mu, v );
+		printf( "μ: %lf, E(X;μ): %lf\n", mu, v );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, E(X;µ): %0.4f', mu, mean );
+logEachMap( 'μ: %0.4f, E(X;μ): %0.4f', mu, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/README.md
@@ -99,7 +99,7 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, Median(X;µ): %0.4f', mu, median );
+logEachMap( 'μ: %0.4f, Median(X;μ): %0.4f', mu, median );
 ```
 
 </section>
@@ -185,7 +185,7 @@ int main( void ) {
     for ( i = 0; i < 10; i++ ) {
         mu = random_uniform( 0.0, 20.0 );
         m = stdlib_base_dists_degenerate_median( mu );
-        printf( "µ: %lf, Median(X;µ): %lf\n", mu, m );
+        printf( "μ: %lf, Median(X;μ): %lf\n", mu, m );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/examples/c/example.c
@@ -33,6 +33,6 @@ int main( void ) {
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( 0.0, 20.0 );
 		m = stdlib_base_dists_degenerate_median( mu );
-		printf( "µ: %lf, Median(X;µ): %lf\n", mu, m );
+		printf( "μ: %lf, Median(X;μ): %lf\n", mu, m );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, Median(X;µ): %0.4f', mu, median );
+logEachMap( 'μ: %0.4f, Median(X;μ): %0.4f', mu, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mgf/README.md
@@ -121,7 +121,7 @@ var opts = {
 var t = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, M_X(t;µ): %0.4f', t, mu, mgf );
+logEachMap( 'x: %0.4f, μ: %0.4f, M_X(t;μ): %0.4f', t, mu, mgf );
 ```
 
 </section>
@@ -211,7 +211,7 @@ int main( void ) {
         t = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         result = stdlib_base_dists_degenerate_mgf( t, mu );
-        printf( "t: %lf, µ: %lf, M_X(t;µ): %lf\n", t, mu, result );
+        printf( "t: %lf, μ: %lf, M_X(t;μ): %lf\n", t, mu, result );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mgf/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		t = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		result = stdlib_base_dists_degenerate_mgf( t, mu );
-		printf( "t: %lf, µ: %lf, M_X(t;µ): %lf\n", t, mu, result );
+		printf( "t: %lf, μ: %lf, M_X(t;μ): %lf\n", t, mu, result );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mgf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mgf/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var t = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, M_X(t;µ): %0.4f', t, mu, mgf );
+logEachMap( 'x: %0.4f, μ: %0.4f, M_X(t;μ): %0.4f', t, mu, mgf );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/README.md
@@ -99,7 +99,7 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, mode(X;µ): %0.4f', mu, mode );
+logEachMap( 'μ: %0.4f, mode(X;μ): %0.4f', mu, mode );
 ```
 
 </section>
@@ -185,7 +185,7 @@ int main( void ) {
     for ( i = 0; i < 10; i++ ) {
         mu = random_uniform( 0.0, 20.0 );
         m = stdlib_base_dists_degenerate_mode( mu );
-        printf( "µ: %lf, mode(X;µ): %lf\n", mu, m );
+        printf( "μ: %lf, mode(X;μ): %lf\n", mu, m );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/examples/c/example.c
@@ -33,6 +33,6 @@ int main( void ) {
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( 0.0, 20.0 );
 		m = stdlib_base_dists_degenerate_mode( mu );
-		printf( "µ: %lf, mode(X;µ): %lf\n", mu, m );
+		printf( "μ: %lf, mode(X;μ): %lf\n", mu, m );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, mode(X;µ): %0.4f', mu, mode );
+logEachMap( 'μ: %0.4f, mode(X;μ): %0.4f', mu, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/README.md
@@ -116,7 +116,7 @@ var opts = {
 var x = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %d, µ: %d, f(x;µ): %0.4f', x, mu, pdf );
+logEachMap( 'x: %d, μ: %d, f(x;μ): %0.4f', x, mu, pdf );
 ```
 
 </section>
@@ -206,7 +206,7 @@ int main( void ) {
         x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         result = stdlib_base_dists_degenerate_pdf( x, mu );
-        printf( "x: %lf, µ: %lf, f(x;µ): %lf \n", x, mu, result );
+        printf( "x: %lf, μ: %lf, f(x;μ): %lf \n", x, mu, result );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		result = stdlib_base_dists_degenerate_pdf( x, mu );
-		printf( "x: %lf, µ: %lf, f(x;µ): %lf \n", x, mu, result );
+		printf( "x: %lf, μ: %lf, f(x;μ): %lf \n", x, mu, result );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var x = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %d, µ: %d, f(x;µ): %0.4f', x, mu, pdf );
+logEachMap( 'x: %d, μ: %d, f(x;μ): %0.4f', x, mu, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/README.md
@@ -86,7 +86,7 @@ var opts = {
 var x = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %d, µ: %d, P(X=x;µ): %0.4f', x, mu, pmf );
+logEachMap( 'x: %d, μ: %d, P(X=x;μ): %0.4f', x, mu, pmf );
 ```
 
 </section>
@@ -176,7 +176,7 @@ int main( void ) {
         x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         result = stdlib_base_dists_degenerate_pmf( x, mu );
-        printf( "x: %lf, µ: %lf, P(X=x;µ): %lf \n", x, mu, result );
+        printf( "x: %lf, μ: %lf, P(X=x;μ): %lf \n", x, mu, result );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		result = stdlib_base_dists_degenerate_pmf( x, mu );
-		printf( "x: %lf, µ: %lf, P(X=x;µ): %lf \n", x, mu, result );
+		printf( "x: %lf, μ: %lf, P(X=x;μ): %lf \n", x, mu, result );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var x = discreteUniform( 100, 0, 5, opts );
 var mu = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'x: %d, µ: %d, P(X=x;µ): %0.4f', x, mu, pmf );
+logEachMap( 'x: %d, μ: %d, P(X=x;μ): %0.4f', x, mu, pmf );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/README.md
@@ -39,7 +39,7 @@ Q(p;\mu) = \inf \left\{x \in {\mathbb {R}}:p \leq F(x;\mu)\right\} = \mu
 
 <!-- </equation> -->
 
-for `0 <= p <= 1` and where `µ` is the constant value of the distribution.
+for `0 <= p <= 1` and where `μ` is the constant value of the distribution.
 
 </section>
 
@@ -100,7 +100,7 @@ var opts = {
 var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, Q(p;µ): %0.4f', p, mu, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, Q(p;μ): %0.4f', p, mu, quantile );
 ```
 
 </section>
@@ -189,7 +189,7 @@ int main( void ) {
         p = random_uniform( 0.0, 1.0 );
         mu = random_uniform( -20.0, 20.0 );
         result = stdlib_base_dists_degenerate_quantile( p, mu );
-        printf( "p: %lf, µ: %lf, Q(p;µ): %lf \n", p, mu, result );
+        printf( "p: %lf, μ: %lf, Q(p;μ): %lf \n", p, mu, result );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		p = random_uniform( 0.0, 1.0 );
 		mu = random_uniform( -20.0, 20.0 );
 		result = stdlib_base_dists_degenerate_quantile( p, mu );
-		printf( "p: %lf, µ: %lf, Q(p;µ): %lf \n", p, mu, result );
+		printf( "p: %lf, μ: %lf, Q(p;μ): %lf \n", p, mu, result );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, Q(p;µ): %0.4f', p, mu, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, Q(p;μ): %0.4f', p, mu, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/README.md
@@ -102,7 +102,7 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, SD(X;µ): %0.4f', mu, stdev );
+logEachMap( 'μ: %0.4f, SD(X;μ): %0.4f', mu, stdev );
 ```
 
 </section>
@@ -188,7 +188,7 @@ int main( void ) {
     for ( i = 0; i < 10; i++ ) {
         mu = random_uniform( -20.0, 20.0 );
         result = stdlib_base_dists_degenerate_stdev( mu );
-        printf( "µ: %lf, SD(X;µ): %lf\n", mu, result );
+        printf( "μ: %lf, SD(X;μ): %lf\n", mu, result );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/examples/c/example.c
@@ -33,6 +33,6 @@ int main( void ) {
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -20.0, 20.0 );
 		result = stdlib_base_dists_degenerate_stdev( mu );
-		printf( "µ: %lf, SD(X;µ): %lf\n", mu, result );
+		printf( "μ: %lf, SD(X;μ): %lf\n", mu, result );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, SD(X;µ): %0.4f', mu, stdev );
+logEachMap( 'μ: %0.4f, SD(X;μ): %0.4f', mu, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/README.md
@@ -102,7 +102,7 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, Var(X;µ): %0.4f', mu, variance );
+logEachMap( 'μ: %0.4f, Var(X;μ): %0.4f', mu, variance );
 ```
 
 </section>
@@ -188,7 +188,7 @@ int main( void ) {
     for ( i = 0; i < 25; i++ ) {
         mu = random_uniform( -50.0, 50.0 );
         y = stdlib_base_dists_degenerate_variance( mu );
-        printf( "µ: %lf, Var(X;µ): %lf\n", mu, y );
+        printf( "μ: %lf, Var(X;μ): %lf\n", mu, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/examples/c/example.c
@@ -33,6 +33,6 @@ int main( void ) {
 	for ( i = 0; i < 25; i++ ) {
 		mu = random_uniform( -50.0, 50.0 );
 		y = stdlib_base_dists_degenerate_variance( mu );
-		printf( "µ: %lf, Var(X;µ): %lf\n", mu, y );
+		printf( "μ: %lf, Var(X;μ): %lf\n", mu, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var mu = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'µ: %0.4f, Var(X;µ): %0.4f', mu, variance );
+logEachMap( 'μ: %0.4f, Var(X;μ): %0.4f', mu, variance );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/README.md
@@ -127,7 +127,7 @@ var beta = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var x = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, β: %0.4f, F(x;µ,β): %0.4f', x, mu, beta, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, β: %0.4f, F(x;μ,β): %0.4f', x, mu, beta, cdf );
 ```
 
 </section>
@@ -219,7 +219,7 @@ int main( void ) {
         mu = random_uniform( 0.0, 10.0 );
         beta = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_gumbel_cdf( x, mu, beta );
-        printf( "x: %lf, µ: %lf, β: %lf, F(x;µ,β): %lf\n", x, mu, beta, y );
+        printf( "x: %lf, μ: %lf, β: %lf, F(x;μ,β): %lf\n", x, mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		beta = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_gumbel_cdf( x, mu, beta );
-		printf( "x: %lf, µ: %lf, β: %lf, F(x;µ,β): %lf\n", x, mu, beta, y );
+		printf( "x: %lf, μ: %lf, β: %lf, F(x;μ,β): %lf\n", x, mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/cdf/examples/index.js
@@ -29,4 +29,4 @@ var beta = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var x = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, β: %0.4f, F(x;µ,β): %0.4f', x, mu, beta, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, β: %0.4f, F(x;μ,β): %0.4f', x, mu, beta, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/entropy/README.md
@@ -123,7 +123,7 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, h(X;µ,β): %0.4f', mu, beta, entropy );
+logEachMap( 'μ: %0.4f, β: %0.4f, h(X;μ,β): %0.4f', mu, beta, entropy );
 ```
 
 </section>
@@ -212,7 +212,7 @@ int main( void ) {
         mu = random_uniform( 0.0, 10.0 );
         beta = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_gumbel_entropy( mu, beta );
-        printf( "µ: %lf, β: %lf, h(X;µ,β): %lf\n", mu, beta, y );
+        printf( "μ: %lf, β: %lf, h(X;μ,β): %lf\n", mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/entropy/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		beta = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_gumbel_entropy( mu, beta );
-		printf( "µ: %lf, β: %lf, h(X;µ,β): %lf\n", mu, beta, y );
+		printf( "μ: %lf, β: %lf, h(X;μ,β): %lf\n", mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/entropy/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, h(X;µ,β): %0.4f', mu, beta, entropy );
+logEachMap( 'μ: %0.4f, β: %0.4f, h(X;μ,β): %0.4f', mu, beta, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/kurtosis/README.md
@@ -121,7 +121,7 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, Kurt(X;µ,β): %0.4f', mu, beta, kurtosis );
+logEachMap( 'μ: %0.4f, β: %0.4f, Kurt(X;μ,β): %0.4f', mu, beta, kurtosis );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         beta = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_gumbel_kurtosis( mu, beta );
-        printf( "µ: %lf, β: %lf, Kurt(X;µ,β): %lf\n", mu, beta, y );
+        printf( "μ: %lf, β: %lf, Kurt(X;μ,β): %lf\n", mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/kurtosis/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		beta = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_gumbel_kurtosis( mu, beta );
-		printf( "µ: %lf, β: %lf, Kurt(X;µ,β): %lf\n", mu, beta, y );
+		printf( "μ: %lf, β: %lf, Kurt(X;μ,β): %lf\n", mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/kurtosis/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, Kurt(X;µ,β): %0.4f', mu, beta, kurtosis );
+logEachMap( 'μ: %0.4f, β: %0.4f, Kurt(X;μ,β): %0.4f', mu, beta, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/logcdf/README.md
@@ -137,7 +137,7 @@ var beta = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var x = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, β: %0.4f, ln(F(x;µ,β)): %0.4f', x, mu, beta, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, β: %0.4f, ln(F(x;μ,β)): %0.4f', x, mu, beta, logcdf );
 ```
 
 </section>
@@ -229,7 +229,7 @@ int main( void ) {
         mu = random_uniform( 0.0, 10.0 );
         beta = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_gumbel_logcdf( x, mu, beta );
-        printf( "x: %lf, µ: %lf, β: %lf, ln(F(x;µ,β)): %lf\n", x, mu, beta, y );
+        printf( "x: %lf, μ: %lf, β: %lf, ln(F(x;μ,β)): %lf\n", x, mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/logcdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		beta = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_gumbel_logcdf( x, mu, beta );
-		printf( "x: %lf, µ: %lf, β: %lf, ln(F(x;µ,β)): %lf\n", x, mu, beta, y );
+		printf( "x: %lf, μ: %lf, β: %lf, ln(F(x;μ,β)): %lf\n", x, mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/logcdf/examples/index.js
@@ -29,4 +29,4 @@ var beta = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var x = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, β: %0.4f, ln(F(x;µ,β)): %0.4f', x, mu, beta, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, β: %0.4f, ln(F(x;μ,β)): %0.4f', x, mu, beta, logcdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/logpdf/README.md
@@ -137,7 +137,7 @@ var beta = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var x = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, β: %0.4f, ln(f(x;µ,β)): %0.4f', x, mu, beta, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, β: %0.4f, ln(f(x;μ,β)): %0.4f', x, mu, beta, logpdf );
 ```
 
 </section>
@@ -229,7 +229,7 @@ int main( void ) {
         mu = random_uniform( 0.0, 10.0 );
         beta = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_gumbel_logpdf( x, mu, beta );
-        printf( "x: %lf, µ: %lf, β: %lf, ln(f(x;µ,β)): %lf\n", x, mu, beta, y );
+        printf( "x: %lf, μ: %lf, β: %lf, ln(f(x;μ,β)): %lf\n", x, mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/logpdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/logpdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		beta = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_gumbel_logpdf( x, mu, beta );
-		printf( "x: %lf, µ: %lf, β: %lf, ln(f(x;µ,β)): %lf\n", x, mu, beta, y );
+		printf( "x: %lf, μ: %lf, β: %lf, ln(f(x;μ,β)): %lf\n", x, mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/logpdf/examples/index.js
@@ -29,4 +29,4 @@ var beta = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var x = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, β: %0.4f, ln(f(x;µ,β)): %0.4f', x, mu, beta, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, β: %0.4f, ln(f(x;μ,β)): %0.4f', x, mu, beta, logpdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/README.md
@@ -123,7 +123,7 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, E(X;µ,β): %0.4f', mu, beta, mean );
+logEachMap( 'μ: %0.4f, β: %0.4f, E(X;μ,β): %0.4f', mu, beta, mean );
 ```
 
 </section>
@@ -212,7 +212,7 @@ int main( void ) {
         mu = random_uniform( 0.0, 10.0 );
         beta = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_gumbel_mean( mu, beta );
-        printf( "µ: %lf, β: %lf, E(X;µ,β): %lf\n", mu, beta, y );
+        printf( "μ: %lf, β: %lf, E(X;μ,β): %lf\n", mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		beta = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_gumbel_mean( mu, beta );
-		printf( "µ: %lf, β: %lf, E(X;µ,β): %lf\n", mu, beta, y );
+		printf( "μ: %lf, β: %lf, E(X;μ,β): %lf\n", mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mean/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, E(X;µ,β): %0.4f', mu, beta, mean );
+logEachMap( 'μ: %0.4f, β: %0.4f, E(X;μ,β): %0.4f', mu, beta, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/README.md
@@ -123,7 +123,7 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, Median(X;µ,β): %0.4f', mu, beta, median );
+logEachMap( 'μ: %0.4f, β: %0.4f, Median(X;μ,β): %0.4f', mu, beta, median );
 ```
 
 </section>
@@ -212,7 +212,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         beta = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_gumbel_median( mu, beta );
-        printf( "µ: %lf, β: %lf, Median(X;µ,β): %lf\n", mu, beta, y );
+        printf( "μ: %lf, β: %lf, Median(X;μ,β): %lf\n", mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		beta = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_gumbel_median( mu, beta );
-		printf( "µ: %lf, β: %lf, Median(X;µ,β): %lf\n", mu, beta, y );
+		printf( "μ: %lf, β: %lf, Median(X;μ,β): %lf\n", mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/median/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, Median(X;µ,β): %0.4f', mu, beta, median );
+logEachMap( 'μ: %0.4f, β: %0.4f, Median(X;μ,β): %0.4f', mu, beta, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/README.md
@@ -147,7 +147,7 @@ var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var t = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 't: %0.4f, µ: %0.4f, β: %0.4f, M_X(t;µ,β): %0.4f', t, mu, beta, mgf );
+logEachMap( 't: %0.4f, μ: %0.4f, β: %0.4f, M_X(t;μ,β): %0.4f', t, mu, beta, mgf );
 ```
 
 </section>
@@ -239,7 +239,7 @@ int main( void ) {
         mu = random_uniform( 0.0, 10.0 );
         beta = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_gumbel_mgf( t, mu, beta );
-        printf( "t: %lf, µ: %lf, β: %lf, M_X(t;µ,β): %lf\n", t, mu, beta, y );
+        printf( "t: %lf, μ: %lf, β: %lf, M_X(t;μ,β): %lf\n", t, mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		beta = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_gumbel_mgf( t, mu, beta );
-		printf( "t: %lf, µ: %lf, β: %lf, M_X(t;µ,β): %lf\n", t, mu, beta, y );
+		printf( "t: %lf, μ: %lf, β: %lf, M_X(t;μ,β): %lf\n", t, mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mgf/examples/index.js
@@ -29,4 +29,4 @@ var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var t = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 't: %0.4f, µ: %0.4f, β: %0.4f, M_X(t;µ,β): %0.4f', t, mu, beta, mgf );
+logEachMap( 't: %0.4f, μ: %0.4f, β: %0.4f, M_X(t;μ,β): %0.4f', t, mu, beta, mgf );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mode/README.md
@@ -121,7 +121,7 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, mode(X;µ,β): %0.4f', mu, beta, mode );
+logEachMap( 'μ: %0.4f, β: %0.4f, mode(X;μ,β): %0.4f', mu, beta, mode );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         beta = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_gumbel_mode( mu, beta );
-        printf( "µ: %lf, β: %lf, mode(X;µ,β): %lf\n", mu, beta, y );
+        printf( "μ: %lf, β: %lf, mode(X;μ,β): %lf\n", mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mode/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		beta = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_gumbel_mode( mu, beta );
-		printf( "µ: %lf, β: %lf, mode(X;µ,β): %lf\n", mu, beta, y );
+		printf( "μ: %lf, β: %lf, mode(X;μ,β): %lf\n", mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/mode/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var beta = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, mode(X;µ,β): %0.4f', mu, beta, mode );
+logEachMap( 'μ: %0.4f, β: %0.4f, mode(X;μ,β): %0.4f', mu, beta, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/README.md
@@ -127,7 +127,7 @@ var beta = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var x = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, β: %0.4f, f(x;µ,β): %0.4f', x, mu, beta, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, β: %0.4f, f(x;μ,β): %0.4f', x, mu, beta, pdf );
 ```
 
 </section>
@@ -219,7 +219,7 @@ int main( void ) {
         mu = random_uniform( 0.0, 10.0 );
         beta = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_gumbel_pdf( x, mu, beta );
-        printf( "x: %lf, µ: %lf, β: %lf, f(x;µ,β): %lf\n", x, mu, beta, y );
+        printf( "x: %lf, μ: %lf, β: %lf, f(x;μ,β): %lf\n", x, mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		beta = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_gumbel_pdf( x, mu, beta );
-		printf( "x: %lf, µ: %lf, β: %lf, f(x;µ,β): %lf\n", x, mu, beta, y );
+		printf( "x: %lf, μ: %lf, β: %lf, f(x;μ,β): %lf\n", x, mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/pdf/examples/index.js
@@ -29,4 +29,4 @@ var beta = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var x = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, β: %0.4f, f(x;µ,β): %0.4f', x, mu, beta, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, β: %0.4f, f(x;μ,β): %0.4f', x, mu, beta, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/quantile/README.md
@@ -138,7 +138,7 @@ var beta = uniform( 100, EPS, 10.0, opts );
 var mu = uniform( 100, -5.0, 5.0, opts );
 var p = uniform( 100, 0.0, 1.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, β: %0.4f, Q(p;µ,β): %0.4f', p, mu, beta, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, β: %0.4f, Q(p;μ,β): %0.4f', p, mu, beta, quantile );
 ```
 
 </section>
@@ -231,7 +231,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         beta = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_gumbel_quantile( p, mu, beta );
-        printf( "p: %lf, µ: %lf, β: %lf, Q(p;µ,β): %lf\n", p, mu, beta, y );
+        printf( "p: %lf, μ: %lf, β: %lf, Q(p;μ,β): %lf\n", p, mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/quantile/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/quantile/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		beta = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_gumbel_quantile( p, mu, beta );
-		printf( "p: %lf, µ: %lf, β: %lf, Q(p;µ,β): %lf\n", p, mu, beta, y );
+		printf( "p: %lf, μ: %lf, β: %lf, Q(p;μ,β): %lf\n", p, mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/quantile/examples/index.js
@@ -30,4 +30,4 @@ var beta = uniform( 100, EPS, 10.0, opts );
 var mu = uniform( 100, -5.0, 5.0, opts );
 var p = uniform( 100, 0.0, 1.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, β: %0.4f, Q(p;µ,β): %0.4f', p, mu, beta, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, β: %0.4f, Q(p;μ,β): %0.4f', p, mu, beta, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/skewness/README.md
@@ -123,7 +123,7 @@ var opts = {
 var beta = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, skew(X;µ,β): %0.4f', mu, beta, skewness );
+logEachMap( 'μ: %0.4f, β: %0.4f, skew(X;μ,β): %0.4f', mu, beta, skewness );
 ```
 
 </section>
@@ -212,7 +212,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         beta = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_gumbel_skewness( mu, beta );
-        printf( "µ: %lf, β: %lf, Skew(X;µ,β): %lf\n", mu, beta, y );
+        printf( "μ: %lf, β: %lf, Skew(X;μ,β): %lf\n", mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/skewness/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		beta = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_gumbel_skewness( mu, beta );
-		printf( "µ: %lf, β: %lf, Skew(X;µ,β): %lf\n", mu, beta, y );
+		printf( "μ: %lf, β: %lf, Skew(X;μ,β): %lf\n", mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/skewness/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var beta = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, skew(X;µ,β): %0.4f', mu, beta, skewness );
+logEachMap( 'μ: %0.4f, β: %0.4f, skew(X;μ,β): %0.4f', mu, beta, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/README.md
@@ -121,7 +121,7 @@ var opts = {
 var beta = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, SD(X;µ,β): %0.4f', mu, beta, stdev );
+logEachMap( 'μ: %0.4f, β: %0.4f, SD(X;μ,β): %0.4f', mu, beta, stdev );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         beta = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_gumbel_stdev( mu, beta );
-        printf( "µ: %lf, β: %lf, SD(X;µ,β): %lf\n", mu, beta, y );
+        printf( "μ: %lf, β: %lf, SD(X;μ,β): %lf\n", mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		beta = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_gumbel_stdev( mu, beta );
-		printf( "µ: %lf, β: %lf, SD(X;µ,β): %lf\n", mu, beta, y );
+		printf( "μ: %lf, β: %lf, SD(X;μ,β): %lf\n", mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/stdev/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var beta = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, SD(X;µ,β): %0.4f', mu, beta, stdev );
+logEachMap( 'μ: %0.4f, β: %0.4f, SD(X;μ,β): %0.4f', mu, beta, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/README.md
@@ -121,7 +121,7 @@ var opts = {
 var beta = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, Var(X;µ,β): %0.4f', mu, beta, variance );
+logEachMap( 'μ: %0.4f, β: %0.4f, Var(X;μ,β): %0.4f', mu, beta, variance );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         beta = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_gumbel_variance( mu, beta );
-        printf( "µ: %lf, β: %lf, Var(X;µ,β): %lf\n", mu, beta, y );
+        printf( "μ: %lf, β: %lf, Var(X;μ,β): %lf\n", mu, beta, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		beta = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_gumbel_variance( mu, beta );
-		printf( "µ: %lf, β: %lf, Var(X;µ,β): %lf\n", mu, beta, y );
+		printf( "μ: %lf, β: %lf, Var(X;μ,β): %lf\n", mu, beta, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/variance/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var beta = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, β: %0.4f, Var(X;µ,β): %0.4f', mu, beta, variance );
+logEachMap( 'μ: %0.4f, β: %0.4f, Var(X;μ,β): %0.4f', mu, beta, variance );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/cdf/README.md
@@ -124,7 +124,7 @@ var x = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %04f, µ: %04f, b: %04f, F(x;µ,b): %04f', x, mu, b, cdf );
+logEachMap( 'x: %04f, μ: %04f, b: %04f, F(x;μ,b): %04f', x, mu, b, cdf );
 ```
 
 </section>
@@ -216,7 +216,7 @@ int main( void ) {
         b = random_uniform( 0.0, 20.0 );
         x = random_uniform( 0.0, 1.0 );
         y = stdlib_base_dists_laplace_cdf( x, mu, b );
-        printf( "x: %lf, µ: %lf, b: %lf, F(x;µ,b): %lf\n", x, mu, b, y );
+        printf( "x: %lf, μ: %lf, b: %lf, F(x;μ,b): %lf\n", x, mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/cdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		b = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_laplace_cdf( x, mu, b );
-		printf( "x: %lf, µ: %lf, b: %lf, F(x;µ,b): %lf\n", x, mu, b, y );
+		printf( "x: %lf, μ: %lf, b: %lf, F(x;μ,b): %lf\n", x, mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/cdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %04f, µ: %04f, b: %04f, F(x;µ,b): %04f', x, mu, b, cdf );
+logEachMap( 'x: %04f, μ: %04f, b: %04f, F(x;μ,b): %04f', x, mu, b, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/entropy/README.md
@@ -123,7 +123,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, h(X;µ,b): %0.4f', mu, b, entropy );
+logEachMap( 'μ: %0.4f, b: %0.4f, h(X;μ,b): %0.4f', mu, b, entropy );
 ```
 
 </section>
@@ -212,7 +212,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         b = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_entropy( mu, b );
-        printf( "µ: %lf, b: %lf, h(X;µ,b): %lf\n", mu, b, y );
+        printf( "μ: %lf, b: %lf, h(X;μ,b): %lf\n", mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/entropy/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		b = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_entropy( mu, b );
-		printf( "µ: %lf, b: %lf, h(X;µ,b): %lf\n", mu, b, y );
+		printf( "μ: %lf, b: %lf, h(X;μ,b): %lf\n", mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/entropy/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, h(X;µ,b): %0.4f', mu, b, entropy );
+logEachMap( 'μ: %0.4f, b: %0.4f, h(X;μ,b): %0.4f', mu, b, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/kurtosis/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, Kurt(X;µ,b): %0.4f', mu, b, kurtosis );
+logEachMap( 'μ: %0.4f, b: %0.4f, Kurt(X;μ,b): %0.4f', mu, b, kurtosis );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         b = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_kurtosis( mu, b );
-        printf( "µ: %lf, b: %lf, Kurt(X;µ,b): %lf\n", mu, b, y );
+        printf( "μ: %lf, b: %lf, Kurt(X;μ,b): %lf\n", mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/kurtosis/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		b = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_kurtosis( mu, b );
-		printf( "µ: %lf, b: %lf, Kurt(X;µ,b): %lf\n", mu, b, y );
+		printf( "μ: %lf, b: %lf, Kurt(X;μ,b): %lf\n", mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/kurtosis/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, Kurt(X;µ,b): %0.4f', mu, b, kurtosis );
+logEachMap( 'μ: %0.4f, b: %0.4f, Kurt(X;μ,b): %0.4f', mu, b, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/README.md
@@ -134,7 +134,7 @@ var x = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, b: %0.4f, ln(F(x;µ,b)): %0.4f', x, mu, b, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, b: %0.4f, ln(F(x;μ,b)): %0.4f', x, mu, b, logcdf );
 ```
 
 </section>
@@ -226,7 +226,7 @@ int main( void ) {
         b = random_uniform( 0.0, 20.0 );
         x = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_logcdf( x, mu, b );
-        printf( "x: %lf, µ: %lf, b: %lf, ln(F(x;µ,b)): %lf\n", x, mu, b, y );
+        printf( "x: %lf, μ: %lf, b: %lf, ln(F(x;μ,b)): %lf\n", x, mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		x = random_uniform( -5.0, 5.0 );
 		b = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_logcdf( x, mu, b );
-		printf( "x: %lf, µ: %lf, b: %lf, ln(F(x;µ,b)): %lf\n", x, mu, b, y );
+		printf( "x: %lf, μ: %lf, b: %lf, ln(F(x;μ,b)): %lf\n", x, mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, b: %0.4f, ln(F(x;µ,b)): %0.4f', x, mu, b, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, b: %0.4f, ln(F(x;μ,b)): %0.4f', x, mu, b, logcdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/README.md
@@ -140,7 +140,7 @@ var x = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, b: %0.4f, ln(f(x;µ,b)): %0.4f', x, mu, b, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, b: %0.4f, ln(f(x;μ,b)): %0.4f', x, mu, b, logpdf );
 ```
 
 </section>
@@ -232,7 +232,7 @@ int main( void ) {
         b = random_uniform( 0.0, 20.0 );
         x = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_logpdf( x, mu, b );
-        printf( "x: %lf, µ: %lf, b: %lf, ln(f(x;µ,b)): %lf\n", x, mu, b, y );
+        printf( "x: %lf, μ: %lf, b: %lf, ln(f(x;μ,b)): %lf\n", x, mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		x = random_uniform( -5.0, 5.0 );
 		b = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_logpdf( x, mu, b );
-		printf( "x: %lf, µ: %lf, b: %lf, ln(f(x;µ,b)): %lf\n", x, mu, b, y );
+		printf( "x: %lf, μ: %lf, b: %lf, ln(f(x;μ,b)): %lf\n", x, mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logpdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, b: %0.4f, ln(f(x;µ,b)): %0.4f', x, mu, b, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, b: %0.4f, ln(f(x;μ,b)): %0.4f', x, mu, b, logpdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, E(X;µ,b): %0.4f', mu, b, mean );
+logEachMap( 'μ: %0.4f, b: %0.4f, E(X;μ,b): %0.4f', mu, b, mean );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         scale = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_mean( mu, scale );
-        printf( "µ: %lf, scale: %lf, E(X;µ,scale): %lf\n", mu, scale, y );
+        printf( "μ: %lf, scale: %lf, E(X;μ,scale): %lf\n", mu, scale, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		scale = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_mean( mu, scale );
-		printf( "µ: %lf, scale: %lf, E(X;µ,scale): %lf\n", mu, scale, y );
+		printf( "μ: %lf, scale: %lf, E(X;μ,scale): %lf\n", mu, scale, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mean/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, E(X;µ,b): %0.4f', mu, b, mean );
+logEachMap( 'μ: %0.4f, b: %0.4f, E(X;μ,b): %0.4f', mu, b, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/median/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, Median(X;µ,b): %0.4f', mu, b, median );
+logEachMap( 'μ: %0.4f, b: %0.4f, Median(X;μ,b): %0.4f', mu, b, median );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         scale = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_median( mu, scale );
-        printf( "µ: %lf, scale: %lf, Median(X;µ,scale): %lf\n", mu, scale, y );
+        printf( "μ: %lf, scale: %lf, Median(X;μ,scale): %lf\n", mu, scale, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/median/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		scale = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_median( mu, scale );
-		printf( "µ: %lf, scale: %lf, Median(X;µ,scale): %lf\n", mu, scale, y );
+		printf( "μ: %lf, scale: %lf, Median(X;μ,scale): %lf\n", mu, scale, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/median/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, Median(X;µ,b): %0.4f', mu, b, median );
+logEachMap( 'μ: %0.4f, b: %0.4f, Median(X;μ,b): %0.4f', mu, b, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/README.md
@@ -151,7 +151,7 @@ var t = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 't: %0.4f, µ: %0.4f, b: %0.4f, M_X(t;µ,b): %0.4f', t, mu, b, mgf );
+logEachMap( 't: %0.4f, μ: %0.4f, b: %0.4f, M_X(t;μ,b): %0.4f', t, mu, b, mgf );
 ```
 
 </section>
@@ -243,7 +243,7 @@ int main( void ) {
         b = random_uniform( 0.1, 20.0 );
         t = random_uniform( -1.0/b, 1.0/b );
         y = stdlib_base_dists_laplace_mgf( t, mu, b );
-        printf( "t: %lf, µ: %lf, b: %lf, M_X(t;µ,b): %lf\n", t, mu, b, y );
+        printf( "t: %lf, μ: %lf, b: %lf, M_X(t;μ,b): %lf\n", t, mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		b = random_uniform( 0.1, 20.0 );
 		t = random_uniform( -1.0/b, 1.0/b );
 		y = stdlib_base_dists_laplace_mgf( t, mu, b );
-		printf( "t: %lf, µ: %lf, b: %lf, M_X(t;µ,b): %lf\n", t, mu, b, y );
+		printf( "t: %lf, μ: %lf, b: %lf, M_X(t;μ,b): %lf\n", t, mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/examples/index.js
@@ -29,4 +29,4 @@ var t = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 't: %0.4f, µ: %0.4f, b: %0.4f, M_X(t;µ,b): %0.4f', t, mu, b, mgf );
+logEachMap( 't: %0.4f, μ: %0.4f, b: %0.4f, M_X(t;μ,b): %0.4f', t, mu, b, mgf );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, mode(X;µ,b): %0.4f', mu, b, mode );
+logEachMap( 'μ: %0.4f, b: %0.4f, mode(X;μ,b): %0.4f', mu, b, mode );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         b = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_mode( mu, b );
-        printf( "µ: %lf, b: %lf, mode(X;µ,b): %lf\n", mu, b, y );
+        printf( "μ: %lf, b: %lf, mode(X;μ,b): %lf\n", mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		b = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_mode( mu, b );
-		printf( "µ: %lf, b: %lf, mode(X;µ,b): %lf\n", mu, b, y );
+		printf( "μ: %lf, b: %lf, mode(X;μ,b): %lf\n", mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, mode(X;µ,b): %0.4f', mu, b, mode );
+logEachMap( 'μ: %0.4f, b: %0.4f, mode(X;μ,b): %0.4f', mu, b, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/README.md
@@ -130,7 +130,7 @@ var x = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, b: %0.4f, f(x;µ,b): %0.4f', x, mu, b, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, b: %0.4f, f(x;μ,b): %0.4f', x, mu, b, pdf );
 ```
 
 </section>
@@ -222,7 +222,7 @@ int main( void ) {
         mu = random_uniform( 0.0, 10.0 );
         b = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_laplace_pdf( x, mu, b );
-        printf( "x: %lf, µ: %lf, b: %lf, f(x;µ,b): %lf\n", x, mu, b, y );
+        printf( "x: %lf, μ: %lf, b: %lf, f(x;μ,b): %lf\n", x, mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		b = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_laplace_pdf( x, mu, b );
-		printf( "x: %lf, µ: %lf, b: %lf, f(x;µ,b): %lf\n", x, mu, b, y );
+		printf( "x: %lf, μ: %lf, b: %lf, f(x;μ,b): %lf\n", x, mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 100, 0.0, 10.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, b: %0.4f, f(x;µ,b): %0.4f', x, mu, b, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, b: %0.4f, f(x;μ,b): %0.4f', x, mu, b, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/README.md
@@ -134,7 +134,7 @@ var p = uniform( 100, 0.0, 1.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, b: %0.4f, Q(p;µ,b): %0.4f', p, mu, b, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, b: %0.4f, Q(p;μ,b): %0.4f', p, mu, b, quantile );
 ```
 
 </section>
@@ -226,7 +226,7 @@ int main( void ) {
         b = random_uniform( 0.0, 20.0 );
         p = random_uniform( 0.0, 1.0 );
         y = stdlib_base_dists_laplace_quantile( p, mu, b );
-        printf( "p: %lf, µ: %lf, b: %lf, Q(p;µ,b): %lf\n", p, mu, b, y );
+        printf( "p: %lf, μ: %lf, b: %lf, Q(p;μ,b): %lf\n", p, mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		b = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_quantile( p, mu, b );
-		printf( "p: %lf, µ: %lf, b: %lf, Q(p;µ,b): %lf\n", p, mu, b, y );
+		printf( "p: %lf, μ: %lf, b: %lf, Q(p;μ,b): %lf\n", p, mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/quantile/examples/index.js
@@ -29,4 +29,4 @@ var p = uniform( 100, 0.0, 1.0, opts );
 var mu = uniform( 100, 0.0, 10.0, opts );
 var b = uniform( 100, 0.0, 10.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, b: %0.4f, Q(p;µ,b): %0.4f', p, mu, b, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, b: %0.4f, Q(p;μ,b): %0.4f', p, mu, b, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/skewness/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, skew(X;µ,b): %0.4f', mu, b, skewness );
+logEachMap( 'μ: %0.4f, b: %0.4f, skew(X;μ,b): %0.4f', mu, b, skewness );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         b = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_skewness( mu, b );
-        printf( "µ: %lf, b: %lf, skew(X;µ,b): %lf\n", mu, b, y );
+        printf( "μ: %lf, b: %lf, skew(X;μ,b): %lf\n", mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/skewness/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		b = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_skewness( mu, b );
-		printf( "µ: %lf, b: %lf, skew(X;µ,b): %lf\n", mu, b, y );
+		printf( "μ: %lf, b: %lf, skew(X;μ,b): %lf\n", mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/skewness/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, skew(X;µ,b): %0.4f', mu, b, skewness );
+logEachMap( 'μ: %0.4f, b: %0.4f, skew(X;μ,b): %0.4f', mu, b, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, SD(X;µ,b): %0.4f', mu, b, stdev );
+logEachMap( 'μ: %0.4f, b: %0.4f, SD(X;μ,b): %0.4f', mu, b, stdev );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         b = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_stdev( mu, b );
-        printf( "µ: %lf, b: %lf, SD(X;µ,b): %lf\n", mu, b, y );
+        printf( "μ: %lf, b: %lf, SD(X;μ,b): %lf\n", mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		b = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_stdev( mu, b );
-		printf( "µ: %lf, b: %lf, SD(X;µ,b): %lf\n", mu, b, y );
+		printf( "μ: %lf, b: %lf, SD(X;μ,b): %lf\n", mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/stdev/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, SD(X;µ,b): %0.4f', mu, b, stdev );
+logEachMap( 'μ: %0.4f, b: %0.4f, SD(X;μ,b): %0.4f', mu, b, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/variance/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, Var(X;µ,b): %0.4f', mu, b, variance );
+logEachMap( 'μ: %0.4f, b: %0.4f, Var(X;μ,b): %0.4f', mu, b, variance );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         b = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_laplace_variance( mu, b );
-        printf( "µ: %lf, b: %lf, Var(X;µ,b): %lf\n", mu, b, y );
+        printf( "μ: %lf, b: %lf, Var(X;μ,b): %lf\n", mu, b, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/variance/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		b = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_laplace_variance( mu, b );
-		printf( "µ: %lf, b: %lf, Var(X;µ,b): %lf\n", mu, b, y );
+		printf( "μ: %lf, b: %lf, Var(X;μ,b): %lf\n", mu, b, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/variance/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var b = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, b: %0.4f, Var(X;µ,b): %0.4f', mu, b, variance );
+logEachMap( 'μ: %0.4f, b: %0.4f, Var(X;μ,b): %0.4f', mu, b, variance );

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/README.md
@@ -131,7 +131,7 @@ for ( i = 0; i < 100; i++ ) {
     x = ( randu()*10.0 ) + mu;
     c = ( randu()*10.0 ) + EPS;
     y = cdf( x, mu, c );
-    console.log( 'x: %d, µ: %d, c: %d, F(x;µ,c): %d', x.toFixed( 4 ), mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+    console.log( 'x: %d, μ: %d, c: %d, F(x;μ,c): %d', x.toFixed( 4 ), mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }
 ```
 
@@ -224,7 +224,7 @@ int main( void ) {
         mu = random_uniform( -20.0, 0.0 );
         c = random_uniform( 0.1, 10.0 );
         y = stdlib_base_dists_levy_cdf( x, mu, c );
-        printf( "x: %lf, µ: %lf, c: %lf, F(x;µ,c): %lf\n", x, mu, c, y );
+        printf( "x: %lf, μ: %lf, c: %lf, F(x;μ,c): %lf\n", x, mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( -20.0, 0.0 );
 		c = random_uniform( 0.1, 10.0 );
 		y = stdlib_base_dists_levy_cdf( x, mu, c );
-		printf( "x: %lf, µ: %lf, c: %lf, F(x;µ,c): %lf\n", x, mu, c, y );
+		printf( "x: %lf, μ: %lf, c: %lf, F(x;μ,c): %lf\n", x, mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/cdf/examples/index.js
@@ -33,5 +33,5 @@ for ( i = 0; i < 100; i++ ) {
 	x = ( randu()*10.0 ) + mu;
 	c = ( randu()*10.0 ) + EPS;
 	y = cdf( x, mu, c );
-	console.log( 'x: %d, µ: %d, c: %d, F(x;µ,c): %d', x.toFixed( 4 ), mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+	console.log( 'x: %d, μ: %d, c: %d, F(x;μ,c): %d', x.toFixed( 4 ), mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/README.md
@@ -125,7 +125,7 @@ for ( i = 0; i < 10; i++ ) {
     mu = ( randu()*10.0 ) - 5.0;
     c = randu() * 20.0;
     y = entropy( mu, c );
-    console.log( 'µ: %d, c: %d, h(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+    console.log( 'μ: %d, c: %d, h(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }
 ```
 
@@ -215,7 +215,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         c = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_levy_entropy( mu, c );
-        printf( "mu = %lf; c = %lf; h(X;µ,c) = %lf\n", mu, c, y );
+        printf( "mu = %lf; c = %lf; h(X;μ,c) = %lf\n", mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		c = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_levy_entropy( mu, c );
-		printf( "mu = %lf; c = %lf; h(X;µ,c) = %lf\n", mu, c, y );
+		printf( "mu = %lf; c = %lf; h(X;μ,c) = %lf\n", mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/entropy/examples/index.js
@@ -30,5 +30,5 @@ for ( i = 0; i < 10; i++ ) {
 	mu = ( randu()*10.0 ) - 5.0;
 	c = randu() * 20.0;
 	y = entropy( mu, c );
-	console.log( 'µ: %d, c: %d, h(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+	console.log( 'μ: %d, c: %d, h(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/README.md
@@ -141,7 +141,7 @@ for ( i = 0; i < 100; i++ ) {
     x = ( randu()*10.0 ) + mu;
     c = ( randu()*10.0 ) + EPS;
     y = logcdf( x, mu, c );
-    console.log( 'x: %d, µ: %d, c: %d, ln(F(x;µ,c)): %d', x.toFixed( 4 ), mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+    console.log( 'x: %d, μ: %d, c: %d, ln(F(x;μ,c)): %d', x.toFixed( 4 ), mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }
 ```
 
@@ -235,7 +235,7 @@ int main( void ) {
         x = random_uniform( mu, mu + 10.0 );
         c = random_uniform(STDLIB_CONSTANT_FLOAT64_EPS, 10.0 );
         y = stdlib_base_dists_levy_logcdf( x, mu, c );
-        printf( "x: %lf, µ: %lf, c: %lf, ln(F(x;µ,c)): %lf\n", x, mu, c, y );
+        printf( "x: %lf, μ: %lf, c: %lf, ln(F(x;μ,c)): %lf\n", x, mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		x = random_uniform( mu, mu + 10.0 );
 		c = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 10.0 );
 		y = stdlib_base_dists_levy_logcdf( x, mu, c );
-		printf( "x: %lf, µ: %lf, c: %lf, ln(F(x;µ,c)): %lf\n", x, mu, c, y );
+		printf( "x: %lf, μ: %lf, c: %lf, ln(F(x;μ,c)): %lf\n", x, mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logcdf/examples/index.js
@@ -33,5 +33,5 @@ for ( i = 0; i < 100; i++ ) {
 	x = ( randu()*10.0 ) + mu;
 	c = ( randu()*10.0 ) + EPS;
 	y = logcdf( x, mu, c );
-	console.log( 'x: %d, µ: %d, c: %d, ln(F(x;µ,c)): %d', x.toFixed( 4 ), mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+	console.log( 'x: %d, μ: %d, c: %d, ln(F(x;μ,c)): %d', x.toFixed( 4 ), mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/README.md
@@ -138,7 +138,7 @@ for ( i = 0; i < 10; i++ ) {
     x = ( randu()*10.0 ) + mu;
     c = ( randu()*10.0 ) + EPS;
     y = logpdf( x, mu, c );
-    console.log( 'x: %d, µ: %d, c: %d, ln(f(x;µ,c)): %d', x, mu, c, y );
+    console.log( 'x: %d, μ: %d, c: %d, ln(f(x;μ,c)): %d', x, mu, c, y );
 }
 ```
 
@@ -232,7 +232,7 @@ int main( void ) {
         x = random_uniform( mu, mu + 10.0 );
         c = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_levy_logpdf( x, mu, c );
-        printf( "x: %lf, µ: %lf, c: %lf, ln(f(x;µ,c)): %lf\n", x, mu, c, y );
+        printf( "x: %lf, μ: %lf, c: %lf, ln(f(x;μ,c)): %lf\n", x, mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		x = random_uniform( mu, mu + 10.0 );
 		c = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_levy_logpdf( x, mu, c );
-		printf( "x: %lf, µ: %lf, c: %lf, ln(f(x;µ,c)): %lf\n", x, mu, c, y );
+		printf( "x: %lf, μ: %lf, c: %lf, ln(f(x;μ,c)): %lf\n", x, mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/examples/index.js
@@ -33,5 +33,5 @@ for ( i = 0; i < 10; i++ ) {
 	x = ( randu()*10.0 ) + mu;
 	c = ( randu()*10.0 ) + EPS;
 	y = logpdf( x, mu, c );
-	console.log( 'x: %d, µ: %d, c: %d, ln(f(x;µ,c)): %d', x, mu, c, y );
+	console.log( 'x: %d, μ: %d, c: %d, ln(f(x;μ,c)): %d', x, mu, c, y );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mean/README.md
@@ -123,7 +123,7 @@ for ( i = 0; i < 10; i++ ) {
     mu = ( randu()*10.0 ) - 5.0;
     c = randu() * 20.0;
     y = mean( mu, c );
-    console.log( 'µ: %d, c: %d, E(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+    console.log( 'μ: %d, c: %d, E(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }
 ```
 
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         c = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_levy_mean( mu, c );
-        printf( "µ: %lf, c: %lf, E(X;µ,c): %lf\n", mu, c, y );
+        printf( "μ: %lf, c: %lf, E(X;μ,c): %lf\n", mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mean/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		c = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_levy_mean( mu, c );
-		printf( "µ: %lf, c: %lf, E(X;µ,c): %lf\n", mu, c, y );
+		printf( "μ: %lf, c: %lf, E(X;μ,c): %lf\n", mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mean/examples/index.js
@@ -30,5 +30,5 @@ for ( i = 0; i < 10; i++ ) {
 	mu = ( randu()*10.0 ) - 5.0;
 	c = randu() * 20.0;
 	y = mean( mu, c );
-	console.log( 'µ: %d, c: %d, E(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+	console.log( 'μ: %d, c: %d, E(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/median/README.md
@@ -123,7 +123,7 @@ for ( i = 0; i < 10; i++ ) {
     mu = ( randu()*10.0 ) - 5.0;
     c = randu() * 20.0;
     y = median( mu, c );
-    console.log( 'µ: %d, c: %d, Median(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+    console.log( 'μ: %d, c: %d, Median(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }
 ```
 
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         c = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_levy_median( mu, c );
-        printf( "µ: %lf, c: %lf, Median(X;µ,c): %lf\n", mu, c, y );
+        printf( "μ: %lf, c: %lf, Median(X;μ,c): %lf\n", mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/median/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		c = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_levy_median( mu, c );
-		printf( "µ: %lf, c: %lf, Median(X;µ,c): %lf\n", mu, c, y );
+		printf( "μ: %lf, c: %lf, Median(X;μ,c): %lf\n", mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/median/examples/index.js
@@ -30,5 +30,5 @@ for ( i = 0; i < 10; i++ ) {
 	mu = ( randu()*10.0 ) - 5.0;
 	c = randu() * 20.0;
 	y = median( mu, c );
-	console.log( 'µ: %d, c: %d, Median(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+	console.log( 'μ: %d, c: %d, Median(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mode/README.md
@@ -123,7 +123,7 @@ for ( i = 0; i < 10; i++ ) {
     mu = ( randu()*10.0 ) - 5.0;
     c = randu() * 20.0;
     y = mode( mu, c );
-    console.log( 'µ: %d, c: %d, mode(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+    console.log( 'μ: %d, c: %d, mode(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }
 ```
 
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         c = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_levy_mode( mu, c );
-        printf( "µ: %lf, c: %lf, mode(X;µ,c): %lf\n", mu, c, y );
+        printf( "μ: %lf, c: %lf, mode(X;μ,c): %lf\n", mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mode/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		c = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_levy_mode( mu, c );
-		printf( "µ: %lf, c: %lf, mode(X;µ,c): %lf\n", mu, c, y );
+		printf( "μ: %lf, c: %lf, mode(X;μ,c): %lf\n", mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/mode/examples/index.js
@@ -30,5 +30,5 @@ for ( i = 0; i < 10; i++ ) {
 	mu = ( randu()*10.0 ) - 5.0;
 	c = randu() * 20.0;
 	y = mode( mu, c );
-	console.log( 'µ: %d, c: %d, mode(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+	console.log( 'μ: %d, c: %d, mode(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/README.md
@@ -128,7 +128,7 @@ for ( i = 0; i < 10; i++ ) {
     x = uniform( mu, mu + 10.0 );
     c = uniform( EPS, 10.0 );
     y = pdf( x, mu, c );
-    console.log( 'x: %d, µ: %d, c: %d, f(x;µ,c): %d', x, mu, c, y );
+    console.log( 'x: %d, μ: %d, c: %d, f(x;μ,c): %d', x, mu, c, y );
 }
 ```
 
@@ -222,7 +222,7 @@ int main( void ) {
         x = random_uniform( mu, mu + 10.0 );
         c = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_levy_pdf( x, mu, c );
-        printf( "x: %lf, µ: %lf, c: %lf, f(x;µ,c): %lf\n", x, mu, c, y );
+        printf( "x: %lf, μ: %lf, c: %lf, f(x;μ,c): %lf\n", x, mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		x = random_uniform( mu, mu + 10.0 );
 		c = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_levy_pdf( x, mu, c );
-		printf( "x: %lf, µ: %lf, c: %lf, f(x;µ,c): %lf\n", x, mu, c, y );
+		printf( "x: %lf, μ: %lf, c: %lf, f(x;μ,c): %lf\n", x, mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/pdf/examples/index.js
@@ -33,5 +33,5 @@ for ( i = 0; i < 10; i++ ) {
 	x = ( randu()*10.0 ) + mu;
 	c = ( randu()*10.0 ) + EPS;
 	y = pdf( x, mu, c );
-	console.log( 'x: %d, µ: %d, c: %d, f(x;µ,c): %d', x, mu, c, y );
+	console.log( 'x: %d, μ: %d, c: %d, f(x;μ,c): %d', x, mu, c, y );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/README.md
@@ -39,7 +39,7 @@ Q(p;\mu,c)= \mu + \frac{c}{2 \cdot \mathop{\mathrm{erfcinv}}(p)^2}
 
 <!-- </equation> -->
 
-for `0 <= p < 1`, where `µ` is the location parameter and `c > 0` is the scale parameter.
+for `0 <= p < 1`, where `μ` is the location parameter and `c > 0` is the scale parameter.
 
 </section>
 
@@ -137,7 +137,7 @@ for ( i = 0; i < 10; i++ ) {
     mu = randu() * 10.0;
     c = randu() * 10.0;
     y = quantile( p, mu, c );
-    console.log( 'p: %d, µ: %d, c: %d, Q(p;µ,c): %d', p, mu, c, y );
+    console.log( 'p: %d, μ: %d, c: %d, Q(p;μ,c): %d', p, mu, c, y );
 }
 ```
 
@@ -229,7 +229,7 @@ int main( void ) {
         mu = random_uniform( 0.0, 10.0 );
         c = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_levy_quantile( p, mu, c );
-        printf( "p: %lf, µ: %lf, c: %lf, Q(p;µ,c): %lf\n", p, mu, c, y );
+        printf( "p: %lf, μ: %lf, c: %lf, Q(p;μ,c): %lf\n", p, mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		c = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_levy_quantile( p, mu, c );
-		printf( "p: %lf, µ: %lf, c: %lf, Q(p;µ,c): %lf\n", p, mu, c, y );
+		printf( "p: %lf, μ: %lf, c: %lf, Q(p;μ,c): %lf\n", p, mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/quantile/examples/index.js
@@ -32,5 +32,5 @@ for ( i = 0; i < 10; i++ ) {
 	mu = randu() * 10.0;
 	c = randu() * 10.0;
 	y = quantile( p, mu, c );
-	console.log( 'p: %d, µ: %d, c: %d, Q(p;µ,c): %d', p, mu, c, y );
+	console.log( 'p: %d, μ: %d, c: %d, Q(p;μ,c): %d', p, mu, c, y );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/stdev/README.md
@@ -123,7 +123,7 @@ for ( i = 0; i < 10; i++ ) {
     mu = ( randu()*10.0 ) - 5.0;
     c = randu() * 20.0;
     y = stdev( mu, c );
-    console.log( 'µ: %d, c: %d, SD(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+    console.log( 'μ: %d, c: %d, SD(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }
 ```
 
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         c = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_levy_stdev( mu, c );
-        printf( "µ: %lf, c: %lf, SD(X;µ,c): %lf\n", mu, c, y );
+        printf( "μ: %lf, c: %lf, SD(X;μ,c): %lf\n", mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/stdev/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		c = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_levy_stdev( mu, c );
-		printf( "µ: %lf, c: %lf, SD(X;µ,c): %lf\n", mu, c, y );
+		printf( "μ: %lf, c: %lf, SD(X;μ,c): %lf\n", mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/stdev/examples/index.js
@@ -30,5 +30,5 @@ for ( i = 0; i < 10; i++ ) {
 	mu = ( randu()*10.0 ) - 5.0;
 	c = randu() * 20.0;
 	y = stdev( mu, c );
-	console.log( 'µ: %d, c: %d, SD(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+	console.log( 'μ: %d, c: %d, SD(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/variance/README.md
@@ -123,7 +123,7 @@ for ( i = 0; i < 10; i++ ) {
     mu = ( randu()*10.0 ) - 5.0;
     c = randu() * 20.0;
     y = variance( mu, c );
-    console.log( 'µ: %d, c: %d, Var(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+    console.log( 'μ: %d, c: %d, Var(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }
 ```
 
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         c = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_levy_variance( mu, c );
-        printf( "µ: %lf, c: %lf, Var(X;µ,c): %lf\n", mu, c, y );
+        printf( "μ: %lf, c: %lf, Var(X;μ,c): %lf\n", mu, c, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/variance/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		c = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_levy_variance( mu, c );
-		printf( "µ: %lf, c: %lf, Var(X;µ,c): %lf\n", mu, c, y );
+		printf( "μ: %lf, c: %lf, Var(X;μ,c): %lf\n", mu, c, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/variance/examples/index.js
@@ -30,5 +30,5 @@ for ( i = 0; i < 10; i++ ) {
 	mu = ( randu()*10.0 ) - 5.0;
 	c = randu() * 20.0;
 	y = variance( mu, c );
-	console.log( 'µ: %d, c: %d, Var(X;µ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
+	console.log( 'μ: %d, c: %d, Var(X;μ,c): %d', mu.toFixed( 4 ), c.toFixed( 4 ), y.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/README.md
@@ -137,7 +137,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, F(x;µ,s): %0.4f', x, mu, s, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, F(x;μ,s): %0.4f', x, mu, s, cdf );
 ```
 
 </section>
@@ -229,7 +229,7 @@ int main( void ) {
         s = random_uniform( 0.0, 10.0 );
         x = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_logistic_cdf( x, mu, s );
-        printf( "x: %lf, µ: %lf, s: %lf, F(x;µ,s): %lf\n", x, mu, s, y );
+        printf( "x: %lf, μ: %lf, s: %lf, F(x;μ,s): %lf\n", x, mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		s = random_uniform( 0.0, 10.0 );
 		x = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_logistic_cdf( x, mu, s );
-		printf( "x: %lf, µ: %lf, s: %lf, F(x;µ,s): %lf\n", x, mu, s, y );
+		printf( "x: %lf, μ: %lf, s: %lf, F(x;μ,s): %lf\n", x, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/cdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, F(x;µ,s): %0.4f', x, mu, s, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, F(x;μ,s): %0.4f', x, mu, s, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, h(X;µ,s): %0.4f', mu, s, entropy );
+logEachMap( 'μ: %0.4f, s: %0.4f, h(X;μ,s): %0.4f', mu, s, entropy );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_entropy( mu, s );
-        printf( "µ: %lf, s: %lf, h(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, h(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 ) - 5.0;
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_logistic_entropy( mu, s );
-		printf( "µ: %lf, s: %lf, h(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, h(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, h(X;µ,s): %0.4f', mu, s, entropy );
+logEachMap( 'μ: %0.4f, s: %0.4f, h(X;μ,s): %0.4f', mu, s, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/kurtosis/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Kurt(X;µ,s): %0.4f', mu, s, kurtosis );
+logEachMap( 'μ: %0.4f, s: %0.4f, Kurt(X;μ,s): %0.4f', mu, s, kurtosis );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_kurtosis( mu, s );
-        printf( "µ: %lf, s: %lf, Kurt(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, Kurt(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/kurtosis/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_logistic_kurtosis( mu, s );
-		printf( "µ: %lf, s: %lf, Kurt(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, Kurt(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/kurtosis/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Kurt(X;µ,s): %0.4f', mu, s, kurtosis );
+logEachMap( 'μ: %0.4f, s: %0.4f, Kurt(X;μ,s): %0.4f', mu, s, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/README.md
@@ -147,7 +147,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, ln(F(x;µ,s)): %0.4f', x, mu, s, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, ln(F(x;μ,s)): %0.4f', x, mu, s, logcdf );
 ```
 
 </section>
@@ -239,7 +239,7 @@ int main( void ) {
         s = random_uniform( 0.0, 20.0 );
         x = random_uniform( -10.0, 10.0 );
         y = stdlib_base_dists_logistic_logcdf( x, mu, s );
-        printf( "x: %lf, µ: %lf, s: %lf, ln(F(x;µ,s)): %lf\n", x, mu, s, y );
+        printf( "x: %lf, μ: %lf, s: %lf, ln(F(x;μ,s)): %lf\n", x, mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		s = random_uniform( 0.0, 10.0 );
 		x = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_logistic_logcdf( x, mu, s );
-		printf( "x: %lf, µ: %lf, s: %lf, ln(F(x;µ,s)): %lf\n", x, mu, s, y );
+		printf( "x: %lf, μ: %lf, s: %lf, ln(F(x;μ,s)): %lf\n", x, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logcdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, ln(F(x;µ,s)): %0.4f', x, mu, s, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, ln(F(x;μ,s)): %0.4f', x, mu, s, logcdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logpdf/README.md
@@ -141,7 +141,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, ln(f(x;µ,s)): %0.4f', x, mu, s, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, ln(f(x;μ,s)): %0.4f', x, mu, s, logpdf );
 ```
 
 </section>
@@ -233,7 +233,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_logpdf( x, mu, s );
-        printf( "x: %lf, µ: %lf, s: %lf, ln(f(x;µ,s)): %lf\n", x, mu, s, y );
+        printf( "x: %lf, μ: %lf, s: %lf, ln(f(x;μ,s)): %lf\n", x, mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logpdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logpdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		s = random_uniform( -5.0, 5.0 );
 		x = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_logistic_logpdf( x, mu, s );
-		printf( "x: %lf, µ: %lf, s: %lf, ln(f(x;µ,s)): %lf\n", x, mu, s, y );
+		printf( "x: %lf, μ: %lf, s: %lf, ln(f(x;μ,s)): %lf\n", x, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/logpdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, ln(f(x;µ,s)): %0.4f', x, mu, s, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, ln(f(x;μ,s)): %0.4f', x, mu, s, logpdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, E(X;µ,s): %0.4f', mu, s, mean );
+logEachMap( 'μ: %0.4f, s: %0.4f, E(X;μ,s): %0.4f', mu, s, mean );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_mean( mu, s );
-        printf( "µ: %lf, s: %lf, E(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, E(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_logistic_mean( mu, s );
-		printf( "µ: %lf, s: %lf, E(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, E(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mean/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, E(X;µ,s): %0.4f', mu, s, mean );
+logEachMap( 'μ: %0.4f, s: %0.4f, E(X;μ,s): %0.4f', mu, s, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/median/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Median(X;µ,s): %0.4f', mu, s, median );
+logEachMap( 'μ: %0.4f, s: %0.4f, Median(X;μ,s): %0.4f', mu, s, median );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_median( mu, s );
-        printf( "µ: %lf, s: %lf, Median(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, Median(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/median/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_logistic_median( mu, s );
-		printf( "µ: %lf, s: %lf, Median(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, Median(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/median/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Median(X;µ,s): %0.4f', mu, s, median );
+logEachMap( 'μ: %0.4f, s: %0.4f, Median(X;μ,s): %0.4f', mu, s, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/README.md
@@ -141,7 +141,7 @@ var t = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 2.0, opts );
 
-logEachMap( 't: %0.4f, µ: %0.4f, s: %0.4f, M_X(t;µ,s): %0.4f', t, mu, s, mgf );
+logEachMap( 't: %0.4f, μ: %0.4f, s: %0.4f, M_X(t;μ,s): %0.4f', t, mu, s, mgf );
 ```
 
 </section>
@@ -233,7 +233,7 @@ int main( void ) {
         s = random_uniform( 0.0, 20.0 );
         t = random_uniform( 0.0, 10.0 );
         y = stdlib_base_dists_logistic_mgf( t, mu, s );
-        printf( "t: %lf, µ: %lf, s: %lf, M_X(t;µ,s): %lf\n", t, mu, s, y );
+        printf( "t: %lf, μ: %lf, s: %lf, M_X(t;μ,s): %lf\n", t, mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		s = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_logistic_mgf( t, mu, s );
-		printf( "t: %lf, µ: %lf, s: %lf, M_X(t;µ,s): %lf\n", t, mu, s, y );
+		printf( "t: %lf, μ: %lf, s: %lf, M_X(t;μ,s): %lf\n", t, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mgf/examples/index.js
@@ -29,4 +29,4 @@ var t = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 2.0, opts );
 
-logEachMap( 't: %0.4f, µ: %0.4f, s: %0.4f, M_X(t;µ,s): %0.4f', t, mu, s, mgf );
+logEachMap( 't: %0.4f, μ: %0.4f, s: %0.4f, M_X(t;μ,s): %0.4f', t, mu, s, mgf );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mode/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, mode(X;µ,s): %0.4f', mu, s, mode );
+logEachMap( 'μ: %0.4f, s: %0.4f, mode(X;μ,s): %0.4f', mu, s, mode );
 ```
 
 </section>
@@ -206,7 +206,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_mode( mu, s );
-        printf( "µ: %lf, s: %lf, mode(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, mode(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mode/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_logistic_mode( mu, s );
-		printf( "µ: %lf, s: %lf, mode(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, mode(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/mode/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, mode(X;µ,s): %0.4f', mu, s, mode );
+logEachMap( 'μ: %0.4f, s: %0.4f, mode(X;μ,s): %0.4f', mu, s, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/pdf/README.md
@@ -131,7 +131,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, f(x;µ,s): %0.4f', x, mu, s, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, f(x;μ,s): %0.4f', x, mu, s, pdf );
 ```
 
 </section>
@@ -223,7 +223,7 @@ int main( void ) {
         s = random_uniform( 0.0, 20.0 );
         x = random_uniform( -10.0, 10.0 );
         y = stdlib_base_dists_logistic_pdf( x, mu, s );
-        printf( "x: %lf, µ: %lf, s: %lf, f(x;µ,s): %lf\n", x, mu, s, y );
+        printf( "x: %lf, μ: %lf, s: %lf, f(x;μ,s): %lf\n", x, mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/pdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 );
 		s = random_uniform( 0.0, 10.0 );
 		y = stdlib_base_dists_logistic_pdf( x, mu, s );
-		printf( "x: %lf, µ: %lf, s: %lf, f(x;µ,s): %lf\n", x, mu, s, y );
+		printf( "x: %lf, μ: %lf, s: %lf, f(x;μ,s): %lf\n", x, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/pdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, s: %0.4f, f(x;µ,s): %0.4f', x, mu, s, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, s: %0.4f, f(x;μ,s): %0.4f', x, mu, s, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/quantile/README.md
@@ -39,7 +39,7 @@ Q(p;\mu,s)= \mu + s \ln \left( \frac{p}{1-p} \right )
 
 <!-- </equation> -->
 
-for `0 <= p < 1`, where `µ` is the location parameter and `s > 0` is the scale parameter.
+for `0 <= p < 1`, where `μ` is the location parameter and `s > 0` is the scale parameter.
 
 </section>
 
@@ -141,7 +141,7 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, s: %0.4f, Q(p;µ,s): %0.4f', p, mu, s, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, s: %0.4f, Q(p;μ,s): %0.4f', p, mu, s, quantile );
 ```
 
 </section>
@@ -233,7 +233,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_quantile( p, mu, s );
-        printf( "p:: %lf, µ:: %lf, s: %lf, Q(p;µ,s): %lf\n", p, mu, s, y );
+        printf( "p:: %lf, μ:: %lf, s: %lf, Q(p;μ,s): %lf\n", p, mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/quantile/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/quantile/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		p = random_uniform( 0.0, 1.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_logistic_quantile( p, mu, s );
-		printf( "p:: %lf, µ:: %lf, s: %lf, Q(p;µ,s): %lf\n", p, mu, s, y );
+		printf( "p:: %lf, μ:: %lf, s: %lf, Q(p;μ,s): %lf\n", p, mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/quantile/examples/index.js
@@ -29,4 +29,4 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, 0.0, 10.0, opts );
 var s = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, s: %0.4f, Q(p;µ,s): %0.4f', p, mu, s, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, s: %0.4f, Q(p;μ,s): %0.4f', p, mu, s, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/skewness/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, skew(X;µ,s): %0.4f', mu, s, skewness );
+logEachMap( 'μ: %0.4f, s: %0.4f, skew(X;μ,s): %0.4f', mu, s, skewness );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_skewness( mu, s );
-        printf( "µ:: %lf, s: %lf, Skewness(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ:: %lf, s: %lf, Skewness(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/skewness/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_logistic_skewness( mu, s );
-		printf( "µ:: %lf, s: %lf, Skewness(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ:: %lf, s: %lf, Skewness(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/skewness/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, skew(X;µ,s): %0.4f', mu, s, skewness );
+logEachMap( 'μ: %0.4f, s: %0.4f, skew(X;μ,s): %0.4f', mu, s, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, SD(X;µ,s): %0.4f', mu, s, stdev );
+logEachMap( 'μ: %0.4f, s: %0.4f, SD(X;μ,s): %0.4f', mu, s, stdev );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_stdev( mu, s );
-        printf( "µ: %lf, s: %lf, SD(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, SD(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_logistic_stdev( mu, s );
-		printf( "µ: %lf, s: %lf, SD(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, SD(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/stdev/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, SD(X;µ,s): %0.4f', mu, s, stdev );
+logEachMap( 'μ: %0.4f, s: %0.4f, SD(X;μ,s): %0.4f', mu, s, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/README.md
@@ -121,7 +121,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Var(X;µ,s): %0.4f', mu, s, variance );
+logEachMap( 'μ: %0.4f, s: %0.4f, Var(X;μ,s): %0.4f', mu, s, variance );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         s = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_logistic_variance( mu, s );
-        printf( "µ: %lf, s: %lf, Var(X;µ,s): %lf\n", mu, s, y );
+        printf( "μ: %lf, s: %lf, Var(X;μ,s): %lf\n", mu, s, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		s = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_logistic_variance( mu, s );
-		printf( "µ: %lf, s: %lf, Var(X;µ,s): %lf\n", mu, s, y );
+		printf( "μ: %lf, s: %lf, Var(X;μ,s): %lf\n", mu, s, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/variance/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var s = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, s: %0.4f, Var(X;µ,s): %0.4f', mu, s, variance );
+logEachMap( 'μ: %0.4f, s: %0.4f, Var(X;μ,s): %0.4f', mu, s, variance );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/cdf/README.md
@@ -125,7 +125,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, F(x;µ,σ): %0.4f', x, mu, sigma, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, F(x;μ,σ): %0.4f', x, mu, sigma, cdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/cdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, F(x;µ,σ): %0.4f', x, mu, sigma, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, F(x;μ,σ): %0.4f', x, mu, sigma, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/README.md
@@ -124,7 +124,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, h(X;µ,σ): %0.4f', mu, sigma, entropy );
+logEachMap( 'μ: %0.4f, σ: %0.4f, h(X;μ,σ): %0.4f', mu, sigma, entropy );
 ```
 
 </section>
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_lognormal_entropy( mu, sigma );
-        printf( "µ: %.4f, σ: %.4f, h(X;µ,σ): %.4f\n", mu, sigma, y );
+        printf( "μ: %.4f, σ: %.4f, h(X;μ,σ): %.4f\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_entropy( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, h(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, h(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/entropy/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, h(X;µ,σ): %0.4f', mu, sigma, entropy );
+logEachMap( 'μ: %0.4f, σ: %0.4f, h(X;μ,σ): %0.4f', mu, sigma, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/kurtosis/README.md
@@ -124,7 +124,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Kurt(X;µ,σ): %0.4f', mu, sigma, kurtosis );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Kurt(X;μ,σ): %0.4f', mu, sigma, kurtosis );
 ```
 
 </section>
@@ -213,7 +213,7 @@ int main( void ) {
         sigma = random_uniform( 0.1, 5.0 );
         mu = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_lognormal_kurtosis( mu, sigma );
-        printf( "µ: %lf, σ: %lf, Kurt(X;µ,σ): %lf\n", mu, sigma, y );
+        printf( "μ: %lf, σ: %lf, Kurt(X;μ,σ): %lf\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/kurtosis/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		sigma = random_uniform( 0.1, 5.0 );
 		mu = random_uniform( 0.0, 20.0 );
 		y = stdlib_base_dists_lognormal_kurtosis( mu, sigma );
-		printf( "µ: %lf, σ: %lf, Kurt(X;µ,σ): %lf\n", mu, sigma, y );
+		printf( "μ: %lf, σ: %lf, Kurt(X;μ,σ): %lf\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/kurtosis/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Kurt(X;µ,σ): %0.4f', mu, sigma, kurtosis );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Kurt(X;μ,σ): %0.4f', mu, sigma, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/README.md
@@ -117,7 +117,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, ln(F(x;µ,σ)): %0.4f', x, mu, sigma, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, ln(F(x;μ,σ)): %0.4f', x, mu, sigma, logcdf );
 ```
 
 </section>
@@ -209,7 +209,7 @@ int main( void ) {
         mu = random_uniform( -10.0, 10.0 );
         sigma = random_uniform( 0.1, 10.0 );
         y = stdlib_base_dists_lognormal_logcdf( x, mu, sigma );
-        printf( "x: %lf, µ: %lf, σ: %lf, ln(F(x;µ,σ)): %lf\n", x, mu, sigma, y );
+        printf( "x: %lf, μ: %lf, σ: %lf, ln(F(x;μ,σ)): %lf\n", x, mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/examples/c/example.c
@@ -37,6 +37,6 @@ int main( void ) {
 		mu = random_uniform( -10.0, 10.0 );
 		sigma = random_uniform( 0.1, 10.0 );
 		y = stdlib_base_dists_lognormal_logcdf( x, mu, sigma );
-		printf( "x: %lf, µ: %lf, σ: %lf, ln(F(x;µ,σ)): %lf\n", x, mu, sigma, y );
+		printf( "x: %lf, μ: %lf, σ: %lf, ln(F(x;μ,σ)): %lf\n", x, mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logcdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, ln(F(x;µ,σ)): %0.4f', x, mu, sigma, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, ln(F(x;μ,σ)): %0.4f', x, mu, sigma, logcdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/README.md
@@ -127,7 +127,7 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, ln(f(x;µ,σ)): %0.4f', x, mu, sigma, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, ln(f(x;μ,σ)): %0.4f', x, mu, sigma, logpdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/logpdf/examples/index.js
@@ -29,4 +29,4 @@ var x = uniform( 10, 0.0, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, ln(f(x;µ,σ)): %0.4f', x, mu, sigma, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, ln(f(x;μ,σ)): %0.4f', x, mu, sigma, logpdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/README.md
@@ -124,7 +124,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, E(X;µ,σ): %0.4f', mu, sigma, mean );
+logEachMap( 'μ: %0.4f, σ: %0.4f, E(X;μ,σ): %0.4f', mu, sigma, mean );
 ```
 
 </section>
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_lognormal_mean( mu, sigma );
-        printf( "µ: %.4f, σ: %.4f, E(X;µ,σ): %.4f\n", mu, sigma, y );
+        printf( "μ: %.4f, σ: %.4f, E(X;μ,σ): %.4f\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_mean( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, E(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, E(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mean/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, E(X;µ,σ): %0.4f', mu, sigma, mean );
+logEachMap( 'μ: %0.4f, σ: %0.4f, E(X;μ,σ): %0.4f', mu, sigma, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/README.md
@@ -124,7 +124,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Median(X;µ,σ): %0.4f', mu, sigma, median );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Median(X;μ,σ): %0.4f', mu, sigma, median );
 ```
 
 </section>
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_lognormal_median( mu, sigma );
-        printf( "µ: %.4f, σ: %.4f, Median(X;µ,σ): %.4f\n", mu, sigma, y );
+        printf( "μ: %.4f, σ: %.4f, Median(X;μ,σ): %.4f\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_median( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, Median(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, Median(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/median/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Median(X;µ,σ): %0.4f', mu, sigma, median );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Median(X;μ,σ): %0.4f', mu, sigma, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/README.md
@@ -124,7 +124,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, mode(X;µ,σ): %0.4f', mu, sigma, mode );
+logEachMap( 'μ: %0.4f, σ: %0.4f, mode(X;μ,σ): %0.4f', mu, sigma, mode );
 ```
 
 </section>
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_lognormal_mode( mu, sigma );
-        printf( "µ: %.4f, σ: %.4f, Mode(X;µ,σ): %.4f\n", mu, sigma, y );
+        printf( "μ: %.4f, σ: %.4f, Mode(X;μ,σ): %.4f\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_mode( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, Mode(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, Mode(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/mode/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, mode(X;µ,σ): %0.4f', mu, sigma, mode );
+logEachMap( 'μ: %0.4f, σ: %0.4f, mode(X;μ,σ): %0.4f', mu, sigma, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/README.md
@@ -128,7 +128,7 @@ var x = uniform( 10, 0.1, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, EPS, 5.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, f(x;µ,σ): %0.4f', x, mu, sigma, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, f(x;μ,σ): %0.4f', x, mu, sigma, pdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/examples/index.js
@@ -30,4 +30,4 @@ var x = uniform( 10, 0.1, 10.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, EPS, 5.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, f(x;µ,σ): %0.4f', x, mu, sigma, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, f(x;μ,σ): %0.4f', x, mu, sigma, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/quantile/README.md
@@ -140,7 +140,7 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, σ: %0.4f, Q(p;µ,σ): %0.4f', p, mu, sigma, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, σ: %0.4f, Q(p;μ,σ): %0.4f', p, mu, sigma, quantile );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/quantile/examples/index.js
@@ -29,4 +29,4 @@ var p = uniform( 10, 0.0, 1.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, σ: %0.4f, Q(p;µ,σ): %0.4f', p, mu, sigma, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, σ: %0.4f, Q(p;μ,σ): %0.4f', p, mu, sigma, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/skewness/README.md
@@ -124,7 +124,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, skew(X;µ,σ): %0.4f', mu, sigma, skewness );
+logEachMap( 'μ: %0.4f, σ: %0.4f, skew(X;μ,σ): %0.4f', mu, sigma, skewness );
 ```
 
 </section>
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_lognormal_skewness( mu, sigma );
-        printf("µ: %.4f, σ: %.4f, skew(X;µ,σ): %.4f\n", mu, sigma, y);
+        printf("μ: %.4f, σ: %.4f, skew(X;μ,σ): %.4f\n", mu, sigma, y);
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/skewness/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_skewness( mu, sigma );
-		printf("µ: %.4f, σ: %.4f, skew(X;µ,σ): %.4f\n", mu, sigma, y);
+		printf("μ: %.4f, σ: %.4f, skew(X;μ,σ): %.4f\n", mu, sigma, y);
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/skewness/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, skew(X;µ,σ): %0.4f', mu, sigma, skewness );
+logEachMap( 'μ: %0.4f, σ: %0.4f, skew(X;μ,σ): %0.4f', mu, sigma, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/README.md
@@ -124,7 +124,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, SD(X;µ,σ): %0.4f', mu, sigma, stdev );
+logEachMap( 'μ: %0.4f, σ: %0.4f, SD(X;μ,σ): %0.4f', mu, sigma, stdev );
 ```
 
 </section>
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_lognormal_stdev( mu, sigma );
-        printf("µ: %.4f, σ: %.4f, SD(X; µ, σ): %.4f\n", mu, sigma, y);
+        printf("μ: %.4f, σ: %.4f, SD(X; μ, σ): %.4f\n", mu, sigma, y);
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_stdev( mu, sigma );
-		printf("µ: %.4f, σ: %.4f, SD(X; µ, σ): %.4f\n", mu, sigma, y);
+		printf("μ: %.4f, σ: %.4f, SD(X; μ, σ): %.4f\n", mu, sigma, y);
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/stdev/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, SD(X;µ,σ): %0.4f', mu, sigma, stdev );
+logEachMap( 'μ: %0.4f, σ: %0.4f, SD(X;μ,σ): %0.4f', mu, sigma, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/README.md
@@ -124,7 +124,7 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Var(X;µ,σ): %0.4f', mu, sigma, variance );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Var(X;μ,σ): %0.4f', mu, sigma, variance );
 ```
 
 </section>
@@ -213,7 +213,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_lognormal_variance( mu, sigma );
-        printf( "µ: %lf, σ: %lf, Var(X;µ,σ): %lf\n", mu, sigma, y );
+        printf( "μ: %lf, σ: %lf, Var(X;μ,σ): %lf\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_lognormal_variance( mu, sigma );
-		printf( "µ: %lf, σ: %lf, Var(X;µ,σ): %lf\n", mu, sigma, y );
+		printf( "μ: %lf, σ: %lf, Var(X;μ,σ): %lf\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var mu = uniform( 10, -5.0, 5.0, opts );
 var sigma = uniform( 10, 0.0, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Var(X;µ,σ): %0.4f', mu, sigma, variance );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Var(X;μ,σ): %0.4f', mu, sigma, variance );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/README.md
@@ -39,7 +39,7 @@ F(x;\mu,\sigma) = \frac{1}{2} \left[ 1 + \mathop{\mathrm{erf}}\left( \frac{x-\mu
 
 <!-- </equation> -->
 
-where `µ` is the mean and `σ` is the standard deviation.
+where `μ` is the mean and `σ` is the standard deviation.
 
 </section>
 
@@ -137,7 +137,7 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var x = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, F(x;µ,σ): %0.4f', x, mu, sigma, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, F(x;μ,σ): %0.4f', x, mu, sigma, cdf );
 ```
 
 </section>
@@ -229,7 +229,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_normal_cdf( x, mu, sigma );
-        printf( "x: %lf, µ: %lf, σ: %lf, F(x;µ,σ): %lf\n", x, mu, sigma, y );
+        printf( "x: %lf, μ: %lf, σ: %lf, F(x;μ,σ): %lf\n", x, mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_cdf( x, mu, sigma );
-		printf( "x: %lf, µ: %lf, σ: %lf, F(x;µ,σ): %lf\n", x, mu, sigma, y );
+		printf( "x: %lf, μ: %lf, σ: %lf, F(x;μ,σ): %lf\n", x, mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/examples/index.js
@@ -29,4 +29,4 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var x = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, F(x;µ,σ): %0.4f', x, mu, sigma, cdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, F(x;μ,σ): %0.4f', x, mu, sigma, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/include/stdlib/stats/base/dists/normal/cdf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/include/stdlib/stats/base/dists/normal/cdf.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the cumulative distribution function (CDF) for a normal distribution with mean µ and standard deviation σ at a value `x`.
+* Evaluates the cumulative distribution function (CDF) for a normal distribution with mean μ and standard deviation σ at a value `x`.
 */
 double stdlib_base_dists_normal_cdf( const double x, const double mu, const double sigma );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the cumulative distribution function (CDF) for a normal distribution with mean µ and standard deviation σ at a value `x`.
+* Evaluates the cumulative distribution function (CDF) for a normal distribution with mean μ and standard deviation σ at a value `x`.
 *
 * @private
 * @param {number} x - input value

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/README.md
@@ -118,7 +118,7 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, h(X;µ,σ): %0.4f', mu, sigma, entropy );
+logEachMap( 'μ: %0.4f, σ: %0.4f, h(X;μ,σ): %0.4f', mu, sigma, entropy );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_entropy( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, h(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, h(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, h(X;µ,σ): %0.4f', mu, sigma, entropy );
+logEachMap( 'μ: %0.4f, σ: %0.4f, h(X;μ,σ): %0.4f', mu, sigma, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/README.md
@@ -118,7 +118,7 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Kurt(X;µ,σ): %0.4f', mu, sigma, kurtosis );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Kurt(X;μ,σ): %0.4f', mu, sigma, kurtosis );
 ```
 
 </section>
@@ -207,7 +207,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_normal_kurtosis( mu, sigma );
-        printf( "µ: %.4f, σ: %.4f, Kurt(X;µ,σ): %.4f\n", mu, sigma, y );
+        printf( "μ: %.4f, σ: %.4f, Kurt(X;μ,σ): %.4f\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_kurtosis( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, Kurt(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, Kurt(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Kurt(X;µ,σ): %0.4f', mu, sigma, kurtosis );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Kurt(X;μ,σ): %0.4f', mu, sigma, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/README.md
@@ -117,7 +117,7 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var x = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, ln(F(x;µ,σ)): %0.4f', x, mu, sigma, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, ln(F(x;μ,σ)): %0.4f', x, mu, sigma, logcdf );
 ```
 
 </section>
@@ -209,7 +209,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_normal_logcdf( x, mu, sigma );
-        printf( "x: %lf, µ: %lf, σ: %lf, ln(F(x;µ,σ)): %lf\n", x, mu, sigma, y );
+        printf( "x: %lf, μ: %lf, σ: %lf, ln(F(x;μ,σ)): %lf\n", x, mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/examples/c/example.c
@@ -37,7 +37,7 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_logcdf( x, mu, sigma );
-		printf( "x: %lf, µ: %lf, σ: %lf, ln(F(x;µ,σ)): %lf\n", x, mu, sigma, y );
+		printf( "x: %lf, μ: %lf, σ: %lf, ln(F(x;μ,σ)): %lf\n", x, mu, sigma, y );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/examples/index.js
@@ -29,4 +29,4 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var x = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, ln(F(x;µ,σ)): %0.4f', x, mu, sigma, logcdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, ln(F(x;μ,σ)): %0.4f', x, mu, sigma, logcdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/README.md
@@ -39,7 +39,7 @@ f(x;\mu,\sigma)=\frac{1}{\sigma\sqrt{2\pi}}\, e^{-\frac{(x - \mu)^2}{2 \sigma^2}
 
 <!-- </equation> -->
 
-where `µ` is the mean and `σ` is the standard deviation.
+where `μ` is the mean and `σ` is the standard deviation.
 
 </section>
 
@@ -131,7 +131,7 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var x = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, ln(f(x;µ,σ)): %0.4f', x, mu, sigma, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, ln(f(x;μ,σ)): %0.4f', x, mu, sigma, logpdf );
 ```
 
 </section>
@@ -223,7 +223,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_normal_logpdf( x, mu, sigma );
-        printf( "x: %lf, µ: %lf, σ: %lf, ln(f(x;µ,σ)): %lf\n", x, mu, sigma, y );
+        printf( "x: %lf, μ: %lf, σ: %lf, ln(f(x;μ,σ)): %lf\n", x, mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_logpdf( x, mu, sigma );
-		printf( "x: %lf, µ: %lf, σ: %lf, ln(f(x;µ,σ)): %lf\n", x, mu, sigma, y );
+		printf( "x: %lf, μ: %lf, σ: %lf, ln(f(x;μ,σ)): %lf\n", x, mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/examples/index.js
@@ -29,4 +29,4 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var x = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, ln(f(x;µ,σ)): %0.4f', x, mu, sigma, logpdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, ln(f(x;μ,σ)): %0.4f', x, mu, sigma, logpdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/README.md
@@ -121,7 +121,7 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, E(X;µ,σ): %0.4f', mu, sigma, mean );
+logEachMap( 'μ: %0.4f, σ: %0.4f, E(X;μ,σ): %0.4f', mu, sigma, mean );
 ```
 
 </section>
@@ -201,7 +201,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_normal_mean( mu, sigma );
-        printf( "µ: %.4f, σ: %.4f, Mean(X;µ,σ): %.4f\n", mu, sigma, y );
+        printf( "μ: %.4f, σ: %.4f, Mean(X;μ,σ): %.4f\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_mean( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, Mean(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, Mean(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, E(X;µ,σ): %0.4f', mu, sigma, mean );
+logEachMap( 'μ: %0.4f, σ: %0.4f, E(X;μ,σ): %0.4f', mu, sigma, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/README.md
@@ -121,7 +121,7 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Median(X;µ,σ): %0.4f', mu, sigma, median );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Median(X;μ,σ): %0.4f', mu, sigma, median );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_normal_median( mu, sigma );
-        printf( "µ: %.4f, σ: %.4f, Median(X;µ,σ): %.4f\n", mu, sigma, y );
+        printf( "μ: %.4f, σ: %.4f, Median(X;μ,σ): %.4f\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_median( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, Median(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, Median(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Median(X;µ,σ): %0.4f', mu, sigma, median );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Median(X;μ,σ): %0.4f', mu, sigma, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/README.md
@@ -141,7 +141,7 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var t = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 't: %0.4f, µ: %0.4f, σ: %0.4f, M_X(t;µ,σ): %0.4f', t, mu, sigma, mgf );
+logEachMap( 't: %0.4f, μ: %0.4f, σ: %0.4f, M_X(t;μ,σ): %0.4f', t, mu, sigma, mgf );
 ```
 
 </section>
@@ -234,7 +234,7 @@ int main( void ) {
         mu = random_uniform( -50.0, 50.0 );
         sigma = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_normal_mgf( t, mu, sigma );
-        printf( "t: %lf, µ: %lf, σ: %lf, M_X(t;µ,σ): %lf\n", t, mu, sigma, y );
+        printf( "t: %lf, μ: %lf, σ: %lf, M_X(t;μ,σ): %lf\n", t, mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -50.0, 50.0 );
 		sigma = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_normal_mgf( t, mu, sigma );
-		printf( "t: %lf, µ: %lf, σ: %lf, M_X(t;µ,σ): %lf\n", t, mu, sigma, y );
+		printf( "t: %lf, μ: %lf, σ: %lf, M_X(t;μ,σ): %lf\n", t, mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/examples/index.js
@@ -29,4 +29,4 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var t = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 't: %0.4f, µ: %0.4f, σ: %0.4f, M_X(t;µ,σ): %0.4f', t, mu, sigma, mgf );
+logEachMap( 't: %0.4f, μ: %0.4f, σ: %0.4f, M_X(t;μ,σ): %0.4f', t, mu, sigma, mgf );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/README.md
@@ -121,7 +121,7 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, mode(X;µ,σ): %0.4f', mu, sigma, mode );
+logEachMap( 'μ: %0.4f, σ: %0.4f, mode(X;μ,σ): %0.4f', mu, sigma, mode );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_normal_mode( mu, sigma );
-        printf("µ: %.4f, σ: %.4f, mode(X;µ,σ): %.4f\n", mu, sigma, y);
+        printf("μ: %.4f, σ: %.4f, mode(X;μ,σ): %.4f\n", mu, sigma, y);
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_mode( mu, sigma );
-		printf("µ: %.4f, σ: %.4f, mode(X;µ,σ): %.4f\n", mu, sigma, y);
+		printf("μ: %.4f, σ: %.4f, mode(X;μ,σ): %.4f\n", mu, sigma, y);
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, mode(X;µ,σ): %0.4f', mu, sigma, mode );
+logEachMap( 'μ: %0.4f, σ: %0.4f, mode(X;μ,σ): %0.4f', mu, sigma, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/README.md
@@ -39,7 +39,7 @@ f(x;\mu,\sigma)=\frac{1}{\sigma\sqrt{2\pi}}\, e^{-\frac{(x - \mu)^2}{2 \sigma^2}
 
 <!-- </equation> -->
 
-where `µ` is the mean and `σ` is the standard deviation.
+where `μ` is the mean and `σ` is the standard deviation.
 
 </section>
 
@@ -131,7 +131,7 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var x = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, f(x;µ,σ): %0.4f', x, mu, sigma, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, f(x;μ,σ): %0.4f', x, mu, sigma, pdf );
 ```
 
 </section>
@@ -224,7 +224,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_normal_pdf( x, mu, sigma );
-        printf( "x: %lf, µ: %lf, σ: %lf, f(x;µ,σ): %lf\n", x, mu, sigma, y );
+        printf( "x: %lf, μ: %lf, σ: %lf, f(x;μ,σ): %lf\n", x, mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_normal_pdf( x, mu, sigma );
-		printf( "x: %lf, µ: %lf, σ: %lf, f(x;µ,σ): %lf\n", x, mu, sigma, y );
+		printf( "x: %lf, μ: %lf, σ: %lf, f(x;μ,σ): %lf\n", x, mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/examples/index.js
@@ -29,4 +29,4 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var x = uniform( 10, 0.0, 10.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, σ: %0.4f, f(x;µ,σ): %0.4f', x, mu, sigma, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, σ: %0.4f, f(x;μ,σ): %0.4f', x, mu, sigma, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/README.md
@@ -39,7 +39,7 @@ Q(p;\mu,\sigma) = \mu+\sigma\sqrt{2}\,\mathop{\mathrm{erf}}^{-1}(2p-1)
 
 <!-- </equation> -->
 
-for `0 <= p <= 1`, where `µ` is the mean and `σ` is the standard deviation.
+for `0 <= p <= 1`, where `μ` is the mean and `σ` is the standard deviation.
 
 </section>
 
@@ -141,7 +141,7 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var p = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, σ: %0.4f, Q(p;µ,σ): %0.4f', p, mu, sigma, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, σ: %0.4f, Q(p;μ,σ): %0.4f', p, mu, sigma, quantile );
 ```
 
 </section>
@@ -234,7 +234,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_normal_quantile( p, mu, sigma );
-        printf( "p:%.4f, µ: %.4f, σ: %.4f, Q(p;µ,σ): %.4f\n", p, mu, sigma, y );
+        printf( "p:%.4f, μ: %.4f, σ: %.4f, Q(p;μ,σ): %.4f\n", p, mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_normal_quantile( p, mu, sigma );
-		printf( "p:%.4f, µ: %.4f, σ: %.4f, Q(p;µ,σ): %.4f\n", p, mu, sigma, y );
+		printf( "p:%.4f, μ: %.4f, σ: %.4f, Q(p;μ,σ): %.4f\n", p, mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/examples/index.js
@@ -29,4 +29,4 @@ var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 var p = uniform( 10, 0.0, 1.0, opts );
 
-logEachMap( 'p: %0.4f, µ: %0.4f, σ: %0.4f, Q(p;µ,σ): %0.4f', p, mu, sigma, quantile );
+logEachMap( 'p: %0.4f, μ: %0.4f, σ: %0.4f, Q(p;μ,σ): %0.4f', p, mu, sigma, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/README.md
@@ -118,7 +118,7 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, skew(X;µ,σ): %0.4f', mu, sigma, skewness );
+logEachMap( 'μ: %0.4f, σ: %0.4f, skew(X;μ,σ): %0.4f', mu, sigma, skewness );
 ```
 
 </section>
@@ -207,7 +207,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_normal_skewness( mu, sigma );
-        printf( "µ: %.4f, σ: %.4f, skew(X;µ,σ): %.4f\n", mu, sigma, y );
+        printf( "μ: %.4f, σ: %.4f, skew(X;μ,σ): %.4f\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_skewness( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, skew(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, skew(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, skew(X;µ,σ): %0.4f', mu, sigma, skewness );
+logEachMap( 'μ: %0.4f, σ: %0.4f, skew(X;μ,σ): %0.4f', mu, sigma, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/README.md
@@ -95,7 +95,7 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, SD(X;µ,σ): %0.4f', mu, sigma, stdev );
+logEachMap( 'μ: %0.4f, σ: %0.4f, SD(X;μ,σ): %0.4f', mu, sigma, stdev );
 ```
 
 </section>
@@ -184,7 +184,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_normal_stdev( mu, sigma );
-        printf( "µ: %.4f, σ: %.4f, SD(X;µ,σ): %.4f\n", mu, sigma, y );
+        printf( "μ: %.4f, σ: %.4f, SD(X;μ,σ): %.4f\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( -5.0, 5.0 );
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_stdev( mu, sigma );
-		printf( "µ: %.4f, σ: %.4f, SD(X;µ,σ): %.4f\n", mu, sigma, y );
+		printf( "μ: %.4f, σ: %.4f, SD(X;μ,σ): %.4f\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, SD(X;µ,σ): %0.4f', mu, sigma, stdev );
+logEachMap( 'μ: %0.4f, σ: %0.4f, SD(X;μ,σ): %0.4f', mu, sigma, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/variance/README.md
@@ -118,7 +118,7 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Var(X;µ,σ): %0.4f', mu, sigma, variance );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Var(X;μ,σ): %0.4f', mu, sigma, variance );
 ```
 
 </section>
@@ -207,7 +207,7 @@ int main( void ) {
         mu = random_uniform( -5.0, 5.0 );
         sigma = random_uniform( 0.0, 20.0 );
         y = stdlib_base_dists_normal_variance( mu, sigma );
-        printf( "µ: %lf, σ: %lf, Var(X;µ,σ): %lf\n", mu, sigma, y );
+        printf( "μ: %lf, σ: %lf, Var(X;μ,σ): %lf\n", mu, sigma, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/variance/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( 0.0, 10.0 ) - 5.0;
 		sigma = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_normal_variance( mu, sigma );
-		printf( "µ: %lf, σ: %lf, Var(X;µ,σ): %lf\n", mu, sigma, y );
+		printf( "μ: %lf, σ: %lf, Var(X;μ,σ): %lf\n", mu, sigma, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/variance/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var sigma = uniform( 10, 0.0, 20.0, opts );
 var mu = uniform( 10, -5.0, 5.0, opts );
 
-logEachMap( 'µ: %0.4f, σ: %0.4f, Var(X;µ,σ): %0.4f', mu, sigma, variance );
+logEachMap( 'μ: %0.4f, σ: %0.4f, Var(X;μ,σ): %0.4f', mu, sigma, variance );

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/README.md
@@ -137,7 +137,7 @@ for ( i = 0; i < 25; i++ ) {
     mu = ( randu() * 20.0 ) - 10.0;
     sigma = ( randu() * 10.0 ) + 2.0;
     y = pdf( x, a, b, mu, sigma );
-    console.log( 'x: %d, a: %d, b: %d, µ: %d, σ: %d, f(x;a,b,µ,σ): %d', x.toFixed( 4 ), a.toFixed( 4 ), b.toFixed( 4 ), mu.toFixed( 4 ), sigma.toFixed( 4 ), y.toFixed( 4 ) );
+    console.log( 'x: %d, a: %d, b: %d, μ: %d, σ: %d, f(x;a,b,μ,σ): %d', x.toFixed( 4 ), a.toFixed( 4 ), b.toFixed( 4 ), mu.toFixed( 4 ), sigma.toFixed( 4 ), y.toFixed( 4 ) );
 }
 ```
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/pdf/examples/index.js
@@ -36,5 +36,5 @@ for ( i = 0; i < 25; i++ ) {
 	mu = ( randu() * 20.0 ) - 10.0;
 	sigma = ( randu() * 10.0 ) + 2.0;
 	y = pdf( x, a, b, mu, sigma );
-	console.log( 'x: %d, a: %d, b: %d, µ: %d, σ: %d, f(x;a,b,µ,σ): %d', x.toFixed( 4 ), a.toFixed( 4 ), b.toFixed( 4 ), mu.toFixed( 4 ), sigma.toFixed( 4 ), y.toFixed( 4 ) );
+	console.log( 'x: %d, a: %d, b: %d, μ: %d, σ: %d, f(x;a,b,μ,σ): %d', x.toFixed( 4 ), a.toFixed( 4 ), b.toFixed( 4 ), mu.toFixed( 4 ), sigma.toFixed( 4 ), y.toFixed( 4 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/kurtosis/README.md
@@ -123,7 +123,7 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, Kurtosis(X;µ,λ): %0.4f', mu, lambda, kurtosis );
+logEachMap( 'μ: %0.4f, λ: %0.4f, Kurtosis(X;μ,λ): %0.4f', mu, lambda, kurtosis );
 ```
 
 </section>
@@ -212,7 +212,7 @@ int main( void ) {
         mu = random_uniform( 0.1, 5.0 );
         lambda = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_wald_kurtosis( mu, lambda );
-        printf( "µ: %.4f, λ: %.4f, Kurtosis(X;µ,λ): %.4f\n", mu, lambda, y );
+        printf( "μ: %.4f, λ: %.4f, Kurtosis(X;μ,λ): %.4f\n", mu, lambda, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/kurtosis/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/kurtosis/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( 0.1, 10.0 );
 		lambda = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_wald_kurtosis( mu, lambda );
-		printf( "µ: %.4f, λ: %.4f, Kurtosis(X;µ,λ): %.4f\n", mu, lambda, y );
+		printf( "μ: %.4f, λ: %.4f, Kurtosis(X;μ,λ): %.4f\n", mu, lambda, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/kurtosis/examples/index.js
@@ -29,4 +29,4 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, Kurtosis(X;µ,λ): %0.4f', mu, lambda, kurtosis );
+logEachMap( 'μ: %0.4f, λ: %0.4f, Kurtosis(X;μ,λ): %0.4f', mu, lambda, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/mean/README.md
@@ -125,7 +125,7 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, E(X;µ,λ): %0.4f', mu, lambda, mean );
+logEachMap( 'μ: %0.4f, λ: %0.4f, E(X;μ,λ): %0.4f', mu, lambda, mean );
 ```
 
 </section>
@@ -214,7 +214,7 @@ int main( void ) {
         mu = random_uniform( 0.1, 5.0 );
         lambda = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_wald_mean( mu, lambda );
-        printf( "µ: %.4f, λ: %.4f, Mean(X;µ,λ): %.4f\n", mu, lambda, y );
+        printf( "μ: %.4f, λ: %.4f, Mean(X;μ,λ): %.4f\n", mu, lambda, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/mean/examples/c/example.c
@@ -35,7 +35,7 @@ int main( void ) {
 		mu = random_uniform( 0.1, 10.0 );
 		lambda = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_wald_mean( mu, lambda );
-		printf( "µ: %.4f, λ: %.4f, Mean(X;µ,λ): %.4f\n", mu, lambda, y );
+		printf( "μ: %.4f, λ: %.4f, Mean(X;μ,λ): %.4f\n", mu, lambda, y );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/mean/examples/index.js
@@ -29,4 +29,4 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, E(X;µ,λ): %0.4f', mu, lambda, mean );
+logEachMap( 'μ: %0.4f, λ: %0.4f, E(X;μ,λ): %0.4f', mu, lambda, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/mode/README.md
@@ -126,7 +126,7 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, mode(X;µ,λ): %0.4f', mu, lambda, mode );
+logEachMap( 'μ: %0.4f, λ: %0.4f, mode(X;μ,λ): %0.4f', mu, lambda, mode );
 ```
 
 </section>
@@ -216,7 +216,7 @@ int main( void ) {
         mu = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 10.0 );
         lambda = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_wald_mode( mu, lambda );
-        printf( "µ: %.4f, λ: %.4f, mode(X;µ,λ): %.4f\n", mu, lambda, y );
+        printf( "μ: %.4f, λ: %.4f, mode(X;μ,λ): %.4f\n", mu, lambda, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/mode/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		mu = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 10.0 );
 		lambda = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_wald_mode( mu, lambda );
-		printf( "µ: %.4f, λ: %.4f, mode(X;µ,λ): %.4f\n", mu, lambda, y );
+		printf( "μ: %.4f, λ: %.4f, mode(X;μ,λ): %.4f\n", mu, lambda, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/mode/examples/index.js
@@ -29,4 +29,4 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, mode(X;µ,λ): %0.4f', mu, lambda, mode );
+logEachMap( 'μ: %0.4f, λ: %0.4f, mode(X;μ,λ): %0.4f', mu, lambda, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/README.md
@@ -39,7 +39,7 @@ f(x;\mu,\lambda) = \sqrt{\frac{\lambda}{2\pi x^3}}\, e^{-\frac{\lambda(x-\mu)^2}
 
 <!-- </equation> -->
 
-where `µ > 0` is the mean and `λ > 0` is the shape parameter.
+where `μ > 0` is the mean and `λ > 0` is the shape parameter.
 
 </section>
 
@@ -152,7 +152,7 @@ var x = uniform( 10, EPS, 10.0, opts );
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, λ: %0.4f, f(x;µ,λ): %0.4f', x, mu, lambda, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, λ: %0.4f, f(x;μ,λ): %0.4f', x, mu, lambda, pdf );
 ```
 
 </section>
@@ -245,7 +245,7 @@ int main( void ) {
         mu = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 10.0 );
         lambda = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_wald_pdf( x, mu, lambda );
-        printf( "x: %lf, µ: %lf, λ: %lf, f(x;µ,λ): %lf\n", x, mu, lambda, y );
+        printf( "x: %lf, μ: %lf, λ: %lf, f(x;μ,λ): %lf\n", x, mu, lambda, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/examples/c/example.c
@@ -38,6 +38,6 @@ int main( void ) {
 		mu = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 10.0 );
 		lambda = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 10.0 );
 		y = stdlib_base_dists_wald_pdf( x, mu, lambda );
-		printf( "x: %lf, µ: %lf, λ: %lf, f(x;µ,λ): %lf\n", x, mu, lambda, y );
+		printf( "x: %lf, μ: %lf, λ: %lf, f(x;μ,λ): %lf\n", x, mu, lambda, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/pdf/examples/index.js
@@ -30,4 +30,4 @@ var x = uniform( 10, EPS, 10.0, opts );
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'x: %0.4f, µ: %0.4f, λ: %0.4f, f(x;µ,λ): %0.4f', x, mu, lambda, pdf );
+logEachMap( 'x: %0.4f, μ: %0.4f, λ: %0.4f, f(x;μ,λ): %0.4f', x, mu, lambda, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/README.md
@@ -123,7 +123,7 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, skew(X;µ,λ): %0.4f', mu, lambda, skewness );
+logEachMap( 'μ: %0.4f, λ: %0.4f, skew(X;μ,λ): %0.4f', mu, lambda, skewness );
 ```
 
 </section>
@@ -212,7 +212,7 @@ int main( void ) {
         mu = random_uniform( 0.1, 5.0 );
         lambda = random_uniform( 0.1, 20.0 );
         y = stdlib_base_dists_wald_skewness( mu, lambda );
-        printf( "µ: %.4f, λ: %.4f, skew(X;µ,λ): %.4f\n", mu, lambda, y );
+        printf( "μ: %.4f, λ: %.4f, skew(X;μ,λ): %.4f\n", mu, lambda, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/examples/c/example.c
@@ -35,6 +35,6 @@ int main( void ) {
 		mu = random_uniform( 0.1, 10.0 );
 		lambda = random_uniform( 0.1, 20.0 );
 		y = stdlib_base_dists_wald_skewness( mu, lambda );
-		printf( "µ: %.4f, λ: %.4f, skew(X;µ,λ): %.4f\n", mu, lambda, y );
+		printf( "μ: %.4f, λ: %.4f, skew(X;μ,λ): %.4f\n", mu, lambda, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/skewness/examples/index.js
@@ -29,4 +29,4 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, skew(X;µ,λ): %0.4f', mu, lambda, skewness );
+logEachMap( 'μ: %0.4f, λ: %0.4f, skew(X;μ,λ): %0.4f', mu, lambda, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/variance/README.md
@@ -120,7 +120,7 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, Var(X;µ,λ): %0.4f', mu, lambda, variance );
+logEachMap( 'μ: %0.4f, λ: %0.4f, Var(X;μ,λ): %0.4f', mu, lambda, variance );
 ```
 
 </section>
@@ -210,7 +210,7 @@ int main( void ) {
         mu = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 5.0 );
         lambda = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
         y = stdlib_base_dists_wald_variance( mu, lambda );
-        printf( "µ: %.4f, λ: %.4f, Var(X;µ,λ): %.4f\n", mu, lambda, y );
+        printf( "μ: %.4f, λ: %.4f, Var(X;μ,λ): %.4f\n", mu, lambda, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/variance/examples/c/example.c
@@ -36,6 +36,6 @@ int main( void ) {
 		mu = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 10.0 );
 		lambda = random_uniform( STDLIB_CONSTANT_FLOAT64_EPS, 20.0 );
 		y = stdlib_base_dists_wald_variance( mu, lambda );
-		printf( "µ: %lf, λ: %lf, Var(X;µ,λ): %lf\n", mu, lambda, y );
+		printf( "μ: %lf, λ: %lf, Var(X;μ,λ): %lf\n", mu, lambda, y );
 	}
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/wald/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/wald/variance/examples/index.js
@@ -29,4 +29,4 @@ var opts = {
 var mu = uniform( 10, EPS, 10.0, opts );
 var lambda = uniform( 10, EPS, 20.0, opts );
 
-logEachMap( 'µ: %0.4f, λ: %0.4f, Var(X;µ,λ): %0.4f', mu, lambda, variance );
+logEachMap( 'μ: %0.4f, λ: %0.4f, Var(X;μ,λ): %0.4f', mu, lambda, variance );

--- a/lib/node_modules/@stdlib/stats/incr/mgmean/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/mgmean/README.md
@@ -61,7 +61,7 @@ var accumulator = incrmgmean( 3 );
 
 #### accumulator( \[x] )
 
-If provided an input value `x`, the accumulator function returns an updated [geometric mean][geometric-mean]. If not provided an input value `x`, the accumulator function returns the current [geometric-mean][geometric-mean].
+If provided an input value `x`, the accumulator function returns an updated [geometric mean][geometric-mean]. If not provided an input value `x`, the accumulator function returns the current [geometric mean][geometric-mean].
 
 ```javascript
 var accumulator = incrmgmean( 3 );

--- a/lib/node_modules/@stdlib/stats/incr/mhmean/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/mhmean/README.md
@@ -61,7 +61,7 @@ var accumulator = incrmhmean( 3 );
 
 #### accumulator( \[x] )
 
-If provided an input value `x`, the accumulator function returns an updated [harmonic mean][harmonic-mean]. If not provided an input value `x`, the accumulator function returns the current [harmonic-mean][harmonic-mean].
+If provided an input value `x`, the accumulator function returns an updated [harmonic mean][harmonic-mean]. If not provided an input value `x`, the accumulator function returns the current [harmonic mean][harmonic-mean].
 
 ```javascript
 var accumulator = incrmhmean( 3 );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request propagates fixes merged to `develop` between 2026-07-17 21:55 (-0700) and 2026-07-18 02:25 (-0700) (`b31b3f111...254d999f6`) to sibling packages with the same underlying defects.

### 4197c814 — fix: use variadic API for computing the minimum value

The source commit fixed `tag-typedef-typos` by replacing 3-argument calls to the binary `min` with the variadic `minn`, swapping a shape-options `array` allocation for `zeros`, and replacing string-concatenated `context.report` messages with `@stdlib/string/format`. This PR carries the same two propagation-safe patterns — variadic-friendly allocation via `zeros` and `format`-based report messages — to the remaining lint rule packages sharing this code shape. A repo-wide search turned up no other 3-argument calls to the binary `min`/`max`, so no further `minn` migration is needed.

-   `_tools/eslint/rules/jsdoc-typedef-typos`
-   `_tools/repl-txt/rules/section-heading-style`
-   `_tools/repl-txt/rules/interface-spacing`
-   `_tools/repl-txt/rules/whitelisted-sections`
-   `_tools/repl-txt/rules/section-order`

### 4a96d8c9 — chore: clean-up

The source commit corrected two isolated instances in `stats/base/dists/anglit/mode` and `stats/incr/nanmhmean` that this PR now propagates.

**µ → μ.** `stats/base/dists/anglit/mode` used U+00B5 (micro sign) in its README and example output where U+03BC (Greek small letter mu) denotes the mean/location parameter. All 940 remaining occurrences across `stats/base/dists/*` were audited; every one names the mean/location parameter, none is a micro-unit prefix, and Greek μ is already the established convention in 213 sibling files. Replaced across all 354 affected files (119 READMEs, 119 JS examples, 114 C examples) plus the doc comments in `normal/cdf`'s `native.js` and C header.

**Hyphenated link label used as prose.** `stats/incr/nanmhmean`'s README read "the current [harmonic-mean][harmonic-mean]", treating the link anchor's hyphenated slug as the sentence text; corrected to "the current [harmonic mean][harmonic-mean]". The same defect recurs in `stats/incr/mhmean` and `stats/incr/mgmean`, fixed identically here. `stats/incr/midrange` and its siblings are excluded — "mid-range" is correct, hyphenated English, not a link-label artifact.

**Targets:**

-   `stats/base/dists/*` (README.md, examples/index.js, examples/c/example.c, plus `normal/cdf/lib/native.js` and its C header) — µ → μ
-   `stats/incr/mhmean`, `stats/incr/mgmean` (README.md) — link-label prose fix

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**CI note:** `Run affected tests` and `Calculate test coverage for PR packages` fail with a 30-minute timeout, not a test failure. The µ → μ commit touches 354 packages under `stats/base/dists/*`, so the affected-package resolution queues native add-on builds for all of them; both jobs were killed mid-build (`gumbel/quantile` add-on compiling at the cutoff) with zero assertion failures logged. `Lint Changed Files` and `Run changed examples` pass. The diff is limited to documentation text, example output strings, and byte-identical lint-rule report messages.

Validation performed before applying patches:

-   Pattern search scope: `rg` sweeps over `lib/node_modules/@stdlib` per pattern signature (3-argument `min`/`max` calls, concatenated `context.report` messages, U+00B5 occurrences, hyphenated-label-as-prose link text), with originating packages excluded.
-   Two independent validation passes confirmed each site by reading target files in full (µ sites audited character-context-wide plus per-file-type sampling); a separate adaptation pass produced per-site patches; a style-consistency pass checked patches against surrounding conventions and `docs/style-guides`.
-   `format` conversions preserve byte-identical report output; `%s` was chosen over `%u` in `interface-spacing` to guarantee identical output for all inputs.
-   Deliberately excluded: `datasets/spam-assassin` data files (raw corpus), generated REPL help data, the `stats/incr/*midrange*` READMEs (legitimate hyphenation), the `var mode` → `var main` require-renaming from the source chore commit (convention-wide refactor, no defect), and single-site cleanups with no generalizable pattern (`os/platform` platform list, trailing whitespace).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated fix-propagation routine: candidate sites were located by pattern search, independently validated by multiple review passes, and patched to mirror the cited source commits.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md