### PR TITLE
chore: fix C lint errors

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/smap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/smap/README.md
@@ -205,9 +205,6 @@ static float scale( const float x ) {
     return x * 10.0f;
 }
 
-float X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
-float Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-
 const float X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
 float Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 

--- a/lib/node_modules/@stdlib/strided/base/smap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/smap/README.md
@@ -257,17 +257,17 @@ static float scale( const float x ) {
 
 int main( void ) {
     // Create an input strided array:
-    float X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+    const float X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
 
     // Create an output strided array:
     float Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
     // Specify the number of elements:
-    int64_t N = 6;
+    const int64_t N = 6;
 
     // Define the strides:
-    int64_t strideX = 1;
-    int64_t strideY = -1;
+    const int64_t strideX = 1;
+    const int64_t strideY = -1;
 
     // Apply the callback:
     stdlib_strided_smap( N, X, strideX, Y, strideY, scale );

--- a/lib/node_modules/@stdlib/strided/base/smap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/smap/README.md
@@ -208,7 +208,10 @@ static float scale( const float x ) {
 float X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
 float Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
-int64_t N = 6;
+const float X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+float Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+const int64_t N = 6;
 
 stdlib_strided_smap( N, X, 1, Y, 1, scale );
 ```

--- a/lib/node_modules/@stdlib/strided/base/smap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/smap/examples/c/example.c
@@ -38,8 +38,8 @@ int main( void ) {
 
 	// Define the strides:
 	int64_t strideX = 1;
-const int64_t strideX = 1;
-const int64_t strideY = -1;
+	const int64_t strideX = 1;
+	const int64_t strideY = -1;
 
 	// Apply the callback:
 	stdlib_strided_smap( N, X, strideX, Y, strideY, scale );

--- a/lib/node_modules/@stdlib/strided/base/smap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/smap/examples/c/example.c
@@ -34,11 +34,12 @@ int main( void ) {
 	float Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
 	// Specify the number of elements:
-	int64_t N = 6;
+	const int64_t N = 6;
 
 	// Define the strides:
 	int64_t strideX = 1;
-	int64_t strideY = -1;
+const int64_t strideX = 1;
+const int64_t strideY = -1;
 
 	// Apply the callback:
 	stdlib_strided_smap( N, X, strideX, Y, strideY, scale );

--- a/lib/node_modules/@stdlib/strided/base/smap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/smap/examples/c/example.c
@@ -28,7 +28,7 @@ static float scale( const float x ) {
 
 int main( void ) {
 	// Create an input strided array:
-	float X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+	const float X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
 
 	// Create an output strided array:
 	float Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };

--- a/lib/node_modules/@stdlib/strided/base/smap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/smap/examples/c/example.c
@@ -37,7 +37,6 @@ int main( void ) {
 	const int64_t N = 6;
 
 	// Define the strides:
-	int64_t strideX = 1;
 	const int64_t strideX = 1;
 	const int64_t strideY = -1;
 


### PR DESCRIPTION
Resolves #13733.

## Description
> What is the purpose of this pull request?

This pull request:
-   Fixes a C lint error in `lib/node_modules/@stdlib/strided/base/smap/examples/c/example.c` by declaring the input array `X` as `const`, since it is only read from (passed as `const float *X` to `stdlib_strided_smap`) and never modified.

## Related Issues
> Does this pull request have any related issues?

This pull request has the following related issues:
-   #13733

## Questions
> Any questions for reviewers of this pull request?

No.

## Other
> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verified locally with `cppcheck --enable=style`: the warning is present before the change and gone after. Also confirmed the change compiles cleanly with `gcc -Wall -Wextra` and matches the existing convention used in sibling examples (e.g. `dmap`'s example already declares its input array `const`).

## Checklist
> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance
> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md