### PR TITLE
test: migrate `math/base/special/acot` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acot/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acot/test/test.js
@@ -26,8 +26,7 @@ var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/number/float64/base/assert/is-almost-same-value' );
 var acot = require( './../lib' );
 
 
@@ -53,8 +52,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse cotangent for medium positive values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -63,21 +60,13 @@ tape( 'the function computes the inverse cotangent for medium positive values', 
 	expected = mediumPositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for medium negative values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -86,21 +75,13 @@ tape( 'the function computes the inverse cotangent for medium negative values', 
 	expected = mediumNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for large positive values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -109,21 +90,13 @@ tape( 'the function computes the inverse cotangent for large positive values', f
 	expected = largePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for large negative values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -132,21 +105,13 @@ tape( 'the function computes the inverse cotangent for large negative values', f
 	expected = largeNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for larger positive values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -155,21 +120,13 @@ tape( 'the function computes the inverse cotangent for larger positive values', 
 	expected = largerPositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for larger negative values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -178,21 +135,13 @@ tape( 'the function computes the inverse cotangent for larger negative values', 
 	expected = largerNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for huge positive values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -201,21 +150,13 @@ tape( 'the function computes the inverse cotangent for huge positive values', fu
 	expected = hugePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for huge negative values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -224,13 +165,7 @@ tape( 'the function computes the inverse cotangent for huge negative values', fu
 	expected = hugeNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acot/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acot/test/test.native.js
@@ -27,8 +27,7 @@ var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/number/float64/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -62,8 +61,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse cotangent for medium positive values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -72,21 +69,13 @@ tape( 'the function computes the inverse cotangent for medium positive values', 
 	expected = mediumPositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for medium negative values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,21 +84,13 @@ tape( 'the function computes the inverse cotangent for medium negative values', 
 	expected = mediumNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for large positive values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -118,21 +99,13 @@ tape( 'the function computes the inverse cotangent for large positive values', o
 	expected = largePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for large negative values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -141,21 +114,13 @@ tape( 'the function computes the inverse cotangent for large negative values', o
 	expected = largeNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for larger positive values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -164,21 +129,13 @@ tape( 'the function computes the inverse cotangent for larger positive values', 
 	expected = largerPositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for larger negative values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -187,21 +144,13 @@ tape( 'the function computes the inverse cotangent for larger negative values', 
 	expected = largerNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for huge positive values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -210,21 +159,13 @@ tape( 'the function computes the inverse cotangent for huge positive values', op
 	expected = hugePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse cotangent for huge negative values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -233,13 +174,7 @@ tape( 'the function computes the inverse cotangent for huge negative values', op
 	expected = hugeNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = acot( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i]+'.' );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

- Migrates the tests for `@stdlib/math/base/special/acot` to use precise ULP-based bounds for floating-point comparisons rather than relative epsilon tolerances.
- Replaces absolute differences and epsilon logic with `@stdlib/number/float64/base/assert/is-almost-same-value` across all 8 testing loops in both the JavaScript and C++ native add-on test suites.
- Applies strict empirical ULP maximums computed from the provided JSON fixtures (1 ULP for all positive and negative test cases).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
