### PR TITLE
test: migrate `math/base/special/cbrtf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.js
@@ -69,7 +69,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -88,7 +88,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`',
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -107,7 +107,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -126,7 +126,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -145,7 +145,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`',
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -164,7 +164,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', f
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -183,7 +183,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -202,7 +202,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -221,7 +221,7 @@ tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', f
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -240,7 +240,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -259,7 +259,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -278,7 +278,7 @@ tape( 'the function evaluates the cubic root of subnormal `x`', function test( t
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -298,7 +298,7 @@ tape( 'the function evaluates the cubic root of `x` (huge negative)', function t
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -318,7 +318,7 @@ tape( 'the function evaluates the cubic root of `x` (huge positive)', function t
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.js
@@ -26,8 +26,7 @@ var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var cbrtf = require( './../lib' );
 
 
@@ -59,8 +58,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -72,9 +69,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -82,8 +77,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]'
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,9 +88,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`',
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -105,8 +96,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`',
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -118,9 +107,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -128,8 +115,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`'
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -141,9 +126,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -151,8 +134,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', 
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -164,9 +145,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`',
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -174,8 +153,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`',
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -187,9 +164,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', f
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -197,8 +172,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', f
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -210,9 +183,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -220,8 +191,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`'
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -233,9 +202,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -243,8 +210,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', 
 
 tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -256,9 +221,7 @@ tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', f
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -266,8 +229,6 @@ tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', f
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1e-308]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -279,9 +240,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -289,8 +248,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-308]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -302,9 +259,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -312,8 +267,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-
 
 tape( 'the function evaluates the cubic root of subnormal `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -325,9 +278,7 @@ tape( 'the function evaluates the cubic root of subnormal `x`', function test( t
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -335,8 +286,6 @@ tape( 'the function evaluates the cubic root of subnormal `x`', function test( t
 
 tape( 'the function evaluates the cubic root of `x` (huge negative)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -349,9 +298,7 @@ tape( 'the function evaluates the cubic root of `x` (huge negative)', function t
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -359,8 +306,6 @@ tape( 'the function evaluates the cubic root of `x` (huge negative)', function t
 
 tape( 'the function evaluates the cubic root of `x` (huge positive)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -373,9 +318,7 @@ tape( 'the function evaluates the cubic root of `x` (huge positive)', function t
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.native.js
@@ -78,7 +78,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -97,7 +97,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`',
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -116,7 +116,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -135,7 +135,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -154,7 +154,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`',
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -173,7 +173,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', o
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -192,7 +192,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -211,7 +211,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -230,7 +230,7 @@ tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', o
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -249,7 +249,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -268,7 +268,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -287,7 +287,7 @@ tape( 'the function evaluates the cubic root of subnormal `x`', opts, function t
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -307,7 +307,7 @@ tape( 'the function evaluates the cubic root of `x` (huge negative)', opts, func
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -327,7 +327,7 @@ tape( 'the function evaluates the cubic root of `x` (huge positive)', opts, func
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.native.js
@@ -27,8 +27,7 @@ var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -68,8 +67,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -81,9 +78,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -91,8 +86,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-50,-500]'
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -104,9 +97,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`',
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -114,8 +105,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[50,500]`',
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -127,9 +116,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -137,8 +124,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-50]`'
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -150,9 +135,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -160,8 +143,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[20,50]`', 
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -173,9 +154,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`',
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -183,8 +162,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-20,-3]`',
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -196,9 +173,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', o
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -206,8 +181,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[3,20]`', o
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -219,9 +192,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -229,8 +200,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-3,-0.8]`'
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -242,9 +211,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -252,8 +219,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[0.8,3]`', 
 
 tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -265,9 +230,7 @@ tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', o
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -275,8 +238,6 @@ tape( 'the function evaluates cubic root of `x` on the interval `[-0.8,0.8]`', o
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1e-308]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -288,9 +249,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -298,8 +257,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[-1e-300,-1
 
 tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-308]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -311,9 +268,7 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -321,8 +276,6 @@ tape( 'the function evaluates the cubic root of `x` on the interval `[1e-300,1e-
 
 tape( 'the function evaluates the cubic root of subnormal `x`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -334,9 +287,7 @@ tape( 'the function evaluates the cubic root of subnormal `x`', opts, function t
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -344,8 +295,6 @@ tape( 'the function evaluates the cubic root of subnormal `x`', opts, function t
 
 tape( 'the function evaluates the cubic root of `x` (huge negative)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -358,9 +307,7 @@ tape( 'the function evaluates the cubic root of `x` (huge negative)', opts, func
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -368,8 +315,6 @@ tape( 'the function evaluates the cubic root of `x` (huge negative)', opts, func
 
 tape( 'the function evaluates the cubic root of `x` (huge positive)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -382,9 +327,7 @@ tape( 'the function evaluates the cubic root of `x` (huge positive)', opts, func
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValuef( y, expected[i], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

- Migrates the `@stdlib/math/base/special/cbrtf` package tests from relative tolerance testing to ULP-based difference testing using `isAlmostSameValue`.
- Removes all outdated `delta` and `tol` variables across the package test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
