### PR TITLE
test: migrate `math/base/special/truncn` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/truncn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncn/test/test.js
@@ -25,11 +25,9 @@ var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
@@ -202,8 +200,6 @@ tape( 'if `n > 308` and `x > 0`, the function returns `+0`', function test( t ) 
 
 tape( 'the function supports rounding very small numbers (including subnormals)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;

--- a/lib/node_modules/@stdlib/math/base/special/truncn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncn/test/test.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -236,13 +237,7 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = truncn( x, n[i] );
-		if ( v === expected[i] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
-		} else {
-			delta = abs( v - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/truncn/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncn/test/test.native.js
@@ -26,11 +26,9 @@ var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
@@ -192,8 +190,6 @@ tape( 'if `n > 308` and `x > 0`, the function returns `+0`', opts, function test
 
 tape( 'the function supports rounding very small numbers (including subnormals)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;

--- a/lib/node_modules/@stdlib/math/base/special/truncn/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncn/test/test.native.js
@@ -22,6 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -226,13 +227,7 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = truncn( x, n[i] );
-		if ( v === expected[i] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
-		} else {
-			delta = abs( v - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests in `@stdlib/math/base/special/truncn` from relative tolerance testing to ULP-based difference testing, utilizing `@stdlib/assert/is-almost-same-value`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The `isAlmostSameValue` function replaces the manual `delta <= tol` checks with a ULP budget of `1`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
