### PR TITLE
fix(@stdlib/string/base/atob): guard against undefined `atob` global

### DIFF
--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -20,7 +20,7 @@
 
 // MAIN //
 
-var main = ( typeof atob === 'function' ) ? atob : null;
+var main = ( typeof atob === 'function' ) ? atob : null; // eslint-disable-line n/no-unsupported-features/node-builtins
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/string/base/atob/lib/global.js
+++ b/lib/node_modules/@stdlib/string/base/atob/lib/global.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MAIN //
+
+var main = ( typeof atob === 'function' ) ? atob : null;
+
+
 // EXPORTS //
 
-module.exports = atob;
+module.exports = main;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a `ReferenceError: atob is not defined` crash on Node.js v12/v14 in `@stdlib/string/base/atob` by guarding the module-scope reference to the `atob` global.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Failing run**
[`linux_test` #29681875444](https://github.com/stdlib-js/stdlib/actions/runs/29681875444), jobs "Node.js v12" and "Node.js v14", branch `develop`.

**Symptom**
```
ReferenceError: atob is not defined
    at Object.<anonymous> (.../lib/node_modules/@stdlib/string/base/atob/lib/global.js:23:18)
```

**Root cause**
`global.js` did `module.exports = atob;` — a bare reference evaluated at require time. Node <16 doesn't define `atob` globally. `index.js` requires `main.js` (which requires `global.js`) unconditionally, before `@stdlib/assert/has-atob-support` ever runs, so the crash preempts the environment-detection logic meant to handle exactly this case.

**Fix**
`global.js` now reads:
```js
var main = ( typeof atob === 'function' ) ? atob : null;
module.exports = main;
```
`typeof` on an undeclared identifier never throws. On Node 16+/browsers, behavior is unchanged — the native function is exported as before. `hasAtobSupport()` still gates the polyfill path in `index.js`; `main.js`'s try/catch is untouched.

**Validation**
- `vm` sandbox with no global `atob`: `global.js` no longer throws, exports `null`.
- End-to-end on native-`atob` Node: `atob('SGVsbG8sIHdvcmxk')` → `'Hello, world'` through `global.js` → `main.js` → `index.js`.
- `npm test` / `make lint-pkg` not runnable in this sandbox (no `node_modules`; `npm install` blocked by registry min-release-age policy on `es-object-atoms@^1.1.2`). `node --check` confirms valid syntax.
- Three independent reviews (correctness, regression-scope, style) — all approve, no blocking findings.

**Reviewer notes**
Non-blocking: fix is platform-agnostic and should also cover this failure class on other Node <16 matrix jobs (`windows_test_npm_install`, `macos_test_npm_install`), not just `linux_test`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, running an automated CI-failure investigation and fix routine: it identified the failing run, diagnosed the root cause, authored the fix, and drafted this description, all based on the linked CI failure log.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01BoFC4tfNmrCzJ79F9ySGah)_