### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/factory.js
@@ -64,10 +64,7 @@ function factory( mu, b ) {
 	*/
 	function mgf( t ) {
 		var bt;
-		if ( isnan( t ) ) {
-			return NaN;
-		}
-		if ( abs( t ) >= 1.0/b ) {
+		if ( isnan( t ) || abs( t ) >= 1.0/b ) {
 			return NaN;
 		}
 		bt = b * t;

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mgf/lib/factory.js
@@ -64,6 +64,9 @@ function factory( mu, b ) {
 	*/
 	function mgf( t ) {
 		var bt;
+		if ( isnan( t ) ) {
+			return NaN;
+		}
 		if ( abs( t ) >= 1.0/b ) {
 			return NaN;
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/pdf/lib/factory.js
@@ -64,6 +64,7 @@ function factory( mu, b ) {
 	* @param {number} x - input value
 	* @returns {number} evaluated PDF
 	*
+	* @example
 	* var y = pdf( -3.14 );
 	* // returns <number>
 	*/


### PR DESCRIPTION
## Description

Two mechanical drift corrections in `stats/base/dists/laplace`, each normalizing a `lib/factory.js` private closure to the convention shared by its sibling function members. No behavior, signatures, or test expectations change.

### `stats/base/dists/laplace/mgf`

The private `mgf` closure returned by `factory` omitted the leading `isnan( t )` short-circuit that its own `lib/main.js` and 5 of 6 sibling function factories apply before any arithmetic (83% conformance). Added it as the first guard. Output is identical for every input — `mgf( NaN )` already returned `NaN` through arithmetic propagation — so this is a consistency fix, not a behavior change.

### `stats/base/dists/laplace/pdf`

The private `pdf` closure returned by `factory` carried an untagged usage snippet in its JSDoc; every other function member tags it with `@example` (5 of 6 siblings; 83% conformance). Added the missing tag. Documentation only.

## Related Issues

No.

## Questions

No.

## Other

Both corrections were surfaced by a majority-vote drift sweep over the 15 members of `stats/base/dists/laplace` (75% threshold) and confirmed by independent source review; each is a single-package, behavior-preserving patch confined to `lib/factory.js`.

Deliberately excluded from this PR:

-   `ctor`'s absence of native-C scaffolding and of the `location-scale`/`exponential family` keywords — intentional, `ctor` is a pure-JS constructor class.
-   `stdev`'s python (rather than julia) test fixtures — a valid alternative that would cascade to expected test data.
-   The `## C APIs` "rate parameter" label for `b` in `cdf`/`logcdf`/`logpdf`/`quantile`/`mode` — a genuine documentation error, but with no ≥75% namespace majority (9 "scale" / 5 "rate") and a fix that requires the domain judgment that "scale" is correct. Left for a maintainer.

No overlap with open PR #13410 (touches only laplace READMEs) or merged PR #12449 (mgf `@param` JSDoc normalization — distinct items).

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated cross-package API drift-detection sweep. The routine extracted structural and semantic features from every member of `stats/base/dists/laplace`, computed a per-feature majority pattern at a 75% threshold, validated each candidate correction against the package source and its siblings, and applied only mechanical, behavior-preserving patches. A maintainer should audit and promote out of draft.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sw1TscYtQ82XDG4btdDLw2)_