### PR TITLE
test: migrate `math/base/special/coth` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/coth/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/coth/test/test.js
@@ -26,8 +26,7 @@ var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var coth = require( './../lib' );
 
 
@@ -50,8 +49,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the hyperbolic cotangent', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -64,21 +61,13 @@ tape( 'the function computes the hyperbolic cotangent', function test( t ) {
 			continue;
 		}
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.75 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cotangent (tiny negative)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -88,21 +77,13 @@ tape( 'the function computes the hyperbolic cotangent (tiny negative)', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cotangent (tiny positive)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -112,21 +93,13 @@ tape( 'the function computes the hyperbolic cotangent (tiny positive)', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cotangent (large negative)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -136,21 +109,13 @@ tape( 'the function computes the hyperbolic cotangent (large negative)', functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cotangent (large positive)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -160,13 +125,7 @@ tape( 'the function computes the hyperbolic cotangent (large positive)', functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/coth/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/coth/test/test.native.js
@@ -28,8 +28,7 @@ var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 
 
 // VARIABLES //
@@ -59,8 +58,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the hyperbolic cotangent', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -73,21 +70,13 @@ tape( 'the function computes the hyperbolic cotangent', opts, function test( t )
 			continue;
 		}
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.75 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cotangent (tiny negative)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -97,21 +86,13 @@ tape( 'the function computes the hyperbolic cotangent (tiny negative)', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cotangent (tiny positive)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -121,21 +102,13 @@ tape( 'the function computes the hyperbolic cotangent (tiny positive)', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cotangent (large negative)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -145,21 +118,13 @@ tape( 'the function computes the hyperbolic cotangent (large negative)', opts, f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cotangent (large positive)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -169,13 +134,7 @@ tape( 'the function computes the hyperbolic cotangent (large positive)', opts, f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coth( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/coth` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values verified by direct ULP-difference computation over all test fixtures: the `data` fixture requires a maximum ULP of `2`; the `tiny_negative`, `tiny_positive`, `large_negative`, and `large_positive` fixtures match exactly and thus use plain `t.strictEqual`.
-   `2` was confirmed to be the tightest bound (an ULP of `1` produces failures across the `data` fixture); the test suite was run twice at the final bound to confirm no flakiness.

The native (C) addon could not be built/exercised in this environment (no prebuilt addon present and native module builds are unavailable here), so `test.native.js` was updated to mirror the same tolerances as `test.js`, consistent with the precedent set by prior conversions of the closely-related `sinh`/`csch` packages, which found no JS-vs-C divergence for this class of function.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code (running as an unattended scheduled task), including the test migration and the computation/verification of minimum ULP tolerances directly against the fixtures.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_013fWHjsbHLMeFAnA4Qhx7xt)_