### PR TITLE
feat: add `number/uint64/base/get-low-word`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Low Word
 
-> Return an unsigned 32-bit integer corresponding to the low 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
+> Return a 32-bit unsigned integer corresponding to the low 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var getLowWord = require( '@stdlib/number/uint64/base/get-low-word' );
 
 #### getLowWord( a )
 
-Returns an unsigned 32-bit integer corresponding to the low 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
+Returns a 32-bit unsigned integer corresponding to the low 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
 
 ```javascript
 var Uint64 = require( '@stdlib/number/uint64/ctor' );

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/README.md
@@ -1,0 +1,100 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Low Word
+
+> Return an unsigned 32-bit integer corresponding to the low 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var getLowWord = require( '@stdlib/number/uint64/base/get-low-word' );
+```
+
+#### getLowWord( a )
+
+Returns an unsigned 32-bit integer corresponding to the low 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
+
+```javascript
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+
+var a = new Uint64( 4294967296 );
+var w = getLowWord( a );
+// returns 0
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var getLowWord = require( '@stdlib/number/uint64/base/get-low-word' );
+
+var a = new Uint64( 4294967296 );
+console.log( getLowWord( a ) );
+// => 0
+
+a = new Uint64( 0xffffffff );
+console.log( getLowWord( a ) );
+// => 4294967295
+
+a = new Uint64( 0x123400005678 );
+console.log( getLowWord( a ) );
+// => 22136
+
+a = Uint64.of( 1234, 5678 );
+console.log( getLowWord( a ) );
+// => 5678
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/number/uint64/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/uint64/ctor
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/benchmark/benchmark.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/assert/is-nan' ).isPrimitive;
+var bench = require( '@stdlib/bench' );
+var MAX_SAFE_INTEGER = require( '@stdlib/constants/float64/max-safe-integer' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var pkg = require( './../package.json' ).name;
+var getLowWord = require( './../lib' );
+
+
+// VARIABLES //
+
+var rand = discreteUniform.factory( 0, MAX_SAFE_INTEGER );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var N;
+	var a;
+	var i;
+	var w;
+
+	N = 100;
+	values = [];
+	for ( i = 0; i < N; i++ ) {
+		values.push( new Uint64( rand() ) );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		a = values[ i % N ];
+		w = getLowWord( a );
+		if ( isnan( w ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( w ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/repl.txt
@@ -1,0 +1,25 @@
+
+{{alias}}( a )
+    Returns an unsigned 32-bit integer corresponding to the low 32-bit word of
+    a 64-bit unsigned integer.
+
+    Parameters
+    ----------
+    a: Uint64
+        Input value.
+
+    Returns
+    -------
+    out: integer
+        Lower order word (unsigned 32-bit integer).
+
+    Examples
+    --------
+    > var a = new {{alias:@stdlib/number/uint64/ctor}}( 4294967296 )
+    <Uint64>[ 4294967296n ]
+    > var w = {{alias}}( a )
+    0
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( a )
-    Returns an unsigned 32-bit integer corresponding to the low 32-bit word of
-    a 64-bit unsigned integer.
+    Returns a 32-bit unsigned integer corresponding to the low 32-bit word of a
+    64-bit unsigned integer.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/repl.txt
@@ -11,7 +11,7 @@
     Returns
     -------
     out: integer
-        Lower order word (unsigned 32-bit integer).
+        Lower order word (32-bit unsigned integer).
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 import { Uint64 } from '@stdlib/types/number';
 
 /**
-* Returns a  32-bit unsigned integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
+* Returns a 32-bit unsigned integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
 *
 * @param a - input value
 * @returns lower order word (unsigned 32-bit integer)

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/index.d.ts
@@ -1,0 +1,43 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Uint64 } from '@stdlib/types/number';
+
+/**
+* Returns an unsigned 32-bit integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
+*
+* @param a - input value
+* @returns higher order word (unsigned 32-bit integer)
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 4294967296 );
+* var w = getLowWord( a );
+* // returns 0
+*/
+declare function getLowWord( a: Uint64 ): number;
+
+
+// EXPORTS //
+
+export = getLowWord;

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/index.d.ts
@@ -26,7 +26,7 @@ import { Uint64 } from '@stdlib/types/number';
 * Returns a 32-bit unsigned integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
 *
 * @param a - input value
-* @returns lower order word (unsigned 32-bit integer)
+* @returns lower order word (32-bit unsigned integer)
 *
 * @example
 * var Uint64 = require( '@stdlib/number/uint64/ctor' );

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/index.d.ts
@@ -23,10 +23,10 @@
 import { Uint64 } from '@stdlib/types/number';
 
 /**
-* Returns an unsigned 32-bit integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
+* Returns a  32-bit unsigned integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
 *
 * @param a - input value
-* @returns higher order word (unsigned 32-bit integer)
+* @returns lower order word (unsigned 32-bit integer)
 *
 * @example
 * var Uint64 = require( '@stdlib/number/uint64/ctor' );

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/docs/types/test.ts
@@ -1,0 +1,47 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Uint64 = require( '@stdlib/number/uint64/ctor' );
+import getLowWord = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	const a = new Uint64( 5 );
+	getLowWord( a ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided an argument that is not a 64-bit unsigned integer...
+{
+	getLowWord( 5 ); // $ExpectError
+	getLowWord( '5' ); // $ExpectError
+	getLowWord( true ); // $ExpectError
+	getLowWord( false ); // $ExpectError
+	getLowWord( [] ); // $ExpectError
+	getLowWord( {} ); // $ExpectError
+	getLowWord( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const a = new Uint64( 5 );
+	getLowWord(); // $ExpectError
+	getLowWord( a, a ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/examples/index.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var getLowWord = require( './../lib' );
+
+var a = new Uint64( 4294967296 );
+console.log( getLowWord( a ) );
+// => 0
+
+a = new Uint64( 0xffffffff );
+console.log( getLowWord( a ) );
+// => 4294967295
+
+a = new Uint64( 0x123400005678 );
+console.log( getLowWord( a ) );
+// => 22136
+
+a = Uint64.of( 1234, 5678 );
+console.log( getLowWord( a ) );
+// => 5678

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/lib/index.js
@@ -1,0 +1,42 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return an unsigned 32-bit integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
+*
+* @module @stdlib/number/uint64/base/get-low-word
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+* var getLowWord = require( '@stdlib/number/uint64/base/get-low-word' );
+*
+* var a = new Uint64( 4294967296 );
+* var w = getLowWord( a );
+* // returns 0
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Return an unsigned 32-bit integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
+* Return a 32-bit unsigned integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
 *
 * @module @stdlib/number/uint64/base/get-low-word
 *

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/lib/main.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Returns an unsigned 32-bit integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
+*
+* @param {Uint64} a - input value
+* @returns {uinteger32} higher order word
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 4294967296 );
+* var w = getLowWord( a );
+* // returns 0
+*/
+function getLowWord( a ) {
+	return a.lo;
+}
+
+
+// EXPORTS //
+
+module.exports = getLowWord;

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/lib/main.js
@@ -21,10 +21,10 @@
 // MAIN //
 
 /**
-* Returns an unsigned 32-bit integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
+* Returns a 32-bit unsigned integer corresponding to the low 32-bit word of a 64-bit unsigned integer.
 *
 * @param {Uint64} a - input value
-* @returns {uinteger32} higher order word
+* @returns {uinteger32} lower order word
 *
 * @example
 * var Uint64 = require( '@stdlib/number/uint64/ctor' );

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/number/uint64/base/get-low-word",
   "version": "0.0.0",
-  "description": "Return an unsigned 32-bit integer corresponding to the low 32-bit word of a 64-bit unsigned integer.",
+  "description": "Return a 32-bit unsigned integer corresponding to the low 32-bit word of a 64-bit unsigned integer.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/number/uint64/base/get-low-word",
+  "version": "0.0.0",
+  "description": "Return an unsigned 32-bit integer corresponding to the low 32-bit word of a 64-bit unsigned integer.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "base",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "types",
+    "type",
+    "uint64",
+    "unsigned",
+    "64-bit",
+    "integer",
+    "int",
+    "get",
+    "low",
+    "word"
+  ]
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/get-low-word/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/get-low-word/test/test.js
@@ -1,0 +1,83 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var getLowWord = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof getLowWord, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an integer', function test( t ) {
+	var a;
+	var w;
+
+	a = new Uint64( 4294967296 );
+	w = getLowWord( a );
+
+	t.ok( isInteger( w ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the low 32-bit word of a 64-bit unsigned integer', function test( t ) {
+	var values;
+	var a;
+	var v;
+	var w;
+	var i;
+
+	values = [
+		0,
+		1,
+		2,
+		3,
+		4,
+		5,
+		10,
+		99,
+		100,
+		999,
+		1000,
+		999999,
+		1000000,
+		999999999,
+		1000000000,
+		UINT32_MAX
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		v = values[ i ];
+		a = Uint64.of( 0, v );
+		w = getLowWord( a );
+		t.strictEqual( w, v, 'returns expected value' );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a package to retrieve the low 32-bit word of a 64-bit unsigned integer.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
