### PR TITLE
feat: add `@stdlib/string/base/truncate-middle-grapheme-clusters`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/README.md
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/README.md
@@ -1,0 +1,92 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# truncateMiddle
+
+> Truncate the middle grapheme clusters of a string to return a string having a specified length.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var truncateMiddle = require( '@stdlib/string/base/truncate-middle-grapheme-clusters' );
+```
+
+#### truncateMiddle( str, len, seq )
+
+Truncates the middle grapheme clusters of a string to return a string having a specified length.
+
+```javascript
+var out = truncateMiddle( 'beep boop', 7, '...' );
+// returns 'be...op'
+
+out = truncateMiddle( 'beep boop', 7, '!' );
+// returns 'bee!oop'
+
+out = truncateMiddle( 'beep boop', 7, '!!!' );
+// returns 'be!!!op'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var truncateMiddle = require( '@stdlib/string/base/truncate-middle-grapheme-clusters' );
+
+var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+var out = truncateMiddle( str, 15, '...' );
+// returns 'Lorem ... elit.'
+
+str = 'To be or not to be, that is the question';
+out = truncateMiddle( str, 19, '|' );
+// returns 'To be or | question'
+
+str = 'The quick fox jumps over the lazy dog.';
+out = truncateMiddle( str, 28, '...' );
+// returns 'The quick fox...he lazy dog.'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/README.md
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2023 The Stdlib Authors.
+Copyright (c) 2026 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -58,9 +58,9 @@ out = truncateMiddle( 'beep boop', 7, '!!!' );
 ```javascript
 var truncateMiddle = require( '@stdlib/string/base/truncate-middle-grapheme-clusters' );
 
-var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+var str = 'Hello, world! Welcome to the universe.';
 var out = truncateMiddle( str, 15, '...' );
-// returns 'Lorem ... elit.'
+// returns 'Hello,...verse.'
 
 str = 'To be or not to be, that is the question';
 out = truncateMiddle( str, 19, '|' );

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/benchmark/benchmark.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var truncateMiddle = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc',
+		'🐶🐮🐷🐰🐸'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = truncateMiddle( values[ i%values.length ], 7, '...' );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/repl.txt
@@ -1,0 +1,31 @@
+
+{{alias}}( str, len, seq )
+    Truncates the middle grapheme clusters of a string to return a string
+    having a specified length.
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    len: integer
+        Output string length.
+
+    seq: string
+        Custom replacement sequence.
+
+    Returns
+    -------
+    out: string
+        Truncated string.
+
+    Examples
+    --------
+    > var str = 'beep boop';
+    > var out = {{alias}}( str, 5, '...' )
+    'b...p'
+    > out = {{alias}}( str, 5, '|' )
+    'be|op'
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/index.d.ts
@@ -1,0 +1,59 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Truncates the middle grapheme clusters of a string to return a string having a specified length.
+*
+* @param str - input string
+* @param len - output string length (including sequence)
+* @param seq - custom replacement sequence
+* @returns truncated string
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '...' );
+* // returns 'b...p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '>>>' );
+* // returns 'b>>>p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 10, '...' );
+* // returns 'beep boop'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 0, '...' );
+* // returns ''
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 2, '...' );
+* // returns '..'
+*/
+declare function truncateMiddle( str: string, len: number, seq: string ): string;
+
+
+// EXPORTS //
+
+export = truncateMiddle;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/test.ts
@@ -1,0 +1,63 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import truncateMiddle = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	truncateMiddle( 'abcdefghi', 3, '...' ); // $ExpectType string
+}
+
+//  The compiler throws an error if the function is not provided a string as its first argument...
+{
+	truncateMiddle( true, 6, '...' ); // $ExpectError
+	truncateMiddle( false, 6, '...' ); // $ExpectError
+	truncateMiddle( 3, 6, '...' ); // $ExpectError
+	truncateMiddle( [], 6, '...' ); // $ExpectError
+	truncateMiddle( {}, 6, '...' ); // $ExpectError
+	truncateMiddle( ( x: number ): number => x, 6, '...' ); // $ExpectError
+}
+
+//  The compiler throws an error if the function is not provided a number as its second argument...
+{
+	truncateMiddle( 'abd', true, '...' ); // $ExpectError
+	truncateMiddle( 'abd', false, '...' ); // $ExpectError
+	truncateMiddle( 'abd', 'abc', '...' ); // $ExpectError
+	truncateMiddle( 'abd', [], '...' ); // $ExpectError
+	truncateMiddle( 'abd', {}, '...' ); // $ExpectError
+	truncateMiddle( 'abd', ( x: number ): number => x, '...' ); // $ExpectError
+}
+
+//  The compiler throws an error if the function is not provided a string as its third argument...
+{
+	truncateMiddle( 'beep boop', 4, true ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, false ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, 123 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, [], 0 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, {}, 0 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	truncateMiddle(); // $ExpectError
+	truncateMiddle( 'abc', 4, '|', true ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var truncateMiddle = require( './../lib' );
+
+var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+var out = truncateMiddle( str, 15, '...' );
+console.log( out );
+// => 'Lorem ... elit.'
+
+str = 'To be or not to be, that is the question';
+out = truncateMiddle( str, 19, '|' );
+console.log( out );
+// => 'To be or | question'
+
+str = 'The quick fox jumps over the lazy dog.';
+out = truncateMiddle( str, 28, '...' );
+console.log( out );
+// => 'The quick fox...he lazy dog.'

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@
 
 var truncateMiddle = require( './../lib' );
 
-var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+var str = 'Hello, world! Welcome to the universe.';
 var out = truncateMiddle( str, 15, '...' );
 console.log( out );
-// => 'Lorem ... elit.'
+// => 'Hello,...verse.'
 
 str = 'To be or not to be, that is the question';
 out = truncateMiddle( str, 19, '|' );

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Truncate the middle grapheme clusters of a string to return a string having a specified length.
+*
+* @module @stdlib/string/base/truncate-middle-grapheme-clusters
+*
+* @example
+* var truncateMiddle = require( '@stdlib/string/base/truncate-middle-grapheme-clusters' );
+*
+* var out = truncateMiddle( 'beep boop', 7, '...' );
+* // returns 'be...op'
+*
+* out = truncateMiddle( 'beep boop', 7, '|' );
+* // returns 'bee|oop'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/main.js
@@ -76,7 +76,7 @@ function truncateMiddle( str, len, seq ) {
 	var seqEnd;
 	var idx2;
 	var idx1;
-	
+
 	seqLength = numGraphemeClusters( seq );
 	strLength = numGraphemeClusters( str );
 	fromIndex = 0;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/main.js
@@ -1,0 +1,112 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var numGraphemeClusters = require( '@stdlib/string/num-grapheme-clusters' );
+var nextGraphemeClusterBreak = require( '@stdlib/string/next-grapheme-cluster-break' );
+var sliceGraphemeClusters = require( '@stdlib/string/base/slice-grapheme-clusters' );
+var round = require( '@stdlib/math/base/special/round' );
+var floor = require( '@stdlib/math/base/special/floor' );
+
+
+// MAIN //
+
+/**
+* Truncates the middle grapheme clusters of a string to return a string having a specified length.
+*
+* @param {string} str - input string
+* @param {integer} len - output string length (including sequence)
+* @param {string} seq - custom replacement sequence
+* @returns {string} truncated string
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '...' );
+* // returns 'b...p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '>>>' );
+* // returns 'b>>>p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 10, '...' );
+* // returns 'beep boop'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 0, '...' );
+* // returns ''
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 2, '...' );
+* // returns '..'
+*
+* @example
+* var str = '🐺 Wolf Brothers 🐺';
+* var out = truncateMiddle( str, 7, '...' );
+* // returns '🐺 ... 🐺'
+*/
+function truncateMiddle( str, len, seq ) {
+	var seqLength;
+	var fromIndex;
+	var strLength;
+	var seqStart;
+	var nVisual;
+	var seqEnd;
+	var idx2;
+	var idx1;
+	
+	seqLength = numGraphemeClusters( seq );
+	strLength = numGraphemeClusters( str );
+	fromIndex = 0;
+	if ( len > strLength ) {
+		return str;
+	}
+	if ( len - seqLength < 0 ) {
+		return sliceGraphemeClusters( seq, 0, len );
+	}
+	seqStart = round( ( len - seqLength ) / 2 );
+	seqEnd = strLength - floor( ( len - seqLength ) / 2 );
+	nVisual = 0;
+	while ( nVisual < seqStart ) {
+		idx1 = nextGraphemeClusterBreak( str, fromIndex );
+		fromIndex = idx1;
+		nVisual += 1;
+	}
+	idx2 = idx1;
+	while ( idx2 > 0 ) {
+		idx2 = nextGraphemeClusterBreak( str, fromIndex );
+		if ( idx2 >= seqEnd + fromIndex - nVisual ) {
+			break;
+		}
+		fromIndex = idx2;
+		nVisual += 1;
+	}
+	return str.substring( 0, idx1 ) + seq + str.substring( idx2 );
+}
+
+
+// EXPORTS //
+
+module.exports = truncateMiddle;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/package.json
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/string/base/truncate-middle-grapheme-clusters",
+  "version": "0.0.0",
+  "description": "Truncate the middle grapheme clusters of a string to return a string having a specified length.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "base",
+    "truncate",
+    "middle",
+    "character",
+    "char",
+    "grapheme",
+    "unicode"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/test/test.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var truncateMiddle = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof truncateMiddle, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'b...p';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 10;
+	expected = 'beep boop';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 0;
+	expected = '';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 1;
+	expected = '.';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length (custom replacement sequence)', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'be|op';
+	actual = truncateMiddle( str, len, '|' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 7;
+	expected = 'bee!oop';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 3;
+	expected = 'b!p';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves part of #1062 

## Description

> What is the purpose of this pull request?

This pull request:

- Adds the `@stdlib/string/base/truncate-middle-grapheme-clusters` package.
- Implements a base utility function that truncates a string in the middle to a specified length based on grapheme clusters.
- Ensures that complex visual characters spanning multiple Unicode code points (such as emojis with modifiers) are not split when truncating strings.
- Serves as the default dispatching target for the top-level `@stdlib/string/truncate-middle` package.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- Part of #1062 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I utilized an AI assistant to automate the generation of test cases and benchmark scaffolding. The core logic implementation and integration were authored manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
