### PR TITLE
test: migrate `math/base/special/atandf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/atandf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/atandf/test/test.js
@@ -22,9 +22,8 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var atandf = require( './../lib' );
 
 
@@ -50,8 +49,6 @@ tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 
 tape( 'the function computes the arctangent in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -63,21 +60,13 @@ tape( 'the function computes the arctangent in degrees (negative values)', funct
 	for ( i = 0; i < x.length; i++ ) {
 		y = atandf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -89,13 +78,7 @@ tape( 'the function computes the arctangent in degrees (positive values)', funct
 	for ( i = 0; i < x.length; i++ ) {
 		y = atandf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/atandf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/atandf/test/test.native.js
@@ -23,9 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -59,8 +58,6 @@ tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 
 tape( 'the function computes the arctangent in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -72,21 +69,13 @@ tape( 'the function computes the arctangent in degrees (negative values)', opts,
 	for ( i = 0; i < x.length; i++ ) {
 		y = atandf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arctangent in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -98,13 +87,7 @@ tape( 'the function computes the arctangent in degrees (positive values)', opts,
 	for ( i = 0; i < x.length; i++ ) {
 		y = atandf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

This pull request migrates `test/test.js` and `test/test.native.js` of `math/base/special/atandf` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value`, following the merged precedent for single-precision packages (e.g. `math/base/special/hypotf`, PR #12808).

- Replaces the `delta`/`tol`/`EPS`/`absf`-based tolerance checks in both the "negative values" and "positive values" test cases with `t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' )`.
- Removes the now-unused `absf` and `EPS` requires; keeps the existing `float64ToFloat32` coercion of fixture expected values (unchanged from before).
- **Minimum required ULP value: `1`** for both the JavaScript and native implementations, verified by direct ULP-difference computation over both fixture files (`negative.json`, `positive.json`; combined 4009 assertions). The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN=atandf`) and its outputs were independently checked for max ULP difference against the fixtures (native negative: 1, native positive: 1; JS negative: 1, JS positive: 1).
- Ran the full test suite for the package twice (`make test TESTS_FILTER=".*/math/base/special/atandf/.*"`) at ULP=1 to confirm deterministic passing (4009/4009 both runs, both files).
- `npx eslint` is clean on both changed files.
- No other files were changed.

## Related Issues

- #11352

## Questions

No.

### AI Assistance

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Disclosure

This PR was authored by an automated Claude Code agent running as a scheduled task, following the conventions established in prior merged ULP-migration PRs for this issue (e.g. #12808, #12799).

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMishK8rqypNc5A41RM6rv)_