### PR TITLE
feat: add `plot/vega/base/assert-is-symbol-mark-encoding`

### DIFF
--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/README.md
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/README.md
@@ -1,0 +1,139 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isSymbolMarkEncoding
+
+> Test if an input value is a symbol mark [encoding][@stdlib/plot/vega/mark/symbol/encoding].
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isSymbolMarkEncoding = require( '@stdlib/plot/vega/base/assert/is-symbol-mark-encoding' );
+```
+
+#### isSymbolMarkEncoding( value )
+
+Tests if an input value is a symbol mark [encoding][@stdlib/plot/vega/mark/symbol/encoding].
+
+```javascript
+var Value = require( '@stdlib/plot/vega/value/ctor' );
+var EncodingSet = require( '@stdlib/plot/vega/mark/symbol/encoding-set' );
+var Encoding = require( '@stdlib/plot/vega/mark/symbol/encoding' );
+
+var v = new Encoding({
+    'enter': new EncodingSet({
+        'x': new Value({
+            'field': 'x',
+            'scale': 'xScale'
+        })
+    })
+});
+var bool = isSymbolMarkEncoding( v );
+// returns true
+
+bool = isSymbolMarkEncoding( {} );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Value = require( '@stdlib/plot/vega/value/ctor' );
+var EncodingSet = require( '@stdlib/plot/vega/mark/symbol/encoding-set' );
+var Encoding = require( '@stdlib/plot/vega/mark/symbol/encoding' );
+var isSymbolMarkEncoding = require( '@stdlib/plot/vega/base/assert/is-symbol-mark-encoding' );
+
+var v = new Encoding({
+    'update': new EncodingSet({
+        'x': new Value({
+            'field': 'x',
+            'scale': 'xScale'
+        })
+    })
+});
+var bool = isSymbolMarkEncoding( v );
+// returns true
+
+bool = isSymbolMarkEncoding( {} );
+// returns false
+
+bool = isSymbolMarkEncoding( 'foo' );
+// returns false
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/plot/vega/mark/symbol/encoding]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/plot/vega/mark/symbol/encoding
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/benchmark/benchmark.js
@@ -1,0 +1,106 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var EncodingSet = require( '@stdlib/plot/vega/mark/symbol/encoding-set' );
+var Encoding = require( '@stdlib/plot/vega/mark/symbol/encoding' );
+var Value = require( '@stdlib/plot/vega/value/ctor' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var isSymbolMarkEncoding = require( './../lib' );
+
+
+// MAIN //
+
+bench( format( '%s::true', pkg ), function benchmark( b ) {
+	var values;
+	var out;
+	var v;
+	var i;
+
+	values = [
+		new Encoding({
+			'update': new EncodingSet({
+				'x': new Value({
+					'field': 'x',
+					'scale': 'xScale'
+				})
+			})
+		}),
+		new Encoding({
+			'enter': new EncodingSet({
+				'y': new Value({
+					'field': 'y',
+					'scale': 'yScale'
+				})
+			})
+		})
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = values[ i%values.length ];
+		out = isSymbolMarkEncoding( v );
+		if ( typeof out !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( out ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::false', pkg ), function benchmark( b ) {
+	var values;
+	var out;
+	var v;
+	var i;
+
+	values = [
+		'foo',
+		'bar',
+		'',
+		'beep',
+		'boop',
+		[],
+		{}
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = values[ i%values.length ];
+		out = isSymbolMarkEncoding( v );
+		if ( typeof out !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( out ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/docs/repl.txt
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/docs/repl.txt
@@ -1,0 +1,30 @@
+
+{{alias}}( value )
+    Tests if an input value is a symbol mark encoding.
+
+    Parameters
+    ----------
+    value: any
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating if an input value is a symbol mark encoding.
+
+    Examples
+    --------
+    > var opts = { 'field': 'x', 'scale': 'xScale' };
+    > var v = new {{alias:@stdlib/plot/vega/value/ctor}}( opts );
+    > opts = { 'x': v };
+    > var eset = new {{alias:@stdlib/plot/vega/mark/symbol/encoding-set}}( opts );
+    > opts = { 'update': eset };
+    > var enc = new {{alias:@stdlib/plot/vega/mark/symbol/encoding}}( opts );
+    > var bool = {{alias}}( enc )
+    true
+    > bool = {{alias}}( {} )
+    false
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/docs/repl.txt
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/docs/repl.txt
@@ -14,13 +14,13 @@
 
     Examples
     --------
-    > var opts = { 'field': 'x', 'scale': 'xScale' };
-    > var v = new {{alias:@stdlib/plot/vega/value/ctor}}( opts );
-    > opts = { 'x': v };
-    > var eset = new {{alias:@stdlib/plot/vega/mark/symbol/encoding-set}}( opts );
-    > opts = { 'update': eset };
-    > var enc = new {{alias:@stdlib/plot/vega/mark/symbol/encoding}}( opts );
-    > var bool = {{alias}}( enc )
+    > var o = { 'field': 'x', 'scale': 'xScale' };
+    > var v = new {{alias:@stdlib/plot/vega/value/ctor}}( o );
+    > o = { 'x': v };
+    > v = new {{alias:@stdlib/plot/vega/mark/symbol/encoding-set}}( o );
+    > o = { 'update': v };
+    > v = new {{alias:@stdlib/plot/vega/mark/symbol/encoding}}( o );
+    > var bool = {{alias}}( v )
     true
     > bool = {{alias}}( {} )
     false

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/docs/types/index.d.ts
@@ -1,0 +1,54 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests whether an input value is a symbol mark encoding.
+*
+* @param v - value to test
+* @returns boolean indicating whether an input value is a symbol mark encoding
+*
+* @example
+* var Value = require( '@stdlib/plot/vega/value/ctor' );
+* var EncodingSet = require( '@stdlib/plot/vega/mark/symbol/encoding-set' );
+* var Encoding = require( '@stdlib/plot/vega/mark/symbol/encoding' );
+*
+* var v = new Encoding({
+*     'update': new EncodingSet({
+*         'x': new Value({
+*             'field': 'x',
+*             'scale': 'xScale'
+*         })
+*     })
+* });
+* var bool = isSymbolMarkEncoding( v );
+* // returns true
+*
+* bool = isSymbolMarkEncoding( {} );
+* // returns false
+*
+* bool = isSymbolMarkEncoding( 'foo' );
+* // returns false
+*/
+declare function isSymbolMarkEncoding( v: any ): boolean;
+
+
+// EXPORTS //
+
+export = isSymbolMarkEncoding;

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/docs/types/test.ts
@@ -1,0 +1,34 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isSymbolMarkEncoding = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isSymbolMarkEncoding( {} ); // $ExpectType boolean
+	isSymbolMarkEncoding( 'foo' ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isSymbolMarkEncoding(); // $ExpectError
+	isSymbolMarkEncoding( undefined, 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/examples/index.js
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/examples/index.js
@@ -1,0 +1,44 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Value = require( '@stdlib/plot/vega/value/ctor' );
+var EncodingSet = require( '@stdlib/plot/vega/mark/symbol/encoding-set' );
+var Encoding = require( '@stdlib/plot/vega/mark/symbol/encoding' );
+var isSymbolMarkEncoding = require( './../lib' );
+
+var v = new Encoding({
+	'update': new EncodingSet({
+		'x': new Value({
+			'field': 'x',
+			'scale': 'xScale'
+		})
+	})
+});
+var bool = isSymbolMarkEncoding( v );
+console.log( bool );
+// => true
+
+bool = isSymbolMarkEncoding( {} );
+console.log( bool );
+// => false
+
+bool = isSymbolMarkEncoding( 'foo' );
+console.log( bool );
+// => false

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/lib/index.js
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/lib/index.js
@@ -1,0 +1,57 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test whether an input value is a symbol mark encoding.
+*
+* @module @stdlib/plot/vega/base/assert/is-symbol-mark-encoding
+*
+* @example
+* var Value = require( '@stdlib/plot/vega/value/ctor' );
+* var EncodingSet = require( '@stdlib/plot/vega/mark/symbol/encoding-set' );
+* var Encoding = require( '@stdlib/plot/vega/mark/symbol/encoding' );
+* var isSymbolMarkEncoding = require( '@stdlib/plot/vega/base/assert/is-symbol-mark-encoding' );
+*
+* var v = new Encoding({
+*     'update': new EncodingSet({
+*         'x': new Value({
+*             'field': 'x',
+*             'scale': 'xScale'
+*         })
+*     })
+* });
+* var bool = isSymbolMarkEncoding( v );
+* // returns true
+*
+* bool = isSymbolMarkEncoding( {} );
+* // returns false
+*
+* bool = isSymbolMarkEncoding( 'foo' );
+* // returns false
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/lib/main.js
@@ -1,0 +1,72 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isObject = require( '@stdlib/assert/is-object' );
+var Encoding = require( '@stdlib/plot/vega/mark/symbol/encoding' );
+
+
+// MAIN //
+
+/**
+* Tests whether an input value is a symbol mark encoding.
+*
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating whether an input value is a symbol mark encoding
+*
+* @example
+* var Value = require( '@stdlib/plot/vega/value/ctor' );
+* var EncodingSet = require( '@stdlib/plot/vega/mark/symbol/encoding-set' );
+* var Encoding = require( '@stdlib/plot/vega/mark/symbol/encoding' );
+*
+* var v = new Encoding({
+*     'update': new EncodingSet({
+*         'x': new Value({
+*             'field': 'x',
+*             'scale': 'xScale'
+*         })
+*     })
+* });
+* var bool = isSymbolMarkEncoding( v );
+* // returns true
+*
+* bool = isSymbolMarkEncoding( {} );
+* // returns false
+*
+* bool = isSymbolMarkEncoding( 'foo' );
+* // returns false
+*/
+function isSymbolMarkEncoding( value ) {
+	return (
+		value instanceof Encoding ||
+
+		// The following is a set of rather imperfect heuristics for handling instances originating in a different realm...
+		(
+			isObject( value ) &&
+			value.constructor.name === 'SymbolEncoding'
+		)
+	);
+}
+
+
+// EXPORTS //
+
+module.exports = isSymbolMarkEncoding;

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/package.json
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/plot/vega/base/assert/is-symbol-mark-encoding",
+  "version": "0.0.0",
+  "description": "Test if an input value is a symbol mark encoding.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "plot",
+    "base",
+    "vega",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "assert",
+    "test",
+    "check",
+    "is",
+    "valid",
+    "validate",
+    "validation",
+    "isvalid"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/test/test.js
+++ b/lib/node_modules/@stdlib/plot/vega/base/assert/is-symbol-mark-encoding/test/test.js
@@ -1,0 +1,86 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Value = require( '@stdlib/plot/vega/value/ctor' );
+var EncodingSet = require( '@stdlib/plot/vega/mark/symbol/encoding-set' );
+var Encoding = require( '@stdlib/plot/vega/mark/symbol/encoding' );
+var isSymbolMarkEncoding = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isSymbolMarkEncoding, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a symbol mark encoding instance', function test( t ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		new Encoding({
+			'update': new EncodingSet({
+				'x': new Value({
+					'field': 'x',
+					'scale': 'xScale'
+				})
+			})
+		})
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		bool = isSymbolMarkEncoding( values[ i ] );
+		t.strictEqual( bool, true, 'returns expected value when provided '+values[ i ] );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a symbol mark encoding instance', function test( t ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'',
+		'beep',
+		'boop',
+		'foo',
+		'bar',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		bool = isSymbolMarkEncoding( values[ i ] );
+		t.strictEqual( bool, false, 'returns expected value when provided '+values[ i ] );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   feat: add `plot/vega/base/assert-is-symbol-mark-encoding`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [X] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
