### PR TITLE
test: migrate `math/base/special/cscd` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cscd/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/test/test.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var cscd = require( './../lib' );
 
 
@@ -83,12 +82,12 @@ tape( 'the function returns `+0` if provided `+infinity`', function test( t ) {
 
 tape( 'the function computes the cosecant in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var ULP;
 	var x;
 	var y;
 	var i;
 
+	ULP = 2;
 	x = negative.x;
 	expected = negative.expected;
 
@@ -98,25 +97,19 @@ tape( 'the function computes the cosecant in degrees (negative values)', functio
 			t.strictEqual( y, NINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var ULP;
 	var x;
 	var y;
 	var i;
 
+	ULP = 2;
 	x = positive.x;
 	expected = positive.expected;
 
@@ -126,13 +119,7 @@ tape( 'the function computes the cosecant in degrees (positive values)', functio
 			t.strictEqual( y, PINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cscd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/test/test.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -92,12 +91,12 @@ tape( 'the function returns `+0` if provided `+infinity`', opts, function test( 
 
 tape( 'the function computes the cosecant in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var ULP;
 	var x;
 	var y;
 	var i;
 
+	ULP = 2;
 	x = negative.x;
 	expected = negative.expected;
 
@@ -107,25 +106,19 @@ tape( 'the function computes the cosecant in degrees (negative values)', opts, f
 			t.strictEqual( y, NINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
+	var ULP;
 	var x;
 	var y;
 	var i;
 
+	ULP = 2;
 	x = positive.x;
 	expected = positive.expected;
 
@@ -135,13 +128,7 @@ tape( 'the function computes the cosecant in degrees (positive values)', opts, f
 			t.strictEqual( y, PINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Summary

Migrates `math/base/special/cscd` test cases from relative-tolerance (EPS-scaled delta/tol) comparisons to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`, per the guidance in #11352.

- `test/test.js` and `test/test.native.js` both updated (native tests are currently skipped in this environment as the native add-on could not be built, but mirror the same ULP value as the JS tests).
- Final ULP constant: **`ULP = 2`** for both the negative-value and positive-value fixture blocks.
- This was determined empirically: `ULP = 1` fails (59 assertion failures), `ULP = 2` passes all 2009 assertions, confirmed deterministic across two consecutive runs. A direct computation of the exact ULP distance between actual and expected values over both fixture sets confirms a max distance of 2 ULPs.
- No other files were changed.

Resolves a part of #11352.

---
_Generated by [Claude Code](https://claude.ai/code/session_016QDANDYFavHa8MRh1brVfS)_