### PR TITLE
test: migrate `math/base/special/acotdf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acotdf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acotdf/test/test.js
@@ -22,8 +22,7 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var acotdf = require( './../lib' );
 
@@ -44,8 +43,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the arccotangent in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -57,21 +54,13 @@ tape( 'the function computes the arccotangent in degrees (negative values)', fun
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		y = acotdf( x[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = 1.7 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccotangent in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -83,13 +72,7 @@ tape( 'the function computes the arccotangent in degrees (positive values)', fun
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		y = acotdf( x[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = 1.7 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acotdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acotdf/test/test.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -53,8 +52,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the arccotangent in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -66,21 +63,13 @@ tape( 'the function computes the arccotangent in degrees (negative values)', opt
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		y = acotdf( x[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = 1.7 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arccotangent in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -92,13 +81,7 @@ tape( 'the function computes the arccotangent in degrees (positive values)', opt
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		y = acotdf( x[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = absf( y - e );
-			tol = 1.7 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

- Migrates the tests for `@stdlib/math/base/special/acotdf` to use precise ULP-based bounds for floating-point comparisons rather than relative epsilon tolerances.
- Replaces absolute differences and epsilon logic with `@stdlib/number/float32/base/assert/is-almost-same-value` for both the JavaScript and C++ native add-on test suites.
- Applies strict empirical ULP maximums computed from the provided JSON fixtures (2 ULPs for negative values, 2 ULPs for positive values).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
