### PR TITLE
docs: fix examples and descriptions

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/wasm/dasum/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dasum/README.md
@@ -30,7 +30,7 @@ limitations under the License.
 var dasum = require( '@stdlib/blas/base/wasm/dasum' );
 ```
 
-#### dasum.main( N, x, stride )
+#### dasum.main( N, x, strideX )
 
 Computes the sum of absolute values.
 

--- a/lib/node_modules/@stdlib/blas/base/wasm/scnrm2/package.json
+++ b/lib/node_modules/@stdlib/blas/base/wasm/scnrm2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/blas/base/wasm/scnrm2",
   "version": "0.0.0",
-  "description": "Multiply a vector `x` by a scalar `alpha`.",
+  "description": "Calculate the L2-norm of a single-precision complex floating-point vector.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/blas/base/wasm/zcopy/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zcopy/lib/main.js
@@ -42,7 +42,7 @@ var Module = require( './module.js' );
 *
 * // Perform operation:
 * zcopy.main( x.length, x, 1, y, 1 );
-// y => <Complex128Array>[ -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 ]
+* // y => <Complex128Array>[ -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 ]
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
@@ -53,7 +53,7 @@ var Module = require( './module.js' );
 *
 * // Perform operation:
 * zcopy.ndarray( x.length, x, 1, 0, y, -1, 2 );
-// y => <Complex128Array>[ -5.0, -6.0, -3.0, -4.0, -1.0, -2.0 ]
+* // y => <Complex128Array>[ -5.0, -6.0, -3.0, -4.0, -1.0, -2.0 ]
 */
 var zcopy = new Routine();
 zcopy.initializeSync(); // eslint-disable-line n/no-sync

--- a/lib/node_modules/@stdlib/blas/base/wasm/zcopy/lib/routine.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zcopy/lib/routine.js
@@ -56,7 +56,7 @@ var Module = require( './module.js' );
 *
 * // Perform operation:
 * zcopy.main( x.length, x, 1, y, 1 );
-// y => <Complex128Array>[ -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 ]
+* // y => <Complex128Array>[ -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 ]
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
@@ -73,7 +73,7 @@ var Module = require( './module.js' );
 *
 * // Perform operation:
 * zcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );
-// y => <Complex128Array>[ -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 ]
+* // y => <Complex128Array>[ -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 ]
 */
 function Routine() {
 	if ( !( this instanceof Routine ) ) {
@@ -117,7 +117,7 @@ inherits( Routine, Module );
 *
 * // Perform operation:
 * zcopy.main( x.length, x, 1, y, -1 );
-// y => <Complex128Array>[ -5.0, -6.0, -3.0, -4.0, -1.0, -2.0 ]
+* // y => <Complex128Array>[ -5.0, -6.0, -3.0, -4.0, -1.0, -2.0 ]
 */
 setReadOnly( Routine.prototype, 'main', function zcopy( N, x, strideX, y, strideY ) {
 	return this.ndarray( N, x, strideX, stride2offset( N, strideX ), y, strideY, stride2offset( N, strideY ) ); // eslint-disable-line max-len
@@ -154,7 +154,7 @@ setReadOnly( Routine.prototype, 'main', function zcopy( N, x, strideX, y, stride
 *
 * // Perform operation:
 * zcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );
-// y => <Complex128Array>[ -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 ]
+* // y => <Complex128Array>[ -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 ]
 */
 setReadOnly( Routine.prototype, 'ndarray', function zcopy( N, x, strideX, offsetX, y, strideY, offsetY ) {
 	var ptrs;

--- a/lib/node_modules/@stdlib/blas/base/wasm/zdrot/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zdrot/lib/index.js
@@ -33,8 +33,8 @@
 *
 * // Perform operation:
 * zdrot.main( zx.length, zx, 1, zy, 1, 0.8, 0.6 );
-// zx => <Complex128Array>[ 5.0, 6.4, 7.8, 9.2, 10.6, 12.0 ]
-// zy => <Complex128Array>[ ~5.0, 5.2, 5.4, ~5.6, ~5.8, ~6.0 ]
+* // zx => <Complex128Array>[ 5.0, 6.4, 7.8, 9.2, 10.6, 12.0 ]
+* // zy => <Complex128Array>[ ~5.0, 5.2, 5.4, ~5.6, ~5.8, ~6.0 ]
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
@@ -46,8 +46,8 @@
 *
 * // Perform operation:
 * zdrot.ndarray( zx.length, zx, 1, 0, zy, 1, 0, 0.8, 0.6 );
-// zx => <Complex128Array>[ 5.0, 6.4, 7.8, 9.2, 10.6, 12.0 ]
-// zy => <Complex128Array>[ ~5.0, 5.2, 5.4, ~5.6, ~5.8, ~6.0 ]
+* // zx => <Complex128Array>[ 5.0, 6.4, 7.8, 9.2, 10.6, 12.0 ]
+* // zy => <Complex128Array>[ ~5.0, 5.2, 5.4, ~5.6, ~5.8, ~6.0 ]
 *
 * @example
 * var Memory = require( '@stdlib/wasm/memory' );

--- a/lib/node_modules/@stdlib/blas/base/wasm/zdrot/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zdrot/lib/main.js
@@ -42,8 +42,8 @@ var Module = require( './module.js' );
 *
 * // Perform operation:
 * zdrot.main( zx.length, zx, 1, zy, 1, 0.8, 0.6 );
-// zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
-// zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
+* // zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
+* // zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
@@ -54,8 +54,8 @@ var Module = require( './module.js' );
 *
 * // Perform operation:
 * zdrot.ndarray( zx.length, zx, 1, 0, zy, 1, 0, 0.8, 0.6 );
-// zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
-// zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
+* // zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
+* // zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
 */
 var zdrot = new Routine();
 zdrot.initializeSync(); // eslint-disable-line n/no-sync

--- a/lib/node_modules/@stdlib/blas/base/wasm/zdrot/lib/routine.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zdrot/lib/routine.js
@@ -56,8 +56,8 @@ var Module = require( './module.js' );
 *
 * // Perform operation:
 * zdrot.main( zx.length, zx, 1, zy, 1, 0.8, 0.6 );
-// zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
-// zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
+* // zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
+* // zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
@@ -74,8 +74,8 @@ var Module = require( './module.js' );
 *
 * // Perform operation:
 * zdrot.ndarray( zx.length, zx, 1, 0, zy, 1, 0, 0.8, 0.6 );
-// zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
-// zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
+* // zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
+* // zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
 */
 function Routine() {
 	if ( !( this instanceof Routine ) ) {
@@ -121,8 +121,8 @@ inherits( Routine, Module );
 *
 * // Perform operation:
 * zdrot.main( zx.length, zx, 1, zy, 1, 0.8, 0.6 );
-// zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
-// zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
+* // zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
+* // zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
 */
 setReadOnly( Routine.prototype, 'main', function zdrot( N, zx, strideX, zy, strideY, c, s ) {
 	return this.ndarray( N, zx, strideX, stride2offset( N, strideX ), zy, strideY, stride2offset( N, strideY ), c, s ); // eslint-disable-line max-len
@@ -161,8 +161,8 @@ setReadOnly( Routine.prototype, 'main', function zdrot( N, zx, strideX, zy, stri
 *
 * // Perform operation:
 * zdrot.ndarray( zx.length, zx, 1, 0, zy, 1, 0, 0.8, 0.6 );
-// zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
-// zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
+* // zx => <Complex128Array>[ ~-0.2, ~-0.4, ~-0.6, ~-0.8, -1.0, ~-1.2 ]
+* // zy => <Complex128Array>[ 1.4, 2.8, 4.2, 5.6, 7.0, 8.4 ]
 */
 setReadOnly( Routine.prototype, 'ndarray', function zdrot( N, zx, strideX, offsetX, zy, strideY, offsetY, c, s ) {
 	var ptrs;

--- a/lib/node_modules/@stdlib/blas/base/wasm/zscal/lib/module.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zscal/lib/module.js
@@ -127,7 +127,7 @@ inherits( Module, WasmModule );
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NonNegativeInteger} aptr - scalar constant pointer (i.e., byte offset)
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
-* @param {integer} strideX - stride length for `x`
+* @param {integer} strideX - `x` stride length
 * @returns {NonNegativeInteger} input array pointer (i.e., byte offset)
 *
 * @example
@@ -202,7 +202,7 @@ setReadOnly( Module.prototype, 'main', function zscal( N, aptr, xptr, strideX ) 
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NonNegativeInteger} aptr - scalar constant pointer (i.e., byte offset)
 * @param {NonNegativeInteger} xptr - input array pointer (i.e., byte offset)
-* @param {integer} strideX - stride length for `x`
+* @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting `x` index
 * @returns {NonNegativeInteger} input array pointer (i.e., byte offset)
 *

--- a/lib/node_modules/@stdlib/blas/base/wasm/zscal/lib/routine.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/zscal/lib/routine.js
@@ -105,7 +105,7 @@ inherits( Routine, Module );
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Complex128} alpha - scalar constant
 * @param {Complex128Array} x - input array
-* @param {integer} strideX - stride length for `x`
+* @param {integer} strideX - `x` stride length
 * @returns {Complex128Array} input array
 *
 * @example
@@ -142,7 +142,7 @@ setReadOnly( Routine.prototype, 'main', function zscal( N, alpha, x, strideX ) {
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Complex128} alpha - scalar constant
 * @param {Complex128Array} x - input array
-* @param {integer} strideX - stride length for `x`
+* @param {integer} strideX - `x` stride length
 * @param {NonNegativeInteger} offsetX - starting index for `x`
 * @returns {Complex128Array} input array
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request normalizes five documentation and package-metadata deviations in `blas/base/wasm` packages that broke from conventions shared by 94–100% of the namespace, without touching runtime behavior, public signatures, or tests.

### Namespace summary

-   **Members analyzed:** 33 non-autogenerated packages.
-   **Structural features analyzed** (file tree, `package.json` shape, `manifest.json` shape, README heading set/order, `test/` `benchmark/` `examples/` file naming): every feature is **100% conformant** — no structural drift.
-   **Semantic features analyzed** (public signature, return kind, validation prologue, error construction, JSDoc shape, dependencies): uniform, or varying only along genuine data-type / operation axes (real vs. complex, single vs. double precision). Error construction is uniformly `@stdlib/string/format`.
-   **Features with a clear majority (≥75%):** all examined features cleared the threshold (mostly at 100%).
-   **Features excluded for no clear majority:** offset-parameter JSDoc wording (`starting `x` index` vs. `starting index for `x``) splits ~50/50 and was left untouched.

### `blas/base/wasm/dasum`

The README `.main` signature header documented the stride argument as `stride`, diverging from the `strideX` name used by every sibling package (32/33; 97%) and by dasum's own routine code, parameter bullet, and `.ndarray` header. Renamed the header argument to `strideX`. Documentation only.

### `blas/base/wasm/scnrm2`

The `package.json` `description` was a `scal` copy-paste — "Multiply a vector `x` by a scalar `alpha`." — on a routine that computes an L2-norm. Replaced it with the description already carried by the package's own README tagline and `lib/index.js` JSDoc, matching the `nrm2` sibling convention (33/33 packages describe their own operation). This field is surfaced on npm and in the REPL.

### `blas/base/wasm/zcopy`

Six expected-output lines in the JSDoc `@example` blocks sat flush-left (`// y => …`), breaking the `*` doc-comment margin held by 31/33 (94%) siblings. Added the `* ` prefix in `lib/main.js` and `lib/routine.js`; the `=> value` content is byte-identical.

