### PR TITLE
docs: add Git note

### DIFF
--- a/docs/git-notes/bc7c322891b1c0b758e6aef323b2f22a3bab1500.txt
+++ b/docs/git-notes/bc7c322891b1c0b758e6aef323b2f22a3bab1500.txt
@@ -1,0 +1,10 @@
+---
+type: amend-message
+---
+feat: add `blas/ext/base/ndarray/gfirst-index-less-than`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/13596
+Co-authored-by: Athan Reines <kgryte@gmail.com>
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Signed-off-by: Athan Reines <kgryte@gmail.com>
+Closes: https://github.com/stdlib-js/metr-issue-tracker/issues/1022


### PR DESCRIPTION
## Description

This pull request adds a Git note under `docs/git-notes/` proposing a corrected commit message for a commit merged to `develop` in the last 24 hours whose trailers contain a factual error.

- `bc7c322`: malformed trailer — `Signed-off-by: Athan <kgryte@gmail.com>` truncates the name; every other trailer referencing this email (including this same commit's own `Co-authored-by` and `Reviewed-by` lines, and 8 other occurrences across repo history) uses the full `Athan Reines <kgryte@gmail.com>`.

All other commits from the last 24 hours were reviewed for spelling/grammar issues, incorrect `PR-URL`/`Closes`/`Ref` references (verified against the GitHub API), malformed trailers, and Conventional Commits compliance — no other issues were found.

## Related Issues

None.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2oJ9H8Wwj4qFMqREcfp78)_