### PR TITLE
test: migrate `math/base/special/acotf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acotf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acotf/test/test.js
@@ -26,9 +26,8 @@ var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var acotf = require( './../lib' );
 
 
@@ -54,8 +53,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse cotangent for medium positive values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -66,21 +63,13 @@ tape( 'the function computes the inverse cotangent for medium positive values', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.9 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for medium negative values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -91,21 +80,13 @@ tape( 'the function computes the inverse cotangent for medium negative values', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.9 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for large positive values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -116,21 +97,13 @@ tape( 'the function computes the inverse cotangent for large positive values', f
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for large negative values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -141,21 +114,13 @@ tape( 'the function computes the inverse cotangent for large negative values', f
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for larger positive values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -166,21 +131,13 @@ tape( 'the function computes the inverse cotangent for larger positive values', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for larger negative values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -191,21 +148,13 @@ tape( 'the function computes the inverse cotangent for larger negative values', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for huge positive values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -216,21 +165,13 @@ tape( 'the function computes the inverse cotangent for huge positive values', fu
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for huge negative values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -241,13 +182,7 @@ tape( 'the function computes the inverse cotangent for huge negative values', fu
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acotf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acotf/test/test.native.js
@@ -27,9 +27,8 @@ var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -63,8 +62,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse cotangent for medium positive values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -75,21 +72,13 @@ tape( 'the function computes the inverse cotangent for medium positive values', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.9 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for medium negative values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -100,21 +89,13 @@ tape( 'the function computes the inverse cotangent for medium negative values', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.9 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for large positive values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -125,21 +106,13 @@ tape( 'the function computes the inverse cotangent for large positive values', o
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for large negative values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -150,21 +123,13 @@ tape( 'the function computes the inverse cotangent for large negative values', o
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for larger positive values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -175,21 +140,13 @@ tape( 'the function computes the inverse cotangent for larger positive values', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for larger negative values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -200,21 +157,13 @@ tape( 'the function computes the inverse cotangent for larger negative values', 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for huge positive values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -225,21 +174,13 @@ tape( 'the function computes the inverse cotangent for huge positive values', op
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for huge negative values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -250,13 +191,7 @@ tape( 'the function computes the inverse cotangent for huge negative values', op
 	for ( i = 0; i < x.length; i++ ) {
 		y = acotf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e+'.' );
-		} else {
-			delta = abs( y - e );
-			tol = 1.2 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `math/base/special/acotf` test cases from relative-tolerance-based assertions (`EPS`/`abs`/`tol` idiom) to ULP-based assertions using `@stdlib/number/float32/base/assert/is-almost-same-value` in both `test/test.js` and `test/test.native.js`.
-   uses measured minimum ULP bounds per fixture set: `3` for `medium_positive`/`medium_negative`, `2` for `large_positive`/`large_negative`/`larger_positive`/`larger_negative`, and `1` for `huge_positive`/`huge_negative`. Each bound is the smallest integer for which the full fixture set passes (verified by lowering to `N-1` and confirming at least one failure in every group).
-   test suite was run twice at the final ULP bounds for both `test.js` and the native binding (`test.native.js`, built locally via `node-gyp rebuild`) to confirm deterministic results (no FMA/arch flakiness).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Final ULP constants: `3` (medium), `2` (large/larger), `1` (huge).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, running as an automated scheduled task: it discovered the candidate package, studied prior art from already-converted packages, performed the conversion, measured the tightest ULP bounds agentically, and verified the result.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdwkzWLE9t2bM6UifkjNpY)_