### PR TITLE
docs: extract options variable in `dwxmy` examples

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dwxmy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxmy/README.md
@@ -167,19 +167,16 @@ dwxmy.ndarray( 3, x, 1, x.length-3, y, 1, y.length-3, w, 1, w.length-3 );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var dwxmy = require( '@stdlib/blas/ext/base/dwxmy' );
 
-var x = discreteUniform( 10, -100, 100, {
+var opts = {
     'dtype': 'float64'
-});
+};
+var x = discreteUniform( 10, -100, 100, opts );
 console.log( x );
 
-var y = discreteUniform( 10, -100, 100, {
-    'dtype': 'float64'
-});
+var y = discreteUniform( 10, -100, 100, opts );
 console.log( y );
 
-var w = discreteUniform( 10, -100, 100, {
-    'dtype': 'float64'
-});
+var w = discreteUniform( 10, -100, 100, opts );
 console.log( w );
 
 dwxmy( x.length, x, 1, y, 1, w, 1 );

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxmy/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxmy/examples/index.js
@@ -21,19 +21,16 @@
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var dwxmy = require( './../lib' );
 
-var x = discreteUniform( 10, -100, 100, {
+var opts = {
 	'dtype': 'float64'
-});
+};
+var x = discreteUniform( 10, -100, 100, opts );
 console.log( x );
 
-var y = discreteUniform( 10, -100, 100, {
-	'dtype': 'float64'
-});
+var y = discreteUniform( 10, -100, 100, opts );
 console.log( y );
 
-var w = discreteUniform( 10, -100, 100, {
-	'dtype': 'float64'
-});
+var w = discreteUniform( 10, -100, 100, opts );
 console.log( w );
 
 dwxmy( x.length, x, 1, y, 1, w, 1 );


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

- extracts options variable in `dwxmy` examples

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- https://github.com/stdlib-js/metr-issue-tracker/issues/880

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used Cursor+VS Code code-generation tools to help assist with the feature.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md