### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/assert/has-symbol-support/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/has-symbol-support/lib/main.js
@@ -31,8 +31,8 @@
 */
 function hasSymbolSupport() {
 	return (
-		typeof Symbol === 'function' &&
-		typeof Symbol( 'foo' ) === 'symbol'
+		typeof Symbol === 'function' && // eslint-disable-line stdlib/require-globals
+		typeof Symbol( 'foo' ) === 'symbol' // eslint-disable-line stdlib/require-globals
 	);
 }
 

--- a/lib/node_modules/@stdlib/strided/base/reinterpret-float16/lib/main.js
+++ b/lib/node_modules/@stdlib/strided/base/reinterpret-float16/lib/main.js
@@ -16,7 +16,6 @@
 * limitations under the License.
 */
 
-
 'use strict';
 
 // MODULES //

--- a/lib/node_modules/@stdlib/strided/base/reinterpret-float16/lib/main.js
+++ b/lib/node_modules/@stdlib/strided/base/reinterpret-float16/lib/main.js
@@ -16,7 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable stdlib/jsdoc-typedef-typos */
 
 'use strict';
 


### PR DESCRIPTION
Resolves #13096

## Description

> What is the purpose of this pull request?

This pull request:

- Removes an unused `eslint-disable` directive in `@stdlib/strided/base/reinterpret-float16`.
- Properly disables the `stdlib/require-globals` lint rule for native `Symbol` checks in `@stdlib/assert/has-symbol-support` where it's being tested.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #13096

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
