### PR TITLE
refactor: use `constants/float64/nan` and clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/dnrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dnrm2/README.md
@@ -66,9 +66,7 @@ var y = dnrm2( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dzasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dzasum/README.md
@@ -66,9 +66,7 @@ var y = dzasum( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dznrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dznrm2/README.md
@@ -66,9 +66,7 @@ var y = dznrm2( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/gnrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/gnrm2/README.md
@@ -66,9 +66,7 @@ var y = gnrm2( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/scasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/scasum/README.md
@@ -66,9 +66,7 @@ var y = scasum( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/scnrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/scnrm2/README.md
@@ -66,9 +66,7 @@ var y = scnrm2( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/snrm2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/snrm2/README.md
@@ -66,9 +66,7 @@ var y = snrm2( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-less-than/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfirst-index-less-than/README.md
@@ -129,8 +129,6 @@ The function has the following additional parameters:
 
 While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example, to access only the last three elements of each strided array:
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dsome/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsome/README.md
@@ -58,8 +58,6 @@ The function has the following parameters:
 
 The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to test every other element:
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dindex-of-falsy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dindex-of-falsy/README.md
@@ -51,9 +51,7 @@ var idx = dindexOfFalsy( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 If the function is unable to find a falsy element, the function returns `-1`.
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-falsy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gindex-of-falsy/README.md
@@ -51,9 +51,7 @@ var idx = gindexOfFalsy( [ x ] );
 
 The function has the following parameters:
 
--   **arrays**: array-like object containing the following ndarrays:
-
-    -   a one-dimensional input ndarray.
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
 
 If the function is unable to find a falsy element, the function returns `-1`.
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ssome/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssome/README.md
@@ -58,8 +58,6 @@ The function has the following parameters:
 
 The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to test every other element:
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );
 

--- a/lib/node_modules/@stdlib/lapack/base/dgttrf/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/dgttrf/README.md
@@ -241,8 +241,6 @@ The function has the following additional parameters:
 
 While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example,
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
 var Int32Array = require( '@stdlib/array/int32' );

--- a/lib/node_modules/@stdlib/lapack/base/dlassq/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/dlassq/README.md
@@ -113,8 +113,6 @@ The function has the following additional parameters:
 
 While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example,
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
 

--- a/lib/node_modules/@stdlib/lapack/base/dpttrf/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/dpttrf/README.md
@@ -95,8 +95,6 @@ The function has the following additional parameters:
 
 While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example,
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
 

--- a/lib/node_modules/@stdlib/lapack/base/spttrf/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/spttrf/README.md
@@ -95,8 +95,6 @@ The function has the following additional parameters:
 
 While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example,
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );
 

--- a/lib/node_modules/@stdlib/math/base/special/acos/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/acos/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/special/asin",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/fourth-pi"
+        "@stdlib/constants/float64/fourth-pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/special/asin",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/fourth-pi"
+        "@stdlib/constants/float64/fourth-pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/special/asin",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/fourth-pi"
+        "@stdlib/constants/float64/fourth-pi",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/acos/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/acos/src/main.c
@@ -35,6 +35,7 @@
 #include "stdlib/math/base/special/asin.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/constants/float64/fourth_pi.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double MOREBITS = 6.123233995736765886130e-17; // pi/2 = PIO2 + MOREBITS.
@@ -81,10 +82,10 @@ static const double MOREBITS = 6.123233995736765886130e-17; // pi/2 = PIO2 + MOR
 double stdlib_base_acos( const double x ) {
 	double z;
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x < -1.0 || x > 1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x > 0.5 ) {
 		return 2.0 * stdlib_base_asin( stdlib_base_sqrt( 0.5 - ( 0.5 * x ) ) );

--- a/lib/node_modules/@stdlib/math/base/special/acosh/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/ln-two"
+        "@stdlib/constants/float64/ln-two",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/ln-two"
+        "@stdlib/constants/float64/ln-two",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/ln-two"
+        "@stdlib/constants/float64/ln-two",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/acosh/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/src/main.c
@@ -36,6 +36,7 @@
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/ln_two.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double HUGE = 1 << 28; // 2**28
@@ -79,7 +80,7 @@ static const double HUGE = 1 << 28; // 2**28
 double stdlib_base_acosh( const double x ) {
 	double t;
 	if ( stdlib_base_is_nan( x ) || x < 1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 1.0 ) {
 		return 0.0;

--- a/lib/node_modules/@stdlib/math/base/special/asin/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/asin/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/fourth-pi"
+        "@stdlib/constants/float64/fourth-pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/fourth-pi"
+        "@stdlib/constants/float64/fourth-pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/fourth-pi"
+        "@stdlib/constants/float64/fourth-pi",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/asin/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/asin/src/main.c
@@ -34,6 +34,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/constants/float64/fourth_pi.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double MOREBITS = 6.123233995736765886130e-17; // pi/2 = PIO2 + MOREBITS
@@ -165,7 +166,7 @@ double stdlib_base_asin( const double x ) {
 	double z;
 
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x > 0.0 ) {
 		sgn = 0;
@@ -175,7 +176,7 @@ double stdlib_base_asin( const double x ) {
 		a = -x;
 	}
 	if ( a > 1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( a > 0.625 ) {
 		// arcsin(1-x) = pi/2 - sqrt(2x)(1+R(x))

--- a/lib/node_modules/@stdlib/math/base/special/atan2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/atan2/manifest.json
@@ -43,7 +43,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/atan",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -63,7 +64,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/atan",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -83,7 +85,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/atan",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/atan2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/atan2/src/main.c
@@ -37,6 +37,7 @@
 #include "stdlib/math/base/special/atan.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/pi.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 /**
@@ -81,7 +82,7 @@
 double stdlib_base_atan2( const double y, const double x ) {
 	double q;
 	if ( stdlib_base_is_nan( x ) ||	stdlib_base_is_nan( y ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) ) {
 		if ( x == STDLIB_CONSTANT_FLOAT64_PINF ) {

--- a/lib/node_modules/@stdlib/math/base/special/atanh/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/atanh/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/atanh/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/atanh/src/main.c
@@ -35,6 +35,7 @@
 #include "stdlib/math/base/special/log1p.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double NEAR_ZERO = 1.0 / (1 << 28); // 2**-28
@@ -83,7 +84,7 @@ double stdlib_base_atanh( const double x ) {
 	double ax;
 	double t;
 	if ( stdlib_base_is_nan( x ) || x < -1.0 || x > 1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 1.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/assert/is-odd",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/math/base/assert/is-nonnegative-integer"
+        "@stdlib/math/base/assert/is-nonnegative-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/assert/is-odd",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/math/base/assert/is-nonnegative-integer"
+        "@stdlib/math/base/assert/is-nonnegative-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/assert/is-odd",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/math/base/assert/is-nonnegative-integer"
+        "@stdlib/math/base/assert/is-nonnegative-integer",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/math/base/assert/is_odd.h"
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/constants/float64/pinf.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/bernoulli.h"
 #include <stdint.h>
 #include <stdlib.h>
@@ -172,7 +173,7 @@ int32_t MAX_BERNOULLI = 258;
 */
 double stdlib_base_bernoulli( const double n ) {
 	if ( !stdlib_base_is_nonnegative_integer( n ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( n == 1.0 ) {
 		return 0.5;

--- a/lib/node_modules/@stdlib/math/base/special/bessely0/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/bessely0/manifest.json
@@ -44,7 +44,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pi",
-        "@stdlib/constants/float64/sqrt-pi"
+        "@stdlib/constants/float64/sqrt-pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -65,7 +66,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pi",
-        "@stdlib/constants/float64/sqrt-pi"
+        "@stdlib/constants/float64/sqrt-pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -86,7 +88,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pi",
-        "@stdlib/constants/float64/sqrt-pi"
+        "@stdlib/constants/float64/sqrt-pi",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/bessely0/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/bessely0/src/main.c
@@ -38,6 +38,7 @@
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/constants/float64/pi.h"
 #include "stdlib/constants/float64/sqrt_pi.h"
+#include "stdlib/constants/float64/nan.h"
 
 static const double ONE_DIV_SQRT_PI = 1.0 / STDLIB_CONSTANT_FLOAT64_SQRT_PI;
 static const double TWO_DIV_PI = 2.0 / STDLIB_CONSTANT_FLOAT64_PI;
@@ -287,7 +288,7 @@ double stdlib_base_bessely0( const double x ) {
 	double z;
 
 	if ( x < 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/manifest.json
@@ -44,7 +44,8 @@
           "@stdlib/constants/float64/pinf",
           "@stdlib/constants/float64/ninf",
           "@stdlib/constants/float64/pi",
-          "@stdlib/constants/float64/sqrt-pi"
+          "@stdlib/constants/float64/sqrt-pi",
+          "@stdlib/constants/float64/nan"
         ]
       },
       {
@@ -65,7 +66,8 @@
           "@stdlib/constants/float64/pinf",
           "@stdlib/constants/float64/ninf",
           "@stdlib/constants/float64/pi",
-          "@stdlib/constants/float64/sqrt-pi"
+          "@stdlib/constants/float64/sqrt-pi",
+          "@stdlib/constants/float64/nan"
         ]
       },
       {
@@ -86,7 +88,8 @@
           "@stdlib/constants/float64/pinf",
           "@stdlib/constants/float64/ninf",
           "@stdlib/constants/float64/pi",
-          "@stdlib/constants/float64/sqrt-pi"
+          "@stdlib/constants/float64/sqrt-pi",
+          "@stdlib/constants/float64/nan"
         ]
       }
     ]

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/src/main.c
@@ -40,6 +40,7 @@
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/constants/float64/pi.h"
 #include "stdlib/constants/float64/sqrt_pi.h"
+#include "stdlib/constants/float64/nan.h"
 
 static const double ONE_DIV_SQRT_PI = 1.0 / STDLIB_CONSTANT_FLOAT64_SQRT_PI;
 static const double TWO_DIV_PI = 2.0 / STDLIB_CONSTANT_FLOAT64_PI;
@@ -244,7 +245,7 @@ double stdlib_base_bessely1( double x ) {
 	double f;
 
 	if ( x < 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;

--- a/lib/node_modules/@stdlib/math/base/special/beta/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/beta/manifest.json
@@ -44,7 +44,8 @@
         "@stdlib/math/base/special/exp",
         "@stdlib/math/base/special/pow",
         "@stdlib/constants/float64/e",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -65,7 +66,8 @@
         "@stdlib/math/base/special/exp",
         "@stdlib/math/base/special/pow",
         "@stdlib/constants/float64/e",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -86,7 +88,8 @@
         "@stdlib/math/base/special/exp",
         "@stdlib/math/base/special/pow",
         "@stdlib/constants/float64/e",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/beta/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/beta/src/main.c
@@ -38,6 +38,7 @@
 #include "stdlib/math/base/special/pow.h"
 #include "stdlib/constants/float64/e.h"
 #include "stdlib/constants/float64/eps.h"
+#include "stdlib/constants/float64/nan.h"
 
 static const double G = 10.90051099999999983936049829935654997826;
 
@@ -109,10 +110,10 @@ double stdlib_base_beta( const double a, const double b ) {
 	double c;
 
 	if ( stdlib_base_is_nan( a ) || stdlib_base_is_nan( b ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( a < 0.0 || b < 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( b == 1.0 ) {
 		return 1.0 / a;

--- a/lib/node_modules/@stdlib/math/base/special/betaln/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/betaln/manifest.json
@@ -46,7 +46,8 @@
         "@stdlib/math/base/special/ln",
         "@stdlib/constants/float64/ln-sqrt-two-pi",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -69,7 +70,8 @@
         "@stdlib/math/base/special/ln",
         "@stdlib/constants/float64/ln-sqrt-two-pi",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -92,7 +94,8 @@
         "@stdlib/math/base/special/ln",
         "@stdlib/constants/float64/ln-sqrt-two-pi",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/betaln/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/betaln/src/main.c
@@ -34,6 +34,7 @@
 #include "stdlib/constants/float64/ln_sqrt_two_pi.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double ALGMCS[ 15 ] = {
@@ -76,7 +77,7 @@ static double dceval( const double x ) {
 	int32_t i;
 
 	if ( x < -1.1 || x > 1.1 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	b1 = 0.0;
 	b0 = 0.0;
@@ -101,7 +102,7 @@ static double dceval( const double x ) {
 */
 static double gammaCorrection( const double x ) {
 	if ( x < 10.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	// Check for underflow...
@@ -134,7 +135,7 @@ double stdlib_base_betaln( const double a, const double b ) {
 	q = stdlib_base_max( a, b );
 
 	if ( p < 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( p == 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;

--- a/lib/node_modules/@stdlib/math/base/special/binet/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/binet/manifest.json
@@ -42,7 +42,8 @@
         "@stdlib/math/base/special/pow",
         "@stdlib/constants/float64/phi",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -61,7 +62,8 @@
         "@stdlib/math/base/special/pow",
         "@stdlib/constants/float64/phi",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -80,7 +82,8 @@
         "@stdlib/math/base/special/pow",
         "@stdlib/constants/float64/phi",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/binet/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/binet/src/main.c
@@ -23,6 +23,7 @@
 #include "stdlib/constants/float64/phi.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 
 static const double SQRT_5 = 2.23606797749979;
 
@@ -49,7 +50,7 @@ double stdlib_base_binet( const double x ) {
 	double b;
 
 	if ( stdlib_base_is_nan( x ) || x == STDLIB_CONSTANT_FLOAT64_PINF || x == STDLIB_CONSTANT_FLOAT64_NINF ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	a = stdlib_base_pow( STDLIB_CONSTANT_FLOAT64_PHI, x );
 	b = stdlib_base_cospi( x ) / a;

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/manifest.json
@@ -44,7 +44,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/max-safe-integer",
         "@stdlib/math/base/assert/is-integer",
-        "@stdlib/math/base/assert/is-odd"
+        "@stdlib/math/base/assert/is-odd",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -65,7 +66,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/max-safe-integer",
         "@stdlib/math/base/assert/is-integer",
-        "@stdlib/math/base/assert/is-odd"
+        "@stdlib/math/base/assert/is-odd",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -86,7 +88,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/max-safe-integer",
         "@stdlib/math/base/assert/is-integer",
-        "@stdlib/math/base/assert/is-odd"
+        "@stdlib/math/base/assert/is-odd",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/src/main.c
@@ -23,6 +23,7 @@
 #include "stdlib/math/base/special/gcd.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/max_safe_integer.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Computes the binomial coefficient of two integers.
@@ -47,7 +48,7 @@ double stdlib_base_binomcoef( const double n, const double k ) {
 	double s;
 
 	if ( !stdlib_base_is_integer( n ) || !stdlib_base_is_integer( k ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	if ( k < 0 ) {

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/manifest.json
@@ -43,7 +43,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/ln",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -63,7 +64,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/ln",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -83,7 +85,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/ln",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/src/main.c
@@ -22,6 +22,7 @@
 #include "stdlib/math/base/special/abs.h"
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Computes the natural logarithm of the binomial coefficient of two integers.
@@ -36,7 +37,7 @@
 */
 double stdlib_base_binomcoefln( const double n, const double k ) {
 	if ( !stdlib_base_is_integer( n ) || !stdlib_base_is_integer( k ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( n < 0 ) {
 		return stdlib_base_binomcoefln( -n + k - 1, k );

--- a/lib/node_modules/@stdlib/math/base/special/boxcox/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox/manifest.json
@@ -42,7 +42,8 @@
         "@stdlib/math/base/assert/is-positive-zero",
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/expm1",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -61,7 +62,8 @@
         "@stdlib/math/base/assert/is-positive-zero",
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/expm1",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -80,7 +82,8 @@
         "@stdlib/math/base/assert/is-positive-zero",
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/expm1",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/boxcox/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox/src/main.c
@@ -23,6 +23,7 @@
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/math/base/special/expm1.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Computes a one-parameter Box-Cox transformation.
@@ -43,7 +44,7 @@
 */
 double stdlib_base_boxcox( const double x, const double lambda ) {
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( lambda ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_positive_zero( x ) && lambda < 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;

--- a/lib/node_modules/@stdlib/math/base/special/boxcox1p/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox1p/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/expm1",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/expm1",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/expm1",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/boxcox1p/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox1p/src/main.c
@@ -22,6 +22,7 @@
 #include "stdlib/math/base/special/log1p.h"
 #include "stdlib/math/base/special/expm1.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Computes a one-parameter Box-Cox transformation of `1+x`.
@@ -38,7 +39,7 @@ double stdlib_base_boxcox1p( const double x, const double lambda ) {
 	double lgx;
 
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( lambda ) || x < -1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == -1.0 && lambda < 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;

--- a/lib/node_modules/@stdlib/math/base/special/boxcox1pinv/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox1pinv/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/math/base/special/expm1"
+        "@stdlib/math/base/special/expm1",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/math/base/special/expm1"
+        "@stdlib/math/base/special/expm1",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/math/base/special/expm1"
+        "@stdlib/math/base/special/expm1",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/boxcox1pinv/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox1pinv/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/boxcox1pinv.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/expm1.h"
 #include "stdlib/math/base/special/log1p.h"
 #include "stdlib/math/base/special/abs.h"
@@ -37,7 +38,7 @@ double stdlib_base_boxcox1pinv( const double y, const double lambda ) {
 	double ly;
 
 	if ( stdlib_base_is_nan( y ) || stdlib_base_is_nan( lambda ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( lambda == 0.0 ) {
 		return stdlib_base_expm1( y );

--- a/lib/node_modules/@stdlib/math/base/special/boxcoxinv/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/boxcoxinv/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/special/exp",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/special/exp",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/special/exp",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/boxcoxinv/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/boxcoxinv/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/boxcoxinv.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/exp.h"
 #include "stdlib/math/base/special/log1p.h"
 #include "stdlib/math/base/assert/is_nan.h"
@@ -34,7 +35,7 @@
 */
 double stdlib_base_boxcoxinv( const double y, const double lambda ) {
 	if ( stdlib_base_is_nan( y ) || stdlib_base_is_nan( lambda ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( lambda == 0.0 ) {
 		return stdlib_base_exp( y );

--- a/lib/node_modules/@stdlib/math/base/special/ceilb/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ceilb/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/ceil",
         "@stdlib/math/base/special/ceiln",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/ceil",
         "@stdlib/math/base/special/ceiln",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/ceil",
         "@stdlib/math/base/special/ceiln",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/ceilb/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/ceilb/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/ceilb.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/ceil.h"
@@ -41,7 +42,7 @@ double stdlib_base_ceilb( const double x, const int32_t n, const int32_t b ) {
 	double s;
 
 	if ( stdlib_base_is_nan( x ) || b <= 0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/ceilsd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ceilsd/manifest.json
@@ -45,7 +45,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/ceil",
-        "@stdlib/number/float64/base/exponent"
+        "@stdlib/number/float64/base/exponent",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -67,7 +68,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/ceil",
-        "@stdlib/number/float64/base/exponent"
+        "@stdlib/number/float64/base/exponent",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -89,7 +91,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/ceil",
-        "@stdlib/number/float64/base/exponent"
+        "@stdlib/number/float64/base/exponent",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/ceilsd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/ceilsd/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/ceilsd.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/pow.h"
@@ -46,7 +47,7 @@ double stdlib_base_ceilsd( const double x, const int32_t n, const int32_t b ) {
 	double y;
 
 	if ( stdlib_base_is_nan( x ) || n < 1 || b <= 0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/cexp/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cexp/manifest.json
@@ -45,7 +45,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/copysign",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -67,7 +68,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/copysign",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -89,7 +91,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/copysign",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/cexp/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cexp/src/main.c
@@ -24,6 +24,7 @@
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/math/base/special/copysign.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/complex/float64/ctor.h"
 #include "stdlib/complex/float64/reim.h"
 
@@ -55,18 +56,18 @@ stdlib_complex128_t stdlib_base_cexp( const stdlib_complex128_t z ) {
 	stdlib_complex128_reim( z, &re, &im );
 
 	if ( stdlib_base_is_nan( re ) ) {
-		re = 0.0 / 0.0; // NaN
+		re = STDLIB_CONSTANT_FLOAT64_NAN;
 		im = ( im == 0.0 ) ? im : re;
 	} else if ( stdlib_base_is_infinite( im ) ) {
 		if ( re == STDLIB_CONSTANT_FLOAT64_PINF ) {
 			re = -re;
-			im = 0.0 / 0.0; // NaN
+			im = STDLIB_CONSTANT_FLOAT64_NAN;
 		} else if ( re == STDLIB_CONSTANT_FLOAT64_NINF ) {
 			re = -0.0;
 			im = stdlib_base_copysign( 0.0, im );
 		} else {
-			re = 0.0 / 0.0; // NaN
-			im = 0.0 / 0.0; // NaN
+			re = STDLIB_CONSTANT_FLOAT64_NAN;
+			im = STDLIB_CONSTANT_FLOAT64_NAN;
 		}
 	} else {
 		e = stdlib_base_exp( re );

--- a/lib/node_modules/@stdlib/math/base/special/clamp/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/manifest.json
@@ -40,7 +40,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/ternary",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/clamp/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/clamp.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_negative_zero.h"
 
@@ -42,7 +43,7 @@ double stdlib_base_clamp( const double v, const double min, const double max ) {
 		stdlib_base_is_nan( min ) ||
 		stdlib_base_is_nan( max )
 	) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Simple cases...
 	if ( v < min ) {

--- a/lib/node_modules/@stdlib/math/base/special/cos/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cos/manifest.json
@@ -42,7 +42,8 @@
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/kernel-sin",
-        "@stdlib/math/base/special/rempio2"
+        "@stdlib/math/base/special/rempio2",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -61,7 +62,8 @@
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/kernel-sin",
-        "@stdlib/math/base/special/rempio2"
+        "@stdlib/math/base/special/rempio2",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -80,7 +82,8 @@
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/kernel-sin",
-        "@stdlib/math/base/special/rempio2"
+        "@stdlib/math/base/special/rempio2",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/cos/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cos/src/main.c
@@ -34,6 +34,7 @@
 #include "stdlib/number/float64/base/get_high_word.h"
 #include "stdlib/constants/float64/high_word_abs_mask.h"
 #include "stdlib/constants/float64/high_word_exponent_mask.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/kernel_cos.h"
 #include "stdlib/math/base/special/kernel_sin.h"
 #include "stdlib/math/base/special/rempio2.h"
@@ -90,7 +91,7 @@ double stdlib_base_cos( const double x ) {
 	}
 	// Case: cos(Inf or NaN) is NaN */
 	if ( ix >= STDLIB_CONSTANT_FLOAT64_HIGH_WORD_EXPONENT_MASK ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Case: Argument reduction needed...
 	n = stdlib_base_rempio2( x, &Y[ 0 ], &Y[ 1 ] );

--- a/lib/node_modules/@stdlib/math/base/special/cosd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cosd/manifest.json
@@ -43,7 +43,8 @@
         "@stdlib/math/base/special/kernel-sin",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/abs",
-        "@stdlib/math/base/special/fmod"
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -63,7 +64,8 @@
         "@stdlib/math/base/special/kernel-sin",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/abs",
-        "@stdlib/math/base/special/fmod"
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -83,7 +85,8 @@
         "@stdlib/math/base/special/kernel-sin",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/abs",
-        "@stdlib/math/base/special/fmod"
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/cosd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cosd/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/cosd.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/kernel_sin.h"
 #include "stdlib/math/base/special/kernel_cos.h"
 #include "stdlib/math/base/special/deg2rad.h"
@@ -39,7 +40,7 @@ double stdlib_base_cosd( const double x ) {
 	double rx;
 
 	if ( stdlib_base_is_infinite( x ) || stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	rx = stdlib_base_abs( stdlib_base_fmod( x, 360.0 ) );

--- a/lib/node_modules/@stdlib/math/base/special/cospi/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cospi/manifest.json
@@ -47,7 +47,8 @@
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/fmod",
         "@stdlib/constants/float64/pi",
-        "@stdlib/constants/float64/max-safe-integer"
+        "@stdlib/constants/float64/max-safe-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +72,8 @@
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/fmod",
         "@stdlib/constants/float64/pi",
-        "@stdlib/constants/float64/max-safe-integer"
+        "@stdlib/constants/float64/max-safe-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -95,7 +97,8 @@
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/fmod",
         "@stdlib/constants/float64/pi",
-        "@stdlib/constants/float64/max-safe-integer"
+        "@stdlib/constants/float64/max-safe-integer",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/cospi/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cospi/src/main.c
@@ -26,6 +26,7 @@
 #include "stdlib/math/base/special/fmod.h"
 #include "stdlib/constants/float64/pi.h"
 #include "stdlib/constants/float64/max_safe_integer.h"
+#include "stdlib/constants/float64/nan.h"
 
 static const double MAX_INTEGER_P1 = STDLIB_CONSTANT_FLOAT64_MAX_SAFE_INTEGER + 1;
 
@@ -54,7 +55,7 @@ double stdlib_base_cospi( const double x ) {
 	double y;
 
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_infinite( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	ax = stdlib_base_abs( x );
 	if ( ax > MAX_INTEGER_P1 ) {

--- a/lib/node_modules/@stdlib/math/base/special/digamma/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/tan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/tan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/tan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/digamma/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/src/main.c
@@ -35,6 +35,7 @@
 #include "stdlib/math/base/special/tan.h"
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/pi.h"
+#include "stdlib/constants/float64/nan.h"
 
 static const double MIN_SAFE_ASYMPTOTIC = 10.0; // BIG!
 static const double root1 = 1569415565.0 / 1073741824.0;
@@ -223,7 +224,7 @@ double stdlib_base_digamma( const double x ) {
 	double xc;
 
 	if ( stdlib_base_is_nan( x ) || x == 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	// If `x` is negative, use reflection...
@@ -242,7 +243,7 @@ double stdlib_base_digamma( const double x ) {
 
 		// Check for evaluation at a negative pole:
 		if ( rem == 0.0 ) {
-			return 0.0 / 0.0; // NaN
+			return STDLIB_CONSTANT_FLOAT64_NAN;
 		}
 		tmp = STDLIB_CONSTANT_FLOAT64_PI / stdlib_base_tan( STDLIB_CONSTANT_FLOAT64_PI * rem );
 	} else {

--- a/lib/node_modules/@stdlib/math/base/special/dirac-delta/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/dirac-delta/manifest.json
@@ -38,7 +38,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -53,7 +54,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -68,7 +70,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/dirac-delta/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/dirac-delta/src/main.c
@@ -19,6 +19,7 @@
 #include "stdlib/math/base/special/dirac_delta.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/constants/float64/pinf.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Evaluates the Dirac delta function.
@@ -32,7 +33,7 @@
 */
 double stdlib_base_dirac_delta( const double x ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;

--- a/lib/node_modules/@stdlib/math/base/special/dirichlet-eta/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/dirichlet-eta/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/special/powm1",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/riemann-zeta",
-        "@stdlib/constants/float64/ln-two"
+        "@stdlib/constants/float64/ln-two",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/special/powm1",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/riemann-zeta",
-        "@stdlib/constants/float64/ln-two"
+        "@stdlib/constants/float64/ln-two",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/special/powm1",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/riemann-zeta",
-        "@stdlib/constants/float64/ln-two"
+        "@stdlib/constants/float64/ln-two",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/dirichlet-eta/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/dirichlet-eta/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/powm1.h"
 #include "stdlib/constants/float64/ln_two.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/riemann_zeta.h"
 
 /**
@@ -34,7 +35,7 @@
 */
 double stdlib_base_eta( const double s ) {
 	if ( stdlib_base_is_nan( s ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( s == 1.0 ) {
 		// Alternating harmonic series...

--- a/lib/node_modules/@stdlib/math/base/special/ellipe/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ellipe/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/special/ellipk"
+        "@stdlib/math/base/special/ellipk",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/special/ellipk"
+        "@stdlib/math/base/special/ellipk",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/special/ellipk"
+        "@stdlib/math/base/special/ellipk",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/ellipe/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/ellipe/src/main.c
@@ -53,6 +53,7 @@
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/half_pi.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 /* Begin auto-generated functions. The following functions are auto-generated. Do not edit directly. */
@@ -331,7 +332,7 @@ double stdlib_base_ellipe( const double m ) {
 		return 1.0;
 	}
 	if ( x > 1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x < 0.1 ) {
 		t = poly_p1( x - 0.05 );

--- a/lib/node_modules/@stdlib/math/base/special/ellipj/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/manifest.json
@@ -55,7 +55,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/sqrt-eps",
         "@stdlib/constants/float64/eps",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -84,7 +85,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/sqrt-eps",
         "@stdlib/constants/float64/eps",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -113,7 +115,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/sqrt-eps",
         "@stdlib/constants/float64/eps",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/ellipj/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/ellipj/src/main.c
@@ -32,6 +32,7 @@
 #include "stdlib/constants/float64/sqrt_eps.h"
 #include "stdlib/constants/float64/eps.h"
 #include "stdlib/constants/float64/pi.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -100,7 +101,7 @@ void stdlib_base_ellipj( const double u, const double m, double* sn, double* cn,
 		*sn = ( out[ 0 ] / out[ 2 ] ) / k1inv;
 		*cn = out[ 1 ] / out[ 2 ];
 		*dn = 1.0 / out[ 2 ];
-		*am = 0.0 / 0.0; // NaN
+		*am = STDLIB_CONSTANT_FLOAT64_NAN;
 		return;
 	} else if ( m > 1.0 ) {
 		// A&S 16.11.1 for reciprocal parameter, mapping m > 1 to 0 < mu < 1:
@@ -109,7 +110,7 @@ void stdlib_base_ellipj( const double u, const double m, double* sn, double* cn,
 		*sn = out[ 0 ] / k;
 		*cn = out[ 2 ];
 		*dn = out[ 1 ];
-		*am = 0.0 / 0.0; // NaN
+		*am = STDLIB_CONSTANT_FLOAT64_NAN;
 		return;
 	} else if ( m == 0.0 ) {
 		// A&S table 16.6, limiting case m = 0: circular trigonometric functions:
@@ -179,10 +180,10 @@ void stdlib_base_ellipj( const double u, const double m, double* sn, double* cn,
 			if ( N > 8 ) {
 				// Warning: Overflow encountered in iteration. Returning NaN for all output values:
 				NANFLG = true;
-				*sn = 0.0 / 0.0; // NaN
-				*cn = 0.0 / 0.0; // NaN
-				*dn = 0.0 / 0.0; // NaN
-				*am = 0.0 / 0.0; // NaN
+				*sn = STDLIB_CONSTANT_FLOAT64_NAN;
+				*cn = STDLIB_CONSTANT_FLOAT64_NAN;
+				*dn = STDLIB_CONSTANT_FLOAT64_NAN;
+				*am = STDLIB_CONSTANT_FLOAT64_NAN;
 				break;
 			}
 			atmp = ( a + b ) * 0.5;

--- a/lib/node_modules/@stdlib/math/base/special/ellipk/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ellipk/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/constants/float64/half-pi",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/constants/float64/half-pi",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/constants/float64/half-pi",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/ellipk/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/ellipk/src/main.c
@@ -52,6 +52,7 @@
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/half_pi.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double ONE_DIV_PI = 0.3183098861837907;
@@ -358,7 +359,7 @@ double stdlib_base_ellipk( const double m ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;
 	}
 	if ( x > 1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x < 0.1 ) {
 		t = poly_p1( x - 0.05 );

--- a/lib/node_modules/@stdlib/math/base/special/erf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/erf/manifest.json
@@ -43,7 +43,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/exp",
-        "@stdlib/number/float64/base/set-low-word"
+        "@stdlib/number/float64/base/set-low-word",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -62,7 +63,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/exp",
-        "@stdlib/number/float64/base/set-low-word"
+        "@stdlib/number/float64/base/set-low-word",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -81,7 +83,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/exp",
-        "@stdlib/number/float64/base/set-low-word"
+        "@stdlib/number/float64/base/set-low-word",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -100,7 +103,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/exp",
-        "@stdlib/number/float64/base/set-low-word"
+        "@stdlib/number/float64/base/set-low-word",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/erf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/erf/src/main.c
@@ -36,6 +36,7 @@
 #include "stdlib/number/float64/base/set_low_word.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double TINY = 1.0e-300;
@@ -457,7 +458,7 @@ double stdlib_base_erf( const double x ) {
 
 	// Special case: NaN
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Special case: +infinity
 	if ( x == STDLIB_CONSTANT_FLOAT64_PINF ) {

--- a/lib/node_modules/@stdlib/math/base/special/erfc/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/erfc/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/exp",
-        "@stdlib/number/float64/base/set-low-word"
+        "@stdlib/number/float64/base/set-low-word",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/exp",
-        "@stdlib/number/float64/base/set-low-word"
+        "@stdlib/number/float64/base/set-low-word",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/exp",
-        "@stdlib/number/float64/base/set-low-word"
+        "@stdlib/number/float64/base/set-low-word",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/erfc/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/erfc/src/main.c
@@ -36,6 +36,7 @@
 #include "stdlib/number/float64/base/set_low_word.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double TINY = 1.0e-300;
@@ -454,7 +455,7 @@ double stdlib_base_erfc( const double x ) {
 
 	// Special case: NaN
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Special case: +infinity
 	if ( x == STDLIB_CONSTANT_FLOAT64_PINF ) {

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/src/main.c
@@ -35,6 +35,7 @@
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double Y1 = 8.91314744949340820313e-2;
@@ -340,7 +341,7 @@ double stdlib_base_erfcinv( const double x ) {
 
 	// Special case: NaN
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Special case: 0
 	if ( x == 0.0 ) {
@@ -355,7 +356,7 @@ double stdlib_base_erfcinv( const double x ) {
 		return 0.0;
 	}
 	if ( x > 2.0 || x < 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Argument reduction (reduce to interval [0,1]). If `x` is outside [0,1], we can take advantage of the complementary error function reflection formula: `erfc(-z) = 2 - erfc(z)`, by negating the result once finished.
 	if ( x > 1.0 ) {

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/src/main.c
@@ -35,6 +35,7 @@
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double Y1 = 8.91314744949340820313e-2;
@@ -272,7 +273,7 @@ double stdlib_base_erfinv( const double x ) {
 
 	// Special case: NaN
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Special case: 1
 	if ( x == 1.0 ) {
@@ -288,7 +289,7 @@ double stdlib_base_erfinv( const double x ) {
 	}
 	// Special case: |x| > 1 (range error)
 	if ( x > 1.0 || x < -1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Argument reduction (reduce to interval [0,1]). If `x` is negative, we can safely negate the value, taking advantage of the error function being an odd function; i.e., `erf(-x) = -erf(x)`.
 	if ( x < 0.0 ) {

--- a/lib/node_modules/@stdlib/math/base/special/exp10/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/exp10/manifest.json
@@ -42,7 +42,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/ldexp",
-        "@stdlib/constants/float64/min-base10-exponent"
+        "@stdlib/constants/float64/min-base10-exponent",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -61,7 +62,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/ldexp",
-        "@stdlib/constants/float64/min-base10-exponent"
+        "@stdlib/constants/float64/min-base10-exponent",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -80,7 +82,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/ldexp",
-        "@stdlib/constants/float64/min-base10-exponent"
+        "@stdlib/constants/float64/min-base10-exponent",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/exp10/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/exp10/src/main.c
@@ -37,6 +37,7 @@
 #include "stdlib/constants/float64/max_base10_exponent.h"
 #include "stdlib/constants/float64/min_base10_exponent.h"
 #include "stdlib/constants/float64/pinf.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double LOG210 = 3.32192809488736234787e0;
@@ -123,7 +124,7 @@ double stdlib_base_exp10( const double x ) {
 	int32_t n;
 
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x > STDLIB_CONSTANT_FLOAT64_MAX_BASE10_EXPONENT ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;

--- a/lib/node_modules/@stdlib/math/base/special/expit/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/expit/manifest.json
@@ -38,7 +38,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/exp"
+        "@stdlib/math/base/special/exp",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -53,7 +54,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/exp"
+        "@stdlib/math/base/special/exp",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -68,7 +70,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/exp"
+        "@stdlib/math/base/special/exp",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/expit/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/expit/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/expit.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/exp.h"
 #include "stdlib/math/base/assert/is_nan.h"
 
@@ -32,7 +33,7 @@
 */
 double stdlib_base_expit( const double x ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	return 1.0 / ( 1.0 + stdlib_base_exp( -x ) );
 }

--- a/lib/node_modules/@stdlib/math/base/special/factorial/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/factorial/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/gamma",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/gamma",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/gamma",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/factorial/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial/src/main.c
@@ -22,6 +22,7 @@
 #include "stdlib/math/base/special/gamma.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/max_nth_factorial.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double FACTORIALS[ 171 ] = {
@@ -211,11 +212,11 @@ static const double FACTORIALS[ 171 ] = {
 */
 double stdlib_base_factorial( const double x ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_integer( x ) ) {
 		if ( x < 0.0 ) {
-			return 0.0 / 0.0; // NaN
+			return STDLIB_CONSTANT_FLOAT64_NAN;
 		}
 		if ( x <= STDLIB_CONSTANT_FLOAT64_MAX_NTH_FACTORIAL ) {
 			return FACTORIALS[ (int32_t)x ];

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/max-nth-double-factorial",
         "@stdlib/math/base/assert/is-nonnegative-integer",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/max-nth-double-factorial",
         "@stdlib/math/base/assert/is-nonnegative-integer",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/max-nth-double-factorial",
         "@stdlib/math/base/assert/is-nonnegative-integer",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/src/main.c
@@ -22,6 +22,7 @@
 #include "stdlib/math/base/assert/is_nonnegative_integer.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/max_nth_double_factorial.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Evaluates the double factorial of `n`.
@@ -40,7 +41,7 @@ double stdlib_base_factorial2( const double n ) {
 	double i;
 
 	if ( stdlib_base_is_nan( n ) || !stdlib_base_is_nonnegative_integer( n ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( n > STDLIB_CONSTANT_FLOAT64_MAX_NTH_DOUBLE_FACTORIAL ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;

--- a/lib/node_modules/@stdlib/math/base/special/factorialln/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/factorialln/manifest.json
@@ -38,7 +38,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/assert/is-negative-integer",
-        "@stdlib/math/base/special/gammaln"
+        "@stdlib/math/base/special/gammaln",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -53,7 +54,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-negative-integer",
-        "@stdlib/math/base/special/gammaln"
+        "@stdlib/math/base/special/gammaln",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -68,7 +70,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-negative-integer",
-        "@stdlib/math/base/special/gammaln"
+        "@stdlib/math/base/special/gammaln",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/factorialln/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorialln/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/factorialln.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_negative_integer.h"
 #include "stdlib/math/base/special/gammaln.h"
 
@@ -32,7 +33,7 @@
 */
 double stdlib_base_factorialln( const double x ) {
 	if ( stdlib_base_is_negative_integer( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	return stdlib_base_gammaln( x + 1.0 );
 }

--- a/lib/node_modules/@stdlib/math/base/special/falling-factorial/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/falling-factorial/manifest.json
@@ -45,7 +45,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/max",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -67,7 +68,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/max",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -89,7 +91,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/max",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/falling-factorial/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/falling-factorial/src/main.c
@@ -39,6 +39,7 @@
 #include "stdlib/constants/float64/max.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/max_nth_factorial.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -78,7 +79,7 @@ static double risingFactorial( const double x, const int32_t n ) {
 	bool inv;
 
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	nc = n;
 	xc = x;
@@ -146,7 +147,7 @@ double stdlib_base_falling_factorial( const double x, const int32_t n ) {
 	double xc;
 
 	if ( stdlib_base_is_nan( x ) || !stdlib_base_is_nonnegative_integer( n ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 0.0 ) {
 		return 0.0;

--- a/lib/node_modules/@stdlib/math/base/special/fast/acosh/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/acosh/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/assert/is-infinite"
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/assert/is-infinite"
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/assert/is-infinite"
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/fast/acosh/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/acosh/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/fast/acosh.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/ln.h"
@@ -35,7 +36,7 @@
 */
 double stdlib_base_fast_acosh( const double x ) {
 	if ( x < 1.0 ) {
-		return 0.0 / 0.0 ; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_infinite( x ) ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/fast/atanh/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/atanh/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/assert/is-infinite"
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/assert/is-infinite"
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/assert/is-infinite"
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/fast/atanh/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/atanh/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/fast/atanh.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/ln.h"
@@ -37,7 +38,7 @@ double stdlib_base_fast_atanh( const double x ) {
 		return x;
 	}
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_infinite( x ) ) {
-		return 0.0 / 0.0 ; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	return 0.5 * stdlib_base_ln( ( 1.0 + x ) / ( 1.0 - x ) );
 }

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/manifest.json
@@ -40,7 +40,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -19,6 +19,7 @@
 #include "stdlib/math/base/special/fast/pow_int.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/constants/float64/pinf.h"
+#include "stdlib/constants/float64/nan.h"
 
 int32_t ONE = 1;
 int32_t ZERO = 0;
@@ -42,7 +43,7 @@ double stdlib_base_fast_pow( const double x, const int32_t y ) {
 	xc = x;
 	yc = y;
 	if ( stdlib_base_is_nan( xc ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( yc < ZERO ) {
 		yc = -yc;

--- a/lib/node_modules/@stdlib/math/base/special/fibonacci-index/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fibonacci-index/manifest.json
@@ -42,7 +42,8 @@
         "@stdlib/math/base/special/round",
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/assert/is-integer",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -61,7 +62,8 @@
         "@stdlib/math/base/special/round",
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/assert/is-integer",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -80,7 +82,8 @@
         "@stdlib/math/base/special/round",
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/assert/is-integer",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/fibonacci-index/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fibonacci-index/src/main.c
@@ -23,6 +23,7 @@
 #include "stdlib/math/base/special/round.h"
 #include "stdlib/constants/float64/phi.h"
 #include "stdlib/constants/float64/pinf.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdbool.h>
 
 static const double SQRT_5 = 2.23606797749979;
@@ -45,7 +46,7 @@ double stdlib_base_fibonacci_index( const double F ) {
 	double x;
 
 	if ( stdlib_base_is_nan( F ) || stdlib_base_is_integer( F ) == false || F <= 1 || F == STDLIB_CONSTANT_FLOAT64_PINF ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	x = ( F * SQRT_5 ) + 0.5;
 	return stdlib_base_round( stdlib_base_ln( x ) / stdlib_base_ln( STDLIB_CONSTANT_FLOAT64_PHI ) );

--- a/lib/node_modules/@stdlib/math/base/special/floorb/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/floorb/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/floorn",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/floorn",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/floorn",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/floorb/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/floorb/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/floorb.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/floor.h"
@@ -41,7 +42,7 @@ double stdlib_base_floorb( const double x, const int32_t n, const int32_t b ) {
 	double s;
 
 	if ( stdlib_base_is_nan( x ) || b <= 0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/floorsd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/floorsd/manifest.json
@@ -44,7 +44,8 @@
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/floor",
-        "@stdlib/number/float64/base/exponent"
+        "@stdlib/number/float64/base/exponent",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -65,7 +66,8 @@
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/floor",
-        "@stdlib/number/float64/base/exponent"
+        "@stdlib/number/float64/base/exponent",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -86,7 +88,8 @@
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/floor",
-        "@stdlib/number/float64/base/exponent"
+        "@stdlib/number/float64/base/exponent",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/floorsd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/floorsd/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/floorsd.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/pow.h"
@@ -45,7 +46,7 @@ double stdlib_base_floorsd( const double x, const int32_t n, const int32_t b ) {
 	double y;
 
 	if ( stdlib_base_is_nan( x ) || n < 1 || b <= 0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/gamma/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/manifest.json
@@ -49,7 +49,8 @@
         "@stdlib/constants/float64/eulergamma",
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/special/pow",
-        "@stdlib/math/base/special/exp"
+        "@stdlib/math/base/special/exp",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -75,7 +76,8 @@
         "@stdlib/constants/float64/eulergamma",
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/special/pow",
-        "@stdlib/math/base/special/exp"
+        "@stdlib/math/base/special/exp",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -101,7 +103,8 @@
         "@stdlib/constants/float64/eulergamma",
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/special/pow",
-        "@stdlib/math/base/special/exp"
+        "@stdlib/math/base/special/exp",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/gamma/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/manifest.json
@@ -49,8 +49,7 @@
         "@stdlib/constants/float64/eulergamma",
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/special/pow",
-        "@stdlib/math/base/special/exp",
-        "@stdlib/constants/float64/nan"
+        "@stdlib/math/base/special/exp"
       ]
     },
     {
@@ -76,8 +75,7 @@
         "@stdlib/constants/float64/eulergamma",
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/special/pow",
-        "@stdlib/math/base/special/exp",
-        "@stdlib/constants/float64/nan"
+        "@stdlib/math/base/special/exp"
       ]
     },
     {
@@ -103,8 +101,7 @@
         "@stdlib/constants/float64/eulergamma",
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/special/pow",
-        "@stdlib/math/base/special/exp",
-        "@stdlib/constants/float64/nan"
+        "@stdlib/math/base/special/exp"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/gamma/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/src/main.c
@@ -42,6 +42,7 @@
 #include "stdlib/constants/float64/pi.h"
 #include "stdlib/constants/float64/eulergamma.h"
 #include "stdlib/constants/float64/sqrt_two_pi.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/pow.h"
 #include "stdlib/math/base/special/exp.h"
 #include <stdint.h>
@@ -187,7 +188,7 @@ double stdlib_base_gamma( const double x ) {
 	double z;
 
 	if ( ( stdlib_base_is_integer( x ) && x < 0 ) || x == STDLIB_CONSTANT_FLOAT64_NINF || stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 0.0 ) {
 		if ( stdlib_base_is_negative_zero( x ) ) {

--- a/lib/node_modules/@stdlib/math/base/special/gamma/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/src/main.c
@@ -42,7 +42,6 @@
 #include "stdlib/constants/float64/pi.h"
 #include "stdlib/constants/float64/eulergamma.h"
 #include "stdlib/constants/float64/sqrt_two_pi.h"
-#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/pow.h"
 #include "stdlib/math/base/special/exp.h"
 #include <stdint.h>
@@ -188,7 +187,7 @@ double stdlib_base_gamma( const double x ) {
 	double z;
 
 	if ( ( stdlib_base_is_integer( x ) && x < 0 ) || x == STDLIB_CONSTANT_FLOAT64_NINF || stdlib_base_is_nan( x ) ) {
-		return STDLIB_CONSTANT_FLOAT64_NAN;
+		return 0.0 / 0.0; // NaN
 	}
 	if ( x == 0.0 ) {
 		if ( stdlib_base_is_negative_zero( x ) ) {

--- a/lib/node_modules/@stdlib/math/base/special/gamma1pm1/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/gamma1pm1/manifest.json
@@ -42,7 +42,8 @@
         "@stdlib/math/base/special/expm1",
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -61,7 +62,8 @@
         "@stdlib/math/base/special/expm1",
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -80,7 +82,8 @@
         "@stdlib/math/base/special/expm1",
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/gamma1pm1/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma1pm1/src/main.c
@@ -39,6 +39,7 @@
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/constants/float64/eps.h"
+#include "stdlib/constants/float64/nan.h"
 
 static const double Y1 = 0.158963680267333984375;
 static const double Y2 = 0.52815341949462890625;
@@ -282,7 +283,7 @@ static double lgammaSmallImp( const double z, const double zm1, const double zm2
 */
 double stdlib_base_gamma1pm1( const double x ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x < 0.0 ) {
 		if ( x < -0.5 ) {

--- a/lib/node_modules/@stdlib/math/base/special/gammainc/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/gammainc/manifest.json
@@ -69,7 +69,8 @@
         "@stdlib/constants/float64/e",
         "@stdlib/constants/float64/gamma-lanczos-g",
         "@stdlib/constants/float32/smallest-normal",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -111,7 +112,8 @@
         "@stdlib/constants/float64/e",
         "@stdlib/constants/float64/gamma-lanczos-g",
         "@stdlib/constants/float32/smallest-normal",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -153,7 +155,8 @@
         "@stdlib/constants/float64/e",
         "@stdlib/constants/float64/gamma-lanczos-g",
         "@stdlib/constants/float32/smallest-normal",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/gammainc/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gammainc/src/main.c
@@ -62,6 +62,7 @@
 #include "stdlib/constants/float64/max.h"
 #include "stdlib/constants/float64/pi.h"
 #include "stdlib/constants/float64/e.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -1017,7 +1018,7 @@ double stdlib_base_gammainc( const double x, const double a, const bool regulari
 	bool invert;
 
 	if ( x < 0.0 || a <= 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	invert = upper;
 	if ( a >= MAX_NTH_FACTORIAL && !regularized ) {

--- a/lib/node_modules/@stdlib/math/base/special/gammaincinv/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/gammaincinv/manifest.json
@@ -57,7 +57,8 @@
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/constants/float32/max",
         "@stdlib/constants/float64/two-pi",
-        "@stdlib/math/base/special/gammainc"
+        "@stdlib/math/base/special/gammainc",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -88,7 +89,8 @@
         "@stdlib/constants/float32/max",
         "@stdlib/constants/float64/two-pi",
         "@stdlib/constants/float64/eps",
-        "@stdlib/math/base/special/gammainc"
+        "@stdlib/math/base/special/gammainc",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -119,7 +121,8 @@
         "@stdlib/constants/float32/max",
         "@stdlib/constants/float64/two-pi",
         "@stdlib/constants/float64/eps",
-        "@stdlib/math/base/special/gammainc"
+        "@stdlib/math/base/special/gammainc",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/gammaincinv/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gammaincinv/src/main.c
@@ -51,6 +51,7 @@
 #include "stdlib/constants/float64/two_pi.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float32/max.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -1046,7 +1047,7 @@ static double compute( const double a, const double p, const double q ) {
 			invfp = 1.0 / fp;
 		} else {
 			// Overflow problems in one or more steps of the computation...
-			return 0.0 / 0.0; // NaN
+			return STDLIB_CONSTANT_FLOAT64_NAN;
 		}
 	}
 	if ( k < 2 ) {
@@ -1082,13 +1083,13 @@ static double compute( const double a, const double p, const double q ) {
 */
 double stdlib_base_gammaincinv( const double p, const double a, const bool upper ) {
 	if ( stdlib_base_is_nan( p ) || stdlib_base_is_nan( a ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( a < SMALLEST_NORMAL_FLOAT32 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( p > 1.0 || p < 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Case: invert upper gamma function
 	if ( upper ) {

--- a/lib/node_modules/@stdlib/math/base/special/gcd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/gcd/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/special/fmod",
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/special/fmod",
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/special/fmod",
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/gcd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gcd/src/main.c
@@ -22,6 +22,7 @@
 #include "stdlib/math/base/assert/is_integer.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 // 2^63 - 1
@@ -155,7 +156,7 @@ double stdlib_base_gcd( const double a, const double b ) {
 	double bc;
 
 	if ( stdlib_base_is_nan( a ) || stdlib_base_is_nan( b ) ) {
-		return 0.0/0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if (
 		a == STDLIB_CONSTANT_FLOAT64_PINF ||
@@ -163,10 +164,10 @@ double stdlib_base_gcd( const double a, const double b ) {
 		a == STDLIB_CONSTANT_FLOAT64_NINF ||
 		b == STDLIB_CONSTANT_FLOAT64_NINF
 	) {
-		return 0.0/0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( !( stdlib_base_is_integer( a ) && stdlib_base_is_integer( b ) ) ) {
-		return 0.0/0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	ac = a;
 	bc = b;

--- a/lib/node_modules/@stdlib/math/base/special/heaviside/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/heaviside/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/napi/argv-int32",
         "@stdlib/napi/argv-double",
         "@stdlib/napi/create-double",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -69,7 +71,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/heaviside/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/heaviside/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/heaviside.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 
 /**
@@ -32,7 +33,7 @@
 */
 double stdlib_base_heaviside( const double x, const enum STDLIB_BASE_HEAVISIDE_CONTINUITY continuity ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x > 0.0 ) {
 		return 1.0;
@@ -47,9 +48,9 @@ double stdlib_base_heaviside( const double x, const enum STDLIB_BASE_HEAVISIDE_C
 			case STDLIB_BASE_HEAVISIDE_CONTINUITY_RIGHT_CONTINUOUS:
 				return 1.0;
 			case STDLIB_BASE_HEAVISIDE_CONTINUITY_DISCONTINUOUS:
-				return 0.0 / 0.0; // NaN
+				return STDLIB_CONSTANT_FLOAT64_NAN;
 			default:
-				return 0.0 / 0.0; // NaN
+				return STDLIB_CONSTANT_FLOAT64_NAN;
 		}
 	}
 	return 0.0;

--- a/lib/node_modules/@stdlib/math/base/special/hypot/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/hypot/manifest.json
@@ -42,7 +42,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -61,7 +62,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -80,7 +82,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/hypot/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/hypot/src/main.c
@@ -21,6 +21,7 @@
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/constants/float64/pinf.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Computes the hypotenuse avoiding overflow and underflow.
@@ -43,7 +44,7 @@ double stdlib_base_hypot( const double x, const double y ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;
 	}
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( y ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	a = x;
 	b = y;

--- a/lib/node_modules/@stdlib/math/base/special/kernel-betainc/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-betainc/manifest.json
@@ -74,7 +74,8 @@
         "@stdlib/constants/float64/pi",
         "@stdlib/constants/float64/gamma-lanczos-g",
         "@stdlib/constants/float64/eps",
-        "@stdlib/constants/int32/max"
+        "@stdlib/constants/int32/max",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -121,7 +122,8 @@
         "@stdlib/constants/float64/pi",
         "@stdlib/constants/float64/gamma-lanczos-g",
         "@stdlib/constants/float64/eps",
-        "@stdlib/constants/int32/max"
+        "@stdlib/constants/int32/max",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -169,7 +171,8 @@
         "@stdlib/constants/float64/pi",
         "@stdlib/constants/float64/gamma-lanczos-g",
         "@stdlib/constants/float64/eps",
-        "@stdlib/constants/int32/max"
+        "@stdlib/constants/int32/max",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/kernel-betainc/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-betainc/src/main.c
@@ -42,6 +42,7 @@
 #include "stdlib/constants/float32/smallest_normal.h"
 #include "stdlib/constants/float64/smallest_normal.h"
 #include "stdlib/constants/int32/max.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/abs.h"
 #include "stdlib/math/base/special/asin.h"
@@ -351,7 +352,7 @@ static double ibetaPowerTerms( const double a, const double b, const double x, c
 			if ( l <= STDLIB_CONSTANT_FLOAT64_MIN_LN || l >= STDLIB_CONSTANT_FLOAT64_MAX_LN ) {
 				l += stdlib_base_ln( result );
 				if ( l >= STDLIB_CONSTANT_FLOAT64_MAX_LN ) {
-					return 0.0 / 0.0;
+					return STDLIB_CONSTANT_FLOAT64_NAN;
 				}
 				result = stdlib_base_exp( l );
 			} else {
@@ -363,7 +364,7 @@ static double ibetaPowerTerms( const double a, const double b, const double x, c
 			if ( l <= STDLIB_CONSTANT_FLOAT64_MIN_LN || l >= STDLIB_CONSTANT_FLOAT64_MAX_LN ) {
 				l += stdlib_base_ln( result );
 				if ( l >= STDLIB_CONSTANT_FLOAT64_MAX_LN ) {
-					return 0.0 / 0.0;
+					return STDLIB_CONSTANT_FLOAT64_NAN;
 				}
 				result = stdlib_base_exp( l );
 			} else {
@@ -386,7 +387,7 @@ static double ibetaPowerTerms( const double a, const double b, const double x, c
 				} else {
 					l2 += l1 + stdlib_base_ln( result );
 					if ( l2 >= STDLIB_CONSTANT_FLOAT64_MAX_LN ) {
-						return 0.0 / 0.0;
+						return STDLIB_CONSTANT_FLOAT64_NAN;
 					}
 					result = stdlib_base_exp( l2 );
 				}
@@ -398,7 +399,7 @@ static double ibetaPowerTerms( const double a, const double b, const double x, c
 				} else {
 					l2 += l1 + stdlib_base_ln( result );
 					if ( l2 >= STDLIB_CONSTANT_FLOAT64_MAX_LN ) {
-						return 0.0 / 0.0;
+						return STDLIB_CONSTANT_FLOAT64_NAN;
 					}
 					result = stdlib_base_exp( l2 );
 				}
@@ -789,21 +790,21 @@ void stdlib_base_kernel_betainc( double x, double a, double b, const bool regula
 	// Derivative not set...
 	*derivative = -1;
 	if ( stdlib_base_is_nan( x ) || x < 0.0 || x > 1.0 ) {
-		*out = 0.0 / 0.0;
-		*derivative = 0.0 / 0.0;
+		*out = STDLIB_CONSTANT_FLOAT64_NAN;
+		*derivative = STDLIB_CONSTANT_FLOAT64_NAN;
 		return;
 	}
 	if ( regularized ) {
 		if ( a < 0.0 || b < 0.0 ) {
-			*out = 0.0 / 0.0;
-			*derivative = 0.0 / 0.0;
+			*out = STDLIB_CONSTANT_FLOAT64_NAN;
+			*derivative = STDLIB_CONSTANT_FLOAT64_NAN;
 			return;
 		}
 		// Extend to a few very special cases...
 		if ( a == 0.0 ) {
 			if ( b == 0.0 ) {
-				*out = 0.0 / 0.0;
-				*derivative = 0.0 / 0.0;
+				*out = STDLIB_CONSTANT_FLOAT64_NAN;
+				*derivative = STDLIB_CONSTANT_FLOAT64_NAN;
 				return;
 			}
 			if ( b > 0.0 ) {
@@ -817,8 +818,8 @@ void stdlib_base_kernel_betainc( double x, double a, double b, const bool regula
 			}
 		}
 	} else if ( a <= 0.0 || b <= 0.0 ) {
-		*out = 0.0 / 0.0;
-		*derivative = 0.0 / 0.0;
+		*out = STDLIB_CONSTANT_FLOAT64_NAN;
+		*derivative = STDLIB_CONSTANT_FLOAT64_NAN;
 		return;
 	}
 	if ( x == 0.0 ) {

--- a/lib/node_modules/@stdlib/math/base/special/kronecker-delta/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/kronecker-delta/manifest.json
@@ -39,7 +39,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/binary",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       ],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       ],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/kronecker-delta/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/kronecker-delta/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/kronecker_delta.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 
 /**
@@ -36,7 +37,7 @@
 */
 double stdlib_base_kronecker_delta( const double i, const double j ) {
 	if ( stdlib_base_is_nan( i ) || stdlib_base_is_nan( j ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( i == j ) {
 		return 1.0;

--- a/lib/node_modules/@stdlib/math/base/special/ln/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ln/manifest.json
@@ -43,7 +43,8 @@
         "@stdlib/number/float64/base/set-high-word",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/constants/float64/exponent-bias"
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -62,7 +63,8 @@
         "@stdlib/number/float64/base/set-high-word",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/constants/float64/exponent-bias"
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -81,7 +83,8 @@
         "@stdlib/number/float64/base/set-high-word",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/constants/float64/exponent-bias"
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -100,7 +103,8 @@
         "@stdlib/number/float64/base/set-high-word",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/constants/float64/exponent-bias"
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/ln/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/ln/src/main.c
@@ -35,6 +35,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/constants/float64/exponent_bias.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double LN2_HI = 6.93147180369123816490e-01; // 3FE62E42 FEE00000
@@ -127,7 +128,7 @@ double stdlib_base_ln( const double x ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;
 	}
 	if ( stdlib_base_is_nan( x ) || x < 0.0 ) {
-		return 0.0/0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	stdlib_base_float64_get_high_word( x, &hx );
 	xc = x;

--- a/lib/node_modules/@stdlib/math/base/special/log10/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/log10/manifest.json
@@ -46,7 +46,8 @@
         "@stdlib/constants/float64/high-word-significand-mask",
         "@stdlib/number/float64/base/set-low-word",
         "@stdlib/math/base/special/kernel-log1p",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -69,7 +70,8 @@
         "@stdlib/constants/float64/high-word-significand-mask",
         "@stdlib/number/float64/base/set-low-word",
         "@stdlib/math/base/special/kernel-log1p",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -92,7 +94,8 @@
         "@stdlib/constants/float64/high-word-significand-mask",
         "@stdlib/number/float64/base/set-low-word",
         "@stdlib/math/base/special/kernel-log1p",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/log10/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/log10/src/main.c
@@ -39,6 +39,7 @@
 #include "stdlib/constants/float64/high_word_significand_mask.h"
 #include "stdlib/constants/float64/exponent_bias.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/kernel_log1p.h"
 #include <stdint.h>
@@ -87,7 +88,7 @@ double stdlib_base_log10( const double x ) {
 	double y;
 
 	if ( stdlib_base_is_nan( x ) || x < 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	xc = x;
 	stdlib_base_float64_to_words( xc, &hx, &lx );

--- a/lib/node_modules/@stdlib/math/base/special/log1mexp/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/log1mexp/manifest.json
@@ -44,7 +44,8 @@
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/ln-two",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -65,7 +66,8 @@
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/ln-two",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -86,7 +88,8 @@
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/ln-two",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/log1mexp/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1mexp/src/main.c
@@ -25,6 +25,7 @@
 #include "stdlib/math/base/special/abs.h"
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/constants/float64/ln_two.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Computes the natural logarithm of \\( 1-\exp(-|x|) \\).
@@ -39,7 +40,7 @@
 double stdlib_base_log1mexp( const double x ) {
 	double ax;
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;

--- a/lib/node_modules/@stdlib/math/base/special/log1p/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/manifest.json
@@ -42,7 +42,8 @@
         "@stdlib/number/float64/base/set-high-word",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/exponent-bias"
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -61,7 +62,8 @@
         "@stdlib/number/float64/base/set-high-word",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/exponent-bias"
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -80,7 +82,8 @@
         "@stdlib/number/float64/base/set-high-word",
         "@stdlib/constants/float64/ninf",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/exponent-bias"
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/log1p/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/src/main.c
@@ -37,6 +37,7 @@
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/exponent_bias.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 // High and low words of ln(2):
@@ -246,7 +247,7 @@ double stdlib_base_log1p( const double x ) {
 	double u;
 
 	if ( x < -1.0 || stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == -1.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;

--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/exp",
-        "@stdlib/math/base/special/log1p"
+        "@stdlib/math/base/special/log1p",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/exp",
-        "@stdlib/math/base/special/log1p"
+        "@stdlib/math/base/special/log1p",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/exp",
-        "@stdlib/math/base/special/log1p"
+        "@stdlib/math/base/special/log1p",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/log1pexp.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/log1p.h"
 #include "stdlib/math/base/special/exp.h"
@@ -33,7 +34,7 @@
 */
 double stdlib_base_log1pexp( const double x ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x <= -37.0 ) {
 		return stdlib_base_exp( x );

--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/abs",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/abs",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/special/log1p",
         "@stdlib/math/base/special/ln",
         "@stdlib/math/base/special/abs",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/src/main.c
@@ -34,6 +34,7 @@
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/math/base/special/abs.h"
 #include "stdlib/constants/float64/eps.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Evaluates \\( \operatorname{log1pmx}(x) = \ln(1+x) - x \\).
@@ -48,7 +49,7 @@
 double stdlib_base_log1pmx( const double x ) {
 	double ax;
 	if ( x <= -1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	ax = stdlib_base_abs( x );
 	if ( ax > 0.95 ) {

--- a/lib/node_modules/@stdlib/math/base/special/log2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/log2/manifest.json
@@ -46,7 +46,8 @@
         "@stdlib/constants/float64/high-word-significand-mask",
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/math/base/special/kernel-log1p"
+        "@stdlib/math/base/special/kernel-log1p",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -69,7 +70,8 @@
         "@stdlib/constants/float64/high-word-significand-mask",
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/math/base/special/kernel-log1p"
+        "@stdlib/math/base/special/kernel-log1p",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -92,7 +94,8 @@
         "@stdlib/constants/float64/high-word-significand-mask",
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/math/base/special/kernel-log1p"
+        "@stdlib/math/base/special/kernel-log1p",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/log2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/log2/src/main.c
@@ -26,6 +26,7 @@
 #include "stdlib/constants/float64/high_word_significand_mask.h"
 #include "stdlib/constants/float64/exponent_bias.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/kernel_log1p.h"
 #include <stdint.h>
 
@@ -66,7 +67,7 @@ double stdlib_base_log2( const double x ) {
 	double y;
 
 	if ( stdlib_base_is_nan( x ) || x < 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	xc = x;
 	stdlib_base_float64_to_words( xc, &hx, &lx );

--- a/lib/node_modules/@stdlib/math/base/special/logaddexp/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/logaddexp/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/exp",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/constants/float64/ln-two"
+        "@stdlib/constants/float64/ln-two",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/exp",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/constants/float64/ln-two"
+        "@stdlib/constants/float64/ln-two",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/exp",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/constants/float64/ln-two"
+        "@stdlib/constants/float64/ln-two",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/logaddexp/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/logaddexp/src/main.c
@@ -21,6 +21,7 @@
 #include "stdlib/math/base/special/exp.h"
 #include "stdlib/math/base/special/log1p.h"
 #include "stdlib/constants/float64/ln_two.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Computes the natural logarithm of `exp(x) + exp(y)`.
@@ -36,7 +37,7 @@
 double stdlib_base_logaddexp( const double x, const double y ) {
 	double d;
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( y ) ) {
-		return 0.0/0.0;
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == y ) {
 		return x + STDLIB_CONSTANT_FLOAT64_LN2;

--- a/lib/node_modules/@stdlib/math/base/special/logit/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/logit/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-probability",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-probability",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-probability",
         "@stdlib/constants/float64/pinf",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/logit/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/logit/src/main.c
@@ -22,6 +22,7 @@
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Evaluates the logit function.
@@ -35,10 +36,10 @@
 */
 double stdlib_base_logit( const double p ) {
 	if ( stdlib_base_is_nan( p ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( !stdlib_base_is_probability( p ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( p == 0.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;

--- a/lib/node_modules/@stdlib/math/base/special/lucas/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/lucas/manifest.json
@@ -38,7 +38,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/assert/is-nonnegative-integer",
-        "@stdlib/constants/float64/max-safe-nth-lucas"
+        "@stdlib/constants/float64/max-safe-nth-lucas",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -53,7 +54,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nonnegative-integer",
-        "@stdlib/constants/float64/max-safe-nth-lucas"
+        "@stdlib/constants/float64/max-safe-nth-lucas",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -68,7 +70,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nonnegative-integer",
-        "@stdlib/constants/float64/max-safe-nth-lucas"
+        "@stdlib/constants/float64/max-safe-nth-lucas",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/lucas/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/lucas/src/main.c
@@ -19,6 +19,7 @@
 #include "stdlib/math/base/special/lucas.h"
 #include "stdlib/math/base/assert/is_nonnegative_integer.h"
 #include "stdlib/constants/float64/max_safe_nth_lucas.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -118,7 +119,7 @@ static const int64_t lucas_value[ 77 ] = {
 */
 double stdlib_base_lucas( const double n ) {
 	if ( !stdlib_base_is_nonnegative_integer( n ) || n > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_LUCAS ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	return lucas_value[ (size_t)n ];
 }

--- a/lib/node_modules/@stdlib/math/base/special/max/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/max/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-positive-zero",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-positive-zero",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-positive-zero",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/max/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/max/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_positive_zero.h"
 #include "stdlib/constants/float64/pinf.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Returns the maximum value.
@@ -38,7 +39,7 @@
 */
 double stdlib_base_max( const double x, const double y ) {
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( y ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == STDLIB_CONSTANT_FLOAT64_PINF || y == STDLIB_CONSTANT_FLOAT64_PINF ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;

--- a/lib/node_modules/@stdlib/math/base/special/min/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/min/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-negative-zero",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-negative-zero",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-negative-zero",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/min/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/min/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_negative_zero.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Return the minimum value.
@@ -38,7 +39,7 @@
 */
 double stdlib_base_min( const double x, const double y ) {
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( y ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == STDLIB_CONSTANT_FLOAT64_NINF || y == STDLIB_CONSTANT_FLOAT64_NINF ) {
 		return STDLIB_CONSTANT_FLOAT64_NINF;

--- a/lib/node_modules/@stdlib/math/base/special/minmax/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/napi/argv-float64array",
         "@stdlib/napi/export",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -56,7 +57,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/minmax/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/minmax.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_negative_zero.h"
 
@@ -38,8 +39,8 @@
 */
 void stdlib_base_minmax( const double x, const double y, double* min, double* max ) {
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( y ) ) {
-		*min = 0.0 / 0.0; // NaN
-		*max = 0.0 / 0.0; // NaN
+		*min = STDLIB_CONSTANT_FLOAT64_NAN;
+		*max = STDLIB_CONSTANT_FLOAT64_NAN;
 		return;
 	}
 	if ( x == y && x == 0.0 ) {

--- a/lib/node_modules/@stdlib/math/base/special/minmaxabs/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxabs/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/napi/argv-float64array",
         "@stdlib/napi/export",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/abs"
+        "@stdlib/math/base/special/abs",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -56,7 +57,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/abs"
+        "@stdlib/math/base/special/abs",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/abs"
+        "@stdlib/math/base/special/abs",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/minmaxabs/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxabs/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/minmaxabs.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/abs.h"
 #include "stdlib/math/base/assert/is_nan.h"
 
@@ -41,8 +42,8 @@ void stdlib_base_minmaxabs( const double x, const double y, double* min, double*
 	double ay;
 
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( y ) ) {
-		*min = 0.0 / 0.0; // NaN
-		*max = 0.0 / 0.0; // NaN
+		*min = STDLIB_CONSTANT_FLOAT64_NAN;
+		*max = STDLIB_CONSTANT_FLOAT64_NAN;
 		return;
 	}
 	ax = stdlib_base_abs( x );

--- a/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
@@ -47,7 +47,8 @@
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/constants/float64/high-word-significand-mask",
-        "@stdlib/constants/float64/num-high-word-significand-bits"
+        "@stdlib/constants/float64/num-high-word-significand-bits",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -68,7 +69,8 @@
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/constants/float64/high-word-significand-mask",
-        "@stdlib/constants/float64/num-high-word-significand-bits"
+        "@stdlib/constants/float64/num-high-word-significand-bits",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -89,7 +91,8 @@
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/constants/float64/high-word-significand-mask",
-        "@stdlib/constants/float64/num-high-word-significand-bits"
+        "@stdlib/constants/float64/num-high-word-significand-bits",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
@@ -25,6 +25,7 @@
 #include "stdlib/constants/float64/high_word_exponent_mask.h"
 #include "stdlib/constants/float64/high_word_significand_mask.h"
 #include "stdlib/constants/float64/num_high_word_significand_bits.h"
+#include "stdlib/constants/float64/nan.h"
 
 // 4294967295 => 0xffffffff => 11111111111111111111111111111111
 static const uint32_t ALL_ONES = 4294967295;
@@ -68,8 +69,8 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 		return;
 	}
 	if ( stdlib_base_is_nan( x ) ) {
-		*integral = 0.0 / 0.0; // NaN
-		*frac = 0.0 / 0.0; // NaN
+		*integral = STDLIB_CONSTANT_FLOAT64_NAN;
+		*frac = STDLIB_CONSTANT_FLOAT64_NAN;
 		return;
 	}
 	if ( x == STDLIB_CONSTANT_FLOAT64_PINF ) {

--- a/lib/node_modules/@stdlib/math/base/special/nanmax/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/nanmax/manifest.json
@@ -38,7 +38,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/max"
+        "@stdlib/math/base/special/max",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -53,7 +54,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/max"
+        "@stdlib/math/base/special/max",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -68,7 +70,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/max"
+        "@stdlib/math/base/special/max",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/nanmax/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/nanmax/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/nanmax.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/max.h"
 
@@ -37,7 +38,7 @@
 */
 double stdlib_base_nanmax( const double x, const double y ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return stdlib_base_is_nan( y ) ? 0.0 / 0.0 : y;
+		return stdlib_base_is_nan( y ) ? STDLIB_CONSTANT_FLOAT64_NAN : y;
 	}
 	return stdlib_base_is_nan( y ) ? x : stdlib_base_max( x, y );
 }

--- a/lib/node_modules/@stdlib/math/base/special/nanmin/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/nanmin/manifest.json
@@ -38,7 +38,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/min"
+        "@stdlib/math/base/special/min",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -53,7 +54,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/min"
+        "@stdlib/math/base/special/min",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -68,7 +70,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/special/min"
+        "@stdlib/math/base/special/min",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/nanmin/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/nanmin/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/nanmin.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/min.h"
 
@@ -37,7 +38,7 @@
 */
 double stdlib_base_nanmin( const double x, const double y ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return stdlib_base_is_nan( y ) ? 0.0 / 0.0 : y;
+		return stdlib_base_is_nan( y ) ? STDLIB_CONSTANT_FLOAT64_NAN : y;
 	}
 	return stdlib_base_is_nan( y ) ? x : stdlib_base_min( x, y );
 }

--- a/lib/node_modules/@stdlib/math/base/special/negafibonacci/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/negafibonacci/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/constants/float64/max-safe-nth-fibonacci",
         "@stdlib/math/base/special/abs",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/constants/float64/max-safe-nth-fibonacci",
         "@stdlib/math/base/special/abs",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/constants/float64/max-safe-nth-fibonacci",
         "@stdlib/math/base/special/abs",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/negafibonacci/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/negafibonacci/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/math/base/assert/is_integer.h"
 #include "stdlib/math/base/special/abs.h"
 #include "stdlib/constants/float64/max_safe_nth_fibonacci.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdlib.h>
 
 static const double negafibonacci_value[ 79 ] = {
@@ -117,11 +118,11 @@ static const double negafibonacci_value[ 79 ] = {
 double stdlib_base_negafibonacci( const double n ) {
 	double an;
 	if ( !stdlib_base_is_integer( n ) || n > 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	an = stdlib_base_abs( n );
 	if ( an > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FIBONACCI ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	return negafibonacci_value[ (size_t)an ];
 }

--- a/lib/node_modules/@stdlib/math/base/special/negalucas/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/negalucas/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/max-safe-nth-lucas",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/max-safe-nth-lucas",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/special/abs",
         "@stdlib/constants/float64/max-safe-nth-lucas",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/negalucas/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/negalucas/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/math/base/assert/is_integer.h"
 #include "stdlib/math/base/special/abs.h"
 #include "stdlib/constants/float64/max_safe_nth_lucas.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -120,7 +121,7 @@ static const int64_t negalucas_value[ 77 ] = {
 double stdlib_base_negalucas( const double n ) {
 	double an = stdlib_base_abs( n );
 	if ( !stdlib_base_is_integer( n ) || n > 0.0 || an > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_LUCAS ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	return negalucas_value[ (size_t)an ];
 }

--- a/lib/node_modules/@stdlib/math/base/special/pdiff/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/pdiff/manifest.json
@@ -37,7 +37,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/binary",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -51,7 +52,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -65,7 +67,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/pdiff/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/pdiff/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/pdiff.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 
 /**
@@ -36,7 +37,7 @@
 */
 double stdlib_base_pdiff( const double x, const double y ) {
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( y ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x > y ) {
 		return x - y;

--- a/lib/node_modules/@stdlib/math/base/special/powm1/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/manifest.json
@@ -44,8 +44,8 @@
         "@stdlib/math/base/special/trunc",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
-        "@stdlib/math/base/special/fmod"
-
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -66,7 +66,8 @@
         "@stdlib/math/base/special/trunc",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
-        "@stdlib/math/base/special/fmod"
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -87,7 +88,8 @@
         "@stdlib/math/base/special/trunc",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
-        "@stdlib/math/base/special/fmod"
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/powm1/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/src/main.c
@@ -30,6 +30,7 @@
 */
 
 #include "stdlib/math/base/special/powm1.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/abs.h"
 #include "stdlib/math/base/special/expm1.h"
 #include "stdlib/math/base/special/ln.h"
@@ -60,7 +61,7 @@ double stdlib_base_powm1( const double b, const double x ) {
 	double y;
 
 	if ( stdlib_base_is_nan( b ) || stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 0.0 ) {
 		// Any number raised to zero (including 0) is always 1 => b^0 - 1 = 0
@@ -85,11 +86,11 @@ double stdlib_base_powm1( const double b, const double x ) {
 		}
 	} else if ( stdlib_base_trunc( x ) != x ) {
 		// Exponentiation would yield a complex result...
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	result = stdlib_base_pow( bc, x ) - 1.0;
 	if ( stdlib_base_is_infinite( result ) || stdlib_base_is_nan( result ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	return result;
 }

--- a/lib/node_modules/@stdlib/math/base/special/ramp/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ramp/manifest.json
@@ -37,7 +37,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/unary",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -51,7 +52,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -65,7 +67,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/ramp/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/ramp/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/ramp.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 
 /**
@@ -35,7 +36,7 @@
 */
 double stdlib_base_ramp( const double x ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x > 0.0 ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/rempio2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/manifest.json
@@ -49,7 +49,8 @@
         "@stdlib/number/float64/base/from-words",
         "@stdlib/constants/float64/high-word-abs-mask",
         "@stdlib/constants/float64/high-word-exponent-mask",
-        "@stdlib/constants/float64/high-word-significand-mask"
+        "@stdlib/constants/float64/high-word-significand-mask",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +72,8 @@
         "@stdlib/number/float64/base/from-words",
         "@stdlib/constants/float64/high-word-abs-mask",
         "@stdlib/constants/float64/high-word-exponent-mask",
-        "@stdlib/constants/float64/high-word-significand-mask"
+        "@stdlib/constants/float64/high-word-significand-mask",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -93,7 +95,8 @@
         "@stdlib/number/float64/base/from-words",
         "@stdlib/constants/float64/high-word-abs-mask",
         "@stdlib/constants/float64/high-word-exponent-mask",
-        "@stdlib/constants/float64/high-word-significand-mask"
+        "@stdlib/constants/float64/high-word-significand-mask",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/rempio2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/src/main.c
@@ -40,6 +40,7 @@
 #include "stdlib/constants/float64/high_word_abs_mask.h"
 #include "stdlib/constants/float64/high_word_exponent_mask.h"
 #include "stdlib/constants/float64/high_word_significand_mask.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double ZERO =  0.00000000000000000000e+00;       // 0x00000000, 0x00000000
@@ -595,8 +596,8 @@ medium:
 	}
 	// Case: x is NaN or infinity
 	if( ix >= STDLIB_CONSTANT_FLOAT64_HIGH_WORD_EXPONENT_MASK ) {
-		*rem1 = 0.0 / 0.0; // NaN
-		*rem2 = 0.0 / 0.0; // NaN
+		*rem1 = STDLIB_CONSTANT_FLOAT64_NAN;
+		*rem2 = STDLIB_CONSTANT_FLOAT64_NAN;
 		return 0;
 	}
 	// Set z = scalbn(|x|, ilogb(x)-23)...

--- a/lib/node_modules/@stdlib/math/base/special/rempio2f/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2f/manifest.json
@@ -47,7 +47,8 @@
         "@stdlib/number/float32/base/from-word",
         "@stdlib/number/float32/base/to-word",
         "@stdlib/constants/float32/abs-mask",
-        "@stdlib/constants/float32/exponent-mask"
+        "@stdlib/constants/float32/exponent-mask",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -67,7 +68,8 @@
         "@stdlib/number/float32/base/from-word",
         "@stdlib/number/float32/base/to-word",
         "@stdlib/constants/float32/abs-mask",
-        "@stdlib/constants/float32/exponent-mask"
+        "@stdlib/constants/float32/exponent-mask",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -87,7 +89,8 @@
         "@stdlib/number/float32/base/from-word",
         "@stdlib/number/float32/base/to-word",
         "@stdlib/constants/float32/abs-mask",
-        "@stdlib/constants/float32/exponent-mask"
+        "@stdlib/constants/float32/exponent-mask",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/rempio2f/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2f/src/main.c
@@ -38,6 +38,7 @@
 #include "stdlib/number/float32/base/to_word.h"
 #include "stdlib/constants/float32/abs_mask.h"
 #include "stdlib/constants/float32/exponent_mask.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double ZERO =  0.00000000000000000000e+00;       // 0x00000000, 0x00000000
@@ -421,7 +422,7 @@ int32_t stdlib_base_rempio2f( const float x, double *rem ) {
 	}
 	// Case: x is NaN or infinity
 	if( ix >= STDLIB_CONSTANT_FLOAT32_EXPONENT_MASK ) {
-		*rem = 0.0 / 0.0; // NaN
+		*rem = STDLIB_CONSTANT_FLOAT64_NAN;
 		return 0;
 	}
 	// Set z = scalbn(|x|, ilogb(|x|)-23)...

--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/manifest.json
@@ -53,7 +53,8 @@
         "@stdlib/constants/float64/two-pi",
         "@stdlib/constants/float64/sqrt-eps",
         "@stdlib/constants/float64/ln-sqrt-two-pi",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -83,7 +84,8 @@
         "@stdlib/constants/float64/two-pi",
         "@stdlib/constants/float64/sqrt-eps",
         "@stdlib/constants/float64/ln-sqrt-two-pi",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -113,7 +115,8 @@
         "@stdlib/constants/float64/two-pi",
         "@stdlib/constants/float64/sqrt-eps",
         "@stdlib/constants/float64/ln-sqrt-two-pi",
-        "@stdlib/constants/float64/max-nth-factorial"
+        "@stdlib/constants/float64/max-nth-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/src/main.c
@@ -47,6 +47,7 @@
 #include "stdlib/constants/float64/sqrt_eps.h"
 #include "stdlib/constants/float64/ln_sqrt_two_pi.h"
 #include "stdlib/constants/float64/max_nth_factorial.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const int32_t MAX_BERNOULLI_2N = 129;
@@ -708,12 +709,12 @@ double stdlib_base_zeta( const double s ) {
 
 	// Check for `NaN`:
 	if ( stdlib_base_is_nan( s ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	// Check for a pole:
 	if ( s == 1.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	// Check for large value:

--- a/lib/node_modules/@stdlib/math/base/special/rising-factorial/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/rising-factorial/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/gamma-delta-ratio",
-        "@stdlib/math/base/special/falling-factorial"
+        "@stdlib/math/base/special/falling-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/gamma-delta-ratio",
-        "@stdlib/math/base/special/falling-factorial"
+        "@stdlib/math/base/special/falling-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/gamma-delta-ratio",
-        "@stdlib/math/base/special/falling-factorial"
+        "@stdlib/math/base/special/falling-factorial",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/rising-factorial/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/rising-factorial/src/main.c
@@ -31,6 +31,7 @@
 
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/gamma_delta_ratio.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/falling_factorial.h"
 #include <stdint.h>
 #include <stdbool.h>
@@ -67,7 +68,7 @@ double stdlib_base_rising_factorial( const double x, const int32_t n ) {
 	bool inv;
 
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	nc = n;
 	xc = x;

--- a/lib/node_modules/@stdlib/math/base/special/round/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/round/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -58,7 +59,8 @@
       "dependencies": [
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -75,7 +77,8 @@
       "dependencies": [
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -92,7 +95,8 @@
       "dependencies": [
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/round/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/round/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/round.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/floor.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_negative_zero.h"
@@ -33,7 +34,7 @@
 */
 double stdlib_base_round( const double x ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0/0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_negative_zero( x ) || ( x >= -0.5 && x < 0.0 ) ) {
 		return -0.0; // -0

--- a/lib/node_modules/@stdlib/math/base/special/roundb/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/round",
         "@stdlib/math/base/special/roundn",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/round",
         "@stdlib/math/base/special/roundn",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/round",
         "@stdlib/math/base/special/roundn",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/roundb/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/roundb.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/round.h"
@@ -41,7 +42,7 @@ double stdlib_base_roundb( const double x, const int32_t n, const int32_t b ) {
 	double s;
 
 	if ( stdlib_base_is_nan( x ) || b <= 0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/roundn/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/manifest.json
@@ -47,7 +47,8 @@
         "@stdlib/constants/float64/min-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent-subnormal",
         "@stdlib/math/base/assert/is-infinite",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +72,8 @@
         "@stdlib/constants/float64/min-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent-subnormal",
         "@stdlib/math/base/assert/is-infinite",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -95,7 +97,8 @@
         "@stdlib/constants/float64/min-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent-subnormal",
         "@stdlib/math/base/assert/is-infinite",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/roundn/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/src/main.c
@@ -26,6 +26,7 @@
 #include "stdlib/constants/float64/max_base10_exponent.h"
 #include "stdlib/constants/float64/min_base10_exponent.h"
 #include "stdlib/constants/float64/min_base10_exponent_subnormal.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double MAX_INT = STDLIB_CONSTANT_FLOAT64_MAX_SAFE_INTEGER + 1.0;
@@ -117,7 +118,7 @@ double stdlib_base_roundn( const double x, const int32_t n ) {
 	double y;
 
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	if (

--- a/lib/node_modules/@stdlib/math/base/special/roundsd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundsd/manifest.json
@@ -47,7 +47,8 @@
         "@stdlib/number/float64/base/exponent",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/round",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +72,8 @@
         "@stdlib/number/float64/base/exponent",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/round",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -95,7 +97,8 @@
         "@stdlib/number/float64/base/exponent",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/round",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/roundsd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundsd/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/roundsd.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/pow.h"
 #include "stdlib/math/base/assert/is_infinite.h"
@@ -46,7 +47,7 @@ double stdlib_base_roundsd( const double x, const int32_t n, const int32_t b ) {
 	double y;
 
 	if ( stdlib_base_is_nan( x ) || n < 1 ) {
-		return 0.0/0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/sin/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sin/manifest.json
@@ -44,7 +44,8 @@
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/kernel-sin",
-        "@stdlib/math/base/special/rempio2"
+        "@stdlib/math/base/special/rempio2",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -65,7 +66,8 @@
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/kernel-sin",
-        "@stdlib/math/base/special/rempio2"
+        "@stdlib/math/base/special/rempio2",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -86,7 +88,8 @@
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/kernel-sin",
-        "@stdlib/math/base/special/rempio2"
+        "@stdlib/math/base/special/rempio2",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/sin/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sin/src/main.c
@@ -34,6 +34,7 @@
 #include "stdlib/number/float64/base/get_high_word.h"
 #include "stdlib/constants/float64/high_word_abs_mask.h"
 #include "stdlib/constants/float64/high_word_exponent_mask.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/kernel_cos.h"
 #include "stdlib/math/base/special/kernel_sin.h"
 #include "stdlib/math/base/special/rempio2.h"
@@ -90,7 +91,7 @@ double stdlib_base_sin( const double x ) {
 	}
 	// Case: x is NaN or infinity
 	if ( ix >= STDLIB_CONSTANT_FLOAT64_HIGH_WORD_EXPONENT_MASK ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Argument reduction...
 	n = stdlib_base_rempio2( x, &Y[ 0 ], &Y[ 1 ] );

--- a/lib/node_modules/@stdlib/math/base/special/sinc/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sinc/manifest.json
@@ -42,7 +42,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/constants/float64/pi",
-        "@stdlib/math/base/special/sinpi"
+        "@stdlib/math/base/special/sinpi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -61,7 +62,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/constants/float64/pi",
-        "@stdlib/math/base/special/sinpi"
+        "@stdlib/math/base/special/sinpi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -80,7 +82,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/constants/float64/pi",
-        "@stdlib/math/base/special/sinpi"
+        "@stdlib/math/base/special/sinpi",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/sinc/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sinc/src/main.c
@@ -21,6 +21,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/constants/float64/pi.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Computes the normalized cardinal sine of a number.
@@ -53,7 +54,7 @@
 */
 double stdlib_base_sinc( const double x ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) ) {
 		return 0.0;

--- a/lib/node_modules/@stdlib/math/base/special/sincos/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sincos/manifest.json
@@ -43,7 +43,8 @@
         "@stdlib/math/base/special/rempio2",
         "@stdlib/number/float64/base/get-high-word",
         "@stdlib/constants/float64/high-word-exponent-mask",
-        "@stdlib/constants/float64/high-word-abs-mask"
+        "@stdlib/constants/float64/high-word-abs-mask",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -60,7 +61,8 @@
         "@stdlib/math/base/special/rempio2",
         "@stdlib/number/float64/base/get-high-word",
         "@stdlib/constants/float64/high-word-exponent-mask",
-        "@stdlib/constants/float64/high-word-abs-mask"
+        "@stdlib/constants/float64/high-word-abs-mask",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/special/rempio2",
         "@stdlib/number/float64/base/get-high-word",
         "@stdlib/constants/float64/high-word-exponent-mask",
-        "@stdlib/constants/float64/high-word-abs-mask"
+        "@stdlib/constants/float64/high-word-abs-mask",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/sincos/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincos/src/main.c
@@ -19,6 +19,7 @@
 #include "stdlib/math/base/special/sincos.h"
 #include "stdlib/constants/float64/high_word_abs_mask.h"
 #include "stdlib/constants/float64/high_word_exponent_mask.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/number/float64/base/get_high_word.h"
 #include "stdlib/math/base/special/rempio2.h"
 #include <stdint.h>
@@ -131,8 +132,8 @@ void stdlib_base_sincos( const double x, double* sine, double* cosine ) {
 
 	// Case: x is NaN or infinity
 	if ( ix >= STDLIB_CONSTANT_FLOAT64_HIGH_WORD_EXPONENT_MASK ) {
-		*sine = 0.0 / 0.0; // NaN
-		*cosine = 0.0 / 0.0; // NaN
+		*sine = STDLIB_CONSTANT_FLOAT64_NAN;
+		*cosine = STDLIB_CONSTANT_FLOAT64_NAN;
 		return;
 	}
 

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/manifest.json
@@ -47,7 +47,8 @@
         "@stdlib/math/base/special/fmod",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -68,7 +69,8 @@
         "@stdlib/math/base/special/fmod",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -89,7 +91,8 @@
         "@stdlib/math/base/special/fmod",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/src/main.c
@@ -25,6 +25,7 @@
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/constants/float64/pi.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Simultaneously computes the sine and cosine of a number times π.
@@ -47,8 +48,8 @@ void stdlib_base_sincospi( const double x, double* sine, double* cosine ) {
 	double r;
 
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_infinite( x ) ) {
-		*sine = 0.0 / 0.0; // NaN
-		*cosine = 0.0 / 0.0; // NaN
+		*sine = STDLIB_CONSTANT_FLOAT64_NAN;
+		*cosine = STDLIB_CONSTANT_FLOAT64_NAN;
 		return;
 	}
 	r = stdlib_base_fmod( x, 2.0 );

--- a/lib/node_modules/@stdlib/math/base/special/sind/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sind/manifest.json
@@ -44,7 +44,8 @@
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/signum",
         "@stdlib/math/base/special/abs",
-        "@stdlib/math/base/special/fmod"
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -65,7 +66,8 @@
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/signum",
         "@stdlib/math/base/special/abs",
-        "@stdlib/math/base/special/fmod"
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -86,7 +88,8 @@
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/signum",
         "@stdlib/math/base/special/abs",
-        "@stdlib/math/base/special/fmod"
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/sind/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sind/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/sind.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/kernel_sin.h"
 #include "stdlib/math/base/special/kernel_cos.h"
 #include "stdlib/math/base/special/deg2rad.h"
@@ -41,7 +42,7 @@ double stdlib_base_sind( const double x ) {
 	double rx;
 
 	if ( stdlib_base_is_infinite( x ) || stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	rx = stdlib_base_fmod( x, 360.0 );

--- a/lib/node_modules/@stdlib/math/base/special/sinpi/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sinpi/manifest.json
@@ -46,7 +46,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/copysign",
         "@stdlib/math/base/special/fmod",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -69,7 +70,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/copysign",
         "@stdlib/math/base/special/fmod",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -92,7 +94,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/copysign",
         "@stdlib/math/base/special/fmod",
-        "@stdlib/constants/float64/pi"
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/sinpi/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sinpi/src/main.c
@@ -25,6 +25,7 @@
 #include "stdlib/math/base/special/copysign.h"
 #include "stdlib/math/base/special/fmod.h"
 #include "stdlib/constants/float64/pi.h"
+#include "stdlib/constants/float64/nan.h"
 
 /**
 * Computes the value of `sin(πx)`.
@@ -47,7 +48,7 @@ double stdlib_base_sinpi( const double x ) {
 	double ar;
 	double r;
 	if ( stdlib_base_is_nan( x ) || stdlib_base_is_infinite( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	// Argument reduction (reduce to [0,2))...

--- a/lib/node_modules/@stdlib/math/base/special/spence/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/spence/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/pi-squared"
+        "@stdlib/constants/float64/pi-squared",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/pi-squared"
+        "@stdlib/constants/float64/pi-squared",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/ln",
-        "@stdlib/constants/float64/pi-squared"
+        "@stdlib/constants/float64/pi-squared",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/spence/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/spence/src/main.c
@@ -34,6 +34,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/pi_squared.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 // π^2 / 6
@@ -114,7 +115,7 @@ double stdlib_base_spence( const double x ) {
 	double z;
 
 	if ( stdlib_base_is_nan( x ) || x < 0.0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 1.0 ) {
 		return 0.0;

--- a/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/math/base/special/abs"
+        "@stdlib/math/base/special/abs",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/math/base/special/abs"
+        "@stdlib/math/base/special/abs",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/log1p",
-        "@stdlib/math/base/special/abs"
+        "@stdlib/math/base/special/abs",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/src/main.c
@@ -30,6 +30,7 @@
 */
 
 #include "stdlib/math/base/special/sqrt1pm1.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/expm1.h"
 #include "stdlib/math/base/special/log1p.h"
@@ -48,7 +49,7 @@
 */
 double stdlib_base_sqrt1pm1( const double x ) {
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_abs( x ) > 0.75 ) {
 		return stdlib_base_sqrt( 1.0 + x ) - 1.0;

--- a/lib/node_modules/@stdlib/math/base/special/tan/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/tan/manifest.json
@@ -43,7 +43,8 @@
         "@stdlib/constants/float64/high-word-abs-mask",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-tan",
-        "@stdlib/math/base/special/rempio2"
+        "@stdlib/math/base/special/rempio2",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -63,7 +64,8 @@
         "@stdlib/constants/float64/high-word-abs-mask",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-tan",
-        "@stdlib/math/base/special/rempio2"
+        "@stdlib/math/base/special/rempio2",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -83,7 +85,8 @@
         "@stdlib/constants/float64/high-word-abs-mask",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-tan",
-        "@stdlib/math/base/special/rempio2"
+        "@stdlib/math/base/special/rempio2",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/tan/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/tan/src/main.c
@@ -34,6 +34,7 @@
 #include "stdlib/number/float64/base/get_high_word.h"
 #include "stdlib/constants/float64/high_word_abs_mask.h"
 #include "stdlib/constants/float64/high_word_exponent_mask.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/kernel_tan.h"
 #include "stdlib/math/base/special/rempio2.h"
 #include <stdint.h>
@@ -89,7 +90,7 @@ double stdlib_base_tan( const double x ) {
 	}
 	// Case: tan(Inf or NaN) is NaN
 	if ( ix >= STDLIB_CONSTANT_FLOAT64_HIGH_WORD_EXPONENT_MASK ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	// Argument reduction...
 	n = stdlib_base_rempio2( x, &Y[ 0 ], &Y[ 1 ] );

--- a/lib/node_modules/@stdlib/math/base/special/tribonacci/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/tribonacci/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/constants/float64/max-safe-nth-tribonacci",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-nonnegative-integer"
+        "@stdlib/math/base/assert/is-nonnegative-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/constants/float64/max-safe-nth-tribonacci",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-nonnegative-integer"
+        "@stdlib/math/base/assert/is-nonnegative-integer",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/constants/float64/max-safe-nth-tribonacci",
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/math/base/assert/is-nonnegative-integer"
+        "@stdlib/math/base/assert/is-nonnegative-integer",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/tribonacci/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/tribonacci/src/main.c
@@ -18,6 +18,7 @@
 
 #include "stdlib/math/base/special/tribonacci.h"
 #include "stdlib/constants/float64/max_safe_nth_tribonacci.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nonnegative_integer.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include <stdlib.h>
@@ -102,7 +103,7 @@ static const int64_t tribonacci_value[ 64 ] = {
 */
 double stdlib_base_tribonacci( const double n ) {
 	if ( stdlib_base_is_nan( n ) || !stdlib_base_is_nonnegative_integer( n ) || n > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_TRIBONACCI ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	return tribonacci_value[ (size_t)n ];
 }

--- a/lib/node_modules/@stdlib/math/base/special/trigamma/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/trigamma/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/sinpi",
-        "@stdlib/constants/float64/pi-squared"
+        "@stdlib/constants/float64/pi-squared",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/sinpi",
-        "@stdlib/constants/float64/pi-squared"
+        "@stdlib/constants/float64/pi-squared",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/sinpi",
-        "@stdlib/constants/float64/pi-squared"
+        "@stdlib/constants/float64/pi-squared",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/trigamma/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/trigamma/src/main.c
@@ -33,6 +33,7 @@
 #include "stdlib/math/base/special/floor.h"
 #include "stdlib/math/base/special/sinpi.h"
 #include "stdlib/constants/float64/pi_squared.h"
+#include "stdlib/constants/float64/nan.h"
 
 static const double YOFFSET24 = 3.558437347412109375;
 
@@ -267,7 +268,7 @@ double stdlib_base_trigamma( const double x ) {
 	// Check for negative arguments and use reflection:
 	if ( x <= 0.0 ) {
 		if ( stdlib_base_floor( x ) == x ) {
-			return 0.0 / 0.0; // NaN
+			return STDLIB_CONSTANT_FLOAT64_NAN;
 		}
 		s = stdlib_base_sinpi( x );
 		z = 1.0 - x;

--- a/lib/node_modules/@stdlib/math/base/special/truncb/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/trunc",
         "@stdlib/math/base/special/truncn",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/trunc",
         "@stdlib/math/base/special/truncn",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/trunc",
         "@stdlib/math/base/special/truncn",
-        "@stdlib/math/base/special/pow"
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/truncb/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/truncb.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/trunc.h"
@@ -41,7 +42,7 @@ double stdlib_base_truncb( const double x, const int32_t n, const int32_t b ) {
 	double s;
 
 	if ( stdlib_base_is_nan( x ) || b <= 0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/truncn/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/truncn/manifest.json
@@ -47,7 +47,8 @@
         "@stdlib/constants/float64/min-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent-subnormal",
         "@stdlib/math/base/assert/is-infinite",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -71,7 +72,8 @@
         "@stdlib/constants/float64/min-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent-subnormal",
         "@stdlib/math/base/assert/is-infinite",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -95,7 +97,8 @@
         "@stdlib/constants/float64/min-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent-subnormal",
         "@stdlib/math/base/assert/is-infinite",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/truncn/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncn/src/main.c
@@ -26,6 +26,7 @@
 #include "stdlib/constants/float64/max_base10_exponent.h"
 #include "stdlib/constants/float64/min_base10_exponent.h"
 #include "stdlib/constants/float64/min_base10_exponent_subnormal.h"
+#include "stdlib/constants/float64/nan.h"
 #include <stdint.h>
 
 static const double MAX_INT = STDLIB_CONSTANT_FLOAT64_MAX_SAFE_INTEGER + 1.0;
@@ -96,7 +97,7 @@ double stdlib_base_truncn( const double x, const int32_t n ) {
 	double y;
 
 	if ( stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
 	if (

--- a/lib/node_modules/@stdlib/math/base/special/truncsd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/truncsd/manifest.json
@@ -45,7 +45,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/trunc",
-        "@stdlib/number/float64/base/exponent"
+        "@stdlib/number/float64/base/exponent",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -67,7 +68,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/trunc",
-        "@stdlib/number/float64/base/exponent"
+        "@stdlib/number/float64/base/exponent",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -89,7 +91,8 @@
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/trunc",
-        "@stdlib/number/float64/base/exponent"
+        "@stdlib/number/float64/base/exponent",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/truncsd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncsd/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/truncsd.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/special/pow.h"
@@ -46,7 +47,7 @@ double stdlib_base_truncsd( const double x, const int32_t n, const int32_t b ) {
 	double y;
 
 	if ( stdlib_base_is_nan( x ) || n < 1 || b <= 0 ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
 		return x;

--- a/lib/node_modules/@stdlib/math/base/special/wrap/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/wrap/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/trunc",
         "@stdlib/math/base/special/fmod",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/trunc",
         "@stdlib/math/base/special/fmod",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/trunc",
         "@stdlib/math/base/special/fmod",
-        "@stdlib/math/base/assert/is-negative-zero"
+        "@stdlib/math/base/assert/is-negative-zero",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/wrap/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/wrap/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/wrap.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/trunc.h"
 #include "stdlib/math/base/special/fmod.h"
@@ -41,7 +42,7 @@ double stdlib_base_wrap( const double v, const double min, const double max ) {
 	double vc;
 
 	if ( stdlib_base_is_nan( v ) || stdlib_base_is_nan( min ) || stdlib_base_is_nan( max ) || max <= min ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	maxc = max;
 	minc = min;

--- a/lib/node_modules/@stdlib/ndarray/base/assign-scalar/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/assign-scalar/README.md
@@ -40,8 +40,6 @@ var assignScalar = require( '@stdlib/ndarray/base/assign-scalar' );
 
 Assigns a scalar value to every element of an output [ndarray][@stdlib/ndarray/base/ctor].
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var Float64Array = require( '@stdlib/array/float64' );

--- a/lib/node_modules/@stdlib/strided/base/nullary-addon-dispatch/README.md
+++ b/lib/node_modules/@stdlib/strided/base/nullary-addon-dispatch/README.md
@@ -105,8 +105,6 @@ where
 
 Returns a function which dispatches to a native add-on applying a nullary function using alternative indexing semantics.
 
-<!-- eslint-disable max-len -->
-
 ```javascript
 function addon( N, dtypeX, x, strideX ) {
     // Call into native add-on...
@@ -187,8 +185,6 @@ where
 <section class="examples">
 
 ## Examples
-
-<!-- eslint-disable max-len -->
 
 <!-- eslint no-undef: "error" -->
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request propagates fixes merged to `develop` between 2026-07-19 13:04 (-0700) and 2026-07-20 00:58 (-0700) to sibling packages with the same underlying defects. Three patterns, one commit per source commit:

### `0.0/0.0` → `STDLIB_CONSTANT_FLOAT64_NAN` (source: 05aaec1)

Applies the transformation from 05aaec1 ("refactor: use `constants/float64/nan` in `math/base/special/pow`") across the remaining namespace: replaces the inline `0.0/0.0` NaN idiom in `src/main.c` with `STDLIB_CONSTANT_FLOAT64_NAN`, adding the `stdlib/constants/float64/nan.h` include and the `@stdlib/constants/float64/nan` manifest dependency. Covers 99 packages — all remaining `math/base/special` packages using the inline idiom in executable code, including `fast/*`. `math/base/special/fibonacci` is excluded (already covered by open PR #12154), and `math/base/special/gamma` is excluded due to pre-existing trailing whitespace in its `src/main.c` which fails editorconfig linting for any PR touching the file. Doc-comment occurrences of `0.0/0.0` are left untouched, as they are not executable code.

### Flatten single-entry `arrays` parameter descriptions (source: 2b91bfe)

Applies the same flattening from `gany` (2b91bfe) to the remaining `arrays` parameter descriptions still using the nested single-entry list form. Each target function accepts exactly one input ndarray, so the sub-bullet collapses into the parent line: `blas/base/ndarray/dnrm2`, `blas/base/ndarray/dzasum`, `blas/base/ndarray/dznrm2`, `blas/base/ndarray/gnrm2`, `blas/base/ndarray/scasum`, `blas/base/ndarray/scnrm2`, `blas/base/ndarray/snrm2`, `blas/ext/base/ndarray/dindex-of-falsy`, and `blas/ext/base/ndarray/gindex-of-falsy`. No functional or type changes — README-only.

### Remove stale `eslint-disable max-len` annotations (source: 2780757)

This propagates the pattern established in 2780757 ("style: re-enable lint rule"): a `<!-- eslint-disable max-len -->` annotation is stale once every raw line in its governed fenced code block is <=80 characters, since `max-len`'s ignore-options only shorten effective length, never lengthen it. Removes the 10 remaining stale annotations across 9 READMEs — `strided/base/nullary-addon-dispatch` (2), `lapack/base/{dgttrf,dlassq,dpttrf,spttrf}`, `blas/ext/base/{dfirst-index-less-than,dsome,ssome}`, `ndarray/base/assign-scalar` — leaving annotations governing blocks with lines >80 chars untouched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11743 (tracking issue for the `constants/float64/nan` refactor; this PR covers the `math/base/special` namespace)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Candidate sites were enumerated by exact pattern search scoped to each source commit's sibling namespace, then validated per site by two independent reviewing agents (full-file reads confirming the defect is present and the patch is semantics-preserving), an adaptation pass (include placement, per-conf manifest coverage, patch self-containment), and a style-consistency pass (macro usage, manifest entry position/indentation, markdown list and blank-line structure). All 118 validated sites advanced with dual confirmation; two initially flagged patch defects (a mis-indented manifest entry in `powm1` caused by a pre-existing stray blank line, and a second stale annotation in `nullary-addon-dispatch` initially missed) were corrected and re-confirmed by two fresh independent reviewers. `gamma` was subsequently dropped in CI triage (pre-existing lint failure unrelated to the propagation), leaving 117 sites in the final diff.

**Deliberately excluded:** `math/base/special/fibonacci` (open PR #12154), `math/base/special/gamma` (pre-existing trailing whitespace fails editorconfig lint), `math/base/special/{atan2d,fast/max}` (only doc-comment occurrences of the idiom), float32 `0.0f/0.0f` sites (different constant, not a direct analog of the source commit), and annotations governing code blocks with lines exceeding 80 characters.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code via the automated fix-propagation routine: source commits from the last 24 hours on `develop` were analyzed for generalizable fix patterns, candidate sibling sites were enumerated by exact pattern search, and every applied patch was confirmed by two independent validation agents plus adaptation and style-consistency passes before commit.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md