### PR TITLE
style: re-enable lint rule

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/dgemv/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dgemv/README.md
@@ -40,8 +40,6 @@ var dgemv = require( '@stdlib/blas/base/ndarray/dgemv' );
 
 Performs one of the matrix-vector operations `y = alpha*A*x + beta*y` or `y = alpha*A^T*x + beta*y`, where `alpha` and `beta` are scalars, `x` and `y` are one-dimensional ndarrays, and `A` is an `M` by `N` matrix.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float64Matrix = require( '@stdlib/ndarray/matrix/float64' );
 var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
@@ -93,8 +91,6 @@ The function has the following parameters:
 <section class="examples">
 
 ## Examples
-
-<!-- eslint-disable max-len -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dger/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dger/README.md
@@ -40,8 +40,6 @@ var dger = require( '@stdlib/blas/base/ndarray/dger' );
 
 Performs the rank 1 operation `A = alpha*x*y^T + A`, where `alpha` is a scalar, `x` and `y` are one-dimensional ndarrays, and `A` is an `M` by `N` matrix.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float64Matrix = require( '@stdlib/ndarray/matrix/float64' );
 var Float64Vector = require( '@stdlib/ndarray/vector/float64' );
@@ -84,8 +82,6 @@ The function has the following parameters:
 <section class="examples">
 
 ## Examples
-
-<!-- eslint-disable max-len -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/README.md
@@ -90,8 +90,6 @@ The function has the following parameters:
 
 ## Examples
 
