### PR TITLE
refactor: use `constants/float64/nan` in `math/base/special/pow`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/pow/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/pow/manifest.json
@@ -55,7 +55,8 @@
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/number/float64/base/to-words",
-        "@stdlib/constants/float64/num-high-word-significand-bits"
+        "@stdlib/constants/float64/num-high-word-significand-bits",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -87,7 +88,8 @@
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/number/float64/base/to-words",
-        "@stdlib/constants/float64/num-high-word-significand-bits"
+        "@stdlib/constants/float64/num-high-word-significand-bits",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -119,7 +121,8 @@
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/number/float64/base/to-words",
-        "@stdlib/constants/float64/num-high-word-significand-bits"
+        "@stdlib/constants/float64/num-high-word-significand-bits",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/pow/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/pow/src/main.c
@@ -44,6 +44,7 @@
 #include "stdlib/constants/float64/ln_two.h"
 #include "stdlib/constants/float64/exponent_bias.h"
 #include "stdlib/constants/float64/high_word_significand_mask.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/assert/is_integer.h"
@@ -209,7 +210,7 @@ static double polyval_p( const double x ) {
 */
 static double y_is_infinite( const double x, const double y ) {
 	if ( x == -1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 1.0 ) {
 		return 1.0;
@@ -569,7 +570,7 @@ double stdlib_base_pow( const double x, const double y ) {
 
 	xc = x;
 	if ( stdlib_base_is_nan( xc ) || stdlib_base_is_nan( y ) ) {
-		return 0.0/0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	// Split `y` into high and low words:
@@ -639,7 +640,7 @@ double stdlib_base_pow( const double x, const double y ) {
 		stdlib_base_is_integer( y ) == false
 	) {
 		// Signal NaN...
-		return 0.0/0.0;
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	ax = stdlib_base_abs( x );
 


### PR DESCRIPTION
Resolves a part of #11743.

## Description

> What is the purpose of this pull request?

This pull request:

- Replaces inline NaN generation (`0.0/0.0`) in `math/base/special/pow` with the stdlib NaN constant from `@stdlib/constants/float64/nan`.
- Adds the necessary `#include "stdlib/constants/float64/nan.h"` directive to the C source file.
- Updates the `manifest.json` configurations to add `@stdlib/constants/float64/nan` as a dependency.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #11743

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
