### PR TITLE
test: migrate `math/base/special/acovercos` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acovercos/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acovercos/test/test.js
@@ -23,7 +23,7 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/number/float64/base/assert/is-almost-same-value' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var acovercos = require( './../lib' );
 
@@ -44,8 +44,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse coversed cosine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -54,22 +52,14 @@ tape( 'the function computes the inverse coversed cosine', function test( t ) {
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = acovercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = acovercos( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse coversed cosine (small positive numbers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -78,14 +68,8 @@ tape( 'the function computes the inverse coversed cosine (small positive numbers
 	expected = smallPositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = acovercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = acovercos( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acovercos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acovercos/test/test.native.js
@@ -25,8 +25,8 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/number/float64/base/assert/is-almost-same-value' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 
 
 // FIXTURES //
@@ -53,8 +53,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse coversed cosine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -63,22 +61,14 @@ tape( 'the function computes the inverse coversed cosine', opts, function test( 
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = acovercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = acovercos( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse coversed cosine (small positive numbers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -87,14 +77,8 @@ tape( 'the function computes the inverse coversed cosine (small positive numbers
 	expected = smallPositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = acovercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		y = acovercos( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

- Migrates the tests for `@stdlib/math/base/special/acovercos` to use precise ULP-based bounds for floating-point comparisons rather than relative epsilon tolerances.
- Replaces absolute differences and epsilon logic with `@stdlib/number/float64/base/assert/is-almost-same-value` across the JavaScript and C++ native add-on test suites.
- Applies a strict empirical ULP maximum computed from the provided JSON fixtures (1 ULP for all test cases).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
