### PR TITLE
style: remove extraneous whitespace

### DIFF
--- a/lib/node_modules/@stdlib/random/iter/betaprime/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/betaprime/lib/main.js
@@ -42,7 +42,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator for generating pseudorandom numbers drawn from a beta prime distribution.
 *
 * @param {PositiveNumber} alpha - first shape parameter
-* @param {PositiveNumber} beta  - second shape parameter
+* @param {PositiveNumber} beta - second shape parameter
 * @param {Options} [options] - function options
 * @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
 * @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed

--- a/lib/node_modules/@stdlib/random/iter/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/docs/types/index.d.ts
@@ -374,7 +374,7 @@ interface Namespace {
 	* Returns an iterator for generating pseudorandom numbers drawn from an Erlang distribution.
 	*
 	* @param k - shape parameter
-	* @param lambda  - rate parameter
+	* @param lambda - rate parameter
 	* @param options - function options
 	* @throws `k` must be a positive integer
 	* @throws `lambda` must be a positive number
@@ -630,7 +630,7 @@ interface Namespace {
 	* Returns an iterator for generating pseudorandom numbers drawn from an inverse gamma distribution.
 	*
 	* @param alpha - shape parameter
-	* @param beta  - scale parameter
+	* @param beta - scale parameter
 	* @param options - function options
 	* @throws `alpha` must be a positive number
 	* @throws `beta` must be a positive number
@@ -658,7 +658,7 @@ interface Namespace {
 	* Returns an iterator for generating pseudorandom numbers drawn from a Kumaraswamy's double bounded distribution.
 	*
 	* @param a - first shape parameter
-	* @param b  - second shape parameter
+	* @param b - second shape parameter
 	* @param options - function options
 	* @throws `a` must be a positive number
 	* @throws `b` must be a positive number
@@ -1183,7 +1183,7 @@ interface Namespace {
 	* Returns an iterator for generating pseudorandom numbers drawn from a Weibull distribution.
 	*
 	* @param k - scale parameter
-	* @param lambda  - shape parameter
+	* @param lambda - shape parameter
 	* @param options - function options
 	* @throws `k` must be a positive number
 	* @throws `lambda` must be a positive number

--- a/lib/node_modules/@stdlib/random/iter/erlang/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/erlang/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Iterator<T> extends TypedIterator<T> {
 * Returns an iterator for generating pseudorandom numbers drawn from an Erlang distribution.
 *
 * @param k - shape parameter
-* @param lambda  - rate parameter
+* @param lambda - rate parameter
 * @param options - function options
 * @throws `k` must be a positive integer
 * @throws `lambda` must be a positive number

--- a/lib/node_modules/@stdlib/random/iter/erlang/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/erlang/lib/main.js
@@ -43,7 +43,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator for generating pseudorandom numbers drawn from an Erlang distribution.
 *
 * @param {PositiveInteger} k - shape parameter
-* @param {PositiveNumber} lambda  - rate parameter
+* @param {PositiveNumber} lambda - rate parameter
 * @param {Options} [options] - function options
 * @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
 * @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed

--- a/lib/node_modules/@stdlib/random/iter/frechet/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/frechet/lib/main.js
@@ -44,7 +44,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator for generating pseudorandom numbers drawn from a Fréchet distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} s  - rate parameter
+* @param {PositiveNumber} s - rate parameter
 * @param {number} m - location parameter
 * @param {Options} [options] - function options
 * @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers

--- a/lib/node_modules/@stdlib/random/iter/gamma/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/gamma/lib/main.js
@@ -42,7 +42,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator for generating pseudorandom numbers drawn from a gamma distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta  - rate parameter
+* @param {PositiveNumber} beta - rate parameter
 * @param {Options} [options] - function options
 * @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
 * @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed

--- a/lib/node_modules/@stdlib/random/iter/invgamma/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/invgamma/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Iterator<T> extends TypedIterator<T> {
 * Returns an iterator for generating pseudorandom numbers drawn from an inverse gamma distribution.
 *
 * @param alpha - shape parameter
-* @param beta  - scale parameter
+* @param beta - scale parameter
 * @param options - function options
 * @throws `alpha` must be a positive number
 * @throws `beta` must be a positive number

--- a/lib/node_modules/@stdlib/random/iter/invgamma/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/invgamma/lib/main.js
@@ -42,7 +42,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator for generating pseudorandom numbers drawn from an inverse gamma distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta  - scale parameter
+* @param {PositiveNumber} beta - scale parameter
 * @param {Options} [options] - function options
 * @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
 * @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed

--- a/lib/node_modules/@stdlib/random/iter/kumaraswamy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/kumaraswamy/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Iterator<T> extends TypedIterator<T> {
 * Returns an iterator for generating pseudorandom numbers drawn from a Kumaraswamy's double bounded distribution.
 *
 * @param a - first shape parameter
-* @param b  - second shape parameter
+* @param b - second shape parameter
 * @param options - function options
 * @throws `a` must be a positive number
 * @throws `b` must be a positive number

--- a/lib/node_modules/@stdlib/random/iter/kumaraswamy/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/kumaraswamy/lib/main.js
@@ -42,7 +42,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator for generating pseudorandom numbers drawn from a Kumaraswamy's double bounded distribution.
 *
 * @param {PositiveNumber} a - first shape parameter
-* @param {PositiveNumber} b  - second shape parameter
+* @param {PositiveNumber} b - second shape parameter
 * @param {Options} [options] - function options
 * @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
 * @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed

--- a/lib/node_modules/@stdlib/random/iter/pareto-type1/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/pareto-type1/lib/main.js
@@ -42,7 +42,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator for generating pseudorandom numbers drawn from a Pareto (Type I) distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta  - scale parameter
+* @param {PositiveNumber} beta - scale parameter
 * @param {Options} [options] - function options
 * @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
 * @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed

--- a/lib/node_modules/@stdlib/random/iter/weibull/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/iter/weibull/docs/types/index.d.ts
@@ -92,7 +92,7 @@ interface Iterator<T> extends TypedIterator<T> {
 * Returns an iterator for generating pseudorandom numbers drawn from a Weibull distribution.
 *
 * @param k - scale parameter
-* @param lambda  - shape parameter
+* @param lambda - shape parameter
 * @param options - function options
 * @throws `k` must be a positive number
 * @throws `lambda` must be a positive number

--- a/lib/node_modules/@stdlib/random/iter/weibull/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/weibull/lib/main.js
@@ -42,7 +42,7 @@ var format = require( '@stdlib/string/format' );
 * Returns an iterator for generating pseudorandom numbers drawn from a Weibull distribution.
 *
 * @param {PositiveNumber} k - scale parameter
-* @param {PositiveNumber} lambda  - shape parameter
+* @param {PositiveNumber} lambda - shape parameter
 * @param {Options} [options] - function options
 * @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
 * @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/lib/main.js
@@ -39,7 +39,7 @@ var searchRight = require( './search_right.js' );
 *
 * @param {Probability} r - input value
 * @param {NonNegativeInteger} n - number of trials
-* @param {Probability} p  - success probability
+* @param {Probability} p - success probability
 * @returns {NonNegativeInteger} evaluated quantile function
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Propagating fixes merged to `develop` between 2026-07-24 and 2026-07-25 to sibling packages.

This propagated fix corrects a JSDoc double-space typo (`p  - success probability`) at 17 additional sites the source commit 620be0b missed, spanning the `main.js` twin in binomial/quantile, eight `random/iter/*` package `lib/main.js` files, four per-package `docs/types/index.d.ts` files, and four lines in the aggregate `random/iter/docs/types/index.d.ts`. Every neighboring `@param` line in these files uses single spacing before the dash separator, which is the convention enforced by the `stdlib/jsdoc-tag-spacing` lint rule. This change brings all 17 lines into conformance with that rule.

Source: 620be0b ("chore: clean-up", #13643). Target packages:

-   `@stdlib/random/iter/betaprime`
-   `@stdlib/random/iter/erlang`
-   `@stdlib/random/iter/frechet`
-   `@stdlib/random/iter/gamma`
-   `@stdlib/random/iter/invgamma`
-   `@stdlib/random/iter/kumaraswamy`
-   `@stdlib/random/iter/pareto-type1`
-   `@stdlib/random/iter/weibull`
-   `@stdlib/random/iter` (namespace type declarations)
-   `@stdlib/stats/base/dists/binomial/quantile`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation: candidate sites were enumerated via pattern search over all of `lib/node_modules/@stdlib` (`@param` lines with two-plus spaces before the dash, `*.js` and `*.d.ts`); each site was independently confirmed by two validation passes reading each file in full, a mechanical-applicability pass verifying exact before/after strings and single-file self-containment, and a style-consistency pass against `docs/style-guides` and neighboring `@param` lines. After this change, zero occurrences of the pattern remain repo-wide. Excluded from propagation: codebase-wide bracket-spacing style (owned by lint campaigns), `new Array()` lint remediations (owned by per-file lint-error issues), and auto-generated "Related Packages" sections.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine: it identifies fixes recently merged to `develop` and applies them to sibling packages with the same defect, with each target site confirmed by independent validation passes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_011Zi8vKW1yPSGZZTbZCf3BW)_