### PR TITLE
docs: fix descriptions

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-svg-equations/lib/transformer.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-svg-equations/lib/transformer.js
@@ -41,7 +41,7 @@ var RAW = /raw="([^"]*)"/;
 * Transforms a Markdown abstract syntax tree (AST) by finding equation markup and inserting rendered SVGs.
 *
 * @private
-* @param {Node} tree -  - abstract syntax tree (AST)
+* @param {Node} tree - abstract syntax tree (AST)
 * @param {File} file - file
 * @param {Callback} clbk - callback to invoke upon completion
 * @returns {void}

--- a/lib/node_modules/@stdlib/ml/incr/sgd-regression/lib/validate.js
+++ b/lib/node_modules/@stdlib/ml/incr/sgd-regression/lib/validate.js
@@ -41,7 +41,7 @@ var format = require( '@stdlib/string/format' );
 * @param {PositiveNumber} [options.eta0] - constant learning rate
 * @param {PositiveNumber} [options.lambda] - regularization parameter
 * @param {string} [options.learningRate] - the learning rate to use
-* @param {string} [options.loss] -  the loss function to use
+* @param {string} [options.loss] - the loss function to use
 * @param {boolean} [options.intercept] - specifies whether an intercept should be included
 * @returns {(Error|null)} null or an error object
 *

--- a/lib/node_modules/@stdlib/random/array/weibull/docs/repl.txt
+++ b/lib/node_modules/@stdlib/random/array/weibull/docs/repl.txt
@@ -9,10 +9,10 @@
         Output array length.
 
     k: number
-        Scale parameter.
+        Shape parameter.
 
     lambda: number
-        Shape parameter.
+        Scale parameter.
 
     options: Object (optional)
         Options.
@@ -37,10 +37,10 @@
     Parameters
     ----------
     k: number
-        Scale parameter.
+        Shape parameter.
 
     lambda: number
-        Shape parameter.
+        Scale parameter.
 
     out: Array<number>|Float64Array|Float32Array
         Output array.
@@ -77,10 +77,10 @@
     Parameters
     ----------
     k: number (optional)
-        Scale parameter.
+        Shape parameter.
 
     lambda: number (optional)
-        Shape parameter.
+        Scale parameter.
 
     options: Object (optional)
         Options.

