### PR TITLE
feat: add `stats/incr/nanmrmse`

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
@@ -147,8 +147,6 @@ console.log( accumulator() );
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">
-
-
 </section>
 
 <!-- /.related -->

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
@@ -147,6 +147,7 @@ console.log( accumulator() );
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">
+
 </section>
 
 <!-- /.related -->

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
@@ -53,7 +53,7 @@ var incrnanmrmse = require( '@stdlib/stats/incr/nanmrmse' );
 
 #### incrnanmrmse( window )
 
-Returns an accumulator `function` which incrementally computes a moving [root mean squared error][root-mean-squared-error]. The `window` parameter defines the number of values over which to compute the moving [root mean squared error][root-mean-squared-error].
+Returns an accumulator `function` which incrementally computes a moving [root mean squared error][root-mean-squared-error]. The `window` parameter defines the number of values over which to compute the moving [root mean squared error][root-mean-squared-error], ignoring `NaN` values.
 
 ```javascript
 var accumulator = incrnanmrmse( 3 );
@@ -79,16 +79,11 @@ r = accumulator( -1.0, 4.0 ); // [(2.0,3.0), (-1.0,4.0)]
 r = accumulator( 3.0, 9.0 ); // [(2.0,3.0), (-1.0,4.0), (3.0,9.0)]
 // returns ~4.55
 
-// Ignore 'NaN'
-r = accumulator( NaN ); // [(2.0,3.0), (-1.0,4.0), (3.0,9.0)]
+r = accumulator( NaN, 5.0 ); // [(2.0,3.0), (-1.0,4.0), (3.0,9.0)] (NaN pair ignored)
 // returns ~4.55
 
 // Window begins sliding...
 r = accumulator( -7.0, 3.0 ); // [(-1.0,4.0), (3.0,9.0), (-7.0,3.0)]
-// returns ~7.33
-
-// Ignore `undefined` begin passed
-r = accumulator( -7.0 ); // [(-1.0,4.0), (3.0,9.0), (-7.0,3.0)]
 // returns ~7.33
 
 r = accumulator( -5.0, -3.0 ); // [(3.0,9.0), (-7.0,3.0), (-5.0,-3.0)]
@@ -106,8 +101,8 @@ r = accumulator();
 
 ## Notes
 
--   Input values are **not** type checked. If provided `NaN` or a value which, when used in computations, returns the currently accumulated value. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
--   As `W` (x,y) pairs are needed to fill the window buffer, the first `W-1` returned values are calculated from smaller sample sizes. Until the window is full, each returned value is calculated from all provided values.
+-   Input values are **not** type checked. If provided `NaN` for either value, the pair is ignored and the accumulator function returns the current [root mean squared error][root-mean-squared-error] without updating the window. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+-   As `W` (x,y) pairs are needed to fill the window buffer, the first `W-1` returned values are calculated from smaller sample sizes. Until the window is full, each returned value is calculated from all provided values (excluding NaN values).
 
 </section>
 
@@ -120,7 +115,8 @@ r = accumulator();
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
 var incrnanmrmse = require( '@stdlib/stats/incr/nanmrmse' );
 
 var accumulator;
@@ -133,8 +129,8 @@ accumulator = incrnanmrmse( 5 );
 
 // For each simulated datum, update the moving root mean squared error...
 for ( i = 0; i < 100; i++ ) {
-    v1 = ( randu()*100.0 ) - 50.0;
-    v2 = ( randu()*100.0 ) - 50.0;
+    v1 = ( bernoulli( 0.8 ) < 1 ) ? NaN : uniform( -50.0, 50.0 );
+    v2 = ( bernoulli( 0.8 ) < 1 ) ? NaN : uniform( -50.0, 50.0 );
     accumulator( v1, v2 );
 }
 console.log( accumulator() );

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
@@ -148,13 +148,6 @@ console.log( accumulator() );
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/stats/incr/mmse`][@stdlib/stats/incr/mmse]</span><span class="delimiter">: </span><span class="description">compute a moving mean squared error (MSE) incrementally.</span>
--   <span class="package-name">[`@stdlib/stats/incr/mrss`][@stdlib/stats/incr/mrss]</span><span class="delimiter">: </span><span class="description">compute a moving residual sum of squares (RSS) incrementally.</span>
--   <span class="package-name">[`@stdlib/stats/incr/rmse`][@stdlib/stats/incr/rmse]</span><span class="delimiter">: </span><span class="description">compute the root mean squared error (RMSE) incrementally.</span>
 
 </section>
 
