### PR TITLE
fix: normalize hyphens in `kebabcase`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/kebabcase/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/kebabcase/lib/main.js
@@ -28,7 +28,7 @@ var trim = require( '@stdlib/string/base/trim' );
 // VARIABLES //
 
 var RE_WHITESPACE = /\s+/g;
-var RE_SPECIAL = /[!"'(),–.:;<>?`{}|~\/\\\[\]_#$*&^@%]+/g; // eslint-disable-line no-useless-escape
+var RE_SPECIAL = /[\-!"'(),–.:;<>?`{}|~\/\\\[\]_#$*&^@%]+/g; // eslint-disable-line no-useless-escape
 var RE_CAMEL = /([a-z0-9])([A-Z])/g;
 
 

--- a/lib/node_modules/@stdlib/string/base/kebabcase/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/kebabcase/test/test.js
@@ -47,7 +47,9 @@ tape( 'the function converts a string to kebab case', function test( t ) {
 		'foo bar baz',
 		'foo bar baz qux',
 		'foo_bar_baz_qux',
-		'foo_bar baz qux'
+		'foo_bar baz qux',
+		'foo - bar',
+		'foo--bar'
 	];
 
 	expected = [
@@ -60,7 +62,9 @@ tape( 'the function converts a string to kebab case', function test( t ) {
 		'foo-bar-baz',
 		'foo-bar-baz-qux',
 		'foo-bar-baz-qux',
-		'foo-bar-baz-qux'
+		'foo-bar-baz-qux',
+		'foo-bar',
+		'foo-bar'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {


### PR DESCRIPTION
## Description

This pull request:

-   fixes `@stdlib/string/base/kebabcase` to normalize hyphens. The `RE_SPECIAL` regular expression omitted the hyphen, unlike the equivalent `snakecase`, `camelcase`, and `constantcase` implementations. As a result, inputs mixing hyphens and whitespace produced runs of hyphens: `kebabcase( 'foo - bar' )` returned `'foo---bar'` instead of `'foo-bar'`, and `'foo--bar'` was left unchanged. Adding the hyphen to `RE_SPECIAL` makes hyphens behave as word separators and collapse consistently with the other case utilities. The non-base `@stdlib/string/kebabcase` delegates to this implementation, so it is fixed as well.

## Related Issues

None.

## Questions

No.

## Other

All existing `kebabcase` tests still pass; added regression tests for `'foo - bar'` and `'foo--bar'`.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

AI assistance was used only to cross-verify my work for mistakes; the fix and the regression tests were authored by me.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
