### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/package-json/validate/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/package-json/validate/examples/index.js
@@ -18,8 +18,8 @@
 
 'use strict';
 
-var isValid = require( './../lib' );
 var pkg = require( './../package.json' );
+var isValid = require( './../lib' );
 
 var bool = isValid( pkg );
 console.log( bool );

--- a/lib/node_modules/@stdlib/_tools/package-json/validate/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/package-json/validate/examples/index.js
@@ -19,7 +19,6 @@
 'use strict';
 
 var isValid = require( './../lib' );
-
 var pkg = require( './../package.json' );
 
 var bool = isValid( pkg );


### PR DESCRIPTION
Resolves #13632.

## Description

> What is the purpose of this pull request?

This pull request:

-   Removes the empty line separating two consecutive `require` statements in the package JSON validator example.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #13632

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed:

-   The example-specific ESLint check passes.
-   The package JSON validator example runs successfully.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Codex identified the reported lint failure, made the one-line formatting fix, and guided the focused validation commands.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
