### PR TITLE
build(workflows): retry `publish_coverage_pr.yml` push on concurrent PR updates

### DIFF
--- a/.github/workflows/publish_coverage_pr.yml
+++ b/.github/workflows/publish_coverage_pr.yml
@@ -149,44 +149,6 @@ jobs:
           # Avoid storing GitHub token in local Git configuration:
           persist-credentials: false
 
-      # Checkout coverage repository branch for PR:
-      - name: 'Checkout coverage repository branch'
-        if: steps.download-coverage.outcome == 'success'
-        env:
-          PR_NUMBER: ${{ steps.pr-metadata.outputs.pr_number }}
-        run: |
-          cd ./www-test-code-coverage
-          BRANCH_NAME="pr-$PR_NUMBER"
-          if git fetch origin "$BRANCH_NAME"; then
-            git checkout -B "$BRANCH_NAME" FETCH_HEAD
-          else
-            git checkout -b "$BRANCH_NAME"
-          fi
-
-          # Remove all directories except .github and .git from branch:
-          find . -mindepth 1 -maxdepth 1 -type d -not -name '.github' -not -name '.git' -exec git rm -rf {} + || true
-
-      # Copy artifacts to the repository:
-      - name: 'Copy artifacts to the repository'
-        if: steps.download-coverage.outcome == 'success'
-        run: |
-          if [ -d "./artifacts" ]; then
-            cp -R ./artifacts/* ./www-test-code-coverage
-
-            # Get commit SHA and timestamp from the workflow run:
-            commit_sha="${{ github.event.workflow_run.head_sha }}"
-            commit_timestamp=$(date -u +"%Y-%m-%d %H:%M:%S")
-
-            # Append coverage to ndjson files:
-            while IFS= read -r -d '' file; do
-              file="${file//artifacts/www-test-code-coverage}"
-              coverage=$(echo -n '['; grep -oP "(?<=class='fraction'>)[0-9]+/[0-9]+" "$file" | awk -F/ '{ if ($2 != 0) print $1 "," $2 "," ($1/$2)*100; else print $1 "," $2 ",100" }' | tr '\n' ',' | sed 's/,$//'; echo -n ",\"$commit_sha\",\"$commit_timestamp\"]")
-              echo "$coverage" >> "$(dirname "$file")/coverage.ndjson"
-            done < <(find ./artifacts -name 'index.html' -print0)
-          else
-            echo "The artifacts directory does not exist."
-          fi
-
       # Import GPG key to sign commits:
       - name: 'Import GPG key to sign commits'
         if: steps.download-coverage.outcome == 'success'
@@ -199,8 +161,12 @@ jobs:
           git_commit_gpgsign: true
           workdir: ./www-test-code-coverage
 
-      # Commit and push changes:
-      - name: 'Commit and push changes'
+      # Checkout coverage repository branch, copy artifacts, and commit and push changes:
+      #
+      # ## Notes
+      #
+      # -   Multiple `publish_coverage_pr` runs for the same PR (e.g., triggered by successive pushes to the PR) can complete close together and race to push to the same `pr-<number>` branch. As only the last publisher can win a non-fast-forward push, we retry the full checkout-copy-commit cycle against a freshly fetched branch tip on rejection, rather than attempting to rebase or merge a stale commit onto it (which risks conflicts, as the copied coverage report files are wholesale replaced on each run).
+      - name: 'Checkout, copy artifacts, and push coverage report'
         if: steps.download-coverage.outcome == 'success'
         env:
           REPO_GITHUB_TOKEN: ${{ secrets.STDLIB_BOT_PAT_REPO_WRITE }}
@@ -209,8 +175,53 @@ jobs:
         run: |
           cd ./www-test-code-coverage
           BRANCH_NAME="pr-$PR_NUMBER"
+          REMOTE_URL="https://$USER_NAME:$REPO_GITHUB_TOKEN@github.com/stdlib-js/www-test-code-coverage.git"
           git config --local user.email "82920195+stdlib-bot@users.noreply.github.com"
           git config --local user.name "stdlib-bot"
-          git add .
-          git commit -m "Update artifacts" || exit 0
-          git push "https://$USER_NAME:$REPO_GITHUB_TOKEN@github.com/stdlib-js/www-test-code-coverage.git" "$BRANCH_NAME"
+
+          # Get commit SHA from the workflow run:
+          commit_sha="${{ github.event.workflow_run.head_sha }}"
+
+          max_attempts=5
+          attempt=1
+          while true; do
+            if git fetch origin "$BRANCH_NAME"; then
+              git checkout -B "$BRANCH_NAME" FETCH_HEAD
+            else
+              git checkout -B "$BRANCH_NAME"
+            fi
+
+            # Remove all directories except .github and .git from branch:
+            find . -mindepth 1 -maxdepth 1 -type d -not -name '.github' -not -name '.git' -exec git rm -rf {} + || true
+
+            # Get timestamp for this attempt:
+            commit_timestamp=$(date -u +"%Y-%m-%d %H:%M:%S")
+
+            if [ -d "../artifacts" ]; then
+              cp -R ../artifacts/* .
+
+              # Append coverage to ndjson files:
+              while IFS= read -r -d '' file; do
+                file="${file//..\/artifacts/.}"
+                coverage=$(echo -n '['; grep -oP "(?<=class='fraction'>)[0-9]+/[0-9]+" "$file" | awk -F/ '{ if ($2 != 0) print $1 "," $2 "," ($1/$2)*100; else print $1 "," $2 ",100" }' | tr '\n' ',' | sed 's/,$//'; echo -n ",\"$commit_sha\",\"$commit_timestamp\"]")
+                echo "$coverage" >> "$(dirname "$file")/coverage.ndjson"
+              done < <(find ../artifacts -name 'index.html' -print0)
+            else
+              echo "The artifacts directory does not exist."
+            fi
+
+            git add .
+            if ! git commit -m "Update artifacts"; then
+              # Nothing to commit:
+              exit 0
+            fi
+            if git push "$REMOTE_URL" "$BRANCH_NAME"; then
+              exit 0
+            fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "::error::Failed to push to $BRANCH_NAME after $max_attempts attempts due to concurrent updates."
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+            sleep $(( RANDOM % 5 + 1 ))
+          done


### PR DESCRIPTION
None.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a race condition in the `publish_coverage_pr` workflow's "Commit and push changes" step, where two `run_tests_coverage_pr` completions for the same PR trigger overlapping coverage-publish runs, and the second run's push is rejected because its local commit is based on a stale fetch of `stdlib-js/www-test-code-coverage`.
-   merges the "Checkout coverage repository branch", "Copy artifacts to the repository", and "Commit and push changes" steps into a single step, renamed "Checkout, copy artifacts, and push coverage report", wrapped in a retry loop (up to 5 attempts, with 1-5s jitter between attempts).
-   on each attempt: fetches the branch, checks out via `git checkout -B` (creating it fresh if no upstream branch exists yet), wipes all tracked directories except `.github`/`.git`, copies artifacts fresh, appends a `coverage.ndjson` row with a per-attempt timestamp, commits, and pushes. On rejection, re-fetches and redoes the full cycle against the new tip, rather than rebasing or merging the stale commit.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Observed failure: 4 runs failed on 2026-07-27, all for PR #12370, within a 45-minute window, all at "Commit and push changes" with `! [rejected] pr-12370 -> pr-12370 (fetch first)`. Example: https://github.com/stdlib-js/stdlib/actions/runs/30238689016 (also 30238765390, 30238891680, 30240767267).

This is deterministic under concurrency, not flaky. It recurs on any PR that receives rapid successive pushes, since each push triggers its own `run_tests_coverage_pr` → `publish_coverage_pr` run.

Rebase/merge onto the new tip was considered and rejected: the copied coverage HTML files are wholesale-replaced each run, not line-diffable, so a rebase would very likely hit real conflicts. Redoing the checkout/copy fresh against the new tip avoids that.

Validation: YAML parsed with PyYAML; shell checked with `bash -n`; local simulation using a bare repo standing in for `www-test-code-coverage` with two independent checkouts based on the same prior commit — one completes a full publish, the second is left on its now-stale base and reproduces the exact `! [rejected] ... fetch first` error, then the retry logic re-fetches, redoes checkout/copy/commit, and re-pushes cleanly.

Three review passes were run against the diff. Reviewers A and B both flagged that the retry loop's no-upstream-branch branch used `git checkout -b`, which fails with "branch already exists" on any iteration after the first, since iteration 1 already created the local branch. Fixed by using `git checkout -B` in both branches of the fetch/checkout logic, which is idempotent across retries; verified with a standalone repro. Reviewer C approved with nitpicks, both addressed: the step rename above, and moving the per-attempt timestamp computation inside the retry loop so each attempt's `coverage.ndjson` row reflects its own attempt time rather than a single time computed outside the loop.

Not implemented, flagged for follow-up: a `concurrency:` group keyed on PR number would serialize these runs and avoid the race entirely, as an alternative/complementary fix; kept out of this PR to keep the diff scoped to the observed failure. Also note that under the new design, if two runs for the same PR both eventually push, the published report reflects whichever run's retry loop finishes last chronologically, not necessarily the PR's most recent commit — this last-write-wins property already existed before this fix and is now just reachable by both racers instead of only the first.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, based on failed run logs for PR #12370. The diff was validated with YAML/shell syntax checks and a local git simulation reproducing the race, and reviewed through three independent automated passes; one real bug found during review (`git checkout -b` vs `-B`) was fixed and reverified before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013jxg1PXoB9PmiMxAcUa5gH)_