### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/ml/base/loss/float64/modified-huber-gradient/README.md
+++ b/lib/node_modules/@stdlib/ml/base/loss/float64/modified-huber-gradient/README.md
@@ -24,7 +24,7 @@ limitations under the License.
 
 <section class="intro">
 
-The [modified huber loss gradient][modified-huber-loss-gradient] is defined as
+The [modified Huber loss gradient][modified-huber-loss-gradient] is defined as
 
 <!-- <equation class="equation" label="eq:modified_huber_loss_gradient" align="center" raw="
 \frac{\partial \ell}{\partial w_i} = \begin{cases} -4yx_i & \text{if } yp < -1 \\ -2y(1 - yp)x_i & \text{if } -1 \le yp \le 1 \\ 0 & \text{if } yp > 1 \end{cases}" alt="Equation for the modified Huber loss gradient."> -->
@@ -73,10 +73,13 @@ The function accepts the following arguments:
 If any argument is `NaN`, the function returns `NaN`.
 
 ```javascript
-var v = modifiedHuberGradient( 2.0, NaN, 0.782 );
+var v = modifiedHuberGradient( NaN, 1.0, 0.782 );
 // returns NaN
 
 v = modifiedHuberGradient( 1.0, NaN, 0.782 );
+// returns NaN
+
+v = modifiedHuberGradient( 1.0, 1.0, NaN );
 // returns NaN
 
 v = modifiedHuberGradient( NaN, NaN, NaN );

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/pdf/test/test.factory.js
@@ -130,12 +130,12 @@ tape( 'the created function evaluates the pdf for `x` given `mu` and `sigma`', f
 	sigma = data.sigma;
 
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( mu[i], sigma[i] );
-		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual(y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i]);
+		pdf = factory( mu[ i ], sigma[ i ] );
+		y = pdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 1 ), 'within tolerance. x: '+x[i]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. expected: '+expected[i]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 1 ), 'within tolerance. x: '+x[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. expected: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/pdf/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/pdf/test/test.main.js
@@ -95,11 +95,11 @@ tape( 'the function evaluates the pdf for `x` given `mu` and `sigma`', function 
 	sigma = data.sigma;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = pdf( x[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 1 ), 'within tolerance. x: '+x[i]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. expected: '+expected[i]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 1 ), 'within tolerance. x: '+x[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. expected: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/pdf/test/test.native.js
@@ -104,11 +104,11 @@ tape( 'the function evaluates the pdf for `x` given `mu` and `sigma`', opts, fun
 	sigma = data.sigma;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = pdf( x[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 1 ), 'within tolerance. x: '+x[i]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. expected: '+expected[i]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 1 ), 'within tolerance. x: '+x[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. expected: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/include/stdlib/stats/base/dists/invgamma/quantile.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/include/stdlib/stats/base/dists/invgamma/quantile.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the quantile function for an inverse gamma distribution.
+* Evaluates the quantile function for an inverse gamma distribution with shape parameter `alpha` and scale parameter `beta` at a probability `p`.
 */
 double stdlib_base_dists_invgamma_quantile( const double p, const double alpha, const double beta );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/src/main.c
@@ -21,7 +21,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 
 /**
-* Evaluates the quantile function for an inverse gamma distribution.
+* Evaluates the quantile function for an inverse gamma distribution with shape parameter `alpha` and scale parameter `beta` at a probability `p`.
 *
 * @param p        input value
 * @param alpha    shape parameter

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/test/test.native.js
@@ -140,13 +140,13 @@ tape( 'the function evaluates the quantile for `x` given large parameters `alpha
 	beta = bothLarge.beta;
 	p = bothLarge.p;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 200.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -167,19 +167,19 @@ tape( 'the function evaluates the quantile for `x` given large shape parameter `
 	beta = largeShape.beta;
 	p = largeShape.p;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the function evaluates the quantile for `x` given large rate parameter `beta`', opts, function test( t ) {
+tape( 'the function evaluates the quantile for `x` given large scale parameter `beta`', opts, function test( t ) {
 	var expected;
 	var delta;
 	var alpha;
@@ -194,13 +194,13 @@ tape( 'the function evaluates the quantile for `x` given large rate parameter `b
 	beta = largeRate.beta;
 	p = largeRate.p;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-07-24T14:34:00-07:00 (`aef97d0`) and 2026-07-25T03:11:20-07:00 (`b0882ed`). An automated review of that window (12 commits) surfaced the issues below; each was independently re-verified against the diff and the stdlib style guides before being fixed.

This pull request:

**`ml/base/loss/float64/modified-huber-gradient`**

-   Fix casing of "huber" → "Huber" in the modified-huber-gradient README intro, matching every other reference in the file (9a8f1f3, `lib/node_modules/@stdlib/ml/base/loss/float64/modified-huber-gradient/README.md`).
-   Fixes copy-paste slip in `lib/node_modules/@stdlib/ml/base/loss/float64/modified-huber-gradient/README.md` (from 9a8f1f3) where the `x`/`p` NaN examples both had `NaN` in the `y` slot, leaving those cases undemonstrated; now mirrors `squared-error-gradient` with one example per argument plus all-NaN.

**`stats/base/dists/invgamma/quantile`**

-   Restore the omitted `alpha`/`beta`/`p` parameter description dropped from the C doxygen summaries in `include/stdlib/stats/base/dists/invgamma/quantile.h` and `src/main.c` in 525c0cb, aligning wording with `lib/main.js` and every other quantile package's C docs.
-   Fixed the leftover description string introduced alongside the 525c0cb rate→scale rename: `lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/test/test.native.js` still read "given large rate parameter `beta`"; updated to "scale parameter" to match the corrected shape/scale parameterization.
-   Fixed unspaced array indices (`p[i]`, `alpha[i]`, `beta[i]`, `expected[i]`) introduced in 525c0cb's `test/test.native.js` for `stats/base/dists/invgamma/quantile`, bringing them in line with the adjacent `expected[ i ]`/`p[ i ]` usages per the style guide's spaced-array-index rule.

**`stats/base/dists/anglit/pdf`**

-   Fix unspaced array-index and call-padding style violations (`x[i]` → `x[ i ]`, etc.) in the `stats/base/dists/anglit/pdf` tests introduced by 72cc422, across `test/test.factory.js`, `test/test.main.js`, and `test/test.native.js`.

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation performed:**

-   Style-guide compliance audit of all 12 commits in the window (two independent passes against `docs/style-guides`, comparing new packages against mature reference packages).
-   Bug scan of the union diff (two independent passes), including numeric verification of documented example values, JS↔C implementation parity for the new native code, and fixture validation — no runtime bugs found; the items above are docs/style only.
-   All modified JS files pass `node --check`; changes are limited to comments, docs, test description strings, and whitespace (no behavioral changes).

**Deliberately excluded** (to keep this PR high-signal):

-   Anything requiring interpretation or judgment (e.g. the `σ <= 0` README wording in `anglit/pdf` matches the established `anglit/cdf` convention, so it was left alone; likewise the `test.main.js` naming, which is shared by several existing packages).
-   Findings that failed independent re-verification (e.g. a reported "unused `EPS` require" in the `atanh` test migration is in fact still used).
-   Anything outside the 24-hour diff window.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by a scheduled Claude Code review of the last 24 hours of commits merged to `develop`. Claude identified, verified, and applied all fixes; a human maintainer will audit before promoting the PR out of draft.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPPUuXooLzAeUZ35RXXGuq)_