### `blas/base/wasm/zdrot`

The same margin break as `zcopy`, across sixteen lines in `lib/main.js`, `lib/routine.js`, and `lib/index.js`. Added the `* ` prefix so the example output aligns with the surrounding comment; output values are unchanged.

### `blas/base/wasm/zscal`

The `strideX` JSDoc parameter description read "stride length for `x`", reversing the "`x` stride length" wording used by 32/33 (97%) siblings (including the complex-variable `csrot`/`zdrot` forms). Normalized in `lib/routine.js` and `lib/module.js`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

**Validation.** Structural features were extracted across all 33 members from the filesystem and string content. Semantic features were extracted by parallel agents that read each package's `lib/*.js`, `README.md`, and `package.json` in full. Each candidate correction then passed a three-agent drift validation — semantic intentionality (is the deviation a genuine mathematical difference?), cross-reference / test-reliance (do any tests, examples, or type-tests depend on the deviating text?), and structural-majority review (is the majority pattern the right thing to apply?). Only corrections returning `confirmed-drift` on all three lenses were applied.

**Deliberately excluded.** Data-type / operation-driven deviations (dependency sets, per-routine `N <= 0` behavior text); the offset-parameter JSDoc wording, which has no ≥75% majority; generator-owned artifacts (`docs/types/*.d.ts`, `docs/repl.txt`, `scripts/postbuild.wat.js`); and any correction that would require accompanying test or example updates.

This PR is a **draft**; a maintainer should audit the changes before promoting.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by an automated cross-package drift-detection routine run via Claude Code. The routine extracted structural and semantic features from all 33 packages in `@stdlib/blas/base/wasm`, computed per-feature majority patterns at a 75% threshold, and flagged deviating packages. Each candidate correction was independently validated by three agents (semantic-intentionality, cross-reference / test-reliance, and structural-majority review); only corrections confirmed by all three were applied, and each modified file was re-read to confirm the change. Every change is documentation or package metadata — no runtime code, signatures, or tests were modified. A maintainer should audit before promoting out of draft.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hhc7MjisCYfjMHyvjvzaMk)_