### PR TITLE
test: migrate `math/base/special/atan2` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/atan2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/atan2/test/test.native.js
@@ -23,8 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
-var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );

--- a/lib/node_modules/@stdlib/math/base/special/atan2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/atan2/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
-var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PI = require( '@stdlib/constants/float64/pi' );
@@ -196,8 +195,6 @@ tape( 'the function returns `-PI/2` if provided a negative `y` and `x=-0`', opts
 tape( 'the function evaluates the `atan2` function (when x and y are positive)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -207,9 +204,7 @@ tape( 'the function evaluates the `atan2` function (when x and y are positive)',
 	expected = positivePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2( y[i], x[i] );
-		delta = abs( actual - expected[i] );
-		tol = EPS * abs( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -217,8 +212,6 @@ tape( 'the function evaluates the `atan2` function (when x and y are positive)',
 tape( 'the function evaluates the `atan2` function (when x is negative and y is positive)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -228,9 +221,7 @@ tape( 'the function evaluates the `atan2` function (when x is negative and y is 
 	expected = negativePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2( y[i], x[i] );
-		delta = abs( actual - expected[i] );
-		tol = 2.0 * EPS * abs( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -238,8 +229,6 @@ tape( 'the function evaluates the `atan2` function (when x is negative and y is 
 tape( 'the function evaluates the `atan2` function (when x and y are negative)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -249,9 +238,7 @@ tape( 'the function evaluates the `atan2` function (when x and y are negative)',
 	expected = negativeNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2( y[i], x[i] );
-		delta = abs( actual - expected[i] );
-		tol = 2.0 * EPS * abs( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-  Migrates the test cases in `math/base/special/atan2`'s `test.native.js` from relative tolerance testing to ULP difference testing, using `@stdlib/assert/is-almost-same-value`, mirroring the pattern already applied to this package's `test.js`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
