### PR TITLE
refactor: use `format` for error messages in `stats/base/dists/hypergeometric/ctor`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/ctor/lib/main.js
@@ -125,10 +125,10 @@ function Hypergeometric( N, K, n ) {
 		throw new TypeError( format( 'invalid argument. Number of draws must be a nonnegative integer. Value: `%s`.', n ) );
 	}
 	if ( K > N ) {
-		throw new RangeError( 'invalid arguments. Subpopulation size must be less than or equal to the population size.' );
+		throw new RangeError( format( 'invalid arguments. Subpopulation size must be less than or equal to the population size.' ) );
 	}
 	if ( n > N ) {
-		throw new RangeError( 'invalid arguments. Number of draws must be less than or equal to the population size.' );
+		throw new RangeError( format( 'invalid arguments. Number of draws must be less than or equal to the population size.' ) );
 	}
 	defineProperty( this, 'N', {
 		'configurable': false,


### PR DESCRIPTION
Resolves N/A.

## Description

> What is the purpose of this pull request?

This pull request:

-   Routes the two constructor `RangeError` messages in `@stdlib/stats/base/dists/hypergeometric/ctor` (the `K > N` and `n > N` guards in `lib/main.js`) through `@stdlib/string/format`, the canonical error-construction helper.

### `@stdlib/stats/base/dists/hypergeometric/ctor`

The two constructor cross-parameter `RangeError` guards were the only throws in the package built from plain string literals; every other throw in the same file — the three `TypeError` argument checks and all six property setters — already uses `format`. All 34 `stats/base/dists/*/ctor` packages construct thrown errors via `format` (100% conformance), leaving these two the sole plain-string outliers. Message text is unchanged and the thrown type stays `RangeError`, so no observable behavior or test expectation changes.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Diff is +2/-2 in a single file. `format` is already imported. The package tests assert error type (`RangeError`) only, not message text, and `format` returns a constant (no `%`-specifier) message unchanged, so the change is mechanical with no cascade into tests, examples, or docs.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running the cross-package drift-detection routine. The namespace `@stdlib/stats/base/dists/hypergeometric` was selected by uniform-random pick over eligible directories (≥8 direct child packages) under `lib/node_modules/@stdlib/`; structural and per-package semantic features were extracted across all 11 members; majority patterns were computed at the 75% threshold; and three independent validation agents (opus semantic-review, opus cross-reference, sonnet structural-review) confirmed this correction as `confirmed-drift` before any file was edited. The within-namespace vote was internally consistent (matching prior run #12647); this correction was surfaced by the canonical-`format` error-construction invariant and confirmed by the ≥90% ecosystem-wide gate.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013gRepyXVdMTxi5C2VyjZXm)_