### PR TITLE
test: migrate `math/base/special/gamma-lanczos-sum-expg-scaledf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaledf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaledf/test/test.js
@@ -24,12 +24,11 @@ var tape = require( 'tape' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var G = require( '@stdlib/constants/float32/gamma-lanczos-g' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var gammaLanczosSumExpGScaledf = require( './../lib' );
 
 
@@ -49,8 +48,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function evaluates the Lanczos sum (scaled by exp(-g))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -64,13 +61,7 @@ tape( 'the function evaluates the Lanczos sum (scaled by exp(-g))', function tes
 		expected /= pow( x[i]+G-0.5, x[i]-0.5 ) / ( exp( x[i]+G-0.5 ) );
 		expected /= exp( G );
 		expected = f32( expected );
-		if ( y === expected ) {
-			t.strictEqual( y, expected, 'returns expected value' );
-		} else {
-			delta = absf( y - expected );
-			tol = 2.0 * EPS * absf( expected );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaledf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaledf/test/test.native.js
@@ -25,12 +25,11 @@ var tape = require( 'tape' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var G = require( '@stdlib/constants/float32/gamma-lanczos-g' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,8 +57,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) 
 
 tape( 'the function evaluates the Lanczos sum (scaled by exp(-g))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -73,13 +70,7 @@ tape( 'the function evaluates the Lanczos sum (scaled by exp(-g))', opts, functi
 		expected /= pow( x[i]+G-0.5, x[i]-0.5 ) / ( exp( x[i]+G-0.5 ) );
 		expected /= exp( G );
 		expected = f32( expected );
-		if ( y === expected ) {
-			t.strictEqual( y, expected, 'x: '+x[ i ]+', y: '+y+', expected: '+expected );
-		} else {
-			delta = absf( y - expected );
-			tol = 2.0 * EPS * absf( expected );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

Migrates `math/base/special/gamma-lanczos-sum-expg-scaledf` from relative-tolerance testing to ULP-difference testing, per the guidance in #11352.

- `test/test.js` and `test/test.native.js`: replaced the `tol = 2.0 * EPS * absf( expected )` / `delta <= tol` check with `isAlmostSameValue( y, expected, 2 )` from `@stdlib/number/float32/base/assert/is-almost-same-value` (the float32-specific variant, appropriate since this package operates on single-precision values).
- Final ULP bound: **2** (same value used in both `test.js` and `test.native.js`, matching the identical tolerance formula the original tests used for both).
- Measured minimum: ran the 500-point fixture set (`linspace( 1.0, 100.0, 500 )`) directly against `@stdlib/number/float32/base/ulp-difference`; the maximum observed ULP difference across all points was exactly 2 (confirmed deterministic over two runs). A bound of 1 fails 45/500 assertions, confirming 2 is the tightest integer bound.
- `test.native.js` could not be executed in this environment (native addon not prebuilt), so its ULP bound is set to match `test.js` based on the original identical tolerance formula rather than an independent empirical measurement.
- Only the two test files were changed; no `package.json` changes were needed (test-only requires aren't tracked as package dependencies in this repo).

Resolves a part of #11352.


---
_Generated by [Claude Code](https://claude.ai/code/session_0156hFaG9cjKzN67qQBHjkLn)_