### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # dsyr2
 
-> Performs the symmetric rank 2 operation `A = alpha*x*y^T + alpha*y*x^T + A`.
+> Perform the symmetric rank 2 operation `A = alpha*x*y^T + alpha*y*x^T + A`.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/docs/types/test.ts
@@ -42,7 +42,7 @@ import dsyr2 = require( '@stdlib/blas/base/ndarray/dsyr2' );
 		'dtype': 'float64'
 	});
 
-	dsyr2( [ A, x, y, uplo, alpha ] ); // $ExpectType float64ndarray
+	dsyr2( [ x, y, A, uplo, alpha ] ); // $ExpectType float64ndarray
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
@@ -77,5 +77,5 @@ import dsyr2 = require( '@stdlib/blas/base/ndarray/dsyr2' );
 	});
 
 	dsyr2(); // $ExpectError
-	dsyr2( [ A, x, y, uplo, alpha ], {} ); // $ExpectError
+	dsyr2( [ x, y, A, uplo, alpha ], {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/lib/main.js
@@ -47,6 +47,7 @@ var strided = require( '@stdlib/blas/base/dsyr2' ).ndarray;
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {Object} output ndarray
 *
+* @example
 * var Float64Matrix = require( '@stdlib/ndarray/matrix/float64' );
 * var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
 * var resolveEnum = require( '@stdlib/blas/base/matrix-triangle-resolve-enum' );

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/package.json
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/base/ndarray/dsyr2",
   "version": "0.0.0",
-  "description": "Performs the symmetric rank 2 operation `A = alpha*x*y^T + alpha*y*x^T + A`.",
+  "description": "Perform the symmetric rank 2 operation `A = alpha*x*y^T + alpha*y*x^T + A`.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ssyr2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ssyr2/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # ssyr2
 
-> Performs the symmetric rank 2 operation `A = alpha*x*y^T + alpha*y*x^T + A`.
+> Perform the symmetric rank 2 operation `A = alpha*x*y^T + alpha*y*x^T + A`.
 
 <section class="intro">
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ssyr2/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ssyr2/lib/main.js
@@ -47,6 +47,7 @@ var strided = require( '@stdlib/blas/base/ssyr2' ).ndarray;
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {Object} output ndarray
 *
+* @example
 * var Float32Matrix = require( '@stdlib/ndarray/matrix/float32' );
 * var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
 * var resolveEnum = require( '@stdlib/blas/base/matrix-triangle-resolve-enum' );

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ssyr2/package.json
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ssyr2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/base/ndarray/ssyr2",
   "version": "0.0.0",
-  "description": "Performs the symmetric rank 2 operation `A = alpha*x*y^T + alpha*y*x^T + A`.",
+  "description": "Perform the symmetric rank 2 operation `A = alpha*x*y^T + alpha*y*x^T + A`.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gany/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gany/README.md
@@ -51,9 +51,7 @@ var v = gany( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gany/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gany/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { ndarray } from '@stdlib/types/ndarray';
+import { typedndarray } from '@stdlib/types/ndarray';
 
 /**
 * Tests whether at least one element in a one-dimensional ndarray is truthy.
@@ -44,7 +44,7 @@ import { ndarray } from '@stdlib/types/ndarray';
 * var v = gany( [ x ] );
 * // returns true
 */
-declare function gany( arrays: [ ndarray ] ): boolean;
+declare function gany( arrays: [ typedndarray<unknown> ] ): boolean;
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request applies follow-up fixes for commits merged to `develop` between 2026-07-18 14:43 (PT) (`c624655a`) and 2026-07-19 02:10 (PT) (`ad17191d`).

#### `blas/base/ndarray/dsyr2`

-   314e5094 (`blas/base/ndarray/dsyr2`): `docs/types/test.ts` lines 45 and 80 call `dsyr2( [ A, x, y, uplo, alpha ] )`; every other call site in the package—and ssyr2's `test.ts`—use `[ x, y, A, uplo, alpha ]`. Reorder both arrays to match.
-   314e5094: `dsyr2`'s `main.js` JSDoc drops the `@example` tag before the example code — goes straight from `@returns` to the `require` calls, so the block isn't recognized as an example. dsyr/ssyr/gsyr all have it; add `* @example` after `@returns` in `lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/lib/main.js`.
-   314e5094 introduced `blas/base/ndarray/dsyr2/README.md` (L23) and `package.json` with "Performs the symmetric rank 2 operation ..." instead of the imperative "Perform" used everywhere else in `blas/base/ndarray` (dsyr, ssyr, gsyr, dgemm, etc.); fixed both to match the established convention.

#### `blas/base/ndarray/ssyr2`

-   8b15f448: `blas/base/ndarray/ssyr2/lib/main.js` is missing `@example` before the example code in the main export's JSDoc — every sibling (dsyr, ssyr, gsyr) has it. Added `* @example` after `@returns` so doc tooling picks up the example block.
-   8b15f448: README tagline and `package.json` description for `blas/base/ndarray/ssyr2` say "Performs the symmetric rank 2 operation" — every sibling ndarray package uses the imperative "Perform ...". Fixed both to match (README.md line 23, `package.json` description).

#### `blas/ext/base/ndarray/gany`

-   3314d559: README params use the nested "array-like object containing the following ndarrays:" template meant for multi-array functions, but `gany` takes one ndarray, contradicting its own `repl.txt` and dany/sany. Switched to the flat "array-like object containing a one-dimensional input ndarray" phrasing in `lib/node_modules/@stdlib/blas/ext/base/ndarray/gany/README.md`.
-   3314d559: `gany`'s d.ts (`lib/node_modules/@stdlib/blas/ext/base/ndarray/gany/docs/types/index.d.ts`) types `arrays` as bare `ndarray` instead of `typedndarray<unknown>`, unlike every other g-prefixed sibling in `ext/base/ndarray` (gindex-of-truthy/gindex-of-falsy included). Import `typedndarray` and fix the signature to `gany( arrays: [ typedndarray<unknown> ] ): boolean`.

## Related Issues

> Does this pull request have any related issues?

This pull request does not have any related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed on the 49-commit window (`c624655a`..`ad17191d`):

-   Style guide compliance: two independent review passes comparing each new package against `docs/style-guides` and established sibling packages of similar complexity.
-   Bug scan: two independent review passes over the per-commit diffs (diff-only and in-context); no runtime bugs found.
-   Every applied fix was independently re-verified against the working tree before committing.
-   Deliberately excluded: subjective suggestions, preferences not explicitly required by the style guides, anything requiring interpretation, and anything whose validation would require changes outside the window's diff. Auto-generated artifacts (error databases, namespace data tables, REPL help data, regenerated equation SVGs) were treated as out of scope.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was generated by Claude Code as part of an automated follow-up review of commits recently merged to `develop`. All findings were machine-verified against the repository before committing; a human maintainer will audit the changes before this PR is marked ready for review.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7PBf9ov3Q6WHwF2mWhRRg)_