### PR TITLE
docs: fix parameter descriptions and update spacing

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/gscal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/gscal/lib/main.js
@@ -32,7 +32,7 @@ var ndarray = require( './ndarray.js' );
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} alpha - scalar constant
 * @param {NumericArray} x - input array
-* @param {PositiveInteger} stride -  stride length
+* @param {PositiveInteger} stride - stride length
 * @returns {NumericArray} input array
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/cdf/test/test.cdf.js
@@ -95,11 +95,11 @@ tape( 'the function evaluates the cdf for `x` given `mu` and `sigma`', function 
 	sigma = data.sigma;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', σ: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = cdf( x[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', mu: '+mu[ i ]+', σ: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 3 ), 'within tolerance. x: '+x[i]+'. mu: '+mu[i]+'. σ: '+sigma[i]+'. y: '+y+'. E: '+expected[i]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 3 ), 'within tolerance. x: '+x[ i ]+'. mu: '+mu[ i ]+'. σ: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/cdf/test/test.factory.js
@@ -130,12 +130,12 @@ tape( 'the created function evaluates the cdf for `x` given `mu` and `sigma`', f
 	sigma = data.sigma;
 
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( mu[i], sigma[i] );
-		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual(y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', σ: '+sigma[i]+', y: '+y+', expected: '+expected[i]);
+		cdf = factory( mu[ i ], sigma[ i ] );
+		y = cdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', mu: '+mu[ i ]+', σ: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 3 ), 'within tolerance. x: '+x[i]+'. mu: '+mu[i]+'. σ: '+sigma[i]+'. y: '+y+'. E: '+expected[i]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 3 ), 'within tolerance. x: '+x[ i ]+'. mu: '+mu[ i ]+'. σ: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/cdf/test/test.native.js
@@ -104,11 +104,11 @@ tape( 'the function evaluates the cdf for `x` given `mu` and `sigma`', opts, fun
 	sigma = data.sigma;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', σ: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = cdf( x[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', mu: '+mu[ i ]+', σ: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 3 ), 'within tolerance. x: '+x[i]+'. mu: '+mu[i]+'. σ: '+sigma[i]+'. y: '+y+'. E: '+expected[i]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 3 ), 'within tolerance. x: '+x[ i ]+'. mu: '+mu[ i ]+'. σ: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/entropy/test/test.js
