### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-less-than/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-less-than/docs/repl.txt
@@ -57,7 +57,7 @@
     1
 
 
-{{alias}}( N, x, strideX, offsetX, y, strideY, offsetY )
+{{alias}}.ndarray( N, x, strideX, offsetX, y, strideY, offsetY )
     Returns the index of the first element in a double-precision floating-point
     strided array which is less than a corresponding element in another double-
     precision floating-point strided array using alternative indexing semantics.

--- a/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-less-than/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-less-than/docs/types/index.d.ts
@@ -18,8 +18,6 @@
 
 // TypeScript Version: 4.1
 
-/// <reference types="@stdlib/types"/>
-
 /**
 * Interface describing `dfirstIndexLessThan`.
 */

--- a/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-less-than/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-less-than/docs/types/test.ts
@@ -68,7 +68,6 @@ import dfirstIndexLessThan = require( './index' );
 // The compiler throws an error if the function is provided a fourth argument which is not a Float64Array...
 {
 	var x = new Float64Array( [ 1.0, 2.0, 3.0 ] );
-	var y = new Float64Array( [ 1.0, 2.0, 3.0 ] );
 
 	dfirstIndexLessThan( x.length, x, 1, '1', 1 ); // $ExpectError
 	dfirstIndexLessThan( x.length, x, 1, true, 1 ); // $ExpectError

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gxdy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gxdy/README.md
@@ -104,7 +104,7 @@ var opts = {
 var x = discreteUniform( [ 10 ], -100, 100, opts );
 console.log( ndarray2array( x ) );
 
-var y = discreteUniform( [ 10 ], -100, 100, opts );
+var y = discreteUniform( [ 10 ], 1, 100, opts );
 console.log( ndarray2array( y ) );
 
 gxdy( [ x, y ] );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-07-19T13:04:31-07:00 (`2b91bfe`) and 2026-07-20T00:58:01-07:00 (`2f69188`).

This pull request:

-   `blas/ext/base/ndarray/gxdy`: the README examples (`blas/ext/base/ndarray/gxdy/README.md`, introduced in 64d2677) generate `y` via `discreteUniform( [ 10 ], -100, 100, opts )`, allowing zero divisors; changed the bounds to `1, 100` to match `examples/index.js` and the `dxdy`/`sxdy` siblings.
-   `blas/ext/base/dfirst-index-less-than`: removed the stray, unused `@stdlib/types` triple-slash reference directive from `blas/ext/base/dfirst-index-less-than/docs/types/index.d.ts` (introduced in bd18166); the file only touches `Float64Array`/`number`, and neither `sfirst-index-less-than` nor `dfirst-index-equal` carry it.
-   `blas/ext/base/dfirst-index-less-than`: removed the dead `y` declaration in the "fourth argument" test block of `dfirst-index-less-than/docs/types/test.ts`, left over from bd18166 where `y` was never referenced once the fourth argument was swapped for invalid values — matches `sfirst-index-less-than` and `dfirst-index-equal`, which never declared it.
-   `blas/ext/base/dfirst-index-less-than`: fixed the repl.txt signature heading in `dfirst-index-less-than/docs/repl.txt` to include the `.ndarray` suffix, matching the examples below it and `sfirst-index-less-than`/`dfirst-index-equal`; missed in bd18166.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 24 commits merged to `develop` in the 24-hour window were reviewed for (1) stdlib style-guide compliance (`docs/style-guides`), audited by comparison against established sibling/reference packages (`dfirst-index-equal`, `sfirst-index-less-than`, `dxdy`, `sxdy`), and (2) bugs in the introduced code (logic, dtype consistency across `d`/`s`/`g` variants, stride/offset handling, C sources, ULP test migrations). Only objective, independently re-verified issues were retained; subjective concerns, style preferences not required by the style guides, test-coverage gaps, and anything requiring changes outside the reviewed diff were deliberately excluded. Bot-generated churn (equation SVG CDN-hash bumps, regenerated TypeScript declarations, REPL data) was inspected and left untouched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated commit-review routine run with Claude Code: AI agents reviewed the last 24 hours of commits merged to `develop`, and the retained fixes were applied and committed by Claude Code. All findings were independently re-verified against the repository before inclusion.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md