### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/sfirst-index-equal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfirst-index-equal/docs/types/test.ts
@@ -160,7 +160,6 @@ import sfirstIndexEqual = require( './index' );
 // The compiler throws an error if the `ndarray` method is provided a fifth argument which is not a Float32Array...
 {
 	var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
-	var y = new Float32Array( [ 1.0, 2.0, 3.0 ] );
 
 	sfirstIndexEqual.ndarray( x.length, x, 1, 0, '1', 1, 0 ); // $ExpectError
 	sfirstIndexEqual.ndarray( x.length, x, 1, 0, true, 1, 0 ); // $ExpectError

--- a/lib/node_modules/@stdlib/blas/ext/base/sfirst-index-less-than/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfirst-index-less-than/docs/types/test.ts
@@ -160,7 +160,6 @@ import sfirstIndexLessThan = require( './index' );
 // The compiler throws an error if the `ndarray` method is provided a fifth argument which is not a Float32Array...
 {
 	var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
-	var y = new Float32Array( [ 1.0, 2.0, 3.0 ] );
 
 	sfirstIndexLessThan.ndarray( x.length, x, 1, 0, '1', 1, 0 ); // $ExpectError
 	sfirstIndexLessThan.ndarray( x.length, x, 1, 0, true, 1, 0 ); // $ExpectError

--- a/lib/node_modules/@stdlib/math/base/special/cabs2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cabs2/README.md
@@ -83,8 +83,6 @@ var y = cabs2( new Complex128( 5.0, 3.0 ) );
 
 ## Examples
 
-<!-- eslint-disable max-len -->
-
 <!-- eslint no-undef: "error" -->
 
 ```javascript

--- a/lib/node_modules/@stdlib/math/base/special/cabs2f/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cabs2f/README.md
@@ -83,8 +83,6 @@ var y = cabs2f( new Complex64( 5.0, 3.0 ) );
 
 ## Examples
 
-<!-- eslint-disable max-len -->
-
 <!-- eslint no-undef: "error" -->
 
 ```javascript

--- a/lib/node_modules/@stdlib/math/base/special/cabsf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cabsf/README.md
@@ -72,8 +72,6 @@ var y = cabsf( new Complex64( 5.0, 3.0 ) );
 
 ## Examples
 
-<!-- eslint-disable max-len -->
-
 <!-- eslint no-undef: "error" -->
 
 ```javascript

--- a/lib/node_modules/@stdlib/math/base/special/gamma/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/manifest.json
@@ -49,7 +49,8 @@
         "@stdlib/constants/float64/eulergamma",
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/special/pow",
-        "@stdlib/math/base/special/exp"
+        "@stdlib/math/base/special/exp",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -75,7 +76,8 @@
         "@stdlib/constants/float64/eulergamma",
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/special/pow",
-        "@stdlib/math/base/special/exp"
+        "@stdlib/math/base/special/exp",
+        "@stdlib/constants/float64/nan"
       ]
     },
     {
@@ -101,7 +103,8 @@
         "@stdlib/constants/float64/eulergamma",
         "@stdlib/constants/float64/sqrt-two-pi",
         "@stdlib/math/base/special/pow",
-        "@stdlib/math/base/special/exp"
+        "@stdlib/math/base/special/exp",
+        "@stdlib/constants/float64/nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/gamma/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/src/main.c
@@ -208,7 +208,7 @@ double stdlib_base_gamma( const double x ) {
 			return stirlingApprox( x );
 		}
 		p = stdlib_base_floor( q );
-		
+
 		// Check whether `x` is even...
 		i = (int32_t)p;
 		if ( ( i & 1 ) == 0 ) {
@@ -224,7 +224,7 @@ double stdlib_base_gamma( const double x ) {
 		z = q * stdlib_base_sin( STDLIB_CONSTANT_FLOAT64_PI * z );
 		return sign * STDLIB_CONSTANT_FLOAT64_PI / ( stdlib_base_abs( z ) * stirlingApprox( q ) );
 	}
-	
+
 	// Reduce `x`...
 	z = 1.0;
 	xc = x;

--- a/lib/node_modules/@stdlib/math/base/special/gamma/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/src/main.c
@@ -42,6 +42,7 @@
 #include "stdlib/constants/float64/pi.h"
 #include "stdlib/constants/float64/eulergamma.h"
 #include "stdlib/constants/float64/sqrt_two_pi.h"
+#include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/pow.h"
 #include "stdlib/math/base/special/exp.h"
 #include <stdint.h>
@@ -187,7 +188,7 @@ double stdlib_base_gamma( const double x ) {
 	double z;
 
 	if ( ( stdlib_base_is_integer( x ) && x < 0 ) || x == STDLIB_CONSTANT_FLOAT64_NINF || stdlib_base_is_nan( x ) ) {
-		return 0.0 / 0.0; // NaN
+		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 	if ( x == 0.0 ) {
 		if ( stdlib_base_is_negative_zero( x ) ) {

--- a/lib/node_modules/@stdlib/ndarray/base/consensus-order/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/consensus-order/README.md
@@ -83,8 +83,6 @@ The function accepts the following arguments:
 
 ## Examples
 
-<!-- eslint-disable max-len -->
-
 <!-- eslint no-undef: "error" -->
 
 ```javascript

--- a/lib/node_modules/@stdlib/ndarray/base/output-order/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/output-order/README.md
@@ -80,8 +80,6 @@ The function accepts the following arguments:
 
 ## Examples
 
-<!-- eslint-disable max-len -->
-
 <!-- eslint no-undef: "error" -->
 
 ```javascript

--- a/lib/node_modules/@stdlib/ndarray/base/unary-addon-dispatch/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-addon-dispatch/README.md
@@ -125,8 +125,6 @@ where
 
 ## Examples
 
-<!-- eslint-disable max-len -->
-
 <!-- eslint no-undef: "error" -->
 
 ```javascript


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Propagating fixes merged to `develop` between 2026-07-20T13:08-07:00 (b7720097) and 2026-07-20T23:22-05:00 (729ff853) to sibling packages.

This pull request:

-   Propagates b953edd9 ("refactor: use `constants/float64/nan` and clean-up"): manifest and generated-source cleanup in `math/base/special` continues: `gamma` was the last executable left generating NaN by hand (`0.0 / 0.0` in `src/main.c`), and now pulls `STDLIB_CONSTANT_FLOAT64_NAN` via the constants header, with `@stdlib/constants/float64/nan` declared across all three manifest confs. Stale `eslint-disable max-len` directives are dropped from READMEs in `cabsf`, `cabs2`, `cabs2f`, `output-order`, `consensus-order`, and `unary-addon-dispatch`, none of whose guarded example blocks exceed 80 characters. `fibonacci` is excluded here, as it is already covered by open PR #12154.
-   Propagates b7720097 ("chore: clean-up"): removes the vestigial `var y = new Float32Array( ... )` declaration from the ndarray fifth-argument type-error test block in `blas/ext/base/sfirst-index-less-than` and `blas/ext/base/sfirst-index-equal`, matching the clean-up already applied upstream in `dfirst-index-less-than`/`dfirst-index-equal` via #13584. The variable was never referenced in the block; only the type-error invocation matters for the test. Brings the s-prefixed siblings' test files in line with the established end-state.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11743 (related; the `gamma` change applies the same replacement pattern — the remaining repo-wide sites are left to that tracked effort and its open PRs)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed before inclusion: pattern signatures were searched repo-wide (scoped to the source commits' namespaces first); every candidate site was independently verified by two full-file review passes, an adaptation pass producing the exact per-site patch, and a style-consistency pass checked against the source commits' conventions (include placement after the last `constants/float64/*` include; manifest dependency appended at end of each `dependencies` array, matching all 297 insertions in b953edd9). Deliberately excluded: `math/base/special/fibonacci` (open PR #12154), the 588 repo-wide `0.0 / 0.0` sites tracked by #11743, the float32 `0.0f / 0.0f` idiom (separate migration decision), unused `/// &lt;reference types="@stdlib/types"/&gt;` directives (unused-ness requires type-check execution, not text search), and `stdlib/require-globals` disable-comment candidates (all textual matches are false positives due to local `Symbol` shims).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by Claude Code running an automated fix-propagation routine: it identified generalizable fixes merged to `develop` in the last 24 hours, searched for sibling packages with the same defects, and applied the equivalent patches after multiple independent validation passes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcZw388qcomS6xMNV1mpje)_