### PR TITLE
feat: add `number/uint64/base/xor`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/base/xor/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/README.md
@@ -1,0 +1,155 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# xor
+
+> Compute the bitwise XOR of two 64-bit unsigned integers.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var xor = require( '@stdlib/number/uint64/base/xor' );
+```
+
+#### xor( a, b )
+
+Computes the bitwise XOR of two 64-bit unsigned integers.
+
+```javascript
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+
+var a = new Uint64( 5 );
+var b = new Uint64( 15 );
+
+var v = xor( a, b );
+// returns <Uint64>[ 10n ]
+```
+
+#### xor.assign( ah, al, bh, bl, out, stride, offset )
+
+Computes the bitwise XOR of two 64-bit unsigned integers and assigns results to a provided output array.
+
+```javascript
+var Uint32Array = require( '@stdlib/array/uint32' );
+
+var out = new Uint32Array( 2 );
+var v = xor.assign( 1, 2, 3, 4, out, 1, 0 );
+// returns <Uint32Array>[ 2, 6 ]
+
+var bool = ( out === v );
+// returns true
+```
+
+The function supports the following parameters:
+
+-   **ah**: high 32-bit word of the first 64-bit unsigned integer.
+-   **al**: low 32-bit word of the first 64-bit unsigned integer.
+-   **bh**: high 32-bit word of the second 64-bit unsigned integer.
+-   **bl**: low 32-bit word of the second 64-bit unsigned integer.
+-   **out**: output array.
+-   **stride**: stride length for `out`.
+-   **offset**: starting index for `out`.
+
+#### xor.strided( a, sa, oa, b, sb, ob, out, so, oo )
+
+Computes the bitwise XOR of two 64-bit unsigned integers stored in integer-valued strided array views and assigns results to a provided strided output array.
+
+```javascript
+var Uint32Array = require( '@stdlib/array/uint32' );
+
+var a = new Uint32Array( [ 1, 2 ] );
+var b = new Uint32Array( [ 3, 4 ] );
+var out = new Uint32Array( 2 );
+
+var v = xor.strided( a, 1, 0, b, 1, 0, out, 1, 0 );
+// returns <Uint32Array>[ 2, 6 ]
+
+var bool = ( out === v );
+// returns true
+```
+
+The function supports the following parameters:
+
+-   **a**: first 64-bit unsigned integer strided array view containing interleaved 32-bit unsigned integer high and low order words.
+-   **sa**: stride length for `a`.
+-   **oa**: starting index for `a`.
+-   **b**: second 64-bit unsigned integer strided array view containing interleaved 32-bit unsigned integer high and low order words.
+-   **sb**: stride length for `b`.
+-   **ob**: starting index for `b`.
+-   **out**: output array.
+-   **so**: stride length for `out`.
+-   **oo**: starting index for `out`.
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var xor = require( '@stdlib/number/uint64/base/xor' );
+
+var a = new Uint64( 1234567890 );
+var v = xor( a, a );
+console.log( v.toString() );
+// => '0'
+
+var b = new Uint64( 0xffffffff );
+v = xor( a, b );
+console.log( v.toString() );
+// => '3060399405'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/benchmark/benchmark.js
@@ -85,8 +85,7 @@ bench( format( '%s:assign', pkg ), function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		// eslint-disable-next-line max-len
-		out = xor.assign( x[ i%N ], x[ (i+1)%N ], x[ (i+2)%N ], x[ (i+3)%N ], out, 1, 0 );
+		out = xor.assign( x[ i%N ], x[ (i+1)%N ], x[ (i+2)%N ], x[ (i+3)%N ], out, 1, 0 ); // eslint-disable-line max-len
 		if ( typeof out !== 'object' ) {
 			b.fail( 'should return an object' );
 		}

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/benchmark/benchmark.js
@@ -1,0 +1,130 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Uint32Array = require( '@stdlib/array/uint32' );
+var bench = require( '@stdlib/bench' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var xor = require( './../lib' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'uint32'
+};
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var N;
+	var x;
+	var y;
+	var z;
+	var i;
+
+	N = 100;
+	x = discreteUniform( N, 0, UINT32_MAX, options );
+	values = [];
+	for ( i = 0; i < N; i++ ) {
+		values.push( Uint64.of( x[ i ], x[ (i+1)%N ] ) );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = values[ i%N ];
+		z = values[ (i+1)%N ];
+		out = xor( y, z );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !( out instanceof Uint64 ) ) {
+		b.fail( 'should return a Uint64 instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
+	var out;
+	var N;
+	var x;
+	var i;
+
+	N = 100;
+	x = discreteUniform( N, 0, UINT32_MAX, options );
+
+	out = new Uint32Array( 2 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		// eslint-disable-next-line max-len
+		out = xor.assign( x[ i%N ], x[ (i+1)%N ], x[ (i+2)%N ], x[ (i+3)%N ], out, 1, 0 );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !( out instanceof Uint32Array ) ) {
+		b.fail( 'should return a Uint32Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
+	var out;
+	var N;
+	var x;
+	var y;
+	var i;
+	var j;
+
+	N = 50;
+	x = discreteUniform( N*2, 0, UINT32_MAX, options );
+	y = discreteUniform( N*2, 0, UINT32_MAX, options );
+
+	out = new Uint32Array( 2 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		j = ( i % N ) * 2;
+		out = xor.strided( x, 1, j, y, 1, j, out, 1, 0 );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !( out instanceof Uint32Array ) ) {
+		b.fail( 'should return a Uint32Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/docs/repl.txt
@@ -1,0 +1,118 @@
+
+{{alias}}( a, b )
+    Computes the bitwise XOR of two 64-bit unsigned integers.
+
+    Parameters
+    ----------
+    a: Uint64
+        64-bit unsigned integer.
+
+    b: Uint64
+        64-bit unsigned integer.
+
+    Returns
+    -------
+    out: Uint64
+        Result.
+
+    Examples
+    --------
+    > var a = new {{alias:@stdlib/number/uint64/ctor}}( 5 )
+    <Uint64>[ 5n ]
+    > var b = new {{alias:@stdlib/number/uint64/ctor}}( 15 )
+    <Uint64>[ 15n ]
+    > var out = {{alias}}( a, b )
+    <Uint64>[ 10n ]
+
+
+{{alias}}.assign( ah, al, bh, bl, out, stride, offset )
+    Computes the bitwise XOR of two 64-bit unsigned integers and assigns results
+    to a provided output array.
+
+    Parameters
+    ----------
+    ah: integer
+        High 32-bit word of the first 64-bit unsigned integer.
+
+    al: integer
+        Low 32-bit word of the first 64-bit unsigned integer.
+
+    bh: integer
+        High 32-bit word of the second 64-bit unsigned integer.
+
+    bl: integer
+        Low 32-bit word of the second 64-bit unsigned integer.
+
+    out: ArrayLikeObject
+        Output array.
+
+    stride: integer
+        Stride length.
+
+    offset: integer
+        Starting index.
+
+    Returns
+    -------
+    out: ArrayLikeObject
+        Output array.
+
+    Examples
+    --------
+    > var out = new {{alias:@stdlib/array/uint32}}( 2 );
+    > {{alias}}.assign( 1, 2, 3, 4, out, 1, 0 )
+    <Uint32Array>[ 2, 6 ]
+
+
+{{alias}}.strided( a, sa, oa, b, sb, ob, out, so, oo )
+    Computes the bitwise XOR of two 64-bit unsigned integers stored in integer-
+    valued strided array views and assigns results to a provided strided output
+    array.
+
+    Parameters
+    ----------
+    a: ArrayLikeObject
+        First 64-bit unsigned integer strided array view containing interleaved
+        32-bit unsigned integer high and low order words.
+
+    sa: integer
+        Stride length for `a`.
+
+    oa: integer
+        Starting index for `a`.
+
+    b: ArrayLikeObject
+        Second 64-bit unsigned integer strided array view containing interleaved
+        32-bit unsigned integer high and low order words.
+
+    sb: integer
+        Stride length for `b`.
+
+    ob: integer
+        Starting index for `b`.
+
+    out: ArrayLikeObject
+        Output array.
+
+    so: integer
+        Stride length for `out`.
+
+    oo: integer
+        Starting index for `out`.
+
+    Returns
+    -------
+    out: ArrayLikeObject
+        Output array.
+
+    Examples
+    --------
+    > var a = new {{alias:@stdlib/array/uint32}}( [ 1, 2 ] );
+    > var b = new {{alias:@stdlib/array/uint32}}( [ 3, 4 ] );
+    > var out = new {{alias:@stdlib/array/uint32}}( 2 );
+    > {{alias}}.strided( a, 1, 0, b, 1, 0, out, 1, 0 )
+    <Uint32Array>[ 2, 6 ]
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/docs/types/index.d.ts
@@ -1,0 +1,130 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Uint64 } from '@stdlib/types/number';
+import { Collection, NumericArray } from '@stdlib/types/array';
+
+/**
+* Interface for adding two 64-bit unsigned integers.
+*/
+interface Xor {
+	/**
+	* Computes the bitwise XOR of two 64-bit unsigned integers.
+	*
+	* @param a - 64-bit unsigned integer
+	* @param b - 64-bit unsigned integer
+	* @returns result
+	*
+	* @example
+	* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+	*
+	* var a = new Uint64( 5 );
+	* var b = new Uint64( 15 );
+	*
+	* var v = xor( a, b );
+	* // returns <Uint64>[ 10n ]
+	*/
+	( a: Uint64, b: Uint64 ): Uint64;
+
+	/**
+	* Computes the bitwise XOR of two 64-bit unsigned integers and assigns results to a provided output array.
+	*
+	* @param ah - high 32-bit word of the first 64-bit unsigned integer
+	* @param al - low 32-bit word of the first 64-bit unsigned integer
+	* @param bh - high 32-bit word of the second 64-bit unsigned integer
+	* @param bl - low 32-bit word of the second 64-bit unsigned integer
+	* @param out - output array
+	* @param stride - stride length
+	* @param offset - starting index
+	* @returns output array
+	*
+	* @example
+	* var Uint32Array = require( '@stdlib/array/uint32' );
+	*
+	* var out = xor.assign( 1, 2, 3, 4, new Uint32Array( 2 ), 1, 0 );
+	* // returns <Uint32Array>[ 2, 6 ]
+	*/
+	assign<T extends NumericArray | Collection<number>>( ah: number, al: number, bh: number, bl: number, out: T, stride: number, offset: number ): T;
+
+	/**
+	* Computes the bitwise XOR of two 64-bit unsigned integers stored in integer-valued strided array views and assigns results to a provided strided output array.
+	*
+	* @param a - first 64-bit unsigned integer strided array view containing interleaved 32-bit unsigned integer high and low order words
+	* @param sa - stride length for `a`
+	* @param oa - starting index for `a`
+	* @param b - second 64-bit unsigned integer strided array view containing interleaved 32-bit unsigned integer high and low order words
+	* @param sb - stride length for `b`
+	* @param ob - starting index for `b`
+	* @param out - output array
+	* @param so - stride length for `out`
+	* @param oo - starting index for `out`
+	* @returns output array
+	*
+	* @example
+	* var Uint32Array = require( '@stdlib/array/uint32' );
+	*
+	* var a = new Uint32Array( [ 1, 2 ] );
+	* var b = new Uint32Array( [ 3, 4 ] );
+	*
+	* var out = xor.strided( a, 1, 0, b, 1, 0, new Uint32Array( 2 ), 1, 0 );
+	* // returns <Uint32Array>[ 2, 6 ]
+	*/
+	strided<T extends NumericArray | Collection<number>, U extends NumericArray | Collection<number>, V extends NumericArray | Collection<number>>( a: T, sa: number, oa: number, b: U, sb: number, ob: number, out: V, so: number, oo: number ): V;
+}
+
+/**
+* Computes the bitwise XOR of two 64-bit unsigned integers.
+*
+* @param a - 64-bit unsigned integer
+* @param b - 64-bit unsigned integer
+* @returns result
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 5 );
+* var b = new Uint64( 15 );
+*
+* var v = xor( a, b );
+* // returns <Uint64>[ 10n ]
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+*
+* var out = xor.assign( 1, 2, 3, 4, new Uint32Array( 2 ), 1, 0 );
+* // returns <Uint32Array>[ 2, 6 ]
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+*
+* var a = new Uint32Array( [ 1, 2 ] );
+* var b = new Uint32Array( [ 3, 4 ] );
+*
+* var out = xor.strided( a, 1, 0, b, 1, 0, new Uint32Array( 2 ), 1, 0 );
+* // returns <Uint32Array>[ 2, 6 ]
+*/
+declare var xor: Xor;
+
+
+// EXPORTS //
+
+export = xor;

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/docs/types/index.d.ts
@@ -24,7 +24,7 @@ import { Uint64 } from '@stdlib/types/number';
 import { Collection, NumericArray } from '@stdlib/types/array';
 
 /**
-* Interface for adding two 64-bit unsigned integers.
+* Interface for computing the bitwise XOR of two 64-bit unsigned integers.
 */
 interface Xor {
 	/**

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/docs/types/test.ts
@@ -1,0 +1,355 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Uint64 = require( '@stdlib/number/uint64/ctor' );
+import xor = require( './index' );
+
+
+// TESTS //
+
+// The function returns a 64-bit unsigned integer...
+{
+	const a = new Uint64( 5 );
+
+	xor( a, a ); // $ExpectType Uint64
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a 64-bit unsigned integer...
+{
+	const a = new Uint64( 5 );
+
+	xor( true, a ); // $ExpectError
+	xor( false, a ); // $ExpectError
+	xor( null, a ); // $ExpectError
+	xor( undefined, a ); // $ExpectError
+	xor( '5', a ); // $ExpectError
+	xor( [], a ); // $ExpectError
+	xor( {}, a ); // $ExpectError
+	xor( ( x: number ): number => x, a ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a 64-bit unsigned integer...
+{
+	const a = new Uint64( 5 );
+
+	xor( a, true ); // $ExpectError
+	xor( a, false ); // $ExpectError
+	xor( a, null ); // $ExpectError
+	xor( a, undefined ); // $ExpectError
+	xor( a, '5' ); // $ExpectError
+	xor( a, [] ); // $ExpectError
+	xor( a, {} ); // $ExpectError
+	xor( a, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const a = new Uint64( 5 );
+
+	xor(); // $ExpectError
+	xor( a ); // $ExpectError
+	xor( a, a, a ); // $ExpectError
+}
+
+// Attached to the main export is an `assign` method which returns a collection...
+{
+	xor.assign( 1, 2, 3, 4, new Uint32Array( 2 ), 1, 0 ); // $ExpectType Uint32Array
+	xor.assign( 1, 2, 3, 4, new Float64Array( 2 ), 1, 0 ); // $ExpectType Float64Array
+	xor.assign( 1, 2, 3, 4, [ 0, 0 ], 1, 0 ); // $ExpectType number[]
+}
+
+// The compiler throws an error if the `assign` method is provided a first argument which is not a number...
+{
+	const out = new Uint32Array( 2 );
+
+	xor.assign( true, 2, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( false, 2, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( null, 2, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( undefined, 2, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( '5', 2, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( [], 2, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( {}, 2, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( ( x: number ): number => x, 2, 3, 4, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a second argument which is not a number...
+{
+	const out = new Uint32Array( 2 );
+
+	xor.assign( 1, true, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, false, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, null, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, undefined, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, '5', 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, [], 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, {}, 3, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, ( x: number ): number => x, 3, 4, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a third argument which is not a number...
+{
+	const out = new Uint32Array( 2 );
+
+	xor.assign( 1, 2, true, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, false, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, null, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, undefined, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, '5', 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, [], 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, {}, 4, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, ( x: number ): number => x, 4, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...
+{
+	const out = new Uint32Array( 2 );
+
+	xor.assign( 1, 2, 3, true, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, false, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, null, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, undefined, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, '5', out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, [], out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, {}, out, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, ( x: number ): number => x, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a fifth argument which is not a collection...
+{
+	xor.assign( 1, 2, 3, 4, 1, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, true, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, false, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, null, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, undefined, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, '5', 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, [ '5' ], 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, {}, 1, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a sixth argument which is not a number...
+{
+	const out = new Uint32Array( 2 );
+
+	xor.assign( 1, 2, 3, 4, out, true, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, false, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, null, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, undefined, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, '5', 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, [], 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, {}, 0 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a seventh argument which is not a number...
+{
+	const out = new Uint32Array( 2 );
+
+	xor.assign( 1, 2, 3, 4, out, 1, true ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, 1, false ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, 1, null ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, 1, undefined ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, 1, '5' ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, 1, [] ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, 1, {} ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided an unsupported number of arguments...
+{
+	const out = new Uint32Array( 2 );
+
+	xor.assign(); // $ExpectError
+	xor.assign( 1 ); // $ExpectError
+	xor.assign( 1, 2 ); // $ExpectError
+	xor.assign( 1, 2, 3 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, 1 ); // $ExpectError
+	xor.assign( 1, 2, 3, 4, out, 1, 0, {} ); // $ExpectError
+}
+
+// Attached to the main export is a `strided` method which returns a collection...
+{
+	const a = new Uint32Array( 2 );
+	const b = new Uint32Array( 2 );
+
+	xor.strided( a, 1, 0, b, 1, 0, new Uint32Array( 2 ), 1, 0 ); // $ExpectType Uint32Array
+	xor.strided( a, 1, 0, b, 1, 0, new Float64Array( 2 ), 1, 0 ); // $ExpectType Float64Array
+	xor.strided( a, 1, 0, b, 1, 0, [ 0, 0 ], 1, 0 ); // $ExpectType number[]
+}
+
+// The compiler throws an error if the `strided` method is provided a first argument which is not a collection...
+{
+	const b = new Uint32Array( 2 );
+	const out = new Uint32Array( 2 );
+
+	xor.strided( true, 1, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( false, 1, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( null, 1, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( undefined, 1, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( '5', 1, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( [ '5' ], 1, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( {}, 1, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( ( x: number ): number => x, 1, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a second argument which is not a number...
+{
+	const a = new Uint32Array( 2 );
+	const b = new Uint32Array( 2 );
+	const out = new Uint32Array( 2 );
+
+	xor.strided( a, true, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, false, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, null, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, undefined, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, '5', 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, [], 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, {}, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, ( x: number ): number => x, 0, b, 1, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a third argument which is not a number...
+{
+	const a = new Uint32Array( 2 );
+	const b = new Uint32Array( 2 );
+	const out = new Uint32Array( 2 );
+
+	xor.strided( a, 1, true, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, false, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, null, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, undefined, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, '5', b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, [], b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, {}, b, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, ( x: number ): number => x, b, 1, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a fourth argument which is not a collection...
+{
+	const a = new Uint32Array( 2 );
+	const out = new Uint32Array( 2 );
+
+	xor.strided( a, 1, 0, true, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, false, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, null, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, undefined, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, '5', 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, [ '5' ], 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, {}, 1, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, ( x: number ): number => x, 1, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a fifth argument which is not a number...
+{
+	const a = new Uint32Array( 2 );
+	const b = new Uint32Array( 2 );
+	const out = new Uint32Array( 2 );
+
+	xor.strided( a, 1, 0, b, true, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, false, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, null, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, undefined, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, '5', 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, [], 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, {}, 0, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, ( x: number ): number => x, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a sixth argument which is not a number...
+{
+	const a = new Uint32Array( 2 );
+	const b = new Uint32Array( 2 );
+	const out = new Uint32Array( 2 );
+
+	xor.strided( a, 1, 0, b, 1, true, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, false, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, null, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, undefined, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, '5', out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, [], out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, {}, out, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, ( x: number ): number => x, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a seventh argument which is not a collection...
+{
+	const a = new Uint32Array( 2 );
+	const b = new Uint32Array( 2 );
+
+	xor.strided( a, 1, 0, b, 1, 0, 1, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, true, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, false, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, null, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, undefined, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, '5', 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, [ '5' ], 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, {}, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided an eighth argument which is not a number...
+{
+	const a = new Uint32Array( 2 );
+	const b = new Uint32Array( 2 );
+	const out = new Uint32Array( 2 );
+
+	xor.strided( a, 1, 0, b, 1, 0, out, true, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, false, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, null, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, undefined, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, '5', 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, [], 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, {}, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a ninth argument which is not a number...
+{
+	const a = new Uint32Array( 2 );
+	const b = new Uint32Array( 2 );
+	const out = new Uint32Array( 2 );
+
+	xor.strided( a, 1, 0, b, 1, 0, out, 1, true ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, 1, false ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, 1, null ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, 1, undefined ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, 1, '5' ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, 1, [] ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, 1, {} ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided an unsupported number of arguments...
+{
+	const a = new Uint32Array( 2 );
+	const b = new Uint32Array( 2 );
+	const out = new Uint32Array( 2 );
+
+	xor.strided(); // $ExpectError
+	xor.strided( a ); // $ExpectError
+	xor.strided( a, 1 ); // $ExpectError
+	xor.strided( a, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, 1 ); // $ExpectError
+	xor.strided( a, 1, 0, b, 1, 0, out, 1, 0, {} ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/examples/index.js
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var xor = require( './../lib' );
+
+var a = new Uint64( 1234567890 );
+var v = xor( a, a );
+console.log( v.toString() );
+// => '0'
+
+var b = new Uint64( 0xffffffff );
+v = xor( a, b );
+console.log( v.toString() );
+// => '3060399405'

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/lib/assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/lib/assign.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Computes the bitwise XOR of two 64-bit unsigned integers and assigns results to a provided output array.
+*
+* @param {uinteger} ah - high 32-bit word of the first 64-bit unsigned integer
+* @param {uinteger} al - low 32-bit word of the first 64-bit unsigned integer
+* @param {uinteger} bh - high 32-bit word of the second 64-bit unsigned integer
+* @param {uinteger} bl - low 32-bit word of the second 64-bit unsigned integer
+* @param {Collection} out - output array
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - starting index
+* @returns {Collection} output array
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+*
+* var out = assign( 1, 2, 3, 4, new Uint32Array( 2 ), 1, 0 );
+* // returns <Uint32Array>[ 2, 6 ]
+*/
+function assign( ah, al, bh, bl, out, stride, offset ) {
+	ah >>>= 0;
+	al >>>= 0;
+	bh >>>= 0;
+	bl >>>= 0;
+
+	out[ offset ] = ( ah ^ bh ) >>> 0; // hi
+	out[ offset+stride ] = ( al ^ bl ) >>> 0; // lo
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = assign;

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/lib/index.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute the bitwise XOR of two 64-bit unsigned integers.
+*
+* @module @stdlib/number/uint64/base/xor
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+* var xor = require( '@stdlib/number/uint64/base/xor' );
+*
+* var a = new Uint64( 5 );
+* var b = new Uint64( 15 );
+*
+* var v = xor( a, b );
+* // returns <Uint64>[ 10n ]
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var main = require( './main.js' );
+var assign = require( './assign.js' );
+var strided = require( './strided.js' );
+
+
+// MAIN //
+
+setReadOnly( main, 'assign', assign );
+setReadOnly( main, 'strided', strided );
+
+
+// EXPORTS //
+
+module.exports = main;
+
+// exports: { "assign": "main.assign", "strided": "main.strided" }

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/lib/main.js
@@ -52,9 +52,7 @@ var WORKSPACE = new Uint32Array( 6 );
 function xor( a, b ) {
 	toWords( a, WORKSPACE, 1, 0 );
 	toWords( b, WORKSPACE, 1, 2 );
-
-	// eslint-disable-next-line max-len
-	assign( WORKSPACE[0], WORKSPACE[1], WORKSPACE[2], WORKSPACE[3], WORKSPACE, 1, 4 );
+	assign( WORKSPACE[0], WORKSPACE[1], WORKSPACE[2], WORKSPACE[3], WORKSPACE, 1, 4 ); // eslint-disable-line max-len
 	return Uint64.of( WORKSPACE[4], WORKSPACE[5] );
 }
 

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/lib/main.js
@@ -1,0 +1,64 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Uint32Array = require( '@stdlib/array/uint32' );
+var toWords = require( '@stdlib/number/uint64/base/to-words' ).assign;
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var assign = require( './assign.js' );
+
+
+// VARIABLES //
+
+var WORKSPACE = new Uint32Array( 6 );
+
+
+// MAIN //
+
+/**
+* Computes the bitwise XOR of two 64-bit unsigned integers.
+*
+* @param {Uint64} a - 64-bit unsigned integer
+* @param {Uint64} b - 64-bit unsigned integer
+* @returns {Uint64} result
+*
+* @example
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 5 );
+* var b = new Uint64( 15 );
+*
+* var v = xor( a, b );
+* // returns <Uint64>[ 10n ]
+*/
+function xor( a, b ) {
+	toWords( a, WORKSPACE, 1, 0 );
+	toWords( b, WORKSPACE, 1, 2 );
+
+	// eslint-disable-next-line max-len
+	assign( WORKSPACE[0], WORKSPACE[1], WORKSPACE[2], WORKSPACE[3], WORKSPACE, 1, 4 );
+	return Uint64.of( WORKSPACE[4], WORKSPACE[5] );
+}
+
+
+// EXPORTS //
+
+module.exports = xor;

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/lib/strided.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/lib/strided.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var assign = require( './assign.js' );
+
+
+// MAIN //
+
+/**
+* Computes the bitwise XOR of two 64-bit unsigned integers stored in integer-valued strided array views and assigns results to a provided strided output array.
+*
+* @param {Collection} a - first 64-bit unsigned integer strided array view containing interleaved 32-bit unsigned integer high and low order words
+* @param {integer} sa - stride length for `a`
+* @param {NonNegativeInteger} oa - starting index for `a`
+* @param {Collection} b - second 64-bit unsigned integer strided array view containing interleaved 32-bit unsigned integer high and low order words
+* @param {integer} sb - stride length for `b`
+* @param {NonNegativeInteger} ob - starting index for `b`
+* @param {Collection} out - output array
+* @param {integer} so - stride length for `out`
+* @param {NonNegativeInteger} oo - starting index for `out`
+* @returns {Collection} output array
+*
+* @example
+* var Uint32Array = require( '@stdlib/array/uint32' );
+*
+* var a = new Uint32Array( [ 1, 2 ] );
+* var b = new Uint32Array( [ 3, 4 ] );
+*
+* var out = strided( a, 1, 0, b, 1, 0, new Uint32Array( 2 ), 1, 0 );
+* // returns <Uint32Array>[ 2, 6 ]
+*/
+function strided( a, sa, oa, b, sb, ob, out, so, oo ) {
+	assign( a[ oa ], a[ oa+sa ], b[ ob ], b[ ob+sb ], out, so, oo );
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = strided;

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/package.json
@@ -51,7 +51,7 @@
   "keywords": [
     "stdlib",
     "stdmath",
-    "the bitwise",
+    "bitwise",
     "xor",
     "xor64",
     "exclusive-or",

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@stdlib/number/uint64/base/xor",
+  "version": "0.0.0",
+  "description": "Compute the bitwise XOR of two 64-bit unsigned integers.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "the bitwise",
+    "xor",
+    "xor64",
+    "exclusive-or",
+    "uint64",
+    "64-bit",
+    "unsigned",
+    "integer"
+  ]
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/test/test.assign.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/test/test.assign.js
@@ -1,0 +1,71 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isEqualUint32Array = require( '@stdlib/assert/is-equal-uint32array' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var xor = require( './../lib/assign.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof xor, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function computes the bitwise xor of two 64-bit unsigned integers', function test( t ) {
+	var expected;
+	var out;
+	var v;
+
+	// Trivial stride and offset:
+	out = new Uint32Array( 2 );
+	v = xor( 1, 2, 3, 4, out, 1, 0 );
+	expected = new Uint32Array( [ 2, 6 ] );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.ok( isEqualUint32Array( out, expected ), 'returns expected value' );
+
+	// Positive stride:
+	out = new Uint32Array( 4 );
+	v = xor( 1, 2, 3, 4, out, 2, 0 );
+	expected = new Uint32Array( [ 2, 0, 6, 0 ] );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.ok( isEqualUint32Array( out, expected ), 'returns expected value' );
+
+	// Positive stride and non-zero offset:
+	out = new Uint32Array( 4 );
+	v = xor( 1, 2, 3, 4, out, 2, 1 );
+	expected = new Uint32Array( [ 0, 2, 0, 6 ] );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.ok( isEqualUint32Array( out, expected ), 'returns expected value' );
+
+	// Negative stride and non-zero offset:
+	out = new Uint32Array( 2 );
+	v = xor( 1, 2, 3, 4, out, -1, 1 );
+	expected = new Uint32Array( [ 6, 2 ] );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.ok( isEqualUint32Array( out, expected ), 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/test/test.js
@@ -1,0 +1,44 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isMethod = require( '@stdlib/assert/is-method' );
+var xor = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof xor, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is an `assign` method', function test( t ) {
+	t.strictEqual( isMethod( xor, 'assign' ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'attached to the main export is a `strided` method', function test( t ) {
+	t.strictEqual( isMethod( xor, 'strided' ), true, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/test/test.main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/test/test.main.js
@@ -1,0 +1,106 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasBigIntSupport = require( '@stdlib/assert/has-bigint-support' );
+var BigInt = require( '@stdlib/bigint/ctor' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var isEqual = require( '@stdlib/number/uint64/base/assert/is-equal' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var xor = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': !hasBigIntSupport()
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof xor, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function computes the bitwise xor of two 64-bit unsigned integers', function test( t ) {
+	var expected;
+	var out;
+	var a;
+	var b;
+
+	// Small value:
+	a = new Uint64( 5 );
+	b = new Uint64( 15 );
+	out = xor( a, b );
+	expected = new Uint64( 10 );
+	t.ok( isEqual( out, expected ), 'returns expected value' );
+
+	// Same value:
+	a = new Uint64( 9876543210 );
+	b = new Uint64( 9876543210 );
+	out = xor( a, b );
+	expected = new Uint64( 0 );
+	t.ok( isEqual( out, expected ), 'returns expected value' );
+
+	// Large value (64-bit max result):
+	a = new Uint64( UINT32_MAX );
+	b = Uint64.of( UINT32_MAX, 0 );
+	out = xor( a, b );
+	expected = Uint64.of( UINT32_MAX, UINT32_MAX );
+	t.ok( isEqual( out, expected ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function computes the bitwise xor of two 64-bit unsigned integers (random values)', opts, function test( t ) {
+	var big64xsum;
+	var expected;
+	var values;
+	var out;
+	var a;
+	var b;
+	var x;
+	var i;
+
+	x = discreteUniform( 100, 0, UINT32_MAX, {
+		'dtype': 'uint32'
+	});
+	values = [];
+	for ( i = 0; i < x.length; i++ ) {
+		values.push( Uint64.of( x[ i ], x[ (i+1)%x.length ] ) );
+	}
+
+	for ( i = 0; i < values.length; i++ ) {
+		a = values[ i ];
+		b = values[ (i+1)%values.length ];
+		out = xor( a, b );
+		big64xsum = BigInt.asUintN( 64, a.valueOf() ^ b.valueOf() );
+		expected = new Uint64( big64xsum );
+		t.ok( isEqual( out, expected ), 'returns expected value' );
+	}
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/xor/test/test.strided.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/xor/test/test.strided.js
@@ -1,0 +1,81 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isEqualUint32Array = require( '@stdlib/assert/is-equal-uint32array' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var xor = require( './../lib/strided.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof xor, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function computes the bitwise xor of two 64-bit unsigned integers', function test( t ) {
+	var expected;
+	var out;
+	var a;
+	var b;
+	var v;
+
+	// Trivial stride and offset:
+	a = new Uint32Array( [ 1, 2 ] );
+	b = new Uint32Array( [ 3, 4 ] );
+	out = new Uint32Array( 2 );
+	v = xor( a, 1, 0, b, 1, 0, out, 1, 0 );
+	expected = new Uint32Array( [ 2, 6 ] );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.ok( isEqualUint32Array( out, expected ), 'returns expected value' );
+
+	// Positive stride:
+	a = new Uint32Array( [ 1, 0, 0, 2, 0, 0 ] );
+	b = new Uint32Array( [ 3, 0, 4, 0 ] );
+	out = new Uint32Array( 2 );
+	v = xor( a, 3, 0, b, 2, 0, out, 1, 0 );
+	expected = new Uint32Array( [ 2, 6 ] );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.ok( isEqualUint32Array( out, expected ), 'returns expected value' );
+
+	// Positive stride and non-zero offset:
+	a = new Uint32Array( [ 0, 0, 1, 0, 0, 2 ] );
+	b = new Uint32Array( [ 0, 3, 0, 4 ] );
+	out = new Uint32Array( 2 );
+	v = xor( a, 3, 2, b, 2, 1, out, 1, 0 );
+	expected = new Uint32Array( [ 2, 6 ] );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.ok( isEqualUint32Array( out, expected ), 'returns expected value' );
+
+	// Negative stride and non-zero offset:
+	a = new Uint32Array( [ 0, 0, 2, 0, 0, 1 ] );
+	b = new Uint32Array( [ 0, 4, 0, 3 ] );
+	out = new Uint32Array( 2 );
+	v = xor( a, -3, 5, b, -2, 3, out, 1, 0 );
+	expected = new Uint32Array( [ 2, 6 ] );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.ok( isEqualUint32Array( out, expected ), 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a package for computing the bitwise XOR of two 64-bit unsigned integers.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
