### PR TITLE
test: migrate `math/base/special/logaddexp` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/logaddexp/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/logaddexp/test/test.js
@@ -22,10 +22,8 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var logaddexp = require( './../lib' );
 
@@ -103,8 +101,6 @@ tape( 'the function returns `-infinity` if both arguments are `-infinity`', func
 
 tape( 'the function accurately computes the natural logarithm of exp(x) + exp(y)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var v;
@@ -115,13 +111,7 @@ tape( 'the function accurately computes the natural logarithm of exp(x) + exp(y)
 	expected = data.expected;
 	for ( i = 0; i < expected.length; i++ ) {
 		v = logaddexp( x[ i ], y[ i ] );
-		if ( v === expected[ i ] ) {
-			t.strictEqual( v, expected[ i ], 'returns expected value when provided '+x[ i ]+' and '+y[ i ] );
-		} else {
-			delta = abs( expected[ i ] - v );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. actual: '+v+'. expected: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/logaddexp/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/logaddexp/test/test.native.js
@@ -27,8 +27,6 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var randu = require( '@stdlib/random/base/randu' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 
 
 // FIXTURES //
@@ -112,8 +110,6 @@ tape( 'the function returns `-infinity` if both arguments are `-infinity`', opts
 
 tape( 'the function accurately computes the natural logarithm of exp(x) + exp(y)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var v;
@@ -124,13 +120,7 @@ tape( 'the function accurately computes the natural logarithm of exp(x) + exp(y)
 	expected = data.expected;
 	for ( i = 0; i < expected.length; i++ ) {
 		v = logaddexp( x[ i ], y[ i ] );
-		if ( v === expected[ i ] ) {
-			t.strictEqual( v, expected[ i ], 'returns expected value when provided '+x[ i ]+' and '+y[ i ] );
-		} else {
-			delta = abs( expected[ i ] - v );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y[ i ]+'. actual: '+v+'. expected: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( v, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` in `@stdlib/math/base/special/logaddexp` from relative-tolerance (EPS-based) assertions to exact-equality assertions, per the ULP-based testing migration tracked in #11352
-   computes the ULP difference between actual and expected fixture values for the full 1000-case fixture set (`test/fixtures/python/data.json`); the measured maximum ULP difference is **0** for every case (all 1000 assertions match the expected value exactly), so — mirroring the precedent set in `math/base/special/sqrt` (#12764) — plain `t.strictEqual( v, expected[ i ], 'returns expected value' )` is used instead of `isAlmostSameValue`, and no `@stdlib/assert/is-almost-same-value` require is added
-   removes the now-unused `EPS` and `abs` requires and the `delta`/`tol` variable declarations
-   collapses the obsolete exact-equality `if`/`else` short-circuit branch into a single exact assertion

The full JavaScript test suite (1407 assertions) was run twice to confirm deterministic pass. `test/test.native.js` was updated identically to keep the two suites in lockstep; native (compiled addon) assertions were not exercised in this environment since no native build tooling was available, consistent with how the existing test infrastructure already handles this (`opts.skip` when the addon is absent).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written by Claude Code, running as a scheduled/unattended task. It searched the repository for the relative-tolerance test idiom, selected `math/base/special/logaddexp` (checked for collisions against existing open/merged ULP-migration PRs first), studied prior-art commits (including the `sqrt` precedent for the 0-ULP case), computed the ULP differences against the fixtures, applied the migration, and ran the JavaScript test suite twice to confirm determinism before opening this draft PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017P6F9H3z4WJLVsyWxjvScH)_