--- a/lib/node_modules/@stdlib/random/base/weibull/lib/factory.js
+++ b/lib/node_modules/@stdlib/random/base/weibull/lib/factory.js
@@ -245,8 +245,8 @@ function factory() {
 	* Returns a pseudorandom number drawn from a Weibull distribution.
 	*
 	* @private
-	* @param {PositiveNumber} k - scale parameter
-	* @param {PositiveNumber} lambda - shape parameter
+	* @param {PositiveNumber} k - shape parameter
+	* @param {PositiveNumber} lambda - scale parameter
 	* @returns {NonNegativeNumber} pseudorandom number
 	*
 	* @example

--- a/lib/node_modules/@stdlib/random/iter/weibull/README.md
+++ b/lib/node_modules/@stdlib/random/iter/weibull/README.md
@@ -32,7 +32,7 @@ var iterator = require( '@stdlib/random/iter/weibull' );
 
 #### iterator( k, lambda\[, options] )
 
-Returns an iterator for generating pseudorandom numbers drawn from a [Weibull][weibull] distribution with parameters `k` (scale parameter) and `lambda` (shape parameter).
+Returns an iterator for generating pseudorandom numbers drawn from a [Weibull][weibull] distribution with parameters `k` (shape parameter) and `lambda` (scale parameter).
 
 ```javascript
 var it = iterator( 2.0, 5.0 );

--- a/lib/node_modules/@stdlib/random/iter/weibull/docs/repl.txt
+++ b/lib/node_modules/@stdlib/random/iter/weibull/docs/repl.txt
@@ -11,10 +11,10 @@
     Parameters
     ----------
     k: number
-        Scale parameter.
+        Shape parameter.
 
     λ: number
-        Shape parameter.
+        Scale parameter.
 
     options: Object (optional)
         Options.

--- a/lib/node_modules/@stdlib/random/iter/weibull/lib/main.js
+++ b/lib/node_modules/@stdlib/random/iter/weibull/lib/main.js
@@ -41,8 +41,8 @@ var format = require( '@stdlib/string/format' );
 /**
 * Returns an iterator for generating pseudorandom numbers drawn from a Weibull distribution.
 *
-* @param {PositiveNumber} k - scale parameter
-* @param {PositiveNumber} lambda - shape parameter
+* @param {PositiveNumber} k - shape parameter
+* @param {PositiveNumber} lambda - scale parameter
 * @param {Options} [options] - function options
 * @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
 * @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed

--- a/lib/node_modules/@stdlib/random/iter/weibull/test/test.js
+++ b/lib/node_modules/@stdlib/random/iter/weibull/test/test.js
@@ -40,7 +40,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function throws an error if scale parameter `k` is not a positive number', function test( t ) {
+tape( 'the function throws an error if shape parameter `k` is not a positive number', function test( t ) {
 	var values;
 	var i;
 
@@ -70,7 +70,7 @@ tape( 'the function throws an error if scale parameter `k` is not a positive num
 	}
 });
 
-tape( 'the function throws an error if shape parameter `lambda` is not a positive number', function test( t ) {
+tape( 'the function throws an error if scale parameter `lambda` is not a positive number', function test( t ) {
 	var values;
 	var i;
 

--- a/lib/node_modules/@stdlib/random/streams/weibull/README.md
+++ b/lib/node_modules/@stdlib/random/streams/weibull/README.md
@@ -34,7 +34,7 @@ var randomStream = require( '@stdlib/random/streams/weibull' );
 
 #### randomStream( k, lambda\[, options] )
 
-Returns a [readable stream][readable-stream] for generating pseudorandom numbers drawn from a [Weibull][weibull] distribution with parameters `k` (scale) and `lambda` (shape).
+Returns a [readable stream][readable-stream] for generating pseudorandom numbers drawn from a [Weibull][weibull] distribution with parameters `k` (shape) and `lambda` (scale).
 
 ```javascript
 var inspectStream = require( '@stdlib/streams/node/inspect-sink' );

--- a/lib/node_modules/@stdlib/random/streams/weibull/docs/repl.txt
+++ b/lib/node_modules/@stdlib/random/streams/weibull/docs/repl.txt
@@ -11,10 +11,10 @@
     Parameters
     ----------
     k: number
-        Scale parameter.
+        Shape parameter.
 
     λ: number
-        Shape parameter.
+        Scale parameter.
 
     options: Object (optional)
         Options.
@@ -110,10 +110,10 @@
     Parameters
     ----------
     k: number (optional)
-        Scale parameter.
+        Shape parameter.
 
     λ: number (optional)
-        Shape parameter.
+        Scale parameter.
 
     options: Object (optional)
         Options.
@@ -181,10 +181,10 @@
     Parameters
     ----------
     k: number
-        Scale parameter.
+        Shape parameter.
 
     λ: number
-        Shape parameter.
+        Scale parameter.
 
     options: Object (optional)
         Options.

--- a/lib/node_modules/@stdlib/random/streams/weibull/lib/factory.js
+++ b/lib/node_modules/@stdlib/random/streams/weibull/lib/factory.js
@@ -31,8 +31,8 @@ var RandomStream = require( './main.js' );
 /**
 * Returns a function for creating readable streams which generate pseudorandom numbers drawn from a Weibull distribution.
 *
-* @param {PositiveNumber} [k] - scale parameter
-* @param {PositiveNumber} [lambda] - shape parameter
+* @param {PositiveNumber} [k] - shape parameter
+* @param {PositiveNumber} [lambda] - scale parameter
 * @param {Options} [options] - stream options
 * @param {boolean} [options.objectMode=false] - specifies whether a stream should operate in object mode
 * @param {(string|null)} [options.encoding=null] - specifies how `Buffer` objects should be decoded to `strings`
@@ -94,8 +94,8 @@ function factory( k, lambda, options ) {
 	* Returns a readable stream for generating pseudorandom numbers drawn from a Weibull distribution.
 	*
 	* @private
-	* @param {PositiveNumber} k - scale parameter
-	* @param {PositiveNumber} lambda - shape parameter
+	* @param {PositiveNumber} k - shape parameter
+	* @param {PositiveNumber} lambda - scale parameter
 	* @throws {TypeError} `k` must be a positive number
 	* @throws {TypeError} `lambda` must be a positive number
 	* @throws {TypeError} options argument must be an object

--- a/lib/node_modules/@stdlib/random/streams/weibull/test/test.factory.js
+++ b/lib/node_modules/@stdlib/random/streams/weibull/test/test.factory.js
@@ -59,7 +59,7 @@ tape( 'the function returns a factory function (parameters + options)', function
 	t.end();
 });
 
-tape( 'the function returns a function which throws an error if scale parameter `k` is not a positive number primitive', function test( t ) {
+tape( 'the function returns a function which throws an error if shape parameter `k` is not a positive number primitive', function test( t ) {
 	var values;
 	var i;
 
@@ -90,7 +90,7 @@ tape( 'the function returns a function which throws an error if scale parameter 
 	}
 });
 
-tape( 'the function returns a function which throws an error if scale parameter `k` is not a positive number primitive (parameters)', function test( t ) {
+tape( 'the function returns a function which throws an error if shape parameter `k` is not a positive number primitive (parameters)', function test( t ) {
 	var values;
 	var i;
 
@@ -119,7 +119,7 @@ tape( 'the function returns a function which throws an error if scale parameter 
 	}
 });
 
-tape( 'the function returns a function which throws an error if shape parameter `lambda` is not a positive number primitive', function test( t ) {
+tape( 'the function returns a function which throws an error if scale parameter `lambda` is not a positive number primitive', function test( t ) {
 	var values;
 	var i;
 
@@ -150,7 +150,7 @@ tape( 'the function returns a function which throws an error if shape parameter 
 	}
 });
 
-tape( 'the function returns a function which throws an error if shape parameter `lambda` is not a positive number primitive (parameters)', function test( t ) {
+tape( 'the function returns a function which throws an error if scale parameter `lambda` is not a positive number primitive (parameters)', function test( t ) {
 	var values;
 	var i;
 

--- a/lib/node_modules/@stdlib/random/streams/weibull/test/test.main.js
+++ b/lib/node_modules/@stdlib/random/streams/weibull/test/test.main.js
@@ -42,7 +42,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function throws an error if scale parameter `k` is not a positive number primitive', function test( t ) {
+tape( 'the function throws an error if shape parameter `k` is not a positive number primitive', function test( t ) {
 	var values;
 	var i;
 
@@ -72,7 +72,7 @@ tape( 'the function throws an error if scale parameter `k` is not a positive num
 	}
 });
 
-tape( 'the function throws an error if shape parameter `lambda` is not a positive number primitive', function test( t ) {
+tape( 'the function throws an error if scale parameter `lambda` is not a positive number primitive', function test( t ) {
 	var values;
 	var i;
 

--- a/lib/node_modules/@stdlib/random/streams/weibull/test/test.object_mode.js
+++ b/lib/node_modules/@stdlib/random/streams/weibull/test/test.object_mode.js
@@ -36,7 +36,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function throws an error if scale parameter `k` is not a positive number primitive', function test( t ) {
+tape( 'the function throws an error if shape parameter `k` is not a positive number primitive', function test( t ) {
 	var values;
 	var i;
 
@@ -66,7 +66,7 @@ tape( 'the function throws an error if scale parameter `k` is not a positive num
 	}
 });
 
-tape( 'the function throws an error if shape parameter `lambda` is not a positive number primitive', function test( t ) {
+tape( 'the function throws an error if scale parameter `lambda` is not a positive number primitive', function test( t ) {
 	var values;
 	var i;
 

--- a/lib/node_modules/@stdlib/random/strided/weibull/README.md
+++ b/lib/node_modules/@stdlib/random/strided/weibull/README.md
@@ -47,9 +47,9 @@ weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
 The function has the following parameters:
 
 -   **N**: number of indexed elements.
--   **k**: scale parameter.
+-   **k**: shape parameter.
 -   **sk**: index increment for `k`.
--   **lambda**: shape parameter.
+-   **lambda**: scale parameter.
 -   **sl**: index increment for `lambda`.
 -   **out**: output array.
 -   **so**: index increment for `out`.

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
@@ -18,13 +18,13 @@
         Number of indexed elements.
 
     k: ArrayLikeObject
-        Scale parameter.
+        Shape parameter.
 
     sk: integer
         Index increment for `k`.
 
     lambda: ArrayLikeObject
-        Shape parameter.
+        Scale parameter.
 
     sl: integer
         Index increment for `lambda`.
@@ -97,7 +97,7 @@
         Number of indexed elements.
 
     k: ArrayLikeObject
-        Scale parameter.
+        Shape parameter.
 
     sk: integer
         Index increment for `k`.
@@ -106,7 +106,7 @@
         Starting index for `k`.
 
     lambda: ArrayLikeObject
-        Shape parameter.
+        Scale parameter.
 
     sl: integer
         Index increment for `lambda`.

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/main.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/main.js
@@ -31,9 +31,9 @@ var prng = require( './prng.js' );
 * Fills a strided array with pseudorandom numbers drawn from a Weibull distribution.
 *
 * @param {NonNegativeInteger} N - number of indexed elements
-* @param {Collection} k - scale parameter
+* @param {Collection} k - shape parameter
 * @param {integer} sk - `k` stride length
-* @param {Collection} lambda - shape parameter
+* @param {Collection} lambda - scale parameter
 * @param {integer} sl - `lambda` stride length
 * @param {Collection} out - output array
 * @param {integer} so - `out` stride length

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/ndarray.js
@@ -31,10 +31,10 @@ var prng = require( './prng.js' );
 * Fills a strided array with pseudorandom numbers drawn from a Weibull distribution.
 *
 * @param {NonNegativeInteger} N - number of indexed elements
-* @param {Collection} k - scale parameter
+* @param {Collection} k - shape parameter
 * @param {integer} sk - `k` stride length
 * @param {NonNegativeInteger} ok - starting `k` index
-* @param {Collection} lambda - shape parameter
+* @param {Collection} lambda - scale parameter
 * @param {integer} sl - `lambda` stride length
 * @param {NonNegativeInteger} ol - starting `lambda` index
 * @param {Collection} out - output array

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/README.md
@@ -86,7 +86,7 @@ alpha = invgamma.alpha;
 
 #### invgamma.beta
 
-Rate parameter of the distribution. `beta` **must** be a positive number.
+Scale parameter of the distribution. `beta` **must** be a positive number.
 
 ```javascript
 var invgamma = new InvGamma( 2.0, 4.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/docs/repl.txt
@@ -12,7 +12,7 @@
         Shape parameter.
 
     β: number
-        Rate parameter.
+        Scale parameter.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/docs/repl.txt
@@ -12,7 +12,7 @@
         Shape parameter.
 
     β: number
-        Rate parameter.
+        Scale parameter.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/docs/repl.txt
@@ -12,7 +12,7 @@
         Shape parameter.
 
     β: number
-        Rate parameter.
+        Scale parameter.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/docs/repl.txt
@@ -12,7 +12,7 @@
         Shape parameter.
 
     β: number
-        Rate parameter.
+        Scale parameter.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/docs/repl.txt
@@ -12,7 +12,7 @@
         Shape parameter.
 
     β: number
-        Rate parameter.
+        Scale parameter.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/docs/repl.txt
@@ -12,7 +12,7 @@
         Shape parameter.
 
     β: number
-        Rate parameter.
+        Scale parameter.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/docs/repl.txt
@@ -12,7 +12,7 @@
         Shape parameter.
 
     β: number
-        Rate parameter.
+        Scale parameter.
 
     Returns
     -------


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Propagating fixes merged to `develop` between 2026-07-26 and 2026-07-27 to sibling packages. Source commit: 8df3c505 ("docs: fix parameter descriptions and update spacing").

### Swapped shape/scale parameter descriptions in Weibull docs

Documentation across the Weibull PRNG packages described `k` as the scale parameter and `lambda` as the shape parameter, inverted from the canonical parameterization in `random/base/weibull` and `stats/base/dists/weibull`. Corrects `@param` JSDoc, `docs/repl.txt`, README prose, and `tape()` test descriptions in

-   `@stdlib/random/base/weibull`
-   `@stdlib/random/iter/weibull`
-   `@stdlib/random/streams/weibull`
-   `@stdlib/random/strided/weibull`
-   `@stdlib/random/array/weibull`

TypeScript declarations are out of scope (already covered by #12571; namespace declaration files are generated) and the swapped runtime `TypeError` strings in `random/base/weibull/lib/validate.js` are left for a separate `fix:`-typed change, as they are runtime-observable strings catalogued in the error database.

### Capitalized "Rate parameter." for invgamma `beta`

Commit 8df3c505 corrected the lowercase `rate parameter` → `scale parameter` for invgamma's `beta`, but the capitalized `Rate parameter.` sentence-start variant survived in eight sites. `beta` is a scale parameter under the inverse gamma parameterization; the rate parameterization belongs to the gamma distribution, where the identical string in `gamma/ctor/README.md` is correct and untouched. Fixes `docs/repl.txt` for `invgamma/{mean,mode,variance,skewness,stdev,kurtosis,entropy}` and the `invgamma.beta` property description in `invgamma/ctor/README.md`.

### Consistent `@param` separator formatting

Collapsed the two remaining malformed `@param` separators in the tree — a doubled dash in `_tools/remark/plugins/remark-svg-equations/lib/transformer.js` and a doubled space in `ml/incr/sgd-regression/lib/validate.js` — to the standard `name - description` form, completing the cleanup started in 8df3c505.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Candidate sites were enumerated via pattern search over the namespaces touched by the source commit's defect classes (all `random/*/weibull*` packages, all `stats/base/dists/invgamma` subpackages, and a repo-wide sweep for malformed `@param` separators). Every site was independently verified by two validation passes (defect present, parameter attachment confirmed against surrounding context, canonical parameterization confirmed against `random/base/weibull`'s implementation `lambda * pow( -ln(1-u), 1/k )` and distribution moments), an adaptation pass (exact per-site patches, self-contained within each target file), and a style-consistency pass against sibling packages. Deliberately excluded: TypeScript declaration files (overlap with #12571; namespace `.d.ts` files are generated), the runtime `TypeError` messages in `random/base/weibull/lib/validate.js` (flagged `needs-human`: runtime-observable strings under a `docs:`-typed change), generated REPL data artifacts (`repl/help/data/*`, `repl/info/data/*`), and sites where "rate"/"shape" terminology is correct for the distribution in question (Erlang, Wald, gamma).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was generated by an automated fix-propagation routine (Claude Code): it reviews commits merged to `develop` in the last 24 hours for generalizable fixes, locates sibling packages with the same defect, and applies the equivalent fix at sites confirmed by two independent validation agents plus adaptation and style-consistency passes. All 54 changed lines were verified against file content before and after application.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6s8ha8TyDUPenGaWU47E6)_