### PR TITLE
test: migrate `math/base/special/acscdf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acscdf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acscdf/test/test.js
@@ -23,9 +23,9 @@
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var acscdf = require( './../lib' );
 
 
@@ -45,8 +45,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the arccosecant in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -54,25 +52,16 @@ tape( 'the function computes the arccosecant in degrees (negative values)', func
 
 	x = negative.x;
 	expected = negative.expected;
-
 	for ( i = 0; i < x.length; i++ ) {
 		y = acscdf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.8 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosecant in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -80,17 +69,10 @@ tape( 'the function computes the arccosecant in degrees (positive values)', func
 
 	x = positive.x;
 	expected = positive.expected;
-
 	for ( i = 0; i < x.length; i++ ) {
 		y = acscdf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.8 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acscdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acscdf/test/test.native.js
@@ -24,9 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -54,8 +54,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the arccosecant in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -63,25 +61,16 @@ tape( 'the function computes the arccosecant in degrees (negative values)', opts
 
 	x = negative.x;
 	expected = negative.expected;
-
 	for ( i = 0; i < x.length; i++ ) {
 		y = acscdf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.8 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosecant in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -89,17 +78,10 @@ tape( 'the function computes the arccosecant in degrees (positive values)', opts
 
 	x = positive.x;
 	expected = positive.expected;
-
 	for ( i = 0; i < x.length; i++ ) {
 		y = acscdf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.8 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `math/base/special/acscdf` from relative-tolerance (EPS-scaled delta/tol) assertions to ULP-difference assertions via `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, following the precedent of `asecdf`, as `acscdf` is a single-precision function).
-   uses the minimum required ULP value (`2`) for both the negative and positive fixture test blocks. This was determined empirically: `ULP = 1` fails (142 of 6009 assertions), `ULP = 2` passes all 6009 assertions, confirmed deterministic across multiple consecutive runs. A direct computation of the ULP distance between actual and expected values over both fixture sets confirms a max distance of 2 ULPs in each case.
-   removes the now-unused `abs` require and `delta`/`tol` variables, and collapses the obsolete exact-equality short-circuit branches. The `EPS` require is retained, as it is still used by the `uniform()` domain-guard `NaN` tests.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The native add-on could not be built in this sandboxed environment (no `node-gyp`/toolchain available), so `test/test.native.js` could not be executed directly; however, it mirrors the same ULP value (`2`) as the JS test, consistent with prior conversions in this series (e.g. `cscd`, #13664) that noted the same limitation.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code (test migration and minimum-ULP determination via direct computation of ULP distance over the fixture sets).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_011wHetuWY6Bq92EPp5syZM1)_