@@ -72,11 +72,11 @@ tape( 'the function returns the differential entropy of an anglit distribution',
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = entropy( mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = entropy( mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 5 ), 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[i]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 5 ), 'within tolerance. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/entropy/test/test.native.js
@@ -81,11 +81,11 @@ tape( 'the function returns the differential entropy of an anglit distribution',
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = entropy( mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = entropy( mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 5 ), 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[i]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 5 ), 'within tolerance. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/test/test.js
@@ -87,8 +87,8 @@ tape( 'the function returns the expected value of an anglit distribution', funct
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
@@ -104,8 +104,8 @@ tape( 'the function returns the expected value for small `mu` values', function 
 	mu = smallMu.mu;
 	sigma = smallMu.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
@@ -121,8 +121,8 @@ tape( 'the function returns the expected value for large `mu` values', function 
 	mu = largeMu.mu;
 	sigma = largeMu.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
@@ -138,8 +138,8 @@ tape( 'the function returns the expected value for small `sigma` values', functi
 	mu = smallSigma.mu;
 	sigma = smallSigma.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
@@ -155,8 +155,8 @@ tape( 'the function returns the expected value for large `sigma` values', functi
 	mu = largeSigma.mu;
 	sigma = largeSigma.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mean/test/test.native.js
@@ -95,8 +95,8 @@ tape( 'the function returns the expected value of an anglit distribution', opts,
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
@@ -112,8 +112,8 @@ tape( 'the function returns the expected value for small `mu` values', opts, fun
 	mu = smallMu.mu;
 	sigma = smallMu.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
@@ -129,8 +129,8 @@ tape( 'the function returns the expected value for large `mu` values', opts, fun
 	mu = largeMu.mu;
 	sigma = largeMu.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
@@ -146,8 +146,8 @@ tape( 'the function returns the expected value for small `sigma` values', opts, 
 	mu = smallSigma.mu;
 	sigma = smallSigma.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
@@ -163,8 +163,8 @@ tape( 'the function returns the expected value for large `sigma` values', opts, 
 	mu = largeSigma.mu;
 	sigma = largeSigma.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mean( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mean( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/median/test/test.js
@@ -83,8 +83,8 @@ tape( 'the function returns the median of an anglit distribution', function test
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = median( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = median( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/median/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/median/test/test.native.js
@@ -92,8 +92,8 @@ tape( 'the function returns the median of an anglit distribution', opts, functio
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = median( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = median( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mode/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mode/test/test.js
@@ -83,8 +83,8 @@ tape( 'the function returns the mode of an anglit distribution', function test( 
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mode( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mode( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/mode/test/test.native.js
@@ -95,8 +95,8 @@ tape( 'the function returns the mode of an anglit distribution', opts, function 
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = mode( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = mode( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/test/test.factory.js
@@ -140,12 +140,12 @@ tape( 'the created function evaluates the quantile function at `p` given positiv
 	mu = positiveMu.mu;
 	sigma = positiveMu.sigma;
 	for ( i = 0; i < p.length; i++ ) {
-		quantile = factory( mu[i], sigma[i] );
-		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		quantile = factory( mu[ i ], sigma[ i ] );
+		y = quantile( p[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 5 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 5 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();
@@ -165,12 +165,12 @@ tape( 'the created function evaluates the quantile function at `p` given negativ
 	mu = negativeMu.mu;
 	sigma = negativeMu.sigma;
 	for ( i = 0; i < p.length; i++ ) {
-		quantile = factory( mu[i], sigma[i] );
-		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		quantile = factory( mu[ i ], sigma[ i ] );
+		y = quantile( p[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 80 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 80 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();
@@ -190,12 +190,12 @@ tape( 'the created function evaluates the quantile function at `p` given large `
 	mu = largeSigma.mu;
 	sigma = largeSigma.sigma;
 	for ( i = 0; i < p.length; i++ ) {
-		quantile = factory( mu[i], sigma[i] );
-		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		quantile = factory( mu[ i ], sigma[ i ] );
+		y = quantile( p[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 500 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 500 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/test/test.native.js
@@ -125,11 +125,11 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 	mu = positiveMu.mu;
 	sigma = positiveMu.sigma;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 5 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 5 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();
@@ -148,11 +148,11 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 	mu = negativeMu.mu;
 	sigma = negativeMu.sigma;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 80 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 80 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();
@@ -171,11 +171,11 @@ tape( 'the function evaluates the quantile function at `p` given large `sigma`',
 	mu = largeSigma.mu;
 	sigma = largeSigma.sigma;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 500 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 500 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/quantile/test/test.quantile.js
@@ -116,11 +116,11 @@ tape( 'the function evaluates the quantile function at `p` given positive `mu`',
 	mu = positiveMu.mu;
 	sigma = positiveMu.sigma;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 5 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 5 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();
@@ -139,11 +139,11 @@ tape( 'the function evaluates the quantile function at `p` given negative `mu`',
 	mu = negativeMu.mu;
 	sigma = negativeMu.sigma;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 80 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 80 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();
@@ -162,11 +162,11 @@ tape( 'the function evaluates the quantile function at `p` given large `sigma`',
 	mu = largeSigma.mu;
 	sigma = largeSigma.sigma;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], mu[ i ], sigma[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', mu: '+mu[ i ]+', sigma: '+sigma[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
-			t.ok( isAlmostSameValue( y, expected[i], 500 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'.' );
+			t.ok( isAlmostSameValue( y, expected[ i ], 500 ), 'within tolerance. p: '+p[ i ]+'. mu: '+mu[ i ]+'. sigma: '+sigma[ i ]+'. y: '+y+'. E: '+expected[ i ]+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/skewness/test/test.js
@@ -83,8 +83,8 @@ tape( 'the function returns the skewness of an anglit distribution', function te
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = skewness( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = skewness( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/skewness/test/test.native.js
@@ -92,8 +92,8 @@ tape( 'the function returns the skewness of an anglit distribution', opts, funct
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = skewness( mu[i], sigma[i] );
-		t.strictEqual( y, expected[i], 'returns expected value' );
+		y = skewness( mu[ i ], sigma[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/test/test.js
@@ -86,8 +86,8 @@ tape( 'the function returns the standard deviation of an anglit distribution', f
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = stdev( mu[i], sigma[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		y = stdev( mu[ i ], sigma[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/stdev/test/test.native.js
@@ -93,8 +93,8 @@ tape( 'the function returns the standard deviation of an anglit distribution', o
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < mu.length; i++ ) {
-		y = stdev( mu[i], sigma[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 1 ), true, 'returns expected value' );
+		y = stdev( mu[ i ], sigma[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/test/test.js
@@ -86,8 +86,8 @@ tape( 'the function returns the variance of an anglit distribution', function te
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = variance( mu[i], sigma[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
+		y = variance( mu[ i ], sigma[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/anglit/variance/test/test.native.js
@@ -95,8 +95,8 @@ tape( 'the function returns the variance of an anglit distribution', opts, funct
 	mu = data.mu;
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = variance( mu[i], sigma[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 2 ), true, 'returns expected value' );
+		y = variance( mu[ i ], sigma[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/README.md
@@ -55,7 +55,7 @@ var cdf = require( '@stdlib/stats/base/dists/invgamma/cdf' );
 
 #### cdf( x, alpha, beta )
 
-Evaluates the [cumulative distribution function][cdf] (CDF) for an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Evaluates the [cumulative distribution function][cdf] (CDF) for an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var y = cdf( 2.0, 1.0, 1.0 );
@@ -103,7 +103,7 @@ var y = cdf( 2.0, 0.5, -1.0 );
 
 #### cdf.factory( alpha, beta )
 
-Returns a function for evaluating the [cumulative distribution function][cdf] for an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Returns a function for evaluating the [cumulative distribution function][cdf] for an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var mycdf = cdf.factory( 0.5, 0.1 );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/include/stdlib/stats/base/dists/invgamma/cdf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/include/stdlib/stats/base/dists/invgamma/cdf.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the cumulative distribution function (CDF) for an inverse gamma distribution.
+* Evaluates the cumulative distribution function (CDF) for an inverse gamma distribution with shape parameter `alpha` and scale parameter `beta` at a value `x`.
 */
 double stdlib_base_dists_invgamma_cdf( const double x, const double alpha, const double beta );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/test/fixtures/julia/runner.jl
@@ -28,7 +28,7 @@ Generate fixture data and write to file.
 
 * `x`: input value
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples
@@ -76,7 +76,7 @@ alpha = ( rand( 1000 ) .* 10.0 ) .+ 10.0;
 beta = rand( 1000 ) .* 10.0;
 gen( x, alpha, beta, "large_shape.json" );
 
-# Large rate parameter:
+# Large scale parameter:
 x = rand( 1000 ) .* 5.0;
 alpha = rand( 1000 ) .* 10.0;
 beta = ( rand( 1000 ) .* 10.0 ) .+ 10.0;

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/test/test.cdf.js
@@ -117,13 +117,13 @@ tape( 'the function evaluates the cdf for `x` given large `alpha` and `beta`', f
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = cdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 950.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -144,19 +144,19 @@ tape( 'the function evaluates the cdf for `x` given large shape parameter `alpha
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = cdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 400.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the function evaluates the cdf for `x` given large rate parameter `beta`', function test( t ) {
+tape( 'the function evaluates the cdf for `x` given large scale parameter `beta`', function test( t ) {
 	var expected;
 	var delta;
 	var alpha;
@@ -171,13 +171,13 @@ tape( 'the function evaluates the cdf for `x` given large rate parameter `beta`'
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = cdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 350.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/test/test.factory.js
@@ -177,14 +177,14 @@ tape( 'the created function evaluates the cdf for `x` given large `alpha` and `b
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( alpha[i], beta[i] );
-		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		cdf = factory( alpha[ i ], beta[ i ] );
+		y = cdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 950.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -206,20 +206,20 @@ tape( 'the created function evaluates the cdf for `x` given large shape paramete
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( alpha[i], beta[i] );
-		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		cdf = factory( alpha[ i ], beta[ i ] );
+		y = cdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 400.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the created function evaluates the cdf for `x` given large rate parameter `beta`', function test( t ) {
+tape( 'the created function evaluates the cdf for `x` given large scale parameter `beta`', function test( t ) {
 	var expected;
 	var delta;
 	var alpha;
@@ -235,14 +235,14 @@ tape( 'the created function evaluates the cdf for `x` given large rate parameter
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		cdf = factory( alpha[i], beta[i] );
-		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		cdf = factory( alpha[ i ], beta[ i ] );
+		y = cdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 350.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/test/test.native.js
@@ -130,13 +130,13 @@ tape( 'the function evaluates the cdf for `x` given large `alpha`', opts, functi
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = cdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1e-11 * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -157,13 +157,13 @@ tape( 'the function evaluates the cdf for `x` given large `beta`', opts, functio
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = cdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1e-11 * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -184,13 +184,13 @@ tape( 'the function evaluates the cdf for `x` given large `alpha` and `beta`', o
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = cdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1e-11 * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/README.md
@@ -51,7 +51,7 @@ var mode = invgamma.mode;
 // returns 0.5
 ```
 
-By default, `alpha = 1.0` and `beta = 1.0`. To create a distribution having a different `alpha` (shape parameter) and `beta` (rate parameter), provide the corresponding arguments.
+By default, `alpha = 1.0` and `beta = 1.0`. To create a distribution having a different `alpha` (shape parameter) and `beta` (scale parameter), provide the corresponding arguments.
 
 ```javascript
 var invgamma = new InvGamma( 2.0, 4.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/test/test.js
@@ -64,7 +64,7 @@ tape( 'the function throws an error if provided an `alpha` argument which is not
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -95,7 +95,7 @@ tape( 'the function throws an error if provided a `beta` argument which is not a
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -173,7 +173,7 @@ tape( 'the created distribution throws an error if one attempts to set `alpha` t
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 
@@ -217,7 +217,7 @@ tape( 'the created distribution throws an error if one attempts to set `beta` to
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided '+values[ i ] );
 	}
 	t.end();
 

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/docs/types/index.d.ts
@@ -74,7 +74,7 @@ interface Namespace {
 	* -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 	*
 	* @param alpha - shape parameter
-	* @param beta - rate parameter
+	* @param beta - scale parameter
 	* @returns entropy
 	*
 	* @example
@@ -115,7 +115,7 @@ interface Namespace {
 	* -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 	*
 	* @param alpha - shape parameter
-	* @param beta - rate parameter
+	* @param beta - scale parameter
 	* @returns kurtosis
 	*
 	* @example
@@ -178,7 +178,7 @@ interface Namespace {
 	* -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 	*
 	* @param alpha - shape parameter
-	* @param beta - rate parameter
+	* @param beta - scale parameter
 	* @returns expected value
 	*
 	* @example
@@ -219,7 +219,7 @@ interface Namespace {
 	* -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 	*
 	* @param alpha - shape parameter
-	* @param beta - rate parameter
+	* @param beta - scale parameter
 	* @returns mode
 	*
 	* @example
@@ -257,7 +257,7 @@ interface Namespace {
 	*
 	* @param x - input value
 	* @param alpha - shape parameter
-	* @param beta - rate parameter
+	* @param beta - scale parameter
 	* @returns evaluated PDF
 	*
 	* @example
@@ -299,7 +299,7 @@ interface Namespace {
 	* -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 	*
 	* @param alpha - shape parameter
-	* @param beta - rate parameter
+	* @param beta - scale parameter
 	* @returns skewness
 	*
 	* @example
@@ -340,7 +340,7 @@ interface Namespace {
 	* -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 	*
 	* @param alpha - shape parameter
-	* @param beta - rate parameter
+	* @param beta - scale parameter
 	* @returns standard deviation
 	*
 	* @example
@@ -381,7 +381,7 @@ interface Namespace {
 	* -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 	*
 	* @param alpha - shape parameter
-	* @param beta - rate parameter
+	* @param beta - scale parameter
 	* @returns variance
 	*
 	* @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/README.md
@@ -41,7 +41,7 @@ h\left( X \right) = \alpha \!+\!\ln(\beta \, \Gamma (\alpha ))\!-\!(1\!+\!\alpha
 
 <!-- </equation> -->
 
-where `α > 0` is the shape parameter, `β > 0` is the rate parameter, `Γ` and denotes the [gamma][gamma-function] and `Ψ` the [digamma][digamma] function.
+where `α > 0` is the shape parameter, `β > 0` is the scale parameter, `Γ` and denotes the [gamma][gamma-function] and `Ψ` the [digamma][digamma] function.
 
 </section>
 
@@ -59,7 +59,7 @@ var entropy = require( '@stdlib/stats/base/dists/invgamma/entropy' );
 
 #### entropy( alpha, beta )
 
-Returns the [differential entropy][entropy] of an [inverse gamma][invgamma-distribution] distribution with shape parameter `alpha` and rate parameter `beta` (in [nats][nats]).
+Returns the [differential entropy][entropy] of an [inverse gamma][invgamma-distribution] distribution with shape parameter `alpha` and scale parameter `beta` (in [nats][nats]).
 
 ```javascript
 var v = entropy( 1.0, 1.0 );
@@ -179,7 +179,7 @@ double out = stdlib_base_dists_invgamma_entropy( 1.0, 1.0 );
 The function accepts the following arguments:
 
 -   **alpha**: `[in] double` shape parameter.
--   **beta**: `[in] double` rate parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_invgamma_entropy( const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/docs/types/index.d.ts
@@ -26,7 +26,7 @@
 * -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 *
 * @param alpha - shape parameter
-* @param beta - rate parameter
+* @param beta - scale parameter
 * @returns entropy
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/lib/main.js
@@ -32,7 +32,7 @@ var ln = require( '@stdlib/math/base/special/ln' );
 * Returns the differential entropy of an inverse gamma distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {number} entropy
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/lib/native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {number} entropy
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/src/main.c
@@ -25,7 +25,7 @@
 * Returns the differential entropy of an inverse gamma distribution.
 *
 * @param alpha    shape parameter
-* @param beta     rate parameter
+* @param beta     scale parameter
 * @return         entropy
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/test/fixtures/julia/runner.jl
@@ -27,7 +27,7 @@ Generate fixture data and write to file.
 # Arguments
 
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/test/test.js
@@ -106,13 +106,13 @@ tape( 'the function returns the differential entropy of an inverse gamma distrib
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = entropy( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = entropy( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1e-10 * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/test/test.native.js
@@ -115,13 +115,13 @@ tape( 'the function returns the differential entropy of an inverse gamma distrib
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = entropy( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = entropy( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1e-10 * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/README.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 <section class="intro">
 
-The [excess kurtosis][kurtosis] for an [inverse gamma][invgamma-distribution] random variable with shape parameter `α` and rate parameter `β` is
+The [excess kurtosis][kurtosis] for an [inverse gamma][invgamma-distribution] random variable with shape parameter `α` and scale parameter `β` is
 
 <!-- <equation class="equation" label="eq:invgamma_kurtosis" align="center" raw="\operatorname{Kurt}\left( X \right) = \frac {30\,\alpha -66}{(\alpha -3)(\alpha -4)}" alt="Excess kurtosis for an inverse gamma distribution."> -->
 
@@ -59,7 +59,7 @@ var kurtosis = require( '@stdlib/stats/base/dists/invgamma/kurtosis' );
 
 #### kurtosis( alpha, beta )
 
-Returns the [excess kurtosis][kurtosis] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Returns the [excess kurtosis][kurtosis] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var v = kurtosis( 7.0, 5.0 );
@@ -169,7 +169,7 @@ logEachMap( 'α: %0.4f, β: %0.4f, Kurt(X;α,β): %0.4f', alpha, beta, kurtosis 
 
 #### stdlib_base_dists_invgamma_kurtosis( alpha, beta )
 
-Evaluates the [excess kurtosis][kurtosis] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Evaluates the [excess kurtosis][kurtosis] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```c
 double out = stdlib_base_dists_invgamma_kurtosis( 6.0, 1.0 );
@@ -179,7 +179,7 @@ double out = stdlib_base_dists_invgamma_kurtosis( 6.0, 1.0 );
 The function accepts the following arguments:
 
 -   **alpha**: `[in] double` shape parameter.
--   **beta**: `[in] double` rate parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_invgamma_kurtosis( const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/docs/types/index.d.ts
@@ -26,7 +26,7 @@
 * -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 *
 * @param alpha - shape parameter
-* @param beta - rate parameter
+* @param beta - scale parameter
 * @returns kurtosis
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/lib/main.js
@@ -29,7 +29,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 * Returns the excess kurtosis of an inverse gamma distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} excess kurtosis
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/lib/native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} excess kurtosis
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/src/main.c
@@ -23,7 +23,7 @@
 * Returns the excess kurtosis of an inverse gamma distribution.
 *
 * @param alpha    shape parameter
-* @param beta     rate parameter
+* @param beta     scale parameter
 * @return         kurtosis
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/test/fixtures/julia/runner.jl
@@ -27,7 +27,7 @@ Generate fixture data and write to file.
 # Arguments
 
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/test/test.js
@@ -116,13 +116,13 @@ tape( 'the function returns the excess kurtosis of an inverse gamma distribution
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = kurtosis( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = kurtosis( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/test/test.native.js
@@ -125,13 +125,13 @@ tape( 'the function returns the excess kurtosis of an inverse gamma distribution
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = kurtosis( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = kurtosis( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/README.md
@@ -55,7 +55,7 @@ var logpdf = require( '@stdlib/stats/base/dists/invgamma/logpdf' );
 
 #### logpdf( x, alpha, beta )
 
-Evaluates the natural logarithm of the [probability density function][pdf] (PDF) for an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Evaluates the natural logarithm of the [probability density function][pdf] (PDF) for an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var y = logpdf( 2.0, 0.5, 1.0 );
@@ -103,7 +103,7 @@ y = logpdf( 2.0, 1.0, -1.0 );
 
 #### logpdf.factory( alpha, beta )
 
-Returns a `function` for evaluating the natural logarithm of the [PDF][pdf] for an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Returns a `function` for evaluating the natural logarithm of the [PDF][pdf] for an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var mylogPDF = logpdf.factory( 6.0, 7.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/fixtures/julia/runner.jl
@@ -28,7 +28,7 @@ Generate fixture data and write to file.
 
 * `x`: input value
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples
@@ -76,7 +76,7 @@ alpha = ( rand( 1000 ) .* 10.0 ) .+ 10.0;
 beta = rand( 1000 ) .* 10.0;
 gen( x, alpha, beta, "large_shape.json" );
 
-# Large rate parameter:
+# Large scale parameter:
 x = rand( 1000 ) .* 5.0;
 alpha = rand( 1000 ) .* 10.0;
 beta = ( rand( 1000 ) .* 10.0 ) .+ 10.0;

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.factory.js
@@ -177,14 +177,14 @@ tape( 'the created function evaluates the logpdf for `x` given large `alpha` and
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		logpdf = factory( alpha[i], beta[i] );
-		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		logpdf = factory( alpha[ i ], beta[ i ] );
+		y = logpdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -206,20 +206,20 @@ tape( 'the created function evaluates the logpdf for `x` given a large shape par
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		logpdf = factory( alpha[i], beta[i] );
-		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		logpdf = factory( alpha[ i ], beta[ i ] );
+		y = logpdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the created function evaluates the logpdf for `x` given a large rate parameter `beta`', function test( t ) {
+tape( 'the created function evaluates the logpdf for `x` given a large scale parameter `beta`', function test( t ) {
 	var expected;
 	var logpdf;
 	var delta;
@@ -235,14 +235,14 @@ tape( 'the created function evaluates the logpdf for `x` given a large rate para
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		logpdf = factory( alpha[i], beta[i] );
-		y = logpdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		logpdf = factory( alpha[ i ], beta[ i ] );
+		y = logpdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.logpdf.js
@@ -129,13 +129,13 @@ tape( 'the function evaluates the logpdf for `x` given large `alpha` and `beta`'
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = logpdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -156,19 +156,19 @@ tape( 'the function evaluates the logpdf for `x` given large shape parameter `al
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = logpdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the function evaluates the logpdf for `x` given large rate parameter `beta`', function test( t ) {
+tape( 'the function evaluates the logpdf for `x` given large scale parameter `beta`', function test( t ) {
 	var expected;
 	var delta;
 	var alpha;
@@ -183,13 +183,13 @@ tape( 'the function evaluates the logpdf for `x` given large rate parameter `bet
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = logpdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/test/test.native.js
@@ -138,13 +138,13 @@ tape( 'the function evaluates the logpdf for `x` given large `alpha` and `beta`'
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = logpdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -165,19 +165,19 @@ tape( 'the function evaluates the logpdf for `x` given large shape parameter `al
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = logpdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the function evaluates the logpdf for `x` given large rate parameter `beta`', opts, function test( t ) {
+tape( 'the function evaluates the logpdf for `x` given large scale parameter `beta`', opts, function test( t ) {
 	var expected;
 	var delta;
 	var alpha;
@@ -192,13 +192,13 @@ tape( 'the function evaluates the logpdf for `x` given large rate parameter `bet
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = logpdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = logpdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 5.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/README.md
@@ -41,7 +41,7 @@ The [expected value][expected-value] for an [inverse-gamma][invgamma-distributio
 
 <!-- </equation> -->
 
-where `α > 0` is the shape parameter and `β > 0` is the rate parameter.
+where `α > 0` is the shape parameter and `β > 0` is the scale parameter.
 
 </section>
 
@@ -59,7 +59,7 @@ var mean = require( '@stdlib/stats/base/dists/invgamma/mean' );
 
 #### mean( alpha, beta )
 
-Returns the [expected value][expected-value] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Returns the [expected value][expected-value] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var v = mean( 4.0, 12.0 );
@@ -166,7 +166,7 @@ logEachMap( 'α: %0.4f, β: %0.4f, E(X;α,β): %0.4f', alpha, beta, mean );
 
 #### stdlib_base_dists_invgamma_mean( alpha, beta )
 
-Evaluates the [expected value][expected-value] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Evaluates the [expected value][expected-value] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```c
 double out = stdlib_base_dists_invgamma_mean( 4.0, 12.0 );
@@ -176,7 +176,7 @@ double out = stdlib_base_dists_invgamma_mean( 4.0, 12.0 );
 The function accepts the following arguments:
 
 -   **alpha**: `[in] double` shape parameter.
--   **beta**: `[in] double` rate parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_invgamma_mean( const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/docs/types/index.d.ts
@@ -26,7 +26,7 @@
 * -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 *
 * @param alpha - shape parameter
-* @param beta - rate parameter
+* @param beta - scale parameter
 * @returns expected value
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/lib/main.js
@@ -29,7 +29,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 * Returns the expected value of an inverse gamma distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} expected value
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/lib/native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} expected value
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/src/main.c
@@ -22,7 +22,7 @@
 * Returns the expected value of an inverse gamma distribution.
 *
 * @param alpha    shape parameter
-* @param beta     rate parameter
+* @param beta     scale parameter
 * @return         expected value
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/fixtures/julia/runner.jl
@@ -27,7 +27,7 @@ Generate fixture data and write to file.
 # Arguments
 
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/test.js
@@ -107,13 +107,13 @@ tape( 'the function returns the mean of an inverse gamma distribution', function
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = mean( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = mean( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/test.native.js
@@ -116,13 +116,13 @@ tape( 'the function returns the mean of an inverse gamma distribution', opts, fu
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = mean( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = mean( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/README.md
@@ -41,7 +41,7 @@ The [mode][mode] for an [inverse gamma][invgamma-distribution] random variable i
 
 <!-- </equation> -->
 
-where `α > 0` is the shape parameter and `β > 0` is the rate parameter.
+where `α > 0` is the shape parameter and `β > 0` is the scale parameter.
 
 </section>
 
@@ -59,7 +59,7 @@ var mode = require( '@stdlib/stats/base/dists/invgamma/mode' );
 
 #### mode( alpha, beta )
 
-Returns the [mode][mode] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Returns the [mode][mode] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var v = mode( 1.0, 1.0 );
@@ -169,7 +169,7 @@ logEachMap( 'α: %0.4f, β: %0.4f, mode(X;α,β): %0.4f', alpha, beta, mode );
 
 #### stdlib_base_dists_invgamma_mode( alpha, beta )
 
-Evaluates the [mode][mode] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Evaluates the [mode][mode] of an [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```c
 double out = stdlib_base_dists_invgamma_mode( 1.0, 1.0 );
@@ -179,7 +179,7 @@ double out = stdlib_base_dists_invgamma_mode( 1.0, 1.0 );
 The function accepts the following arguments:
 
 -   **alpha**: `[in] double` shape parameter.
--   **beta**: `[in] double` rate parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_invgamma_mode( const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/docs/types/index.d.ts
@@ -26,7 +26,7 @@
 * -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 *
 * @param alpha - shape parameter
-* @param beta - rate parameter
+* @param beta - scale parameter
 * @returns mode
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/lib/main.js
@@ -29,7 +29,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 * Returns the mode of an inverse gamma distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} mode
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/lib/native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} mode
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/src/main.c
@@ -22,7 +22,7 @@
 * Returns the mode of an inverse gamma distribution.
 *
 * @param alpha    shape parameter
-* @param beta     rate parameter
+* @param beta     scale parameter
 * @return         mode
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/test/fixtures/julia/runner.jl
@@ -27,7 +27,7 @@ Generate fixture data and write to file.
 # Arguments
 
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/test/test.js
@@ -107,13 +107,13 @@ tape( 'the function returns the mode of an inverse gamma distribution', function
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = mode( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = mode( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/test/test.native.js
@@ -116,13 +116,13 @@ tape( 'the function returns the mode of an inverse gamma distribution', opts, fu
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = mode( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = mode( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/README.md
@@ -55,7 +55,7 @@ var pdf = require( '@stdlib/stats/base/dists/invgamma/pdf' );
 
 #### pdf( x, alpha, beta )
 
-Evaluates the [probability density function][pdf] (PDF) for an [inverse gamma][inverse-gamma]  distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Evaluates the [probability density function][pdf] (PDF) for an [inverse gamma][inverse-gamma]  distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var y = pdf( 2.0, 0.5, 1.0 );
@@ -103,7 +103,7 @@ y = pdf( 2.0, 1.0, -1.0 );
 
 #### pdf.factory( alpha, beta )
 
-Returns a `function` for evaluating the [PDF][pdf] of an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Returns a `function` for evaluating the [PDF][pdf] of an [inverse gamma][inverse-gamma] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var myPDF = pdf.factory( 6.0, 7.0 );
@@ -169,7 +169,7 @@ logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, f(x;α,β): %0.4f', x, alpha, beta,
 
 #### stdlib_base_dists_invgamma_pdf( x, alpha, beta )
 
-Evaluates the [probability density function][pdf] (PDF) for an [inverse gamma][inverse-gamma]  distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Evaluates the [probability density function][pdf] (PDF) for an [inverse gamma][inverse-gamma]  distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```c
 double out = stdlib_base_dists_invgamma_pdf( 2.0, 0.5, 1.0 );
@@ -180,7 +180,7 @@ The function accepts the following arguments:
 
 -   **x**: `[in] double` input value.
 -   **alpha**: `[in] double` shape parameter.
--   **beta**: `[in] double` rate parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_invgamma_pdf( const double x, const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/docs/types/index.d.ts
@@ -79,10 +79,10 @@ interface PDF {
 	( x: number, alpha: number, beta: number ): number;
 
 	/**
-	* Returns a function for evaluating the probability density function (PDF) for an inverse gamma distribution with shape parameter `alpha` and rate parameter `beta`.
+	* Returns a function for evaluating the probability density function (PDF) for an inverse gamma distribution with shape parameter `alpha` and scale parameter `beta`.
 	*
 	* @param alpha - shape parameter
-	* @param beta - rate parameter
+	* @param beta - scale parameter
 	* @returns PDF
 	*
 	* @example
@@ -102,7 +102,7 @@ interface PDF {
 *
 * @param x - input value
 * @param alpha - shape parameter
-* @param beta - rate parameter
+* @param beta - scale parameter
 * @returns evaluated PDF
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/include/stdlib/stats/base/dists/invgamma/pdf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/include/stdlib/stats/base/dists/invgamma/pdf.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the probability density function (PDF) for an inverse gamma distribution.
+* Evaluates the probability density function (PDF) for an inverse gamma distribution with shape parameter `alpha` and scale parameter `beta` at a value `x`.
 */
 double stdlib_base_dists_invgamma_pdf( const double x, const double alpha, const double beta );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/fixtures/julia/runner.jl
@@ -28,7 +28,7 @@ Generate fixture data and write to file.
 
 * `x`: input value
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples
@@ -76,7 +76,7 @@ alpha = ( rand( 1000 ) .* 10.0 ) .+ 10.0;
 beta = rand( 1000 ) .* 10.0;
 gen( x, alpha, beta, "large_shape.json" );
 
-# Large rate parameter:
+# Large scale parameter:
 x = rand( 1000 ) .* 5.0;
 alpha = rand( 1000 ) .* 10.0;
 beta = ( rand( 1000 ) .* 10.0 ) .+ 10.0;

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.factory.js
@@ -177,14 +177,14 @@ tape( 'the created function evaluates the pdf for `x` given large `alpha` and `b
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( alpha[i], beta[i] );
-		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		pdf = factory( alpha[ i ], beta[ i ] );
+		y = pdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -206,20 +206,20 @@ tape( 'the created function evaluates the pdf for `x` given a large shape parame
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( alpha[i], beta[i] );
-		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		pdf = factory( alpha[ i ], beta[ i ] );
+		y = pdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the created function evaluates the pdf for `x` given a large rate parameter `beta`', function test( t ) {
+tape( 'the created function evaluates the pdf for `x` given a large scale parameter `beta`', function test( t ) {
 	var expected;
 	var delta;
 	var alpha;
@@ -235,14 +235,14 @@ tape( 'the created function evaluates the pdf for `x` given a large rate paramet
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		pdf = factory( alpha[i], beta[i] );
-		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		pdf = factory( alpha[ i ], beta[ i ] );
+		y = pdf( x[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.native.js
@@ -138,13 +138,13 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', o
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 130.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -165,19 +165,19 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 70.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the function evaluates the pdf for `x` given large rate parameter `beta`', opts, function test( t ) {
+tape( 'the function evaluates the pdf for `x` given large scale parameter `beta`', opts, function test( t ) {
 	var expected;
 	var delta;
 	var alpha;
@@ -192,13 +192,13 @@ tape( 'the function evaluates the pdf for `x` given large rate parameter `beta`'
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 75.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/test/test.pdf.js
@@ -129,13 +129,13 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', f
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -156,19 +156,19 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the function evaluates the pdf for `x` given large rate parameter `beta`', function test( t ) {
+tape( 'the function evaluates the pdf for `x` given large scale parameter `beta`', function test( t ) {
 	var expected;
 	var delta;
 	var alpha;
@@ -183,13 +183,13 @@ tape( 'the function evaluates the pdf for `x` given large rate parameter `beta`'
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
-		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = pdf( x[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+', alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/docs/repl.txt
@@ -47,7 +47,7 @@
     > y = {{alias}}( 0.5, -1.0, 1.0 )
     NaN
 
-    // Non-positive rate parameter:
+    // Non-positive scale parameter:
     > y = {{alias}}( 0.5, 1.0, -1.0 )
     NaN
 

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/docs/types/index.d.ts
@@ -81,7 +81,7 @@ interface Quantile {
 	* // returns NaN
 	*
 	* @example
-	* // Non-positive rate parameter:
+	* // Non-positive scale parameter:
 	* var y = quantile( 0.5, 1.0, -1.0 );
 	* // returns NaN
 	*/

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/test/fixtures/julia/runner.jl
@@ -28,7 +28,7 @@ Generate fixture data and write to file.
 
 * `p`: input value
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples
@@ -70,7 +70,7 @@ file = @__FILE__;
 # Extract the directory in which this file resides:
 dir = dirname( file );
 
-# Large rate parameter:
+# Large scale parameter:
 p = rand( 1000 );
 alpha = rand( 1000 ) .* 10.0;
 beta = ( rand( 1000 ) .* 10.0 ) .+ 10.0;

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/test/test.factory.js
@@ -169,14 +169,14 @@ tape( 'the created function evaluates the quantile for `p` given large `alpha` a
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < p.length; i++ ) {
-		quantile = factory( alpha[i], beta[i] );
-		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		quantile = factory( alpha[ i ], beta[ i ] );
+		y = quantile( p[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 200.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -198,20 +198,20 @@ tape( 'the created function evaluates the quantile for `p` given large shape par
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < p.length; i++ ) {
-		quantile = factory( alpha[i], beta[i] );
-		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		quantile = factory( alpha[ i ], beta[ i ] );
+		y = quantile( p[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the created function evaluates the quantile for `p` given large rate parameter `beta`', function test( t ) {
+tape( 'the created function evaluates the quantile for `p` given large scale parameter `beta`', function test( t ) {
 	var expected;
 	var quantile;
 	var delta;
@@ -227,14 +227,14 @@ tape( 'the created function evaluates the quantile for `p` given large rate para
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < p.length; i++ ) {
-		quantile = factory( alpha[i], beta[i] );
-		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		quantile = factory( alpha[ i ], beta[ i ] );
+		y = quantile( p[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/test/test.quantile.js
@@ -125,13 +125,13 @@ tape( 'the function evaluates the quantile for `x` given large parameters `alpha
 	alpha = bothLarge.alpha;
 	beta = bothLarge.beta;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 200.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -152,19 +152,19 @@ tape( 'the function evaluates the quantile for `x` given large shape parameter `
 	alpha = largeShape.alpha;
 	beta = largeShape.beta;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 100.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the function evaluates the quantile for `x` given large rate parameter `beta`', function test( t ) {
+tape( 'the function evaluates the quantile for `x` given large scale parameter `beta`', function test( t ) {
 	var expected;
 	var delta;
 	var alpha;
@@ -179,13 +179,13 @@ tape( 'the function evaluates the quantile for `x` given large rate parameter `b
 	alpha = largeRate.alpha;
 	beta = largeRate.beta;
 	for ( i = 0; i < p.length; i++ ) {
-		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha:'+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = quantile( p[ i ], alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'p: '+p[ i ]+', alpha:'+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/README.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 <section class="intro">
 
-The [skewness][skewness] for an [inverse gamma][invgamma-distribution] random variable with shape parameter `α` and rate parameter `β` is
+The [skewness][skewness] for an [inverse gamma][invgamma-distribution] random variable with shape parameter `α` and scale parameter `β` is
 
 <!-- <equation class="equation" label="eq:invgamma_skewness" align="center" raw="\operatorname{skew}\left( X \right) = \frac{4\sqrt{\alpha-2}}{\alpha-3}" alt="Skewness for an inverse gamma distribution."> -->
 
@@ -59,7 +59,7 @@ var skewness = require( '@stdlib/stats/base/dists/invgamma/skewness' );
 
 #### skewness( alpha, beta )
 
-Returns the [skewness][skewness] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Returns the [skewness][skewness] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var v = skewness( 4.0, 12.0 );
@@ -166,7 +166,7 @@ logEachMap( 'α: %0.4f, β: %0.4f, skew(X;α,β): %0.4f', alpha, beta, skewness 
 
 #### stdlib_base_dists_invgamma_skewness( alpha, beta )
 
-Evaluates the [skewness][skewness] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Evaluates the [skewness][skewness] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```c
 double out = stdlib_base_dists_invgamma_skewness( 4.0, 12.0 );
@@ -176,7 +176,7 @@ double out = stdlib_base_dists_invgamma_skewness( 4.0, 12.0 );
 The function accepts the following arguments:
 
 -   **alpha**: `[in] double` shape parameter.
--   **beta**: `[in] double` rate parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_invgamma_skewness( const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/docs/types/index.d.ts
@@ -26,7 +26,7 @@
 * -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 *
 * @param alpha - shape parameter
-* @param beta - rate parameter
+* @param beta - scale parameter
 * @returns skewness
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/lib/main.js
@@ -30,7 +30,7 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 * Returns the skewness of an inverse gamma distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} skewness
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/lib/native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} skewness
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/src/main.c
@@ -24,7 +24,7 @@
 * Returns the skewness of an inverse gamma distribution.
 *
 * @param alpha    shape parameter
-* @param beta     rate parameter
+* @param beta     scale parameter
 * @return         skewness
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/fixtures/julia/runner.jl
@@ -27,7 +27,7 @@ Generate fixture data and write to file.
 # Arguments
 
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/test.js
@@ -107,13 +107,13 @@ tape( 'the function returns the skewness of a gamma distribution', function test
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = skewness( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = skewness( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/test/test.native.js
@@ -116,13 +116,13 @@ tape( 'the function returns the skewness of a gamma distribution', opts, functio
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = skewness( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = skewness( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/README.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 <section class="intro">
 
-The [standard deviation][standard-deviation] for an [inverse gamma][invgamma-distribution] random variable with shape parameter `α` and rate parameter `β` is
+The [standard deviation][standard-deviation] for an [inverse gamma][invgamma-distribution] random variable with shape parameter `α` and scale parameter `β` is
 
 <!-- <equation class="equation" label="eq:invgamma_stdev" align="center" raw="\sigma = \frac{\beta}{(\alpha-1)\sqrt{\alpha-2}}" alt="Standard deviation for an inverse gamma distribution."> -->
 
@@ -59,7 +59,7 @@ var stdev = require( '@stdlib/stats/base/dists/invgamma/stdev' );
 
 #### stdev( alpha, beta )
 
-Returns the [standard deviation][standard-deviation] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Returns the [standard deviation][standard-deviation] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var v = stdev( 7.0, 7.0 );
@@ -169,7 +169,7 @@ logEachMap( 'α: %0.4f, β: %0.4f, SD(X;α,β): %0.4f', alpha, beta, stdev );
 
 #### stdlib_base_dists_invgamma_stdev( alpha, beta )
 
-Evaluates the [standard deviation][standard-deviation] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Evaluates the [standard deviation][standard-deviation] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```c
 double out = stdlib_base_dists_invgamma_stdev( 3.0, 5.0 );
@@ -179,7 +179,7 @@ double out = stdlib_base_dists_invgamma_stdev( 3.0, 5.0 );
 The function accepts the following arguments:
 
 -   **alpha**: `[in] double` shape parameter.
--   **beta**: `[in] double` rate parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_invgamma_stdev( const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/docs/types/index.d.ts
@@ -26,7 +26,7 @@
 * -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 *
 * @param alpha - shape parameter
-* @param beta - rate parameter
+* @param beta - scale parameter
 * @returns standard deviation
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/lib/main.js
@@ -30,7 +30,7 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 * Returns the standard deviation of an inverse gamma distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} standard deviation
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/lib/native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} standard deviation
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/src/main.c
@@ -23,7 +23,7 @@
 * Returns the standard deviation of an inverse gamma distribution.
 *
 * @param alpha    shape parameter
-* @param beta     rate parameter
+* @param beta     scale parameter
 * @return         standard deviation
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/test/fixtures/julia/runner.jl
@@ -27,7 +27,7 @@ Generate fixture data and write to file.
 # Arguments
 
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/test/test.js
@@ -113,13 +113,13 @@ tape( 'the function returns the standard deviation of an inverse gamma distribut
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = stdev( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = stdev( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/test/test.native.js
@@ -122,13 +122,13 @@ tape( 'the function returns the standard deviation of an inverse gamma distribut
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = stdev( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = stdev( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/README.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 <section class="intro">
 
-The [variance][variance] for an [inverse gamma][invgamma-distribution] random variable with shape parameter `α` and rate parameter `β` is
+The [variance][variance] for an [inverse gamma][invgamma-distribution] random variable with shape parameter `α` and scale parameter `β` is
 
 <!-- <equation class="equation" label="eq:invgamma_variance" align="center" raw="\operatorname{Var}\left( X \right) = \frac{\beta^{2}}{(\alpha-1)^{2}(\alpha-2)}" alt="Variance for an inverse gamma distribution."> -->
 
@@ -59,7 +59,7 @@ var variance = require( '@stdlib/stats/base/dists/invgamma/variance' );
 
 #### variance( alpha, beta )
 
-Returns the [variance][variance] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (rate parameter).
+Returns the [variance][variance] of a [inverse gamma][invgamma-distribution] distribution with parameters `alpha` (shape parameter) and `beta` (scale parameter).
 
 ```javascript
 var v = variance( 7.0, 7.0 );
@@ -179,7 +179,7 @@ double out = stdlib_base_dists_invgamma_variance( 3.0, 5.0 );
 The function accepts the following arguments:
 
 -   **alpha**: `[in] double` shape parameter.
--   **beta**: `[in] double` rate parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_invgamma_variance( const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/docs/types/index.d.ts
@@ -26,7 +26,7 @@
 * -   If `alpha <= 0` or `beta <= 0`, the function returns `NaN`.
 *
 * @param alpha - shape parameter
-* @param beta - rate parameter
+* @param beta - scale parameter
 * @returns variance
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/lib/main.js
@@ -30,7 +30,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 * Returns the variance of an inverse gamma distribution.
 *
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} variance
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/lib/native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {PositiveNumber} alpha - shape parameter
-* @param {PositiveNumber} beta - rate parameter
+* @param {PositiveNumber} beta - scale parameter
 * @returns {PositiveNumber} variance
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/src/main.c
@@ -23,7 +23,7 @@
 * Returns the variance of an inverse gamma distribution.
 *
 * @param alpha    shape parameter
-* @param beta     rate parameter
+* @param beta     scale parameter
 * @return         variance
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/test/fixtures/julia/runner.jl
@@ -27,7 +27,7 @@ Generate fixture data and write to file.
 # Arguments
 
 * `alpha`: shape parameter
-* `beta`: rate parameter
+* `beta`: scale parameter
 * `name::AbstractString`: output filename
 
 # Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/test/test.js
@@ -113,13 +113,13 @@ tape( 'the function returns the variance of an inverse gamma distribution', func
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = variance( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = variance( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/test/test.native.js
@@ -122,13 +122,13 @@ tape( 'the function returns the variance of an inverse gamma distribution', opts
 	alpha = data.alpha;
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
-		y = variance( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
+		y = variance( alpha[ i ], beta[ i ] );
+		if ( y === expected[ i ] ) {
+			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
## Description

&gt; What is the purpose of this pull request?

Propagating fixes merged to `develop` between 2026-07-26 00:12 PDT (`0239983`) and 2026-07-26 03:02 PDT (`a7865fd`) to sibling packages carrying the same defect.

### Pattern: rate parameter → scale parameter (`invgamma`)

Commit b06219c7a (#13653) corrected a test description in `invgamma/quantile`, relabeling `beta` from "rate parameter" to "scale parameter" — for `X ~ Gamma(α, β)`, `1/X ~ InvGamma(α, β)` with `β` a scale, not rate, consistent with stdlib's moment formulas (e.g., `mean = β/(α−1)`) and the Julia `Distributions.jl` fixture generators (`InverseGamma(alpha, beta)`, θ = scale). This propagates the fix to the 101 remaining "rate parameter" occurrences across 64 files under `stats/base/dists/invgamma/**` — JSDoc/TSDoc and C doxygen `@param` blocks, README prose and C-API bullets, `docs/repl.txt`, test descriptions, example comments, and Julia fixture-runner docstrings — several files had both correct and stale labels side by side. Variable names (`largeRate`) and fixture filenames (`large_rate.json`) are left as-is, matching the source commit.

-   `b06219c` ([`chore: clean-up`](https://github.com/stdlib-js/stdlib/commit/b06219c7a1fa57a41fa94841738a83f2d98f62bd))
    -   `stats/base/dists/invgamma/{cdf,ctor,entropy,kurtosis,logpdf,mean,mode,pdf,quantile,skewness,stdev,variance}`
    -   `stats/base/dists/invgamma/docs/types/index.d.ts` (namespace declarations)

### Pattern: doxygen one-liner expansion (`invgamma` siblings)

PR #13653 (`b06219c7a`) expanded the doxygen one-liner in `quantile`'s header and `src/main.c` from "Evaluates the quantile function for an inverse gamma distribution." to name `alpha`, `beta`, and the evaluation argument explicitly; `logpdf` already carried the expanded form in its header. `pdf` and `cdf` still had the short form in their headers while their own `src/main.c` already had the expanded sentence — this propagates that same expansion into `pdf/include/.../pdf.h` and `cdf/include/.../cdf.h`, copied byte-for-byte from each package's `src/main.c`. Headers and implementation now agree across all four `invgamma` packages.

-   `b06219c` ([`chore: clean-up`](https://github.com/stdlib-js/stdlib/commit/b06219c7a1fa57a41fa94841738a83f2d98f62bd))
    -   `stats/base/dists/invgamma/pdf` (header only)
    -   `stats/base/dists/invgamma/cdf` (header only)

### Pattern: unspaced index brackets and paren spacing in dists test suites

Follows up on b06219c7a (#13653) by completing the bracket/paren spacing sweep across the remaining `stats/base/dists/anglit` and `stats/base/dists/invgamma` test files: 304 lines across 46 files normalize `x[i]` → `x[ i ]` style index accesses (`expected`, `alpha`, `beta`, `sigma`, `mu`, `p`, `values`), plus one unspaced outer-paren `t.strictEqual` call in `anglit/cdf/test/test.factory.js`. Purely mechanical spacing changes to match stdlib style; no logic, variable names, or test messages touched.

-   `b06219c` ([`chore: clean-up`](https://github.com/stdlib-js/stdlib/commit/b06219c7a1fa57a41fa94841738a83f2d98f62bd))
    -   `stats/base/dists/anglit/{cdf,entropy,mean,median,mode,quantile,skewness,stdev,variance}` test files
    -   `stats/base/dists/invgamma/{cdf,ctor,entropy,kurtosis,logpdf,mean,mode,pdf,quantile,skewness,stdev,variance}` test files

### Pattern: `@param` whitespace propagation from #13654

01a20c0a2 (#13654) removed doubled spaces around the `-` separator in `@param` tags but only covered `random/iter/*` and `stats/base/dists/binomial/quantile`. A repo-wide sweep for the same defect turned up one more site: `blas/base/gscal/lib/main.js`, where `stride -  stride length` collapses to a single space. The other four hits are out of scope — `random/strided/docs/types/index.d.ts` is generated, `random/strided/weibull/docs/types/index.d.ts` and `ml/incr/sgd-regression/lib/validate.js` are superseded by open PRs #12571 and #13641, and the `_tools` transformer hit is a doubled-hyphen defect requiring a different fix.

-   `01a20c0` ([`style: remove extraneous whitespace`](https://github.com/stdlib-js/stdlib/commit/01a20c0a25103830414ec613971c0088fc65a2b6))
    -   `blas/base/gscal`

## Related Issues

&gt; Does this pull request have any related issues?

No.

## Questions

&gt; Any questions for reviewers of this pull request?

No.

## Other

&gt; Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   **Search scope.** Per source pattern: `rg 'rate parameter'` over `stats/base/dists/invgamma/**` (101 hits, 64 files; zero hits under `random/**` invgamma packages, which already say "scale"); `rg` for short-form doxygen descriptions over invgamma headers and sources; `rg '\[[a-z0-9]+\]'` over `stats/base/dists/{anglit,invgamma}/**/test/*.js` (304 hits, 46 files; `anglit/pdf` and `invgamma/quantile/test/test.native.js` correctly absent — already fixed by the source commit); repo-wide sweep for doubled-space `@param` separators (5 hits, 4 excluded).
-   **Two independent Opus validation agents** each read every candidate file in full and confirmed the defect at all sites, including independently deriving that invgamma's `beta` is a scale parameter (pdf form, scale-linear moment formulas, `Distributions.jl` parameterization) and verifying the namespace `docs/types/index.d.ts` is hand-maintained, not generated. An adaptation pass produced byte-exact patches (confirming C doxygen `@param` column alignment is preserved and no markdown link labels or `` `[in]` `` code spans are touched), and a style-consistency pass verified the post-fix text against already-correct siblings (`rayleigh`, `f` dist test descriptions; `random/base/invgamma` docs).
-   Zero sites were rejected or rated needs-human; every changed line was audited against the expected transformation shapes after application (407 changed lines = 101 + 304 + 2 headers, with the paren fix landing on an already-counted line).

Deliberately excluded:

-   Sites in open-PR collision or generated files (see the `@param` pattern above).
-   `test:` ULP-migration commits (`d98aba7`, `4588717`) — tracked campaign work (#11352), not propagatable defect fixes.
-   `docs: update related packages sections` (`0239983`) — auto-generated churn.
-   Two zero-site patterns from `b06219c`: "modified huber" → "modified Huber" capitalization (only intentional lowercase npm keywords remain) and README NaN per-argument example coverage (all `ml/base/loss` siblings already correct).
-   `largeRate` variables and `large_rate.json` fixture filenames (renaming would cascade into fixture regeneration; matches source-commit precedent).
-   Adjacent pre-existing defects observed but out of pattern scope: garbled clause in `invgamma/entropy/README.md`, doubled space in `invgamma/pdf/README.md` link prose, missing C++ name-mangling comment in `cdf.h`, and the `_tools` doubled-hyphen `@param` defect — logged for a future maintenance pass.

## Checklist

&gt; Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

&gt; When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code on behalf of @Planeshifter as an automated propagation of fixes merged to `develop` over the prior 24 hours. Candidate source commits were filtered for generalizable patterns, sibling sites located via grep-able pattern signatures, and each proposed patch independently validated by parallel reviewer agents (two Opus validation passes, an adaptation pass, and a style-consistency pass) before commits were applied. A maintainer should audit and promote out of draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKqVq4XbqpT9ySwq1tTLBP)_