### PR TITLE
test: migrate `math/base/special/tand` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/tand/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/tand/test/test.js
@@ -21,13 +21,12 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
-var NINF = require( '@stdlib/constants/float64/ninf' );
-var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tand = require( './../lib' );
 
 
@@ -47,11 +46,9 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the tangent of an angle measured in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var i;
 	var x;
 	var y;
-	var i;
 
 	x = negative.x;
 	expected = negative.expected;
@@ -61,9 +58,7 @@ tape( 'the function computes the tangent of an angle measured in degrees (negati
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -71,11 +66,9 @@ tape( 'the function computes the tangent of an angle measured in degrees (negati
 
 tape( 'the function computes the tangent of an angle measured in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var i;
 	var x;
 	var y;
-	var i;
 
 	x = positive.x;
 	expected = positive.expected;
@@ -85,9 +78,7 @@ tape( 'the function computes the tangent of an angle measured in degrees (positi
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/tand/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/tand/test/test.native.js
@@ -22,13 +22,12 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
-var NINF = require( '@stdlib/constants/float64/ninf' );
-var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -56,11 +55,9 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the tangent of an angle measured in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var i;
 	var x;
 	var y;
-	var i;
 
 	x = negative.x;
 	expected = negative.expected;
@@ -70,9 +67,7 @@ tape( 'the function computes the tangent of an angle measured in degrees (negati
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -80,11 +75,9 @@ tape( 'the function computes the tangent of an angle measured in degrees (negati
 
 tape( 'the function computes the tangent of an angle measured in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var i;
 	var x;
 	var y;
-	var i;
 
 	x = positive.x;
 	expected = positive.expected;
@@ -94,9 +87,7 @@ tape( 'the function computes the tangent of an angle measured in degrees (positi
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `@stdlib/math/base/special/tand` from using `EPS` absolute tolerance checks to using ULP-based testing via `isAlmostSameValue`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
