### PR TITLE
docs: add Git notes correcting recent commit messages

### DIFF
--- a/docs/git-notes/bd358c950c73dff39b26630b37fe129b5dc11afd.txt
+++ b/docs/git-notes/bd358c950c73dff39b26630b37fe129b5dc11afd.txt
@@ -1,0 +1,8 @@
+---
+type: amend-message
+---
+docs: add Git note for commit bc7c322891b1c0b758e6aef323b2f22a3bab1500
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/13610
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Signed-off-by: Philipp Burckhardt <pburckhardt@outlook.com>


### PR DESCRIPTION
Resolves none.

## Description

This pull request adds a Git note under `docs/git-notes/` proposing a corrected commit message for a commit merged to `develop` in the last 24 hours whose trailers contain a factual error.

- `bd358c95`: malformed trailer — missing `Signed-off-by` trailer entirely. The pre-squash commit on the source branch (`cf7190b`) carried `Signed-off-by: Philipp Burckhardt <pburckhardt@outlook.com>`, and the squash-merge into `develop` also truncated the subject from `docs: add Git note for commit bc7c322891b1c0b758e6aef323b2f22a3bab1500` down to `docs: add Git note`, dropping the commit reference. The note restores both the full subject and the sign-off trailer.

All other commits from the last 24 hours were reviewed for spelling/grammar issues, incorrect `PR-URL`/`Closes`/`Ref` references (verified against the GitHub API), malformed trailers, and Conventional Commits compliance.

One additional commit, `4bbc3b11` (`feat: add C implementation for stats/base/dists/hypergeometric/kurtosis`), is also missing its `Signed-off-by` trailer, but none of its constituent pre-merge commits carry one, so the correct attribution is ambiguous. Per the routine's guardrails, this was skipped rather than guessed — flagging here for a maintainer to fix manually if desired.

## Related Issues

This pull request has the following related issues:

-   None

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

This PR was written primarily by Claude Code, running as an automated commit-message audit routine.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01S18hqhnN3XyJYYrurJZjtb)_