@@ -167,12 +160,6 @@ console.log( accumulator() );
 [root-mean-squared-error]: https://en.wikipedia.org/wiki/Root-mean-square_deviation
 
 <!-- <related-links> -->
-
-[@stdlib/stats/incr/mmse]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mmse
-
-[@stdlib/stats/incr/mrss]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mrss
-
-[@stdlib/stats/incr/rmse]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/rmse
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/README.md
@@ -1,0 +1,181 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# incrnanmrmse
+
+> Compute a moving [root mean squared error][root-mean-squared-error] (RMSE) incrementally, ignoring `NaN` values.
+
+<section class="intro">
+
+For a window of size `W`, the [**root mean squared error**][root-mean-squared-error] (also known as the **root mean square error** (RMSE) and **root mean square deviation** (RMSD)) is defined as
+
+<!-- <equation class="equation" label="eq:root_mean_squared_error" align="center" raw="\operatorname{RMSE} = \sqrt{ \frac{1}{W} \sum_{i=0}^{W-1} (y_i - x_i)^2 }" alt="Equation for the root mean squared error."> -->
+
+```math
+\mathop{\mathrm{RMSE}} = \sqrt{ \frac{1}{W} \sum_{i=0}^{W-1} (y_i - x_i)^2 }
+```
+
+<!-- <div class="equation" align="center" data-raw-text="\operatorname{RMSE} = \sqrt{ \frac{1}{W} \sum_{i=0}^{W-1} (y_i - x_i)^2 }" data-equation="eq:root_mean_squared_error">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@6c360ad04d4b48c623a626d13723b4dc33ff0e8e/lib/node_modules/@stdlib/stats/incr/mrmse/docs/img/equation_root_mean_squared_error.svg" alt="Equation for the root mean squared error.">
+    <br>
+</div> -->
+
+<!-- </equation> -->
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var incrnanmrmse = require( '@stdlib/stats/incr/nanmrmse' );
+```
+
+#### incrnanmrmse( window )
+
+Returns an accumulator `function` which incrementally computes a moving [root mean squared error][root-mean-squared-error]. The `window` parameter defines the number of values over which to compute the moving [root mean squared error][root-mean-squared-error].
+
+```javascript
+var accumulator = incrnanmrmse( 3 );
+```
+
+#### accumulator( \[x, y] )
+
+If provided input values `x` and `y`, the accumulator function returns an updated [root mean squared error][root-mean-squared-error]. If not provided input values `x` and `y`, the accumulator function returns the current [root mean squared error][root-mean-squared-error].
+
+```javascript
+var accumulator = incrnanmrmse( 3 );
+
+var r = accumulator();
+// returns null
+
+// Fill the window...
+r = accumulator( 2.0, 3.0 ); // [(2.0,3.0)]
+// returns 1.0
+
+r = accumulator( -1.0, 4.0 ); // [(2.0,3.0), (-1.0,4.0)]
+// returns ~3.61
+
+r = accumulator( 3.0, 9.0 ); // [(2.0,3.0), (-1.0,4.0), (3.0,9.0)]
+// returns ~4.55
+
+// Ignore 'NaN'
+r = accumulator( NaN ); // [(2.0,3.0), (-1.0,4.0), (3.0,9.0)]
+// returns ~4.55
+
+// Window begins sliding...
+r = accumulator( -7.0, 3.0 ); // [(-1.0,4.0), (3.0,9.0), (-7.0,3.0)]
+// returns ~7.33
+
+// Ignore `undefined` begin passed
+r = accumulator( -7.0 ); // [(-1.0,4.0), (3.0,9.0), (-7.0,3.0)]
+// returns ~7.33
+
+r = accumulator( -5.0, -3.0 ); // [(3.0,9.0), (-7.0,3.0), (-5.0,-3.0)]
+// returns ~6.83
+
+r = accumulator();
+// returns ~6.83
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   Input values are **not** type checked. If provided `NaN` or a value which, when used in computations, returns the currently accumulated value. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+-   As `W` (x,y) pairs are needed to fill the window buffer, the first `W-1` returned values are calculated from smaller sample sizes. Until the window is full, each returned value is calculated from all provided values.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanmrmse = require( '@stdlib/stats/incr/nanmrmse' );
+
+var accumulator;
+var v1;
+var v2;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanmrmse( 5 );
+
+// For each simulated datum, update the moving root mean squared error...
+for ( i = 0; i < 100; i++ ) {
+    v1 = ( randu()*100.0 ) - 50.0;
+    v2 = ( randu()*100.0 ) - 50.0;
+    accumulator( v1, v2 );
+}
+console.log( accumulator() );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/stats/incr/mmse`][@stdlib/stats/incr/mmse]</span><span class="delimiter">: </span><span class="description">compute a moving mean squared error (MSE) incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/mrss`][@stdlib/stats/incr/mrss]</span><span class="delimiter">: </span><span class="description">compute a moving residual sum of squares (RSS) incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/rmse`][@stdlib/stats/incr/rmse]</span><span class="delimiter">: </span><span class="description">compute the root mean squared error (RMSE) incrementally.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[root-mean-squared-error]: https://en.wikipedia.org/wiki/Root-mean-square_deviation
+
+<!-- <related-links> -->
+
+[@stdlib/stats/incr/mmse]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mmse
+
+[@stdlib/stats/incr/mrss]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mrss
+
+[@stdlib/stats/incr/rmse]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/rmse
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/benchmark/benchmark.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var incrnanmrmse = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var f;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		f = incrnanmrmse( (i%5)+1 );
+		if ( typeof f !== 'function' ) {
+			b.fail( 'should return a function' );
+		}
+	}
+	b.toc();
+	if ( typeof f !== 'function' ) {
+		b.fail( 'should return a function' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( format( '%s::accumulator', pkg ), function benchmark( b ) {
+	var acc;
+	var v;
+	var i;
+
+	acc = incrnanmrmse( 5 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = acc( randu()-0.5, randu()-0.5 );
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( v !== v ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/repl.txt
@@ -33,13 +33,13 @@
     1.0
     > r = accumulator( -5.0, 2.0 )
     5.0
-    > r = accumulator( NaN )
+    > r = accumulator( NaN, 2.0 )
     5.0
     > r = accumulator( 3.0, 2.0 )
     ~4.12
+    > r = accumulator( 3.0, NaN )
+    ~4.12
     > r = accumulator( 5.0, -2.0 )
-    ~5.74
-    > r = accumulator( 5.0 )
     ~5.74
     > r = accumulator()
     ~5.74

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/repl.txt
@@ -1,0 +1,49 @@
+
+{{alias}}( W )
+    Returns an accumulator function which incrementally computes a moving root
+    mean squared error (RMSE), ignoring `NaN` values.
+
+    The `W` parameter defines the number of values over which to compute the
+    moving root mean squared error.
+
+    If provided a value, the accumulator function returns an updated moving root
+    mean squared error. If not provided a value, the accumulator function
+    returns the current moving root mean squared error.
+
+    As `W` values are needed to fill the window buffer, the first `W-1` returned
+    values are calculated from smaller sample sizes. Until the window is full,
+    each returned value is calculated from all provided values.
+
+    Parameters
+    ----------
+    W: integer
+        Window size.
+
+    Returns
+    -------
+    acc: Function
+        Accumulator function.
+
+    Examples
+    --------
+    > var accumulator = {{alias}}( 3 );
+    > var r = accumulator()
+    null
+    > r = accumulator( 2.0, 3.0 )
+    1.0
+    > r = accumulator( -5.0, 2.0 )
+    5.0
+    > r = accumulator( NaN )
+    5.0
+    > r = accumulator( 3.0, 2.0 )
+    ~4.12
+    > r = accumulator( 5.0, -2.0 )
+    ~5.74
+    > r = accumulator( 5.0 )
+    ~5.74
+    > r = accumulator()
+    ~5.74
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/types/index.d.ts
@@ -1,0 +1,80 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* If provided input values, the accumulator function returns an updated root mean squared error. If not provided input values, the accumulator function returns the current root mean squared error.
+*
+* ## Notes
+*
+* -   If provided `NaN` or a value which, when used in computations, results in `NaN`, the currently accumulated value returned.
+*
+* @param x - input value
+* @param y - input value
+* @returns root mean squared error or null
+*/
+type accumulator = ( x?: number, y?: number ) => number | null;
+
+/**
+* Returns an accumulator function which incrementally computes a moving root mean squared error, ignoring `NaN` values.
+*
+* ## Notes
+*
+* -   The `W` parameter defines the number of values over which to compute the moving root mean squared error.
+* -   As `W` values are needed to fill the window buffer, the first `W-1` returned values are calculated from smaller sample sizes. Until the window is full, each returned value is calculated from all provided values.
+*
+* @param W - window size
+* @throws must provide a positive integer
+* @returns accumulator function
+*
+* @example
+* var accumulator = incrnanmrmse( 3 );
+*
+* var r = accumulator();
+* // returns null
+*
+* r = accumulator( 2.0, 3.0 );
+* // returns 1.0
+*
+* r = accumulator( -5.0, 2.0 );
+* // returns 5.0
+*
+* r = accumulator( NaN );
+* // returns 5.0
+*
+* r = accumulator( 3.0, 2.0 );
+* // returns ~4.12
+*
+* r = accumulator( 5.0, -2.0 );
+* // returns ~5.74
+*
+* r = accumulator( 5.0 );
+* // returns ~5.74
+*
+* r = accumulator();
+* // returns ~5.74
+*/
+declare function incrnanmrmse( W: number ): accumulator;
+
+
+// EXPORTS //
+
+export = incrnanmrmse;

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/types/index.d.ts
@@ -23,10 +23,6 @@
 /**
 * If provided input values, the accumulator function returns an updated root mean squared error. If not provided input values, the accumulator function returns the current root mean squared error.
 *
-* ## Notes
-*
-* -   If provided `NaN` or a value which, when used in computations, results in `NaN`, the currently accumulated value returned.
-*
 * @param x - input value
 * @param y - input value
 * @returns root mean squared error or null
@@ -57,16 +53,16 @@ type accumulator = ( x?: number, y?: number ) => number | null;
 * r = accumulator( -5.0, 2.0 );
 * // returns 5.0
 *
-* r = accumulator( NaN );
+* r = accumulator( NaN, 2.0 );
 * // returns 5.0
 *
 * r = accumulator( 3.0, 2.0 );
 * // returns ~4.12
 *
-* r = accumulator( 5.0, -2.0 );
-* // returns ~5.74
+* r = accumulator( 3.0, NaN );
+* // returns ~4.12
 *
-* r = accumulator( 5.0 );
+* r = accumulator( 5.0, -2.0 );
 * // returns ~5.74
 *
 * r = accumulator();

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/docs/types/test.ts
@@ -1,0 +1,74 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import incrnanmrmse = require( './index' );
+
+
+// TESTS //
+
+// The function returns an accumulator function...
+{
+	incrnanmrmse( 3 ); // $ExpectType accumulator
+}
+
+// The compiler throws an error if the function is provided an argument which is not a number...
+{
+	incrnanmrmse( '5' ); // $ExpectError
+	incrnanmrmse( true ); // $ExpectError
+	incrnanmrmse( false ); // $ExpectError
+	incrnanmrmse( null ); // $ExpectError
+	incrnanmrmse( undefined ); // $ExpectError
+	incrnanmrmse( [] ); // $ExpectError
+	incrnanmrmse( {} ); // $ExpectError
+	incrnanmrmse( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an invalid number of arguments...
+{
+	incrnanmrmse(); // $ExpectError
+	incrnanmrmse( 2, 3 ); // $ExpectError
+}
+
+// The function returns an accumulator function which returns an accumulated result...
+{
+	const acc = incrnanmrmse( 3 );
+
+	acc(); // $ExpectType number | null
+	acc( 3.14, 2.0 ); // $ExpectType number | null
+}
+
+// The compiler throws an error if the returned accumulator function is provided invalid arguments...
+{
+	const acc = incrnanmrmse( 3 );
+
+	acc( '5', 2.0 ); // $ExpectError
+	acc( true, 2.0 ); // $ExpectError
+	acc( false, 2.0 ); // $ExpectError
+	acc( null, 2.0 ); // $ExpectError
+	acc( [], 2.0 ); // $ExpectError
+	acc( {}, 2.0 ); // $ExpectError
+	acc( ( x: number ): number => x, 2.0 ); // $ExpectError
+
+	acc( 3.14, '5' ); // $ExpectError
+	acc( 3.14, true ); // $ExpectError
+	acc( 3.14, false ); // $ExpectError
+	acc( 3.14, null ); // $ExpectError
+	acc( 3.14, [] ); // $ExpectError
+	acc( 3.14, {} ); // $ExpectError
+	acc( 3.14, ( x: number ): number => x ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/examples/index.js
@@ -18,7 +18,9 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrnanmrmse = require( './../lib' );
 
 var accumulator;
@@ -33,8 +35,8 @@ accumulator = incrnanmrmse( 5 );
 // For each simulated datum, update the moving root mean squared error...
 console.log( '\nValue\tValue\tRMSE\n' );
 for ( i = 0; i < 100; i++ ) {
-	v1 = ( randu()*100.0 ) - 50.0;
-	v2 = ( randu()*100.0 ) - 50.0;
+	v1 = ( bernoulli( 0.8 ) < 1 ) ? NaN : uniform( -50.0, 50.0 );
+	v2 = ( bernoulli( 0.8 ) < 1 ) ? NaN : uniform( -50.0, 50.0 );
 	rmse = accumulator( v1, v2 );
-	console.log( '%d\t%d\t%d', v1.toFixed( 3 ), v2.toFixed( 3 ), rmse.toFixed( 3 ) );
+	console.log( '%s\t%s\t%s', ( isnan( v1 ) ) ? 'NaN' : v1.toFixed( 3 ), ( isnan( v2 ) ) ? 'NaN' : v2.toFixed( 3 ), ( rmse === null ) ? 'null' : rmse.toFixed( 3 ) );
 }

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/examples/index.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanmrmse = require( './../lib' );
+
+var accumulator;
+var rmse;
+var v1;
+var v2;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanmrmse( 5 );
+
+// For each simulated datum, update the moving root mean squared error...
+console.log( '\nValue\tValue\tRMSE\n' );
+for ( i = 0; i < 100; i++ ) {
+	v1 = ( randu()*100.0 ) - 50.0;
+	v2 = ( randu()*100.0 ) - 50.0;
+	rmse = accumulator( v1, v2 );
+	console.log( '%d\t%d\t%d', v1.toFixed( 3 ), v2.toFixed( 3 ), rmse.toFixed( 3 ) );
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/lib/index.js
@@ -37,16 +37,16 @@
 * r = accumulator( -5.0, 2.0 );
 * // returns 5.0
 *
-* r = accumulator( NaN );
+* r = accumulator( NaN, 2.0 );
 * // returns 5.0
 *
 * r = accumulator( 3.0, 2.0 );
 * // returns ~4.12
 *
-* r = accumulator( 5.0, -2.0 );
-* // returns ~5.74
+* r = accumulator( 3.0, NaN );
+* // returns ~4.12
 *
-* r = accumulator( 5.0 );
+* r = accumulator( 5.0, -2.0 );
 * // returns ~5.74
 *
 * r = accumulator();

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/lib/index.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute a moving root mean squared error (RMSE) incrementally, ignoring `NaN` values.
+*
+* @module @stdlib/stats/incr/nanmrmse
+*
+* @example
+* var incrnanmrmse = require( '@stdlib/stats/incr/nanmrmse' );
+*
+* var accumulator = incrnanmrmse( 3 );
+*
+* var r = accumulator();
+* // returns null
+*
+* r = accumulator( 2.0, 3.0 );
+* // returns 1.0
+*
+* r = accumulator( -5.0, 2.0 );
+* // returns 5.0
+*
+* r = accumulator( NaN );
+* // returns 5.0
+*
+* r = accumulator( 3.0, 2.0 );
+* // returns ~4.12
+*
+* r = accumulator( 5.0, -2.0 );
+* // returns ~5.74
+*
+* r = accumulator( 5.0 );
+* // returns ~5.74
+*
+* r = accumulator();
+* // returns ~5.74
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/lib/main.js
@@ -45,23 +45,23 @@ var incrmrmse = require( '@stdlib/stats/incr/mrmse' );
 * r = accumulator( -5.0, 2.0 );
 * // returns 5.0
 *
-* r = accumulator( NaN );
+* r = accumulator( NaN, 2.0 );
 * // returns 5.0
 *
 * r = accumulator( 3.0, 2.0 );
 * // returns ~4.12
 *
-* r = accumulator( 5.0, -2.0 );
-* // returns ~5.74
+* r = accumulator( 3.0, NaN );
+* // returns ~4.12
 *
-* r = accumulator( 5.0 );
+* r = accumulator( 5.0, -2.0 );
 * // returns ~5.74
 *
 * r = accumulator();
 * // returns ~5.74
 */
 function incrnanmrmse( W ) {
-	var acc = incrmrmse( W );
+	var mrmse = incrmrmse( W );
 	return accumulator;
 
 	/**
@@ -73,15 +73,10 @@ function incrnanmrmse( W ) {
 	* @returns {(number|null)} root mean squared error or null
 	*/
 	function accumulator( x, y ) {
-		if ( arguments.length === 0 ) {
-			return acc();
+		if ( arguments.length === 0 || isnan( x ) || isnan( y ) ) {
+			return mrmse();
 		}
-
-		if ( arguments.length < 2 || isnan( x ) || isnan( y ) ) {
-			return acc();
-		}
-
-		return acc( x, y );
+		return mrmse( x, y );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/lib/main.js
@@ -1,0 +1,91 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var incrmrmse = require( '@stdlib/stats/incr/mrmse' );
+
+
+// MAIN //
+
+/**
+* Returns an accumulator function which incrementally computes a moving root mean squared error, ignoring `NaN` values.
+*
+* @param {PositiveInteger} W - window size
+* @throws {TypeError} must provide a positive integer
+* @returns {Function} accumulator function
+*
+* @example
+* var accumulator = incrnanmrmse( 3 );
+*
+* var r = accumulator();
+* // returns null
+*
+* r = accumulator( 2.0, 3.0 );
+* // returns 1.0
+*
+* r = accumulator( -5.0, 2.0 );
+* // returns 5.0
+*
+* r = accumulator( NaN );
+* // returns 5.0
+*
+* r = accumulator( 3.0, 2.0 );
+* // returns ~4.12
+*
+* r = accumulator( 5.0, -2.0 );
+* // returns ~5.74
+*
+* r = accumulator( 5.0 );
+* // returns ~5.74
+*
+* r = accumulator();
+* // returns ~5.74
+*/
+function incrnanmrmse( W ) {
+	var acc = incrmrmse( W );
+	return accumulator;
+
+	/**
+	* If provided input values, the accumulator function returns an updated root mean squared error. If not provided input values, the accumulator function returns the current root mean squared error.
+	*
+	* @private
+	* @param {number} [x] - input value
+	* @param {number} [y] - input value
+	* @returns {(number|null)} root mean squared error or null
+	*/
+	function accumulator( x, y ) {
+		if ( arguments.length === 0 ) {
+			return acc();
+		}
+
+		if ( arguments.length < 2 || isnan( x ) || isnan( y ) ) {
+			return acc();
+		}
+
+		return acc( x, y );
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = incrnanmrmse;

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@stdlib/stats/incr/nanmrmse",
+  "version": "0.0.0",
+  "description": "Compute a moving root mean squared error (RMSE) incrementally, ignoring NaN values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "error",
+    "err",
+    "rmse",
+    "rmsd",
+    "mse",
+    "msd",
+    "residuals",
+    "squares",
+    "deviation",
+    "difference",
+    "diff",
+    "delta",
+    "incremental",
+    "accumulator",
+    "sliding window",
+    "sliding",
+    "window",
+    "moving",
+    "time series",
+    "timeseries",
+    "forecasting",
+    "forecast",
+    "model",
+    "selection",
+    "evaluation",
+    "prediction",
+    "ignore",
+    "nan"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/package.json
@@ -61,6 +61,7 @@
     "rmsd",
     "mse",
     "msd",
+    "nan",
     "residuals",
     "squares",
     "deviation",
@@ -80,8 +81,6 @@
     "model",
     "selection",
     "evaluation",
-    "prediction",
-    "ignore",
-    "nan"
+    "prediction"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/test/test.js
@@ -1,0 +1,276 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var incrnanmrmse = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof incrnanmrmse, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided a positive integer', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		-5.0,
+		0.0,
+		3.14,
+		true,
+		null,
+		void 0,
+		NaN,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			incrnanmrmse( value );
+		};
+	}
+});
+
+tape( 'the function returns an accumulator function', function test( t ) {
+	t.strictEqual( typeof incrnanmrmse( 3 ), 'function', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the accumulator function computes a moving root mean squared error incrementally', function test( t ) {
+	var expected;
+	var actual;
+	var delta;
+	var data;
+	var acc;
+	var tol;
+	var N;
+	var i;
+
+	data = [
+		[ 2.0, 3.0 ],
+		[ 3.0, -1.0 ],
+		[ 2.0, 5.0 ],
+		[ 4.0, -4.0 ],
+		[ 3.0, 0.0 ],
+		[ -4.0, 5.0 ]
+	];
+	N = data.length;
+
+	acc = incrnanmrmse( 3 );
+
+	expected = [
+		1.0,
+		sqrt( 17.0/2.0 ),
+		sqrt( 26.0/3.0 ),
+		sqrt( 89.0/3.0 ),
+		sqrt( 82.0/3.0 ),
+		sqrt( 154.0/3.0 )
+	];
+	for ( i = 0; i < N; i++ ) {
+		actual = acc( data[i][0], data[i][1] );
+		if ( actual === expected[i] ) {
+			t.strictEqual( actual, expected[i], 'returns expected value' );
+		} else {
+			delta = abs( expected[i] - actual );
+			tol = 1.0 * EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+actual+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'if not provided an input value, the accumulator function returns the current root mean squared error', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [
+		[ 2.0, 3.0 ],
+		[ 3.0, -5.0 ],
+		[ 1.0, 10.0 ]
+	];
+	acc = incrnanmrmse( 2 );
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[i][0], data[i][1] );
+	}
+	t.strictEqual( acc(), sqrt( 145.0/2.0 ), 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided an input value that results in `NaN`, the accumulator function returns the current root mean squared error', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [
+		[ 2.0, 3.0 ],
+		[ 3.0, -5.0 ],
+		[ 1.0, 10.0 ]
+	];
+	acc = incrnanmrmse( 2 );
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[i][0], data[i][1] );
+	}
+	t.strictEqual( acc( NaN ), sqrt( 145.0/2.0 ), 'returns expected value' );
+	t.strictEqual( acc( 10.0 ), sqrt( 145.0/2.0 ), 'returns expected value' );
+	t.end();
+});
+
+tape( 'if data has yet to be provided, the accumulator function returns `null`', function test( t ) {
+	var acc = incrnanmrmse( 3 );
+	t.strictEqual( acc(), null, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided `NaN`, the accumulated value is `NaN` for at least `W` invocations', function test( t ) {
+	var expected;
+	var data;
+	var acc;
+	var v;
+	var i;
+
+	expected = [
+		null,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0
+	];
+
+	data = [
+		[ NaN, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ NaN, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ NaN, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ NaN, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ NaN, 3.14 ],
+		[ NaN, 3.14 ],
+		[ NaN, 3.14 ],
+		[ NaN, 3.14 ],
+		[ 3.14, 3.14 ]
+	];
+
+	acc = incrnanmrmse( 3 );
+
+	for ( i = 0; i < data.length; i++ ) {
+		v = acc( data[i][0], data[i][1] );
+		t.strictEqual( v, expected[ i ], 'returns expected value for window '+i );
+		t.strictEqual( acc(), expected[ i ], 'returns expected value for window '+i );
+	}
+
+	expected = [
+		null,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0
+	];
+
+	data = [
+		[ 3.14, NaN ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, NaN ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, NaN ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, NaN ],
+		[ 3.14, 3.14 ],
+		[ 3.14, 3.14 ],
+		[ 3.14, NaN ],
+		[ 3.14, NaN ],
+		[ 3.14, NaN ],
+		[ 3.14, NaN ],
+		[ 3.14, 3.14 ]
+	];
+
+	acc = incrnanmrmse( 3 );
+
+	for ( i = 0; i < data.length; i++ ) {
+		v = acc( data[i][0], data[i][1] );
+		if ( isnan( expected[ i ] ) ) {
+			t.strictEqual( isnan( v ), true, 'returns expected value for window '+i );
+			t.strictEqual( isnan( acc() ), true, 'returns expected value for window '+i );
+		} else {
+			t.strictEqual( v, expected[ i ], 'returns expected value for window '+i );
+			t.strictEqual( acc(), expected[ i ], 'returns expected value for window '+i );
+		}
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/nanmrmse/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmrmse/test/test.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -71,7 +70,7 @@ tape( 'the function returns an accumulator function', function test( t ) {
 	t.end();
 });
 
-tape( 'the accumulator function computes a moving root mean squared error incrementally', function test( t ) {
+tape( 'the accumulator function computes a moving root mean squared error incrementally, ignoring `NaN` values', function test( t ) {
 	var expected;
 	var actual;
 	var delta;
@@ -85,8 +84,10 @@ tape( 'the accumulator function computes a moving root mean squared error increm
 		[ 2.0, 3.0 ],
 		[ 3.0, -1.0 ],
 		[ 2.0, 5.0 ],
+		[ NaN, 5.0 ],
 		[ 4.0, -4.0 ],
 		[ 3.0, 0.0 ],
+		[ 3.0, NaN ],
 		[ -4.0, 5.0 ]
 	];
 	N = data.length;
@@ -97,7 +98,9 @@ tape( 'the accumulator function computes a moving root mean squared error increm
 		1.0,
 		sqrt( 17.0/2.0 ),
 		sqrt( 26.0/3.0 ),
+		sqrt( 26.0/3.0 ),
 		sqrt( 89.0/3.0 ),
+		sqrt( 82.0/3.0 ),
 		sqrt( 82.0/3.0 ),
 		sqrt( 154.0/3.0 )
 	];
@@ -122,6 +125,7 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 	data = [
 		[ 2.0, 3.0 ],
 		[ 3.0, -5.0 ],
+		[ 3.0, NaN ],
 		[ 1.0, 10.0 ]
 	];
 	acc = incrnanmrmse( 2 );
@@ -132,7 +136,7 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 	t.end();
 });
 
-tape( 'if provided an input value that results in `NaN`, the accumulator function returns the current root mean squared error', function test( t ) {
+tape( 'if provided `NaN`, the accumulator function ignores the input value pair and returns the current root mean squared error', function test( t ) {
 	var data;
 	var acc;
 	var i;
@@ -146,8 +150,9 @@ tape( 'if provided an input value that results in `NaN`, the accumulator functio
 	for ( i = 0; i < data.length; i++ ) {
 		acc( data[i][0], data[i][1] );
 	}
-	t.strictEqual( acc( NaN ), sqrt( 145.0/2.0 ), 'returns expected value' );
-	t.strictEqual( acc( 10.0 ), sqrt( 145.0/2.0 ), 'returns expected value' );
+	t.strictEqual( acc( NaN, 2.0 ), sqrt( 145.0/2.0 ), 'returns expected value' );
+	t.strictEqual( acc( 2.0, NaN ), sqrt( 145.0/2.0 ), 'returns expected value' );
+	t.strictEqual( acc( NaN, NaN ), sqrt( 145.0/2.0 ), 'returns expected value' );
 	t.end();
 });
 
@@ -157,120 +162,13 @@ tape( 'if data has yet to be provided, the accumulator function returns `null`',
 	t.end();
 });
 
-tape( 'if provided `NaN`, the accumulated value is `NaN` for at least `W` invocations', function test( t ) {
-	var expected;
-	var data;
-	var acc;
-	var v;
-	var i;
+tape( 'if only `NaN` values have been provided, the accumulator function returns `null`', function test( t ) {
+	var acc = incrnanmrmse( 3 );
 
-	expected = [
-		null,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0
-	];
+	acc( NaN, 3.14 );
+	acc( 3.14, NaN );
+	acc( NaN, NaN );
 
-	data = [
-		[ NaN, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ NaN, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ NaN, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ NaN, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ NaN, 3.14 ],
-		[ NaN, 3.14 ],
-		[ NaN, 3.14 ],
-		[ NaN, 3.14 ],
-		[ 3.14, 3.14 ]
-	];
-
-	acc = incrnanmrmse( 3 );
-
-	for ( i = 0; i < data.length; i++ ) {
-		v = acc( data[i][0], data[i][1] );
-		t.strictEqual( v, expected[ i ], 'returns expected value for window '+i );
-		t.strictEqual( acc(), expected[ i ], 'returns expected value for window '+i );
-	}
-
-	expected = [
-		null,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0,
-		0.0
-	];
-
-	data = [
-		[ 3.14, NaN ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, NaN ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, NaN ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, NaN ],
-		[ 3.14, 3.14 ],
-		[ 3.14, 3.14 ],
-		[ 3.14, NaN ],
-		[ 3.14, NaN ],
-		[ 3.14, NaN ],
-		[ 3.14, NaN ],
-		[ 3.14, 3.14 ]
-	];
-
-	acc = incrnanmrmse( 3 );
-
-	for ( i = 0; i < data.length; i++ ) {
-		v = acc( data[i][0], data[i][1] );
-		if ( isnan( expected[ i ] ) ) {
-			t.strictEqual( isnan( v ), true, 'returns expected value for window '+i );
-			t.strictEqual( isnan( acc() ), true, 'returns expected value for window '+i );
-		} else {
-			t.strictEqual( v, expected[ i ], 'returns expected value for window '+i );
-			t.strictEqual( acc(), expected[ i ], 'returns expected value for window '+i );
-		}
-	}
+	t.strictEqual( acc(), null, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/stdlib/issues/5606

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds `stats/incr/nanmrmse` which calculates moving product, ignoring NaN values.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   https://github.com/stdlib-js/stdlib/issues/5966
-   https://github.com/stdlib-js/stdlib/issues/5606

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
