### PR TITLE
test: migrate `math/base/special/rsqrt` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rsqrt/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rsqrt/test/test.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var rsqrt = require( './../lib' );
 
 
@@ -52,8 +51,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[50,500]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -65,9 +62,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -75,8 +70,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[20,50]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -88,9 +81,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -98,8 +89,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[3,20]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -111,9 +100,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -121,8 +108,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[0.8,3]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -134,9 +119,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -144,8 +127,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[0.0,0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -157,9 +138,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -167,8 +146,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[1e-300,1e-308]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -180,9 +157,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -190,8 +165,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of subnormal `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -203,9 +176,7 @@ tape( 'the function evaluates the reciprocal square root of subnormal `x`', func
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -213,8 +184,6 @@ tape( 'the function evaluates the reciprocal square root of subnormal `x`', func
 
 tape( 'the function evaluates the reciprocal square root of `x` (huge positive)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -226,9 +195,7 @@ tape( 'the function evaluates the reciprocal square root of `x` (huge positive)'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/rsqrt/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rsqrt/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -61,8 +60,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[50,500]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -74,9 +71,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -84,8 +79,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[20,50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -97,9 +90,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -107,8 +98,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[3,20]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -120,9 +109,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -130,8 +117,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[0.8,3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -143,9 +128,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -153,8 +136,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[0.0,0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -166,9 +147,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -176,8 +155,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of `x` on the interval `[1e-300,1e-308]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -189,9 +166,7 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -199,8 +174,6 @@ tape( 'the function evaluates the reciprocal square root of `x` on the interval 
 
 tape( 'the function evaluates the reciprocal square root of subnormal `x`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -212,9 +185,7 @@ tape( 'the function evaluates the reciprocal square root of subnormal `x`', opts
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -222,8 +193,6 @@ tape( 'the function evaluates the reciprocal square root of subnormal `x`', opts
 
 tape( 'the function evaluates the reciprocal square root of `x` (huge positive)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -235,9 +204,7 @@ tape( 'the function evaluates the reciprocal square root of `x` (huge positive)'
 		if ( y === expected[i] ) {
 			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `@stdlib/math/base/special/rsqrt` unit and native tests from relative tolerance testing to ULP-based difference testing using `@stdlib/assert/is-almost-same-value` with a max ULP difference of 1.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
