### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/zcartesian-product/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/zcartesian-product/src/main.c
@@ -80,7 +80,7 @@ void API_SUFFIX(stdlib_strided_zcartesian_product)( const CBLAS_LAYOUT order, co
 * @param offsetOut   starting index for Out
 */
 void API_SUFFIX(stdlib_strided_zcartesian_product_ndarray)( const CBLAS_INT M, const CBLAS_INT N, const stdlib_complex128_t *X, const CBLAS_INT strideX, const CBLAS_INT offsetX, const stdlib_complex128_t *Y, const CBLAS_INT strideY, const CBLAS_INT offsetY, stdlib_complex128_t *Out, const CBLAS_INT strideOut1, const CBLAS_INT strideOut2, const CBLAS_INT offsetOut ) {
-	CBLAS_INT sa[ 2 ];
+	int64_t sa[ 2 ];
 	CBLAS_INT iy;
 	CBLAS_INT ix;
 	CBLAS_INT io;

--- a/lib/node_modules/@stdlib/blas/ext/base/zcartesian-product/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/zcartesian-product/src/main.c
@@ -23,6 +23,7 @@
 #include "stdlib/blas/base/shared.h"
 #include "stdlib/strided/base/stride2offset.h"
 #include "stdlib/complex/float64/ctor.h"
+#include <stdint.h>
 
 /**
 * Computes the Cartesian product for two double-precision complex floating-point strided arrays.

--- a/lib/node_modules/@stdlib/math/base/special/exp2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/exp2/test/test.native.js
@@ -66,7 +66,7 @@ tape( 'the function accurately computes `2**x` for negative medium numbers', opt
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = exp2( x[ i ] );
-		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'return expected value' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -82,7 +82,7 @@ tape( 'the function accurately computes `2**x` for positive medium numbers', opt
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = exp2( x[ i ] );
-		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'return expected value' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -98,7 +98,7 @@ tape( 'the function accurately computes `2**x` for negative small numbers', opts
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = exp2( x[ i ] );
-		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'return expected value' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -114,7 +114,7 @@ tape( 'the function accurately computes `2**x` for positive small numbers', opts
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = exp2( x[ i ] );
-		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'return expected value' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -130,7 +130,7 @@ tape( 'the function accurately computes `2**x` for very small `x`', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = exp2( x[ i ] );
-		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'return expected value' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/number/uint64/parse/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/parse/README.md
@@ -65,7 +65,7 @@ a = parseUint64( '123abcxyz', 36 );
 
 ## Notes
 
--   The input string must be a valid representation of an 64-bit unsigned integer.
+-   The input string must be a valid representation of a 64-bit unsigned integer.
 -   If the provided string is malformed (e.g., contains invalid characters or is incomplete), the function throws a `SyntaxError`.
 -   If the provided string represents a value greater than `2^64-1` or the radix is not an integer on the interval `[2, 36]`, the function throws a `RangeError`.
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-07-26 14:39 PDT (`f027a8a`) and 2026-07-27 01:40 PDT (`02d9b41`).

This pull request:

-   **`blas/ext/base/zcartesian-product`**: Fix `stdlib_strided_zcartesian_product_ndarray`'s stride buffer type: `sa` was declared `CBLAS_INT sa[ 2 ]` (int32 on non-ILP64 builds) but passed to `stdlib_ndarray_is_row_major`, which expects `int64_t *strides`. The callee was reading garbage past the array and could pick the wrong row-/column-major branch, silently corrupting output placement. Changed to `int64_t sa[ 2 ]`, matching `zcartesian-square`. Introduced in c19010a; see `lib/node_modules/@stdlib/blas/ext/base/zcartesian-product/src/main.c`.
-   **`math/base/special/exp2`**: Fix `test.native.js` (aa63474 — introduces ULP diff testing): five assertion messages read `'return expected value'` instead of `'returns expected value'`, inconsistent with `test.js` from the same commit and the rest of the file. Corrected all five to `'returns expected value'` in `lib/node_modules/@stdlib/math/base/special/exp2/test/test.native.js`.
-   **`number/uint64/parse`**: Fixes an article typo introduced in 0404059: "an 64-bit unsigned integer" → "a 64-bit unsigned integer" in `lib/node_modules/@stdlib/number/uint64/parse/README.md`, aligning the Notes section with the phrasing already used elsewhere in the same README and in sibling packages.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** The 24 commits in the window were reviewed by four independent passes: two style-compliance audits comparing new packages against established sibling packages and the guidelines in `docs/style-guides`, and two bug scans over the full diff (including the new `wxsa` ndarray wrapper family, `gwxmy`, `zcartesian-product` C sources, `number/uint64/parse` parsing logic, and the `ml/base/sgd-classification` penalty packages). Only findings that were independently re-verified against the repository were retained. Deliberately excluded: subjective suggestions, style preferences not required by the style guides, and anything requiring changes outside the reviewed diff to validate (e.g., a possibly-unused `EPS` require in `math/base/special/acscdf` tests and a pre-existing "Rate parameter." wording in regenerated REPL help data).

This PR is a **draft** for maintainer audit; it intentionally does not close any issues.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a scheduled automated review of commits merged to `develop` in the last 24 hours. Claude Code identified the issues, verified them against the repository, and generated the fixes; a maintainer will audit before promoting from draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01YCqgEQhbWHpzMMboqCFg6i)_