### PR TITLE
test: ensure backward compatibility in test assertion

### DIFF
--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_locale_string.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_locale_string.js
@@ -23,6 +23,7 @@
 var tape = require( 'tape' );
 var hasProp = require( '@stdlib/assert/has-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
+var format = require( '@stdlib/string/format' );
 var namedtypedtuple = require( './../lib' );
 
 
@@ -87,7 +88,7 @@ tape( 'the method serializes a tuple as a locale-specific string (default locale
 	Point = namedtypedtuple( [ 'price', 'quantity' ] );
 	p = new Point( [ 123456.789, 9876 ] );
 
-	expected = 'tuple(price=' + (123456.789).toLocaleString() + ', quantity=' + (9876).toLocaleString() + ')';
+	expected = format( 'tuple(price=%s, quantity=%s)', (123456.789).toLocaleString(), (9876).toLocaleString() );
 	actual = p.toLocaleString();
 
 	t.strictEqual( actual, expected, 'returns expected value' );
@@ -103,7 +104,7 @@ tape( 'the method serializes a tuple as a locale-specific string (specified loca
 	Point = namedtypedtuple( [ 'price', 'quantity' ] );
 	p = new Point( [ 123456.789, 9876 ] );
 
-	expected = 'tuple(price=' + (123456.789).toLocaleString( 'de-DE' ) + ', quantity=' + (9876).toLocaleString( 'de-DE' ) + ')';
+	expected = format( 'tuple(price=%s, quantity=%s)', (123456.789).toLocaleString( 'de-DE' ), (9876).toLocaleString( 'de-DE' ) );
 	actual = p.toLocaleString( 'de-DE' );
 
 	t.strictEqual( actual, expected, 'returns expected value' );
@@ -124,7 +125,7 @@ tape( 'the method serializes a tuple as a locale-specific string (locale and opt
 		'currency': 'USD'
 	};
 
-	expected = 'tuple(price=' + (1234.56).toLocaleString( 'en-US', opts ) + ', quantity=' + (50).toLocaleString( 'en-US', opts ) + ')';
+	expected = format( 'tuple(price=%s, quantity=%s)', (1234.56).toLocaleString( 'en-US', opts ), (50).toLocaleString( 'en-US', opts ) );
 	actual = p.toLocaleString( 'en-US', opts );
 
 	t.strictEqual( actual, expected, 'returns expected value' );

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_locale_string.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_locale_string.js
@@ -103,7 +103,7 @@ tape( 'the method serializes a tuple as a locale-specific string (specified loca
 	Point = namedtypedtuple( [ 'price', 'quantity' ] );
 	p = new Point( [ 123456.789, 9876 ] );
 
-	expected = 'tuple(price=123.456,789, quantity=9.876)';
+	expected = 'tuple(price=' + (123456.789).toLocaleString( 'de-DE' ) + ', quantity=' + (9876).toLocaleString( 'de-DE' ) + ')';
 	actual = p.toLocaleString( 'de-DE' );
 
 	t.strictEqual( actual, expected, 'returns expected value' );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a hardcoded locale-specific assertion in `test.to_locale_string.js` for `@stdlib/dstructs/named-typed-tuple` that fails on Node.js versions shipping "small-icu" builds (e.g., Node.js v12 on `linux_test`). Failing run: https://github.com/stdlib-js/stdlib/actions/runs/30532379700. The test hardcoded `'tuple(price=123.456,789, quantity=9.876)'` assuming `de-DE` locale data is always present; small-icu builds only carry `en` locale data and silently fall back to default formatting, so the assertion never matched on those runners. The fix computes `expected` dynamically via `.toLocaleString( 'de-DE' )`, matching the pattern already used by the two sibling tests in the same file.

## Related Issues

> Does this pull request have any related issues?

This pull request has no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verified `(123456.789).toLocaleString('de-DE')` produces `'123.456,789'` on full-icu Node.js (confirmed the fix is a no-op on full-icu runners; the assertion still catches a locale-propagation regression there). Ran the full `test.to_locale_string.js` suite locally (17/17 passing). Reviewed by three independent passes (correctness, regression scope, style/conventions); all approved with no blocking findings.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, run as an automated CI-failure triage routine. The root cause was diagnosed from CI logs and confirmed by direct local reproduction; the fix was reviewed by three independent automated review passes (correctness, regression scope, style) before this PR was opened.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019kqUFdkujpmHrcXTVU4N6s)_