### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/package-json/schema/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/package-json/schema/examples/index.js
@@ -21,6 +21,7 @@
 var Ajv = require( 'ajv' );
 var schema = require( './../lib' );
 var pkg = require( './../package.json' );
+
 var ajv = new Ajv();
 
 var bool = ajv.validate( schema(), pkg );

--- a/lib/node_modules/@stdlib/_tools/package-json/schema/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/package-json/schema/examples/index.js
@@ -20,7 +20,6 @@
 
 var Ajv = require( 'ajv' );
 var schema = require( './../lib' );
-
 var pkg = require( './../package.json' );
 var ajv = new Ajv();
 


### PR DESCRIPTION
Resolves #13569.

## Description

> What is the purpose of this pull request?

This pull request:

-   removes an unexpected empty line between `require` statements in `lib/node_modules/@stdlib/_tools/package-json/schema/examples/index.js`, fixing the `stdlib/no-empty-lines-between-requires` lint error reported by the automated JavaScript lint workflow.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #13569

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored with the assistance of Claude Code.

* * *

@stdlib-js/reviewers