### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/cdf/README.md
@@ -188,7 +188,7 @@ logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, F(x;α,β): %0.4f', x, alpha, beta,
 
 #### stdlib_base_dists_beta_cdf( x, alpha, beta )
 
-Evaluates the [cumulative distribution function][cdf] (CDF) for a [beta][beta-distribution] distribution with first shpae parameter `alpha`and second shape parameter `beta` at a value `x`.
+Evaluates the [cumulative distribution function][cdf] (CDF) for a [beta][beta-distribution] distribution with first shape parameter `alpha` and second shape parameter `beta` at a value `x`.
 
 ```c
 double y = stdlib_base_dists_beta_cdf( 0.5, 1.0, 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/signrank/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/signrank/cdf/README.md
@@ -190,7 +190,7 @@ double stdlib_base_dists_signrank_cdf( const double x, const double n );
 
 ```c
 #include "stdlib/stats/base/dists/signrank/cdf.h"
-#include "stdlib/math/base/special/ceil"
+#include "stdlib/math/base/special/ceil.h"
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/signrank/cdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/signrank/cdf/src/main.c
@@ -37,11 +37,11 @@
 * // returns ~0.037
 */
 double stdlib_base_dists_signrank_cdf( const double x, const double n ) {
+	double mlim;
 	double pui;
 	double *w;
 	double xr;
 	double p;
-	int mlim;
 	int xi;
 	int i;
 	int j;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between `fa5ac3e85` (2026-07-22, 21:49 UTC) and `cd1b1aa16` (2026-07-23, 06:04 UTC).

This pull request:

-   `stats/base/dists/signrank/cdf`: `mlim` was `int` in `lib/node_modules/@stdlib/stats/base/dists/signrank/cdf/src/main.c` (a82a2255), assigned `n*(n+1)/2` in double precision — overflows `INT_MAX` for `n >= 65536`, UB on conversion, and diverges from `lib/main.js`'s double-precision limit. Fixed by declaring `mlim` as `double` to match the JS implementation.
-   `stats/base/dists/signrank/cdf`: in `lib/node_modules/@stdlib/stats/base/dists/signrank/cdf/README.md` (a82a2255), the C API example includes `stdlib/math/base/special/ceil` without the `.h` extension, so it won't compile as written; `examples/c/example.c` in the same commit has it right. Add the extension to match.
-   `stats/base/dists/beta/cdf`: fix typo in `stats/base/dists/beta/cdf` README introduced in fa5ac3e8: "shpae" → "shape" and missing space after `alpha` in the C API description (`lib/node_modules/@stdlib/stats/base/dists/beta/cdf/README.md`).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Review window.** All nine commits merged to `develop` in the 24 hours preceding 2026-07-23 were reviewed: four new distribution packages (`stats/base/dists/anglit/skewness`, `stats/base/dists/burr-type3/cdf`, `stats/base/dists/wald/cdf`, `stats/base/dists/log-logistic/variance`), four C implementation backfills (`stats/base/dists/binomial/cdf`, `stats/base/dists/signrank/cdf`, `stats/base/dists/hypergeometric/kurtosis`, `stats/base/dists/beta/cdf`), and one git-notes docs commit (bd358c95).

**Validation.** Checked: style-guide compliance (`docs/style-guides/javascript`, `docs/style-guides/c`) against reference packages (`stats/base/dists/normal/cdf` and siblings); formula correctness of each implementation against the named distribution (verified algebraically, including the `erfcx`-based overflow avoidance in `wald/cdf`); C-vs-JS parity for each C port; N-API arity macros and `manifest.json` dependencies; README/repl/TypeScript docs for copy-paste errors. Deliberately excluded: subjective style preferences, anything requiring interpretation or changes outside the reviewed diffs (e.g., the small-`N` denominator behavior in `hypergeometric/kurtosis` matches the pre-existing JS implementation and was left as deliberate parity). No other high-signal issues were found.

**Note.** This is a draft for maintainer audit; not requesting review.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by a scheduled automated commit-review run using Claude Code: multiple review agents audited the last 24 hours of commits merged to `develop` for bugs and style-guide violations, and the surviving high-signal fixes were applied and committed by Claude Code.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErZxMF18HhuGHiv1ZKWR19)_