### PR TITLE
docs: fix descriptions

### DIFF
--- a/lib/node_modules/@stdlib/stats/iter/cugmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/iter/cugmean/lib/main.js
@@ -31,7 +31,7 @@ var format = require( '@stdlib/string/format' );
 // MAIN //
 
 /**
-* Returns an iterator which iteratively computes a cumulative arithmetic geometric mean.
+* Returns an iterator which iteratively computes a cumulative geometric mean.
 *
 * @param {Iterator} iterator - input iterator
 * @throws {TypeError} must provide an iterator

--- a/lib/node_modules/@stdlib/stats/iter/cuhmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/iter/cuhmean/lib/main.js
@@ -31,7 +31,7 @@ var format = require( '@stdlib/string/format' );
 // MAIN //
 
 /**
-* Returns an iterator which iteratively computes a cumulative arithmetic geometric mean.
+* Returns an iterator which iteratively computes a cumulative harmonic mean.
 *
 * @param {Iterator} iterator - input iterator
 * @throws {TypeError} must provide an iterator


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects two drifted `lib/main.js` JSDoc summaries in the `@stdlib/stats/iter` namespace, where copy-pasted wording named the wrong statistical operation. Both changes are documentation-only.

**Namespace summary — `@stdlib/stats/iter`**

-   Members analyzed: 43 (all non-autogenerated).
-   Features analyzed: file tree, `package.json` / `directories` shape, README sections and order, test/benchmark/example naming, public signatures, validation prologues, error construction, JSDoc shape, and source dependencies.
-   Features with a clear (≥75%) majority and full conformance: package structure, README section order (`Usage` → `Notes` → `Examples` → `See Also`), file naming, error construction (`format`), iterator validation (`isIteratorLike`), and `@example` presence — all 100% uniform across the namespace.
-   Features without a clear majority (excluded from drift analysis): public signature and return kind. These split principally across three intentional sub-families — aggregate (15, `iterator → number|null`), cumulative (15, `iterator → Iterator`), and moving (13, `(iterator, W) → Iterator`) — each below the 75% threshold, so their differences are correctly not treated as drift.
-   Two outliers survived filtering, both documentation-only.

### `@stdlib/stats/iter/cugmean`

Fixed a stale `arithmetic` qualifier in the `lib/main.js` JSDoc summary for `@stdlib/stats/iter/cugmean`, which incorrectly described the iterator as computing a "cumulative arithmetic geometric mean." This contradicted `index.js`, the README, and the REPL help, all of which correctly describe a cumulative geometric mean, and disagreed with the underlying `@stdlib/stats/incr/gmean` accumulator being wrapped. The summary now reads "cumulative geometric mean," aligning with the `cumulative <operation>` template used across 41/43 `stats/iter` packages; documentation-only, no behavioral change.

### `@stdlib/stats/iter/cuhmean`

Fixed a copy-pasted JSDoc summary in `@stdlib/stats/iter/cuhmean`: `lib/main.js` described the iterator as computing a "cumulative arithmetic geometric mean," which is simply wrong—the package wraps `@stdlib/stats/incr/hmean` and computes a cumulative harmonic mean, as its own `index.js`, README, and REPL help all correctly state. Updated the summary to "cumulative harmonic mean" to match both reality and the `cumulative <operation>` phrasing used by 41/43 other `stats/iter` packages. Docs only; no behavioral change.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

**Validation.** Structural features were extracted from the filesystem; semantic features (public signatures, validation prologues, error construction, JSDoc shape, dependencies) were extracted from source. Candidate outliers were vetted by a three-agent review (semantic, cross-reference, structural), and both surviving corrections were unanimously confirmed as unintentional drift: neither changes observable behavior, and no test or example references the edited strings.

**Deliberately excluded.** Intentional sub-family signature/return-kind differences (no namespace-wide majority); a single `msum` inline-comment wording deviation (dropped — flagged as a cosmetic/style judgment call rather than confirmed drift); and all structural features (zero drift — file trees, `package.json` shapes, and README sections are 100% uniform).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated cross-package drift-detection routine over the `@stdlib/stats/iter` namespace: it extracted structural and semantic features across all 43 members, identified the majority documentation convention, flagged the two `lib/main.js` summaries that named the wrong operation, and applied the corrections. Each finding was verified against that package's own `index.js`, README, and REPL docs and its wrapped `incr/*` dependency. Human review is requested before merge.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3CZyAa5MtCKvYnAtfZTYb)_