### PR TITLE
test: migrate `math/base/special/sin` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/sin/test/test.js
@@ -59,7 +59,7 @@ tape( 'the function computes the sine (medium negative values)', function test( 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -75,7 +75,7 @@ tape( 'the function computes the sine (medium positive values)', function test( 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -91,7 +91,7 @@ tape( 'the function computes the sine (large negative values)', function test( t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -107,7 +107,7 @@ tape( 'the function computes the sine (large positive values)', function test( t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -123,7 +123,7 @@ tape( 'the function computes the sine (huge negative values)', function test( t 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -139,7 +139,7 @@ tape( 'the function computes the sine (huge positive values)', function test( t 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/sin/test/test.js
@@ -24,8 +24,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var sin = require( './../lib' );
@@ -51,8 +50,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the sine (medium negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -62,21 +59,13 @@ tape( 'the function computes the sine (medium negative values)', function test( 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -86,21 +75,13 @@ tape( 'the function computes the sine (medium positive values)', function test( 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -110,21 +91,13 @@ tape( 'the function computes the sine (large negative values)', function test( t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -134,21 +107,13 @@ tape( 'the function computes the sine (large positive values)', function test( t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (huge negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -158,21 +123,13 @@ tape( 'the function computes the sine (huge negative values)', function test( t 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (huge positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -182,13 +139,7 @@ tape( 'the function computes the sine (huge positive values)', function test( t 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sin/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sin/test/test.native.js
@@ -68,7 +68,7 @@ tape( 'the function computes the sine (medium negative values)', opts, function 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -84,7 +84,7 @@ tape( 'the function computes the sine (medium positive values)', opts, function 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -100,7 +100,7 @@ tape( 'the function computes the sine (large negative values)', opts, function t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -116,7 +116,7 @@ tape( 'the function computes the sine (large positive values)', opts, function t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -132,7 +132,7 @@ tape( 'the function computes the sine (huge negative values)', opts, function te
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -148,7 +148,7 @@ tape( 'the function computes the sine (huge positive values)', opts, function te
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sin/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sin/test/test.native.js
@@ -25,8 +25,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -60,8 +59,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the sine (medium negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -71,21 +68,13 @@ tape( 'the function computes the sine (medium negative values)', opts, function 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,21 +84,13 @@ tape( 'the function computes the sine (medium positive values)', opts, function 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -119,21 +100,13 @@ tape( 'the function computes the sine (large negative values)', opts, function t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -143,21 +116,13 @@ tape( 'the function computes the sine (large positive values)', opts, function t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (huge negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -167,21 +132,13 @@ tape( 'the function computes the sine (huge negative values)', opts, function te
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine (huge positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -191,13 +148,7 @@ tape( 'the function computes the sine (huge positive values)', opts, function te
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sin( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.ok( isAlmostSameValue( y, expected[ i ] ), 'x: '+x[i]+'. y: '+y+'. Expected: '+expected[i] );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `math/base/special/sin` tests from relative tolerance (`EPS`) to ULP-based testing using `isAlmostSameValue`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
