### PR TITLE
test: migrate `math/base/special/sind` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sind/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/sind/test/test.js
@@ -21,13 +21,12 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
-var NINF = require( '@stdlib/constants/float64/ninf' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sind = require( './../lib' );
 
 
@@ -53,11 +52,9 @@ tape( 'if provided a `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function computes the sine of an angle measured in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var i;
 	var x;
 	var y;
-	var i;
 
 	x = negative.x;
 	expected = negative.expected;
@@ -67,9 +64,7 @@ tape( 'the function computes the sine of an angle measured in degrees (negative 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -77,11 +72,9 @@ tape( 'the function computes the sine of an angle measured in degrees (negative 
 
 tape( 'the function computes the sine of an angle measured in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var i;
 	var x;
 	var y;
-	var i;
 
 	x = positive.x;
 	expected = positive.expected;
@@ -91,9 +84,7 @@ tape( 'the function computes the sine of an angle measured in degrees (positive 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/sind/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sind/test/test.native.js
@@ -22,13 +22,12 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
-var NINF = require( '@stdlib/constants/float64/ninf' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -62,11 +61,9 @@ tape( 'if provided a `NaN`, the function returns `NaN`', opts, function test( t 
 
 tape( 'the function computes the sine of an angle measured in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var i;
 	var x;
 	var y;
-	var i;
 
 	x = negative.x;
 	expected = negative.expected;
@@ -76,9 +73,7 @@ tape( 'the function computes the sine of an angle measured in degrees (negative 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -86,11 +81,9 @@ tape( 'the function computes the sine of an angle measured in degrees (negative 
 
 tape( 'the function computes the sine of an angle measured in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var i;
 	var x;
 	var y;
-	var i;
 
 	x = positive.x;
 	expected = positive.expected;
@@ -100,9 +93,7 @@ tape( 'the function computes the sine of an angle measured in degrees (positive 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

- Migrates `math/base/special/sind` tests from relative tolerance (`EPS`) to ULP-based testing using `isAlmostSameValue`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
