### PR TITLE
chore: fix JavaScript lint errors (issue #13114)

### DIFF
--- a/lib/node_modules/@stdlib/stats/chi2gof/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/chi2gof/benchmark/benchmark.js
@@ -42,14 +42,14 @@ bench( format( '%s::distribution_name', pkg ), function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Array( len );
-	for ( i = 0; i < x.length; i++ ) {
-		x[ i ] = discreteUniform( 0, 10 );
+	x = [];
+	for ( i = 0; i < len; i++ ) {
+		x.push( discreteUniform( 0, 10 ) );
 	}
 	// Generate frequency table:
-	freqs = new Array( 11 );
+	freqs = [];
 	for ( i = 0; i < 11; i++ ) {
-		freqs[ i ] = 0;
+		freqs.push( 0 );
 	}
 	for ( i = 0; i < len; i++ ) {
 		val = x[ i ];
@@ -82,14 +82,14 @@ bench( format( '%s::distribution_name:simulate=true', pkg ), function benchmark(
 	var i;
 
 	len = 100;
-	x = new Array( len );
-	for ( i = 0; i < x.length; i++ ) {
-		x[ i ] = discreteUniform( 0, 10 );
+	x = [];
+	for ( i = 0; i < len; i++ ) {
+		x.push( discreteUniform( 0, 10 ) );
 	}
 	// Generate frequency table:
-	freqs = new Array( 11 );
+	freqs = [];
 	for ( i = 0; i < 11; i++ ) {
-		freqs[ i ] = 0;
+		freqs.push( 0 );
 	}
 	for ( i = 0; i < len; i++ ) {
 		val = x[ i ];
@@ -125,14 +125,14 @@ bench( format( '%s::distribution_name:simulate=true:iterations=250', pkg ), func
 	var i;
 
 	len = 100;
-	x = new Array( len );
-	for ( i = 0; i < x.length; i++ ) {
-		x[ i ] = discreteUniform( 0, 10 );
+	x = [];
+	for ( i = 0; i < len; i++ ) {
+		x.push( discreteUniform( 0, 10 ) );
 	}
 	// Generate frequency table:
-	freqs = new Array( 11 );
+	freqs = [];
 	for ( i = 0; i < 11; i++ ) {
-		freqs[ i ] = 0;
+		freqs.push( 0 );
 	}
 	for ( i = 0; i < len; i++ ) {
 		val = x[ i ];
@@ -169,14 +169,14 @@ bench( format( '%s::distribution_name:simulate=true:iterations=100', pkg ), func
 	var i;
 
 	len = 100;
-	x = new Array( len );
-	for ( i = 0; i < x.length; i++ ) {
-		x[ i ] = discreteUniform( 0, 10 );
+	x = [];
+	for ( i = 0; i < len; i++ ) {
+		x.push( discreteUniform( 0, 10 ) );
 	}
 	// Generate frequency table:
-	freqs = new Array( 11 );
+	freqs = [];
 	for ( i = 0; i < 11; i++ ) {
-		freqs[ i ] = 0;
+		freqs.push( 0 );
 	}
 	for ( i = 0; i < len; i++ ) {
 		val = x[ i ];
@@ -213,15 +213,15 @@ bench( format( '%s::probabilities', pkg ), function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Array( len );
-	for ( i = 0; i < x.length; i++ ) {
-		x[ i ] = discreteUniform( 0, 10 );
+	x = [];
+	for ( i = 0; i < len; i++ ) {
+		x.push( discreteUniform( 0, 10 ) );
 	}
-	freqs = new Array( 11 );
-	probs = new Array( 11 );
+	freqs = [];
+	probs = [];
 	for ( i = 0; i < 11; i++ ) {
-		freqs[ i ] = 0;
-		probs[ i ] = pmf( i, 0, 10 );
+		freqs.push( 0 );
+		probs.push( pmf( i, 0, 10 ) );
 	}
 	for ( i = 0; i < len; i++ ) {
 		val = x[ i ];
@@ -254,15 +254,15 @@ bench( format( '%s::expected_counts', pkg ), function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Array( len );
-	for ( i = 0; i < x.length; i++ ) {
-		x[ i ] = discreteUniform( 0, 10 );
+	x = [];
+	for ( i = 0; i < len; i++ ) {
+		x.push( discreteUniform( 0, 10 ) );
 	}
-	freqs = new Array( 11 );
-	expected = new Array( 11 );
+	freqs = [];
+	expected = [];
 	for ( i = 0; i < 11; i++ ) {
-		freqs[ i ] = 0;
-		expected[ i ] = pmf( i, 0, 10 ) * len;
+		freqs.push( 0 );
+		expected.push( pmf( i, 0, 10 ) * len );
 	}
 	for ( i = 0; i < len; i++ ) {
 		val = x[ i ];


### PR DESCRIPTION
### Description

Replaced `new Array(n)` with array literals + `.push()` in `benchmark.js` to fix the `stdlib/no-new-array` errors (12 of them).

Also checked the `doctest` error mentioned in the issue (`read-file-list/examples/index.js`) but couldn't reproduce it on current `develop` — the output already matches the comments. Might've been fixed already, happy to look again if needed.

### Related Issues

resolves #13114

-   [x] Read, understood, and followed the [contributing guidelines]