### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/repl-txt/parse/lib/extract_signature.js
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/parse/lib/extract_signature.js
@@ -48,14 +48,6 @@ function extractSignature( str ) {
 	for ( i = 0; i < str.length; i++ ) {
 		ch = str.charAt( i );
 		switch ( state ) {
-		default:
-		case 'name':
-			if ( ch === '(' ) {
-				state = 'params';
-			} else {
-				name += ch;
-			}
-			break;
 		case 'params':
 			if ( ch === ')' ) {
 				if ( param && param.name !== '' ) {
@@ -89,9 +81,17 @@ function extractSignature( str ) {
 					};
 				}
 			}
+			break;
+		case 'name':
+		default:
+			if ( ch === '(' ) {
+				state = 'params';
+			} else {
+				name += ch;
+			}
+			break;
 		}
 	}
-
 	return {
 		'name': name,
 		'parameters': params,


### PR DESCRIPTION
### Description

  Reorders the `switch` statement in `extract_signature.js` so the `default` clause is last, fixing the `default-case-last` ESLint error.

  ### Related Issues

  resolves #13587
  
  -   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)