### PR TITLE
test: migrate `math/base/special/asecd` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/asecd/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asecd/test/test.js
@@ -22,9 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var asecd = require( './../lib' );
 
 
@@ -72,8 +72,6 @@ tape( 'the function returns `NaN` if provided a value less than `+1`', function 
 
 tape( 'the function computes the arcsecant in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -83,21 +81,13 @@ tape( 'the function computes the arcsecant in degrees (negative values)', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecd( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsecant in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -107,13 +97,7 @@ tape( 'the function computes the arcsecant in degrees (positive values)', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecd( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asecd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asecd/test/test.native.js
@@ -23,9 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -81,8 +81,6 @@ tape( 'the function returns `NaN` if provided a value less than `+1`', opts, fun
 
 tape( 'the function computes the arcsecant in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -92,21 +90,13 @@ tape( 'the function computes the arcsecant in degrees (negative values)', opts, 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecd( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsecant in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -116,13 +106,7 @@ tape( 'the function computes the arcsecant in degrees (positive values)', opts, 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecd( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Summary

Migrates `math/base/special/asecd` test cases from relative-tolerance (EPS-scaled delta/tol) comparisons to ULP-difference assertions using `@stdlib/assert/is-almost-same-value`, per the guidance in #11352.

- `test/test.js` and `test/test.native.js` both updated. The idiom mirrors the already-converted sibling package `math/base/special/asecdf` (float32 variant) and `math/base/special/cotd`.
- Final ULP constant: **`ULP = 1`** for both the negative-value and positive-value fixture blocks (used identically in both `test.js` and `test.native.js`).
- This was determined empirically: `ULP = 0` fails (887 of 6009 assertions fail), `ULP = 1` passes all 6009 assertions, confirmed deterministic across two consecutive runs.
- `test/test.native.js` mirrors the same ULP value as the JS tests; the native add-on could not be built/tested in this environment (tests skip via `tryRequire`), consistent with prior converted packages in this family.
- No other files were changed.

Resolves a part of #11352.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XQkEEdK4yUavteSqugEske)_