### PR TITLE
test: migrate `math/base/special/erfcinv` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/test/test.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
-var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var erfcinv = require( './../lib' );
 
 
@@ -96,8 +95,6 @@ tape( 'if provided a value which is either less than `0` or greater than `2`, th
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[0.5,1.5]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -106,21 +103,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x1.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[0.25,0.5]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -129,21 +118,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x2.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[1.5,1.75]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -152,21 +133,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x3.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[1.75,1.9998]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -175,21 +148,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x4.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 13.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[0.0002,0.25]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -198,21 +163,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x5.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 14.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 19 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[1.9998,1.9999..8]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -221,21 +178,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x6.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 9.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[1.9999..8,2]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -247,13 +196,7 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 		if ( expected[ i ] === null ) {
 			expected[ i ] = NINF;
 		}
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/test/test.native.js
@@ -22,13 +22,12 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
-var NINF = require( '@stdlib/constants/float64/ninf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 
 
 // FIXTURES //
@@ -105,8 +104,6 @@ tape( 'if provided a value which is either less than `0` or greater than `2`, th
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[0.5,1.5]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -115,21 +112,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x1.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[0.25,0.5]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -138,21 +127,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x2.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[1.5,1.75]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -161,21 +142,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x3.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[1.75,1.9998]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -184,21 +157,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x4.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 13.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[0.0002,0.25]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -207,21 +172,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x5.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 14.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 19 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[1.9998,1.9999..8]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -230,21 +187,13 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 	x = x6.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = erfcinv( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 9.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 11 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[1.9999..8,2]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -256,13 +205,7 @@ tape( 'the function evaluates the inverse complementary error function for `x` o
 		if ( expected[ i ] === null ) {
 			expected[ i ] = NINF;
 		}
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

This pull request migrates the tests for `@stdlib/math/base/special/erfcinv` (`test/test.js` and `test/test.native.js`) from relative-tolerance (`EPS`-scaled `delta`/`tol`) comparisons to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`.

The seven fixture blocks each had a distinct tolerance multiplier in the original tests (`3.0`, `3.0`, `3.0`, `13.0`, `14.0`, `9.0`, and `1.0` times `EPS`). Final ULP constants were determined empirically by computing the actual maximum ULP distance between the JS implementation's output and the Julia fixture data for each block, then confirming that the tests fail at `N - 1` and pass deterministically (verified across two consecutive runs) at the chosen `N`:

| Fixture interval | Final ULP constant |
| --- | --- |
| `[0.5, 1.5]` | 5 |
| `[0.25, 0.5]` | 3 |
| `[1.5, 1.75]` | 4 |
| `[1.75, 1.9998]` | 20 |
| `[0.0002, 0.25]` | 19 |
| `[1.9998, 1.9999..8]` | 11 |
| `[1.9999..8, 2]` | 1 |

The native add-on could not be built in this environment, so `test.native.js` assertions are skipped, but the file was updated identically to `test.js` (native add-on is expected to produce the same output as the JS implementation).

## Related Issues

This pull request has the following related issues:

- #11352

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgM1ChHVC1zf5aV5M8fRu6)_