-<!-- eslint-disable max-len -->
-
 <!-- eslint no-undef: "error" -->
 
 ```javascript

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ggemv/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ggemv/README.md
@@ -40,8 +40,6 @@ var ggemv = require( '@stdlib/blas/base/ndarray/ggemv' );
 
 Performs one of the matrix-vector operations `y = alpha*A*x + beta*y` or `y = alpha*A^T*x + beta*y`, where `alpha` and `beta` are scalars, `x` and `y` are one-dimensional ndarrays, and `A` is an `M` by `N` matrix.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var matrix = require( '@stdlib/ndarray/matrix/ctor' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
@@ -93,8 +91,6 @@ The function has the following parameters:
 <section class="examples">
 
 ## Examples
-
-<!-- eslint-disable max-len -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/gger/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/gger/README.md
@@ -40,8 +40,6 @@ var gger = require( '@stdlib/blas/base/ndarray/gger' );
 
 Performs the rank 1 operation `A = alpha*x*y^T + A`, where `alpha` is a scalar, `x` and `y` are one-dimensional ndarrays, and `A` is an `M` by `N` matrix.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var matrix = require( '@stdlib/ndarray/matrix/ctor' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
@@ -84,8 +82,6 @@ The function has the following parameters:
 <section class="examples">
 
 ## Examples
-
-<!-- eslint-disable max-len -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/gsyr/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/gsyr/README.md
@@ -40,8 +40,6 @@ var gsyr = require( '@stdlib/blas/base/ndarray/gsyr' );
 
 Performs the symmetric rank 1 operation `A = alpha*x*x^T + A`, where `alpha` is a scalar, `x` is a one-dimensional ndarray, and `A` is an `N` by `N` symmetric matrix.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var matrix = require( '@stdlib/ndarray/matrix/ctor' );
 var vector = require( '@stdlib/ndarray/vector/ctor' );
@@ -87,8 +85,6 @@ The function has the following parameters:
 <section class="examples">
 
 ## Examples
-
-<!-- eslint-disable max-len -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/sgemv/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/sgemv/README.md
@@ -40,8 +40,6 @@ var sgemv = require( '@stdlib/blas/base/ndarray/sgemv' );
 
 Performs one of the matrix-vector operations `y = alpha*A*x + beta*y` or `y = alpha*A^T*x + beta*y`, where `alpha` and `beta` are scalars, `x` and `y` are one-dimensional ndarrays, and `A` is an `M` by `N` matrix.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float32Matrix = require( '@stdlib/ndarray/matrix/float32' );
 var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
@@ -93,8 +91,6 @@ The function has the following parameters:
 <section class="examples">
 
 ## Examples
-
-<!-- eslint-disable max-len -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/sger/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/sger/README.md
@@ -40,8 +40,6 @@ var sger = require( '@stdlib/blas/base/ndarray/sger' );
 
 Performs the rank 1 operation `A = alpha*x*y^T + A`, where `alpha` is a scalar, `x` and `y` are one-dimensional ndarrays, and `A` is an `M` by `N` matrix.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float32Matrix = require( '@stdlib/ndarray/matrix/float32' );
 var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
@@ -84,8 +82,6 @@ The function has the following parameters:
 <section class="examples">
 
 ## Examples
-
-<!-- eslint-disable max-len -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ssyr/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ssyr/README.md
@@ -88,8 +88,6 @@ The function has the following parameters:
 
 ## Examples
 
-<!-- eslint-disable max-len -->
-
 <!-- eslint no-undef: "error" -->
 
 ```javascript

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cunitspace/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cunitspace/README.md
@@ -40,8 +40,6 @@ var cunitspace = require( '@stdlib/blas/ext/base/ndarray/cunitspace' );
 
 Fills a one-dimensional single-precision complex floating-point ndarray with linearly spaced numeric elements which increment by `1` starting from a specified value.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Complex64Vector = require( '@stdlib/ndarray/vector/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zunitspace/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zunitspace/README.md
@@ -40,8 +40,6 @@ var zunitspace = require( '@stdlib/blas/ext/base/ndarray/zunitspace' );
 
 Fills a one-dimensional double-precision complex floating-point ndarray with linearly spaced numeric elements which increment by `1` starting from a specified value.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Complex128Vector = require( '@stdlib/ndarray/vector/complex128' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Propagating fixes merged to `develop` between 2026-07-18T14:43:15-07:00 (c624655) and 2026-07-19T02:10:38-07:00 (ad17191) to sibling packages.

This pull request:

-   mirrors 532cf32 ("style: re-enable lint rule"): removes the `<!-- eslint-disable max-len -->` comments from README intro and example code blocks at eighteen sites across eleven sibling packages where no guarded line exceeds 80 characters outside a comment, string, URL, template literal, or regex literal. `ssyr`, `ssyr2`, `dsyr`, `dsyr2`, and `cgemv` keep their remaining suppressions — each guards an 82-89 character matrix literal with no exempting token, so the rule still fires there. No functional change; lint config untouched.

Source commit: 532cf32. Target packages:

-   `blas/base/ndarray/sger`
-   `blas/base/ndarray/ssyr`
-   `blas/base/ndarray/ggemv`
-   `blas/base/ndarray/sgemv`
-   `blas/base/ndarray/dgemv`
-   `blas/base/ndarray/dsyr2`
-   `blas/base/ndarray/dger`
-   `blas/base/ndarray/gsyr`
-   `blas/base/ndarray/gger`
-   `blas/ext/base/ndarray/zunitspace`
-   `blas/ext/base/ndarray/cunitspace`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation: all 24 candidate suppression sites found by exact-string search across `blas/base/ndarray/*/README.md` and `blas/ext/base/ndarray/*/README.md` were checked line-by-line against the `max-len` configuration (`etc/eslint/rules/style.js`) by two independent validation passes, plus a patch-application pass and a style-consistency pass. Six sites were deliberately excluded as load-bearing (`ssyr`, `ssyr2`, `dsyr`, `dsyr2` intro blocks; both `cgemv` blocks), each containing an 82-89 character matrix-literal line exempted by no `max-len` ignore option. Only sites confirmed by both independent passes were patched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine: it located sibling packages carrying the same unnecessary lint suppressions removed in 532cf32, validated each site against the `max-len` configuration, and applied the equivalent removals.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGRTGPoeWq9TnGnKN2SCUs)_