### PR TITLE
test: migrate `math/base/special/acosdf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acosdf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosdf/test/test.js
@@ -22,10 +22,10 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float32/eps' );
-var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var acosdf = require( './../lib' );
 
 
@@ -51,8 +51,6 @@ tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 
 tape( 'the function computes the arccosine in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -62,21 +60,13 @@ tape( 'the function computes the arccosine in degrees (negative values)', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosdf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 2.8 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosine in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -86,13 +76,7 @@ tape( 'the function computes the arccosine in degrees (positive values)', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosdf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 2.8 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosdf/test/test.native.js
@@ -23,10 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float32/eps' );
-var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -60,8 +60,6 @@ tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 
 tape( 'the function computes the arccosine in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -71,21 +69,13 @@ tape( 'the function computes the arccosine in degrees (negative values)', opts, 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosdf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 2.8 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccosine in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,13 +85,7 @@ tape( 'the function computes the arccosine in degrees (positive values)', opts, 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosdf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 2.8 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

- Migrates the tests for `@stdlib/math/base/special/acosdf` to use precise ULP-based bounds for floating-point comparisons rather than relative epsilon tolerances.
- Replaces absolute differences and epsilon logic with `@stdlib/number/float32/base/assert/is-almost-same-value` for both the JavaScript and C++ native add-on test suites.
- Applies strict empirical ULP maximums computed from the provided JSON fixtures (3 ULPs for negative values, 3 ULPs for positive values).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
