### PR TITLE
docs: improve doctests for ndarray instances in `stats/nanmax`

### DIFF
--- a/lib/node_modules/@stdlib/stats/nanmax/README.md
+++ b/lib/node_modules/@stdlib/stats/nanmax/README.md
@@ -184,7 +184,6 @@ var uniform = require( '@stdlib/random/base/uniform' );
 var filledarrayBy = require( '@stdlib/array/filled-by' );
 var bernoulli = require( '@stdlib/random/base/bernoulli' );
 var getDType = require( '@stdlib/ndarray/dtype' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var nanmax = require( '@stdlib/stats/nanmax' );
 
@@ -200,7 +199,6 @@ var xbuf = filledarrayBy( 25, 'generic', rand );
 
 // Wrap in an ndarray:
 var x = new ndarray( 'generic', xbuf, [ 5, 5 ], [ 5, 1 ], 0, 'row-major' );
-console.log( ndarray2array( x ) );
 
 // Perform a reduction:
 var y = nanmax( x, {
@@ -210,9 +208,7 @@ var y = nanmax( x, {
 // Resolve the output array data type:
 var dt = getDType( y );
 console.log( dt );
-
-// Print the results:
-console.log( ndarray2array( y ) );
+// => 'generic'
 ```
 
 </section>


### PR DESCRIPTION
Progresses #9329.

## Description

> What is the purpose of this pull request?

This pull request:

- Improves doctests for ndarray instances in the `@stdlib/stats/nanmax` package by removing the usage of `ndarray2array` and replacing explicit array decomposition with ndarray instance notation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #9329

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
