### PR TITLE
test: migrate `math/base/special/cotd` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cotd/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cotd/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var cotd = require( './../lib' );
 
 
@@ -51,8 +50,6 @@ tape( 'if provided a `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function computes the cotangent of an angle measured in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -66,21 +63,13 @@ tape( 'the function computes the cotangent of an angle measured in degrees (nega
 			t.strictEqual( y, PINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cotangent of an angle measured in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -94,13 +83,7 @@ tape( 'the function computes the cotangent of an angle measured in degrees (posi
 			t.strictEqual( y, PINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cotd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cotd/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -60,8 +59,6 @@ tape( 'if provided a `NaN`, the function returns `NaN`', opts, function test( t 
 
 tape( 'the function computes the cotangent of an angle measured in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -75,21 +72,13 @@ tape( 'the function computes the cotangent of an angle measured in degrees (nega
 			t.strictEqual( y, PINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cotangent of an angle measured in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -103,13 +92,7 @@ tape( 'the function computes the cotangent of an angle measured in degrees (posi
 			t.strictEqual( y, PINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `@stdlib/math/base/special/cotd` (`test.js` and `test.native.js`) from relative-tolerance (`EPS`-scaled `delta`/`tol`) comparisons to ULP-based comparisons using `@stdlib/assert/is-almost-same-value`.
-   Empirically determined the minimum required ULP bound by computing the actual maximum ULP difference between the JS/native implementations and the Julia fixture data (`negative.json` and `positive.json`), then confirming the tests fail at `maxULP - 1` and pass deterministically (verified over multiple runs) at the chosen bound.
-   Final ULP constant: **3** (used identically in both `test.js` and `test.native.js`; the native add-on was built locally and produces the same maximum ULP difference as the JS implementation).

## Related Issues

This pull request has the following related issues:

-   #11352

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_012HA2UaVJgdSUeFGQfi5UPZ)_