### PR TITLE
test: migrate `math/base/special/fresnels` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fresnels/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnels/test/test.js
@@ -24,8 +24,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var randu = require( '@stdlib/random/base/randu' );
 var fresnels = require( './../lib' );
 
@@ -47,8 +46,6 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function computes the S(x) term of the Fresnel integral (small positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var S;
 	var x;
 	var y;
@@ -59,20 +56,12 @@ tape( 'the function computes the S(x) term of the Fresnel integral (small positi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnels( x[i] );
-		if ( y === S[ i ] ) {
-			t.strictEqual( y, S[ i ], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y - S[i] );
-			tol = 4.0 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, S[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the S(x) term of the Fresnel integral (medium positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var S;
 	var x;
 	var y;
@@ -83,20 +72,12 @@ tape( 'the function computes the S(x) term of the Fresnel integral (medium posit
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnels( x[i] );
-		if ( y === S[ i ] ) {
-			t.strictEqual( y, S[ i ], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, S[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the S(x) term of the Fresnel integral (large positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var S;
 	var x;
 	var y;
@@ -107,20 +88,12 @@ tape( 'the function computes the S(x) term of the Fresnel integral (large positi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnels( x[i] );
-		if ( y === S[ i ] ) {
-			t.strictEqual( y, S[ i ], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, S[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the S(x) term of the Fresnel integral (very large positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var S;
 	var x;
 	var y;
@@ -131,13 +104,7 @@ tape( 'the function computes the S(x) term of the Fresnel integral (very large p
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnels( x[i] );
-		if ( y === S[ i ] ) {
-			t.strictEqual( y, S[ i ], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, S[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/fresnels/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnels/test/test.native.js
@@ -25,8 +25,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var randu = require( '@stdlib/random/base/randu' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -56,8 +55,6 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function computes the S(x) term of the Fresnel integral (small positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var S;
 	var x;
 	var y;
@@ -68,20 +65,12 @@ tape( 'the function computes the S(x) term of the Fresnel integral (small positi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnels( x[i] );
-		if ( y === S[ i ] ) {
-			t.strictEqual( y, S[ i ], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y - S[i] );
-			tol = 4.0 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, S[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the S(x) term of the Fresnel integral (medium positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var S;
 	var x;
 	var y;
@@ -92,20 +81,12 @@ tape( 'the function computes the S(x) term of the Fresnel integral (medium posit
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnels( x[i] );
-		if ( y === S[ i ] ) {
-			t.strictEqual( y, S[ i ], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, S[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the S(x) term of the Fresnel integral (large positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var S;
 	var x;
 	var y;
@@ -116,20 +97,12 @@ tape( 'the function computes the S(x) term of the Fresnel integral (large positi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnels( x[i] );
-		if ( y === S[ i ] ) {
-			t.strictEqual( y, S[ i ], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, S[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the S(x) term of the Fresnel integral (very large positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var S;
 	var x;
 	var y;
@@ -140,13 +113,7 @@ tape( 'the function computes the S(x) term of the Fresnel integral (very large p
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnels( x[i] );
-		if ( y === S[ i ] ) {
-			t.strictEqual( y, S[ i ], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, S[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the unit tests for `math/base/special/fresnels` (`test.js` and `test.native.js`) from relative tolerance testing to ULP difference testing using `@stdlib/assert/is-almost-same-value`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Implementation Note on ULP Tolerances:**
When evaluating the 4 test loops against their corresponding C++ fixtures, the minimum required ULP tolerances were determined as follows per Instruction #4 of RFC #11352 (*"Make sure that you put the minimum required ULP value possible"*):
- **`small.json` (small positive values):** Set to **`4` ULPs**. Near zero, polynomial approximation rounding accumulates up to a 4 ULP gap from the reference fixture (at 1 ULP -> 25 fail; at 2 ULPs -> 8 fail; at 3 ULPs -> 2 fail; at 4 ULPs -> 0 fail).
- **`medium.json`, `large.json`, and `huge.json`:** Set to **`1` ULP**, achieving a 100% pass rate at the standard baseline tolerance.

These bounds represent the exact mathematical floor required to achieve a **100% pass rate (4,505 / 4,505 passing)** across all test suites.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
