### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/gmean/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/gmean/package.json
@@ -23,7 +23,7 @@
   },
   "types": "./docs/types",
   "scripts": {},
-  "homepage": "https://github.com/stdlib-js/stdlib.git",
+  "homepage": "https://github.com/stdlib-js/stdlib",
   "repository": {
     "type": "git",
     "url": "git://github.com/stdlib-js/stdlib.git"

--- a/lib/node_modules/@stdlib/stats/incr/grubbs/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/grubbs/package.json
@@ -23,7 +23,7 @@
   },
   "types": "./docs/types",
   "scripts": {},
-  "homepage": "https://github.com/stdlib-js/stdlib.git",
+  "homepage": "https://github.com/stdlib-js/stdlib",
   "repository": {
     "type": "git",
     "url": "git://github.com/stdlib-js/stdlib.git"

--- a/lib/node_modules/@stdlib/stats/incr/mgrubbs/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/mgrubbs/package.json
@@ -23,7 +23,7 @@
   },
   "types": "./docs/types",
   "scripts": {},
-  "homepage": "https://github.com/stdlib-js/stdlib.git",
+  "homepage": "https://github.com/stdlib-js/stdlib",
   "repository": {
     "type": "git",
     "url": "git://github.com/stdlib-js/stdlib.git"

--- a/lib/node_modules/@stdlib/stats/incr/nanmsum/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmsum/lib/main.js
@@ -30,6 +30,7 @@ var incrmsum = require( '@stdlib/stats/incr/msum' );
 * Returns an accumulator function which incrementally computes a moving sum, ignoring `NaN` values.
 *
 * @param {PositiveInteger} W - window size
+* @throws {TypeError} must provide a positive integer
 * @returns {Function} accumulator function
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/incr/nanprod/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanprod/package.json
@@ -23,7 +23,7 @@
   },
   "types": "./docs/types",
   "scripts": {},
-  "homepage": "https://github.com/stdlib-js/stdlib.git",
+  "homepage": "https://github.com/stdlib-js/stdlib",
   "repository": {
     "type": "git",
     "url": "git://github.com/stdlib-js/stdlib.git"

--- a/lib/node_modules/@stdlib/stats/incr/prod/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/prod/package.json
@@ -23,7 +23,7 @@
   },
   "types": "./docs/types",
   "scripts": {},
-  "homepage": "https://github.com/stdlib-js/stdlib.git",
+  "homepage": "https://github.com/stdlib-js/stdlib",
   "repository": {
     "type": "git",
     "url": "git://github.com/stdlib-js/stdlib.git"


### PR DESCRIPTION
## Description

This pull request normalizes two cross-package inconsistencies in `@stdlib/stats/incr`, surfaced by a majority-vote drift scan across all 159 namespace members:

-   **`homepage` URL (5 packages).** `gmean`, `grubbs`, `mgrubbs`, `nanprod`, and `prod` carried a stray `.git` suffix on `homepage` (`https://github.com/stdlib-js/stdlib.git`), pointing at the clone URL rather than the repository homepage. These are the only five deviations among all 5932 `@stdlib` packages (99.9% conformance; 154/159 within `stats/incr`). Normalized to the suffix-less form; `repository.url` is intentionally left unchanged.
-   **Missing `@throws` JSDoc tag (1 package).** `nanmsum` delegates window-size validation to `incrmsum( W )`, which throws a `TypeError` on an invalid `W`, but did not document the condition. Added `@throws {TypeError} must provide a positive integer`, matching the wording carried by all 17 single-window `nan*` moving siblings. `nanmsum` was the sole omission.

All changes are metadata- or documentation-only; no runtime behavior, signatures, or test expectations change.

**Namespace summary**

-   Target: `@stdlib/stats/incr` — 159 non-autogenerated members (0 autogenerated).
-   Features analyzed: file tree, `package.json` shape (top-level/`directories`/`scripts` keys plus `homepage`/`repository`/`bugs` values), `keywords`, README section list and order, `manifest.json` shape, test/benchmark/example filenames, public signature, return kind, validation prologue, error construction, JSDoc shape (`@param`/`@throws`/`@returns`/`@example`), and `require` dependencies.
-   Features with a clear majority (≥75%): 10 canonical package files at 100%, 18 `package.json` top-level keys at 100%, 5 `directories` keys at 100%, `homepage` value at 99.9% (ecosystem-wide), `## Usage`/`## Examples` at 100% and `## Notes` at 97%, `format`-based error construction at 100% (of 62 throwers), single-window `W` validation via `isPositiveInteger` at 100%, JSDoc `@returns`/`@example` at 100%.
-   Features without a clear majority (excluded): `package.json#scripts` keys (empty in all), top-level `stdlib` key (minority), `lib/validate.js`/`lib/defaults.js` (2 packages each), `## References` (9), and `## See Also` (generator-owned).

## Related Issues

None.

## Questions

No.

## Other

**Per-outlier notes**

### `gmean`, `grubbs`, `mgrubbs`, `nanprod`, `prod`

Stray `.git` on `homepage` resolved. These five were the entire population of `.git`-suffixed `homepage` values across the 5932-package monorepo; every sibling and the rest of `@stdlib` use the suffix-less form. Purely a metadata correction — the clone URL in `repository.url` correctly retains its `.git` suffix and is untouched.

### `nanmsum`

`@throws {TypeError} must provide a positive integer` added to the `incrnanmsum` JSDoc. The tag documents observable behavior: the accumulator forwards `W` to `incrmsum( W )`, which validates and throws. Its direct twin `nanmsumabs` and 16 other single-window `nan*` moving accumulators already carry the identical tag; this brings the last outlier into line without touching code.

**Validation**

-   Structural features were extracted from the filesystem across all 159 members; semantic features (signature, validation prologue, error construction, JSDoc, dependencies) were extracted per package from `lib/main.js`.
-   Surviving candidates were filtered through adversarial drift-validation before applying: structural review confirmed the `homepage` value is the ecosystem-canonical form (5/5932 deviations) and cross-referenced that no test, example, type declaration, or generator reads the field; semantic review confirmed the `nanmsum` `@throws` documents genuine delegated behavior and that all 17 siblings carry it.
-   Deliberately excluded: the 38 packages lacking `docs/img/*.svg` (min/max/range/count/summary types with no closed-form equation — intentional); `## Notes` additions to `covmat`/`pcorrmat` (open PR #12693) and `count`/`nancount` (the NaN-propagation boilerplate does not apply to counters — intentional); the `nanmsum` `@example` `require` line (out of scope for this run); and every feature without a ≥75% majority.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

Drafted by Claude Code as part of a cross-package drift detection routine: structural and semantic features were extracted from all 159 packages in `@stdlib/stats/incr`, the majority pattern was identified per feature, outliers were flagged, and each surviving correction was confirmed by independent adversarial validation before being applied verbatim from the namespace-canonical form. Opened as a draft for a maintainer to promote.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_012ho2JqeDRkZMvs9SwcwiW3)_