### PR TITLE
feat: refactor string `truncate-middle` to support grapheme clusters and code points

### DIFF
--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/README.md
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/README.md
@@ -1,0 +1,92 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# truncateMiddle
+
+> Truncate the middle Unicode code points of a string to return a string having a specified length.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var truncateMiddle = require( '@stdlib/string/base/truncate-middle-code-points' );
+```
+
+#### truncateMiddle( str, len, seq )
+
+Truncates the middle Unicode code points of a string to return a string having a specified length.
+
+```javascript
+var out = truncateMiddle( 'beep boop', 7, '...' );
+// returns 'be...op'
+
+out = truncateMiddle( 'beep boop', 7, '!' );
+// returns 'bee!oop'
+
+out = truncateMiddle( 'beep boop', 7, '!!!' );
+// returns 'be!!!op'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var truncateMiddle = require( '@stdlib/string/base/truncate-middle-code-points' );
+
+var str = 'Hello, world! Welcome to the universe.';
+var out = truncateMiddle( str, 15, '...' );
+// returns 'Hello,...verse.'
+
+str = 'To be or not to be, that is the question';
+out = truncateMiddle( str, 19, '|' );
+// returns 'To be or | question'
+
+str = 'The quick fox jumps over the lazy dog.';
+out = truncateMiddle( str, 28, '...' );
+// returns 'The quick fox...he lazy dog.'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/benchmark/benchmark.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var truncateMiddle = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc',
+		'🐶🐮🐷🐰🐸'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = truncateMiddle( values[ i%values.length ], 7, '...' );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/docs/repl.txt
@@ -1,0 +1,31 @@
+
+{{alias}}( str, len, seq )
+    Truncates the middle Unicode code points of a string to return a string
+    having a specified length.
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    len: integer
+        Output string length.
+
+    seq: string
+        Custom replacement sequence.
+
+    Returns
+    -------
+    out: string
+        Truncated string.
+
+    Examples
+    --------
+    > var str = 'beep boop';
+    > var out = {{alias}}( str, 5, '...' )
+    'b...p'
+    > out = {{alias}}( str, 5, '|' )
+    'be|op'
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/docs/types/index.d.ts
@@ -1,0 +1,59 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Truncates the middle Unicode code points of a string to return a string having a specified length.
+*
+* @param str - input string
+* @param len - output string length (including sequence)
+* @param seq - custom replacement sequence
+* @returns truncated string
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '...' );
+* // returns 'b...p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '>>>' );
+* // returns 'b>>>p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 10, '...' );
+* // returns 'beep boop'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 0, '...' );
+* // returns ''
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 2, '...' );
+* // returns '..'
+*/
+declare function truncateMiddle( str: string, len: number, seq: string ): string;
+
+
+// EXPORTS //
+
+export = truncateMiddle;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/docs/types/test.ts
@@ -1,0 +1,63 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import truncateMiddle = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	truncateMiddle( 'abcdefghi', 3, '...' ); // $ExpectType string
+}
+
+//  The compiler throws an error if the function is not provided a string as its first argument...
+{
+	truncateMiddle( true, 6, '...' ); // $ExpectError
+	truncateMiddle( false, 6, '...' ); // $ExpectError
+	truncateMiddle( 3, 6, '...' ); // $ExpectError
+	truncateMiddle( [], 6, '...' ); // $ExpectError
+	truncateMiddle( {}, 6, '...' ); // $ExpectError
+	truncateMiddle( ( x: number ): number => x, 6, '...' ); // $ExpectError
+}
+
+//  The compiler throws an error if the function is not provided a number as its second argument...
+{
+	truncateMiddle( 'abd', true, '...' ); // $ExpectError
+	truncateMiddle( 'abd', false, '...' ); // $ExpectError
+	truncateMiddle( 'abd', 'abc', '...' ); // $ExpectError
+	truncateMiddle( 'abd', [], '...' ); // $ExpectError
+	truncateMiddle( 'abd', {}, '...' ); // $ExpectError
+	truncateMiddle( 'abd', ( x: number ): number => x, '...' ); // $ExpectError
+}
+
+//  The compiler throws an error if the function is not provided a string as its third argument...
+{
+	truncateMiddle( 'beep boop', 4, true ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, false ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, 123 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, [], 0 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, {}, 0 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	truncateMiddle(); // $ExpectError
+	truncateMiddle( 'abc', 4, '|', true ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var truncateMiddle = require( './../lib' );
+
+var str = 'Hello, world! Welcome to the universe.';
+var out = truncateMiddle( str, 15, '...' );
+console.log( out );
+// => 'Hello,...verse.'
+
+str = 'To be or not to be, that is the question';
+out = truncateMiddle( str, 19, '|' );
+console.log( out );
+// => 'To be or | question'
+
+str = 'The quick fox jumps over the lazy dog.';
+out = truncateMiddle( str, 28, '...' );
+console.log( out );
+// => 'The quick fox...he lazy dog.'

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Truncate the middle Unicode code points of a string to return a string having a specified length.
+*
+* @module @stdlib/string/base/truncate-middle-code-points
+*
+* @example
+* var truncateMiddle = require( '@stdlib/string/base/truncate-middle-code-points' );
+*
+* var out = truncateMiddle( 'beep boop', 7, '...' );
+* // returns 'be...op'
+*
+* out = truncateMiddle( 'beep boop', 7, '|' );
+* // returns 'bee|oop'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/lib/main.js
@@ -1,0 +1,91 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isOdd = require( '@stdlib/math/base/assert/is-odd' );
+var round = require( '@stdlib/math/base/special/round' );
+var numCodePoints = require( '@stdlib/string/num-code-points' );
+var sliceCodePoints = require( '@stdlib/string/base/slice-code-points' );
+
+
+// MAIN //
+
+/**
+* Truncates the middle Unicode code points of a string to return a string having a specified length.
+*
+* @param {string} str - input string
+* @param {integer} len - output string length (including sequence)
+* @param {string} seq - custom replacement sequence
+* @returns {string} truncated string
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '...' );
+* // returns 'b...p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '>>>' );
+* // returns 'b>>>p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 10, '...' );
+* // returns 'beep boop'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 0, '...' );
+* // returns ''
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 2, '...' );
+* // returns '..'
+*/
+function truncateMiddle( str, len, seq ) {
+	var finalLength;
+	var seqLength;
+	var strLength;
+	var seqStart;
+	var seqEnd;
+
+	seqLength = numCodePoints( seq );
+	strLength = numCodePoints( str );
+	if ( len > strLength ) {
+		return str;
+	}
+	finalLength = len - seqLength;
+	if ( finalLength < 0 ) {
+		return sliceCodePoints( seq, 0, len );
+	}
+
+	seqStart = round( finalLength / 2 );
+	seqEnd = ( isOdd( finalLength ) ) ? seqStart-1 : seqStart;
+	seqEnd = strLength - seqEnd;
+
+	return sliceCodePoints( str, 0, seqStart ) + seq + sliceCodePoints( str, seqEnd, strLength );
+}
+
+
+// EXPORTS //
+
+module.exports = truncateMiddle;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/package.json
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/string/base/truncate-middle-code-points",
+  "version": "0.0.0",
+  "description": "Truncate the middle Unicode code points of a string to return a string having a specified length.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "base",
+    "truncate",
+    "middle",
+    "character",
+    "char",
+    "codepoint",
+    "unicode"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-points/test/test.js
@@ -1,0 +1,105 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var truncateMiddle = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof truncateMiddle, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'b...p';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 10;
+	expected = 'beep boop';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 0;
+	expected = '';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 1;
+	expected = '.';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = '🐺 Wolf Brothers 🐺';
+	len = 7;
+	expected = '🐺 ... 🐺';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length (custom replacement sequence)', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'be|op';
+	actual = truncateMiddle( str, len, '|' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 7;
+	expected = 'bee!oop';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 3;
+	expected = 'b!p';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = '🐺 Wolf Brothers 🐺';
+	len = 8;
+	expected = '🐺 Wo>s 🐺';
+	actual = truncateMiddle( str, len, '>' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/README.md
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/README.md
@@ -1,0 +1,92 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# truncateMiddle
+
+> Truncate the middle grapheme clusters of a string to return a string having a specified length.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var truncateMiddle = require( '@stdlib/string/base/truncate-middle-grapheme-clusters' );
+```
+
+#### truncateMiddle( str, len, seq )
+
+Truncates the middle grapheme clusters of a string to return a string having a specified length.
+
+```javascript
+var out = truncateMiddle( 'beep boop', 7, '...' );
+// returns 'be...op'
+
+out = truncateMiddle( 'beep boop', 7, '!' );
+// returns 'bee!oop'
+
+out = truncateMiddle( 'beep boop', 7, '!!!' );
+// returns 'be!!!op'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var truncateMiddle = require( '@stdlib/string/base/truncate-middle-grapheme-clusters' );
+
+var str = 'Hello, world! Welcome to the universe.';
+var out = truncateMiddle( str, 15, '...' );
+// returns 'Hello,...verse.'
+
+str = 'To be or not to be, that is the question';
+out = truncateMiddle( str, 19, '|' );
+// returns 'To be or | question'
+
+str = 'The quick fox jumps over the lazy dog.';
+out = truncateMiddle( str, 28, '...' );
+// returns 'The quick fox...he lazy dog.'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/benchmark/benchmark.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var truncateMiddle = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc',
+		'🐶🐮🐷🐰🐸'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = truncateMiddle( values[ i%values.length ], 7, '...' );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/repl.txt
@@ -1,0 +1,31 @@
+
+{{alias}}( str, len, seq )
+    Truncates the middle grapheme clusters of a string to return a string
+    having a specified length.
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    len: integer
+        Output string length.
+
+    seq: string
+        Custom replacement sequence.
+
+    Returns
+    -------
+    out: string
+        Truncated string.
+
+    Examples
+    --------
+    > var str = 'beep boop';
+    > var out = {{alias}}( str, 5, '...' )
+    'b...p'
+    > out = {{alias}}( str, 5, '|' )
+    'be|op'
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/index.d.ts
@@ -1,0 +1,59 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Truncates the middle grapheme clusters of a string to return a string having a specified length.
+*
+* @param str - input string
+* @param len - output string length (including sequence)
+* @param seq - custom replacement sequence
+* @returns truncated string
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '...' );
+* // returns 'b...p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '>>>' );
+* // returns 'b>>>p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 10, '...' );
+* // returns 'beep boop'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 0, '...' );
+* // returns ''
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 2, '...' );
+* // returns '..'
+*/
+declare function truncateMiddle( str: string, len: number, seq: string ): string;
+
+
+// EXPORTS //
+
+export = truncateMiddle;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/docs/types/test.ts
@@ -1,0 +1,63 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import truncateMiddle = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	truncateMiddle( 'abcdefghi', 3, '...' ); // $ExpectType string
+}
+
+//  The compiler throws an error if the function is not provided a string as its first argument...
+{
+	truncateMiddle( true, 6, '...' ); // $ExpectError
+	truncateMiddle( false, 6, '...' ); // $ExpectError
+	truncateMiddle( 3, 6, '...' ); // $ExpectError
+	truncateMiddle( [], 6, '...' ); // $ExpectError
+	truncateMiddle( {}, 6, '...' ); // $ExpectError
+	truncateMiddle( ( x: number ): number => x, 6, '...' ); // $ExpectError
+}
+
+//  The compiler throws an error if the function is not provided a number as its second argument...
+{
+	truncateMiddle( 'abd', true, '...' ); // $ExpectError
+	truncateMiddle( 'abd', false, '...' ); // $ExpectError
+	truncateMiddle( 'abd', 'abc', '...' ); // $ExpectError
+	truncateMiddle( 'abd', [], '...' ); // $ExpectError
+	truncateMiddle( 'abd', {}, '...' ); // $ExpectError
+	truncateMiddle( 'abd', ( x: number ): number => x, '...' ); // $ExpectError
+}
+
+//  The compiler throws an error if the function is not provided a string as its third argument...
+{
+	truncateMiddle( 'beep boop', 4, true ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, false ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, 123 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, [], 0 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, {}, 0 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	truncateMiddle(); // $ExpectError
+	truncateMiddle( 'abc', 4, '|', true ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var truncateMiddle = require( './../lib' );
+
+var str = 'Hello, world! Welcome to the universe.';
+var out = truncateMiddle( str, 15, '...' );
+console.log( out );
+// => 'Hello,...verse.'
+
+str = 'To be or not to be, that is the question';
+out = truncateMiddle( str, 19, '|' );
+console.log( out );
+// => 'To be or | question'
+
+str = 'The quick fox jumps over the lazy dog.';
+out = truncateMiddle( str, 28, '...' );
+console.log( out );
+// => 'The quick fox...he lazy dog.'

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Truncate the middle grapheme clusters of a string to return a string having a specified length.
+*
+* @module @stdlib/string/base/truncate-middle-grapheme-clusters
+*
+* @example
+* var truncateMiddle = require( '@stdlib/string/base/truncate-middle-grapheme-clusters' );
+*
+* var out = truncateMiddle( 'beep boop', 7, '...' );
+* // returns 'be...op'
+*
+* out = truncateMiddle( 'beep boop', 7, '|' );
+* // returns 'bee|oop'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/lib/main.js
@@ -1,0 +1,112 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var numGraphemeClusters = require( '@stdlib/string/num-grapheme-clusters' );
+var nextGraphemeClusterBreak = require( '@stdlib/string/next-grapheme-cluster-break' );
+var sliceGraphemeClusters = require( '@stdlib/string/base/slice-grapheme-clusters' );
+var round = require( '@stdlib/math/base/special/round' );
+var floor = require( '@stdlib/math/base/special/floor' );
+
+
+// MAIN //
+
+/**
+* Truncates the middle grapheme clusters of a string to return a string having a specified length.
+*
+* @param {string} str - input string
+* @param {integer} len - output string length (including sequence)
+* @param {string} seq - custom replacement sequence
+* @returns {string} truncated string
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '...' );
+* // returns 'b...p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '>>>' );
+* // returns 'b>>>p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 10, '...' );
+* // returns 'beep boop'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 0, '...' );
+* // returns ''
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 2, '...' );
+* // returns '..'
+*
+* @example
+* var str = '🐺 Wolf Brothers 🐺';
+* var out = truncateMiddle( str, 7, '...' );
+* // returns '🐺 ... 🐺'
+*/
+function truncateMiddle( str, len, seq ) {
+	var seqLength;
+	var fromIndex;
+	var strLength;
+	var seqStart;
+	var nVisual;
+	var seqEnd;
+	var idx2;
+	var idx1;
+
+	seqLength = numGraphemeClusters( seq );
+	strLength = numGraphemeClusters( str );
+	fromIndex = 0;
+	if ( len > strLength ) {
+		return str;
+	}
+	if ( len - seqLength < 0 ) {
+		return sliceGraphemeClusters( seq, 0, len );
+	}
+	seqStart = round( ( len - seqLength ) / 2 );
+	seqEnd = strLength - floor( ( len - seqLength ) / 2 );
+	nVisual = 0;
+	while ( nVisual < seqStart ) {
+		idx1 = nextGraphemeClusterBreak( str, fromIndex );
+		fromIndex = idx1;
+		nVisual += 1;
+	}
+	idx2 = idx1;
+	while ( idx2 > 0 ) {
+		idx2 = nextGraphemeClusterBreak( str, fromIndex );
+		if ( idx2 >= seqEnd + fromIndex - nVisual ) {
+			break;
+		}
+		fromIndex = idx2;
+		nVisual += 1;
+	}
+	return str.substring( 0, idx1 ) + seq + str.substring( idx2 );
+}
+
+
+// EXPORTS //
+
+module.exports = truncateMiddle;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/package.json
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/string/base/truncate-middle-grapheme-clusters",
+  "version": "0.0.0",
+  "description": "Truncate the middle grapheme clusters of a string to return a string having a specified length.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "base",
+    "truncate",
+    "middle",
+    "character",
+    "char",
+    "grapheme",
+    "unicode"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-grapheme-clusters/test/test.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var truncateMiddle = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof truncateMiddle, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'b...p';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 10;
+	expected = 'beep boop';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 0;
+	expected = '';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 1;
+	expected = '.';
+	actual = truncateMiddle( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length (custom replacement sequence)', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'be|op';
+	actual = truncateMiddle( str, len, '|' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 7;
+	expected = 'bee!oop';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 3;
+	expected = 'b!p';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/string/truncate-middle/README.md
+++ b/lib/node_modules/@stdlib/string/truncate-middle/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2021 The Stdlib Authors.
+Copyright (c) 2026 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -82,9 +82,9 @@ out = truncateMiddle( 'beep boop', 7, '!!!' );
 ```javascript
 var truncateMiddle = require( '@stdlib/string/truncate-middle' );
 
-var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+var str = 'Hello, world! Welcome to the universe.';
 var out = truncateMiddle( str, 15 );
-// returns 'Lorem ... elit.'
+// returns 'Hello,...verse.'
 
 str = 'To be or not to be, that is the question';
 out = truncateMiddle( str, 19, '|' );

--- a/lib/node_modules/@stdlib/string/truncate-middle/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/truncate-middle/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/truncate-middle/bin/cli
+++ b/lib/node_modules/@stdlib/string/truncate-middle/bin/cli
@@ -3,7 +3,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/truncate-middle/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/truncate-middle/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/truncate-middle/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/truncate-middle/docs/types/index.d.ts
@@ -21,6 +21,24 @@
 /// <reference types="@stdlib/types"/>
 
 /**
+* Interface describing function options.
+*/
+interface Options {
+	/**
+	* Specifies the type of characters to return (default: 'grapheme').
+	*
+	* ## Notes
+	*
+	* -   The following modes are supported:
+	*
+	*     -   `'grapheme'`: grapheme clusters. Appropriate for strings containing visual characters which can span multiple Unicode code points (e.g., emoji).
+	*     -   `'code_point'`: Unicode code points. Appropriate for strings containing visual characters which are comprised of more than one Unicode code unit (e.g., ideographic symbols and punctuation and mathematical alphanumerics).
+	*     -   `'code_unit'`: UTF-16 code units. Appropriate for strings containing visual characters drawn from the basic multilingual plane (BMP) (e.g., common characters, such as those from the Latin, Greek, and Cyrillic alphabets).
+	*/
+	mode?: 'grapheme' | 'code_point' | 'code_unit';
+}
+
+/**
 * Truncates a string in the middle to a specified length.
 *
 * @param str - input string
@@ -58,7 +76,31 @@
 * var out = truncateMiddle( str, 7 );
 * // returns '🐺 ... 🐺'
 */
-declare function truncateMiddle( str: string, len: number, seq?: string ): string;
+*
+* @example
+* var str = '🐺 Wolf Brothers 🐺';
+* var out = truncateMiddle( str, 7, {
+*     'mode': 'code_point'
+* });
+* // returns '🐺 ... 🐺'
+*/
+declare function truncateMiddle( str: string, len: number, options?: Options ): string;
+
+/**
+* Truncates a string in the middle to a specified length.
+*
+* @param str - input string
+* @param len - output string length (including sequence)
+* @param seq - custom replacement sequence (default: `...`)
+* @param options - options
+* @returns truncated string
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '>>>' );
+* // returns 'b>>>p'
+*/
+declare function truncateMiddle( str: string, len: number, seq: string, options?: Options ): string;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/string/truncate-middle/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/truncate-middle/docs/types/index.d.ts
@@ -75,7 +75,6 @@ interface Options {
 * var str = '🐺 Wolf Brothers 🐺';
 * var out = truncateMiddle( str, 7 );
 * // returns '🐺 ... 🐺'
-*/
 *
 * @example
 * var str = '🐺 Wolf Brothers 🐺';

--- a/lib/node_modules/@stdlib/string/truncate-middle/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/truncate-middle/docs/types/index.d.ts
@@ -43,7 +43,7 @@ interface Options {
 *
 * @param str - input string
 * @param len - output string length (including sequence)
-* @param seq - custom replacement sequence (default: `...`)
+* @param options - options
 * @returns truncated string
 *
 * @example

--- a/lib/node_modules/@stdlib/string/truncate-middle/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/truncate-middle/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/truncate-middle/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/truncate-middle/docs/types/test.ts
@@ -25,6 +25,8 @@ import truncateMiddle = require( './index' );
 {
 	truncateMiddle( 'abcdefghi', 3 ); // $ExpectType string
 	truncateMiddle( 'abcdefghi', 10, '|' ); // $ExpectType string
+	truncateMiddle( 'abcdefghi', 3, { 'mode': 'code_point' } ); // $ExpectType string
+	truncateMiddle( 'abcdefghi', 3, '|', { 'mode': 'code_unit' } ); // $ExpectType string
 }
 
 //  The compiler throws an error if the function is not provided a string as its first argument...
@@ -47,18 +49,8 @@ import truncateMiddle = require( './index' );
 	truncateMiddle( 'abd', ( x: number ): number => x, 0 ); // $ExpectError
 }
 
-//  The compiler throws an error if the function is not provided a string as its third argument...
-{
-	truncateMiddle( 'beep boop', 4, true ); // $ExpectError
-	truncateMiddle( 'beep boop', 4, false ); // $ExpectError
-	truncateMiddle( 'beep boop', 4, 123 ); // $ExpectError
-	truncateMiddle( 'beep boop', 4, [], 0 ); // $ExpectError
-	truncateMiddle( 'beep boop', 4, {}, 0 ); // $ExpectError
-	truncateMiddle( 'beep boop', 4, ( x: number ): number => x, 0 ); // $ExpectError
-}
-
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
 	truncateMiddle(); // $ExpectError
-	truncateMiddle( 'abc', 4, '|', true ); // $ExpectError
+	truncateMiddle( 'abc', 4, '|', {}, 'extra' ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/string/truncate-middle/examples/index.js
+++ b/lib/node_modules/@stdlib/string/truncate-middle/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@
 
 var truncateMiddle = require( './../lib' );
 
-var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+var str = 'Hello, world! Welcome to the universe.';
 var out = truncateMiddle( str, 15 );
 console.log( out );
-// => 'Lorem ... elit.'
+// => 'Hello,...verse.'
 
 str = 'To be or not to be, that is the question';
 out = truncateMiddle( str, 19, '|' );

--- a/lib/node_modules/@stdlib/string/truncate-middle/lib/index.js
+++ b/lib/node_modules/@stdlib/string/truncate-middle/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/truncate-middle/lib/main.js
+++ b/lib/node_modules/@stdlib/string/truncate-middle/lib/main.js
@@ -22,11 +22,24 @@
 
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
-var numGraphemeClusters = require( '@stdlib/string/num-grapheme-clusters' );
-var nextGraphemeClusterBreak = require( '@stdlib/string/next-grapheme-cluster-break' );
+var isPlainObject = require( '@stdlib/assert/is-plain-object' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var contains = require( '@stdlib/array/base/assert/contains' ).factory;
 var format = require( '@stdlib/string/format' );
-var round = require( '@stdlib/math/base/special/round' );
-var floor = require( '@stdlib/math/base/special/floor' );
+var truncateMiddleCodeUnit = require( '@stdlib/string/base/truncate-middle' );
+var truncateMiddleCodePoints = require( '@stdlib/string/base/truncate-middle-code-points' );
+var truncateMiddleGraphemeClusters = require( '@stdlib/string/base/truncate-middle-grapheme-clusters' );
+
+
+// VARIABLES //
+
+var MODES = [ 'grapheme', 'code_point', 'code_unit' ];
+var FCNS = {
+	'grapheme': truncateMiddleGraphemeClusters,
+	'code_point': truncateMiddleCodePoints,
+	'code_unit': truncateMiddleCodeUnit
+};
+var isMode = contains( MODES );
 
 
 // MAIN //
@@ -37,9 +50,13 @@ var floor = require( '@stdlib/math/base/special/floor' );
 * @param {string} str - input string
 * @param {integer} len - output string length (including sequence)
 * @param {string} [seq='...'] - custom replacement sequence
+* @param {Options} [options] - options
+* @param {string} [options.mode="grapheme"] - type of "character" to return (must be either `grapheme`, `code_point`, or `code_unit`)
 * @throws {TypeError} first argument must be a string
 * @throws {TypeError} second argument must be a nonnegative integer
 * @throws {TypeError} third argument must be a string
+* @throws {TypeError} options argument must be an object
+* @throws {TypeError} must provide valid options
 * @returns {string} truncated string
 *
 * @example
@@ -72,54 +89,48 @@ var floor = require( '@stdlib/math/base/special/floor' );
 * var out = truncateMiddle( str, 7 );
 * // returns '🐺 ... 🐺'
 */
-function truncateMiddle( str, len, seq ) {
-	var seqLength;
-	var fromIndex;
-	var strLength;
-	var seqStart;
-	var nVisual;
-	var seqEnd;
-	var idx2;
-	var idx1;
+function truncateMiddle( str, len ) {
+	var options;
+	var nargs;
+	var opts;
+	var seq;
+	
 	if ( !isString( str ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a string. Value: `%s`.', str ) );
 	}
 	if ( !isNonNegativeInteger( len ) ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be a nonnegative integer. Value: `%s`.', len ) );
 	}
-	if ( arguments.length > 2 ) {
-		if ( !isString( seq ) ) {
-			throw new TypeError( format( 'invalid argument. Third argument must be a string. Value: `%s`.', seq ) );
+	nargs = arguments.length;
+	if ( nargs > 2 ) {
+		if ( isPlainObject( arguments[ 2 ] ) ) {
+			options = arguments[ 2 ];
+		} else {
+			seq = arguments[ 2 ];
+			if ( !isString( seq ) ) {
+				throw new TypeError( format( 'invalid argument. Third argument must be a string. Value: `%s`.', seq ) );
+			}
+			if ( nargs > 3 ) {
+				options = arguments[ 3 ];
+				if ( !isPlainObject( options ) ) {
+					throw new TypeError( format( 'invalid argument. Options argument must be an object. Value: `%s`.', options ) );
+				}
+			}
 		}
 	}
 	seq = seq || '...';
-	seqLength = numGraphemeClusters( seq );
-	strLength = numGraphemeClusters( str );
-	fromIndex = 0;
-	if ( len > strLength ) {
-		return str;
-	}
-	if ( len - seqLength < 0 ) {
-		return seq.slice( 0, len );
-	}
-	seqStart = round( ( len - seqLength ) / 2 );
-	seqEnd = strLength - floor( ( len - seqLength ) / 2 );
-	nVisual = 0;
-	while ( nVisual < seqStart ) {
-		idx1 = nextGraphemeClusterBreak( str, fromIndex );
-		fromIndex = idx1;
-		nVisual += 1;
-	}
-	idx2 = idx1;
-	while ( idx2 > 0 ) {
-		idx2 = nextGraphemeClusterBreak( str, fromIndex );
-		if ( idx2 >= seqEnd + fromIndex - nVisual ) {
-			break;
+	opts = {
+		'mode': 'grapheme'
+	};
+	if ( options ) {
+		if ( hasOwnProp( options, 'mode' ) ) {
+			opts.mode = options.mode;
+			if ( !isMode( opts.mode ) ) {
+				throw new TypeError( format( 'invalid option. `%s` option must be one of the following: "%s". Value: `%s`.', 'mode', MODES.join( '", "' ), opts.mode ) );
+			}
 		}
-		fromIndex = idx2;
-		nVisual += 1;
 	}
-	return str.substring( 0, idx1 ) + seq + str.substring( idx2 );
+	return FCNS[ opts.mode ]( str, len, seq );
 }
 
 

--- a/lib/node_modules/@stdlib/string/truncate-middle/lib/main.js
+++ b/lib/node_modules/@stdlib/string/truncate-middle/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ function truncateMiddle( str, len ) {
 	var nargs;
 	var opts;
 	var seq;
-	
+
 	if ( !isString( str ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a string. Value: `%s`.', str ) );
 	}

--- a/lib/node_modules/@stdlib/string/truncate-middle/test/fixtures/stdin_error.js.txt
+++ b/lib/node_modules/@stdlib/string/truncate-middle/test/fixtures/stdin_error.js.txt
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/truncate-middle/test/test.cli.js
+++ b/lib/node_modules/@stdlib/string/truncate-middle/test/test.cli.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/truncate-middle/test/test.js
+++ b/lib/node_modules/@stdlib/string/truncate-middle/test/test.js
@@ -1,205 +1,51 @@
-/**
-* @license Apache-2.0
-*
-* Copyright (c) 2021 The Stdlib Authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 
-'use strict';
-
-// MODULES //
-
-var tape = require( 'tape' );
-var truncateMiddle = require( './../lib' );
-
-
-// TESTS //
-
-tape( 'main export is a function', function test( t ) {
-	t.ok( true, __filename );
-	t.strictEqual( typeof truncateMiddle, 'function', 'main export is a function' );
-	t.end();
-});
-
-tape( 'the function throws an error if not provided a string primitive', function test( t ) {
-	var values;
-	var i;
-
-	values = [
-		5,
-		NaN,
-		null,
-		void 0,
-		true,
-		[],
-		{},
-		function noop() {}
-	];
-
-	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
-	}
-	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			truncateMiddle( value );
-		};
-	}
-});
-
-tape( 'the function throws an error if not provided a nonnegative integer as its second argument', function test( t ) {
-	var values;
-	var i;
-
-	values = [
-		'5',
-		-5,
-		3.14,
-		NaN,
-		null,
-		void 0,
-		true,
-		[],
-		{},
-		function noop() {}
-	];
-
-	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
-	}
-	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			truncateMiddle( 'beep boop', value );
-		};
-	}
-});
-
-tape( 'the function throws an error if provided a non-string as a third argument', function test( t ) {
-	var values;
-	var i;
-
-	values = [
-		5,
-		NaN,
-		null,
-		void 0,
-		true,
-		[],
-		{},
-		function noop() {}
-	];
-
-	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
-	}
-	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			truncateMiddle( 'beep boop', 5, value );
-		};
-	}
-});
-
-tape( 'the function truncates a string to the specified length', function test( t ) {
+tape( 'the function truncates a string to the specified length (mode=code_point)', function test( t ) {
 	var expected;
 	var actual;
+	var opts;
 	var str;
 	var len;
 
-	str = 'beep boop';
-	len = 5;
-	expected = 'b...p';
-	actual = truncateMiddle( str, len );
-	t.strictEqual( actual, expected, 'returns expected value' );
-
-	str = 'beep boop';
-	len = 10;
-	expected = 'beep boop';
-	actual = truncateMiddle( str, len );
-	t.strictEqual( actual, expected, 'returns expected value' );
-
-	str = 'beep boop';
-	len = 0;
-	expected = '';
-	actual = truncateMiddle( str, len );
-	t.strictEqual( actual, expected, 'returns expected value' );
-
-	str = 'beep boop';
-	len = 1;
-	expected = '.';
-	actual = truncateMiddle( str, len );
-	t.strictEqual( actual, expected, 'returns expected value' );
+	opts = {
+		'mode': 'code_point'
+	};
 
 	str = '🐺 Wolf Brothers 🐺';
 	len = 7;
 	expected = '🐺 ... 🐺';
-	actual = truncateMiddle( str, len );
-	t.strictEqual( actual, expected, 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function truncates a string to the specified length (custom replacement sequence)', function test( t ) {
-	var expected;
-	var actual;
-	var str;
-	var len;
-
-	str = 'beep boop';
-	len = 5;
-	expected = 'be|op';
-	actual = truncateMiddle( str, len, '|' );
-	t.strictEqual( actual, expected, 'returns expected value' );
-
-	str = 'beep boop';
-	len = 10;
-	expected = 'beep boop';
-	actual = truncateMiddle( str, len, '!' );
-	t.strictEqual( actual, expected, 'returns expected value' );
-
-	str = 'beep boop';
-	len = 3;
-	expected = 'b!p';
-	actual = truncateMiddle( str, len, '!' );
-	t.strictEqual( actual, expected, 'returns expected value' );
-
-	str = 'beep boop';
-	len = 5;
-	expected = 'be😃op';
-	actual = truncateMiddle( str, len, '😃' );
-	t.strictEqual( actual, expected, 'returns expected value' );
-
-	str = 'beep boop foo bar';
-	len = 10;
-	expected = 'be 🙃 🙃 🙃ar';
-	actual = truncateMiddle( str, len, ' 🙃 🙃 🙃' );
+	actual = truncateMiddle( str, len, opts );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	str = '🐺 Wolf Brothers 🐺';
 	len = 8;
 	expected = '🐺 Wo>s 🐺';
-	actual = truncateMiddle( str, len, '>' );
+	actual = truncateMiddle( str, len, '>', opts );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
-	str = 'Hello, world, says 🤖, the robot!';
-	len = 10;
-	expected = 'Hello🤖bot!';
-	actual = truncateMiddle( str, len, '🤖' );
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length (mode=code_unit)', function test( t ) {
+	var expected;
+	var actual;
+	var opts;
+	var str;
+	var len;
+
+	opts = {
+		'mode': 'code_unit'
+	};
+
+	str = '🐺 Wolf Brothers 🐺';
+	len = 7;
+	expected = '\ud83d\udc3a ... \ud83d\udc3a';
+	actual = truncateMiddle( str, len, opts );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'be|op';
+	actual = truncateMiddle( str, len, '|', opts );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/string/truncate-middle/test/test.js
+++ b/lib/node_modules/@stdlib/string/truncate-middle/test/test.js
@@ -1,3 +1,209 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var truncateMiddle = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof truncateMiddle, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided a string primitive', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		null,
+		void 0,
+		true,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			truncateMiddle( value );
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a nonnegative integer as its second argument', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		-5,
+		3.14,
+		NaN,
+		null,
+		void 0,
+		true,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			truncateMiddle( 'beep boop', value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a non-string as a third argument', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		null,
+		void 0,
+		true,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			truncateMiddle( 'beep boop', 5, value );
+		};
+	}
+});
+
+tape( 'the function truncates a string to the specified length', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'b...p';
+	actual = truncateMiddle( str, len );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 10;
+	expected = 'beep boop';
+	actual = truncateMiddle( str, len );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 0;
+	expected = '';
+	actual = truncateMiddle( str, len );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 1;
+	expected = '.';
+	actual = truncateMiddle( str, len );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = '🐺 Wolf Brothers 🐺';
+	len = 7;
+	expected = '🐺 ... 🐺';
+	actual = truncateMiddle( str, len );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length (custom replacement sequence)', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'be|op';
+	actual = truncateMiddle( str, len, '|' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 10;
+	expected = 'beep boop';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 3;
+	expected = 'b!p';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'be😃op';
+	actual = truncateMiddle( str, len, '😃' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop foo bar';
+	len = 10;
+	expected = 'be 🙃 🙃 🙃ar';
+	actual = truncateMiddle( str, len, ' 🙃 🙃 🙃' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = '🐺 Wolf Brothers 🐺';
+	len = 8;
+	expected = '🐺 Wo>s 🐺';
+	actual = truncateMiddle( str, len, '>' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'Hello, world, says 🤖, the robot!';
+	len = 10;
+	expected = 'Hello🤖bot!';
+	actual = truncateMiddle( str, len, '🤖' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
 
 tape( 'the function truncates a string to the specified length (mode=code_point)', function test( t ) {
 	var expected;
@@ -36,9 +242,9 @@ tape( 'the function truncates a string to the specified length (mode=code_unit)'
 		'mode': 'code_unit'
 	};
 
-	str = '🐺 Wolf Brothers 🐺';
-	len = 7;
-	expected = '\ud83d\udc3a ... \ud83d\udc3a';
+	str = 'beep boop';
+	len = 5;
+	expected = 'b...p';
 	actual = truncateMiddle( str, len, opts );
 	t.strictEqual( actual, expected, 'returns expected value' );
 

--- a/lib/node_modules/@stdlib/string/truncate-middle/test/test.js
+++ b/lib/node_modules/@stdlib/string/truncate-middle/test/test.js
@@ -99,7 +99,6 @@ tape( 'the function throws an error if provided a non-string as a third argument
 		void 0,
 		true,
 		[],
-		{},
 		function noop() {}
 	];
 


### PR DESCRIPTION
Resolves part of #1062 (truncate-middle portion).

## Description

> What is the purpose of this pull request?

This pull request:

- Adds `@stdlib/string/base/truncate-middle-code-points` which truncates the middle Unicode code points of a string.
- Adds `@stdlib/string/base/truncate-middle-grapheme-clusters` which truncates the middle grapheme clusters of a string.
- Refactors `@stdlib/string/truncate-middle` to act as a mode dispatcher, supporting `grapheme` (default), `code_point`, and `code_unit` modes via an `options.mode` parameter.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- Part of #1062

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This PR supersedes the previously abandoned PR #1119. All changes requested by the reviewer in that PR (pluralizing the package name, making `seq` a mandatory argument in base packages) have been incorporated.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

I utilized an AI assistant to automate the generation of test cases and benchmark scaffolding. The core logic implementation and integration were authored manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
