### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/line/lib/render.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/line/lib/render.js
@@ -20,6 +20,8 @@
 
 // MODULES //
 
+var falses = require( '@stdlib/array/base/falses' );
+var zeros = require( '@stdlib/array/base/zeros' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var round = require( '@stdlib/math/base/special/round' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
@@ -85,14 +87,13 @@ function render() {
 		glyphs = UNICODE_BRAILLE_ELEMENTS;
 	}
 	// Assign each datum to a bin...
-	idx = [];
-	FLG = [];
+	idx = zeros( len );
+	FLG = falses( len );
 	n = glyphs.length - 1;
 	for ( i = 0; i < len; i++ ) {
 		d = this._data[ i ];
 		if ( !this._isDefined( d, i ) || d === PINF || d === NINF ) {
-			idx.push( void 0 );
-			FLG.push( true );
+			FLG[ i ] = true;
 			continue;
 		}
 		// Normalize the datum (aka feature scaling):
@@ -108,8 +109,7 @@ function render() {
 		} else if ( j > n ) {
 			j = n;
 		}
-		idx.push( j );
-		FLG.push( false );
+		idx[ i ] = j;
 	}
 
 	// TODO: color encoding: one color for both pos and neg or two colors for separate colors

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/line/lib/render.js
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/line/lib/render.js
@@ -85,13 +85,14 @@ function render() {
 		glyphs = UNICODE_BRAILLE_ELEMENTS;
 	}
 	// Assign each datum to a bin...
-	idx = new Array( len );
-	FLG = new Array( len );
+	idx = [];
+	FLG = [];
 	n = glyphs.length - 1;
 	for ( i = 0; i < len; i++ ) {
 		d = this._data[ i ];
 		if ( !this._isDefined( d, i ) || d === PINF || d === NINF ) {
-			FLG[ i ] = true;
+			idx.push( void 0 );
+			FLG.push( true );
 			continue;
 		}
 		// Normalize the datum (aka feature scaling):
@@ -107,7 +108,8 @@ function render() {
 		} else if ( j > n ) {
 			j = n;
 		}
-		idx[ i ] = j;
+		idx.push( j );
+		FLG.push( false );
 	}
 
 	// TODO: color encoding: one color for both pos and neg or two colors for separate colors


### PR DESCRIPTION
Resolves #13616 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes JavaScript linting errors in `lib/node_modules/@stdlib/plot/sparklines/unicode/line/lib/render.js` by replacing `new Array()` constructor calls with array literals and `push()`, in compliance with the `stdlib/no-new-array` ESLint rule.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #13616 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No


@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
