### PR TITLE
docs: fix REPL examples in `blas/ext/base/zcartesian-square`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/zcartesian-square/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/zcartesian-square/docs/repl.txt
@@ -41,23 +41,23 @@
     Examples
     --------
     // Standard Usage:
-    > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0 ] );
-    > var out = new {{alias:@stdlib/array/complex128}}( 2 );
+    > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
+    > var out = new {{alias:@stdlib/array/complex128}}( 8 );
     > {{alias}}( 'row-major', x.length, x, 1, out, 2 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0 ]
+    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
 
     // Using `N` and stride parameters:
-    > x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
-    > out = new {{alias:@stdlib/array/complex128}}( 2 );
-    > {{alias}}( 'row-major', 1, x, 2, out, 2 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0 ]
+    > x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 0.0, 0.0, 3.0, 4.0, 0.0, 0.0 ] );
+    > out = new {{alias:@stdlib/array/complex128}}( 8 );
+    > {{alias}}( 'row-major', 2, x, 2, out, 2 )
+    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
 
     // Using view offsets:
-    > var x0 = new {{alias:@stdlib/array/complex128}}( [ 0.0, 0.0, 1.0, 2.0 ] );
+    > var x0 = new {{alias:@stdlib/array/complex128}}( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ] );
     > var x1 = new {{alias:@stdlib/array/complex128}}( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
-    > out = new {{alias:@stdlib/array/complex128}}( 2 );
-    > {{alias}}( 'row-major', 1, x1, 1, out, 2 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0 ]
+    > out = new {{alias:@stdlib/array/complex128}}( 8 );
+    > {{alias}}( 'row-major', 2, x1, 1, out, 2 )
+    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
 
 
 {{alias}}.ndarray( N, x, sx, ox, out, so1, so2, oo )
@@ -106,16 +106,16 @@
     Examples
     --------
     // Standard Usage:
-    > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0 ] );
-    > var out = new {{alias:@stdlib/array/complex128}}( 2 );
+    > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
+    > var out = new {{alias:@stdlib/array/complex128}}( 8 );
     > {{alias}}.ndarray( x.length, x, 1, 0, out, 2, 1, 0 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0 ]
+    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
 
     // Using an index offset:
-    > x = new {{alias:@stdlib/array/complex128}}( [ 0.0, 0.0, 1.0, 2.0 ] );
-    > out = new {{alias:@stdlib/array/complex128}}( 2 );
-    > {{alias}}.ndarray( 1, x, 1, 1, out, 2, 1, 0 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0 ]
+    > x = new {{alias:@stdlib/array/complex128}}( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ] );
+    > out = new {{alias:@stdlib/array/complex128}}( 8 );
+    > {{alias}}.ndarray( 2, x, 1, 1, out, 2, 1, 0 )
+    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/zcartesian-square/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/zcartesian-square/docs/repl.txt
@@ -44,20 +44,28 @@
     > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > var out = new {{alias:@stdlib/array/complex128}}( 8 );
     > {{alias}}( 'row-major', x.length, x, 1, out, 2 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
+    <Complex128Array>
+    > var z = out.get( 2 )
+    <Complex128>[ 1.0, 2.0 ]
+    > z = out.get( 3 )
+    <Complex128>[ 3.0, 4.0 ]
 
     // Using `N` and stride parameters:
     > x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 0.0, 0.0, 3.0, 4.0, 0.0, 0.0 ] );
     > out = new {{alias:@stdlib/array/complex128}}( 8 );
     > {{alias}}( 'row-major', 2, x, 2, out, 2 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
+    <Complex128Array>
+    > z = out.get( 3 )
+    <Complex128>[ 3.0, 4.0 ]
 
     // Using view offsets:
     > var x0 = new {{alias:@stdlib/array/complex128}}( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ] );
     > var x1 = new {{alias:@stdlib/array/complex128}}( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
     > out = new {{alias:@stdlib/array/complex128}}( 8 );
     > {{alias}}( 'row-major', 2, x1, 1, out, 2 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
+    <Complex128Array>
+    > z = out.get( 3 )
+    <Complex128>[ 3.0, 4.0 ]
 
 
 {{alias}}.ndarray( N, x, sx, ox, out, so1, so2, oo )
@@ -109,13 +117,19 @@
     > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > var out = new {{alias:@stdlib/array/complex128}}( 8 );
     > {{alias}}.ndarray( x.length, x, 1, 0, out, 2, 1, 0 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
+    <Complex128Array>
+    > var z = out.get( 2 )
+    <Complex128>[ 1.0, 2.0 ]
+    > z = out.get( 3 )
+    <Complex128>[ 3.0, 4.0 ]
 
     // Using an index offset:
     > x = new {{alias:@stdlib/array/complex128}}( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ] );
     > out = new {{alias:@stdlib/array/complex128}}( 8 );
     > {{alias}}.ndarray( 2, x, 1, 1, out, 2, 1, 0 )
-    <Complex128Array>[ 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ]
+    <Complex128Array>
+    > z = out.get( 3 )
+    <Complex128>[ 3.0, 4.0 ]
 
     See Also
     --------


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-07-26 02:12 (-0500) (`0239983`) and 2026-07-26 15:02 (+0500) (`a7865fd`).

This pull request:

-   **`blas/ext/base/zcartesian-square`**: Fixed the REPL examples in `docs/repl.txt` for `zcartesian-square` (a7865fdde): they used `[ 1.0, 2.0 ]`, a single complex number, so N=1 and none of the stride/offset examples actually strided or offset anything. Replaced with two-element inputs matching the README's `[ 1.0, 2.0, 3.0, 4.0 ]` convention, with expected outputs corrected accordingly.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All commits merged to `develop` in the review window (`0239983`, `4588717`, `d98aba7`, `01a20c0`, `b062197`, `651f410`, `a7865fd`) were audited for stdlib style-guide compliance (compared against `docs/style-guides` and established reference packages, e.g. `dcartesian-square`, `dlacpy`) and scanned for bugs (stride/offset arithmetic, loop bounds, test expectations, C sources, and native bindings were hand-verified). Only objective, independently re-verified issues are included; subjective concerns, style preferences not required by the style guide, and anything requiring changes outside the review window's diff were deliberately excluded. The expected outputs in the fixed examples mirror the package's own README, which was adapted correctly in the originating commit.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated review of recently merged commits; the documentation fix was generated and verified by Claude Code.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018Rjd5jgubG8sWSpMYaq7wJ)_