### PR TITLE
docs: fix C API examples in `blas/ext/base/zwxmy`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/zwxmy/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/zwxmy/README.md
@@ -224,9 +224,9 @@ Multiplies elements of a double-precision complex floating-point strided array `
 ```c
 #include "stdlib/complex/float64/ctor.h"
 
-const float x[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
-const float y[] = { 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };
-float w[] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+const double y[] = { 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 };
+double w[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
 stdlib_strided_zwxmy( 4, (const stdlib_complex128_t *)x, 1, (const stdlib_complex128_t *)y, 1, (stdlib_complex128_t *)w, 1 );
 ```
@@ -256,9 +256,9 @@ Multiplies elements of a double-precision complex floating-point strided array `
 ```c
 #include "stdlib/complex/float64/ctor.h"
 
-const float x[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
-const float y[] = { 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };
-float w[] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+const double x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+const double y[] = { 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 };
+double w[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
 stdlib_strided_zwxmy_ndarray( 4, (const stdlib_complex128_t *)x, 1, 0, (const stdlib_complex128_t *)y, 1, 0, (stdlib_complex128_t *)w, 1, 0 );
 ```
@@ -308,22 +308,22 @@ void stdlib_strided_zwxmy_ndarray( const CBLAS_INT N, const stdlib_complex128_t 
 int main( void ) {
     // Create strided arrays:
     const stdlib_complex128_t x[] = {
-        stdlib_complex128( 1.0f, 2.0f ),
-        stdlib_complex128( 3.0f, 4.0f ),
-        stdlib_complex128( 5.0f, 6.0f ),
-        stdlib_complex128( 7.0f, 8.0f )
+        stdlib_complex128( 1.0, 2.0 ),
+        stdlib_complex128( 3.0, 4.0 ),
+        stdlib_complex128( 5.0, 6.0 ),
+        stdlib_complex128( 7.0, 8.0 )
     };
     const stdlib_complex128_t y[] = {
-        stdlib_complex128( 2.0f, 3.0f ),
-        stdlib_complex128( 4.0f, 5.0f ),
-        stdlib_complex128( 6.0f, 7.0f ),
-        stdlib_complex128( 8.0f, 9.0f )
+        stdlib_complex128( 2.0, 3.0 ),
+        stdlib_complex128( 4.0, 5.0 ),
+        stdlib_complex128( 6.0, 7.0 ),
+        stdlib_complex128( 8.0, 9.0 )
     };
     stdlib_complex128_t w[] = {
-        stdlib_complex128( 0.0f, 0.0f ),
-        stdlib_complex128( 0.0f, 0.0f ),
-        stdlib_complex128( 0.0f, 0.0f ),
-        stdlib_complex128( 0.0f, 0.0f )
+        stdlib_complex128( 0.0, 0.0 ),
+        stdlib_complex128( 0.0, 0.0 ),
+        stdlib_complex128( 0.0, 0.0 ),
+        stdlib_complex128( 0.0, 0.0 )
     };
 
     // Specify the number of indexed elements:
@@ -339,7 +339,7 @@ int main( void ) {
 
     // Print the result:
     for ( int i = 0; i < N; i++ ) {
-        printf( "w[ %i ] = %f + %fi\n", i, stdlib_complex128_real( w[ i ] ), stdlib_complex128_imag( w[ i ] ) );
+        printf( "w[ %i ] = %lf + %lfi\n", i, stdlib_complex128_real( w[ i ] ), stdlib_complex128_imag( w[ i ] ) );
     }
 }
 ```


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-07-30 14:56 PT (22f4f46) and 2026-07-31 04:19 PT (a669750).

This pull request:

-   `blas/ext/base/zwxmy`: Fixed `blas/ext/base/zwxmy` README examples (451c6c8): the C snippets for `stdlib_strided_zwxmy`/`stdlib_strided_zwxmy_ndarray` declared `x`/`w` as `float` arrays cast to `stdlib_complex128_t *`, an 8-byte-per-element vs. 16-byte-per-element mismatch causing OOB reads and float-as-double reinterpretation for N=4. Changed both declarations to `double` with matching literals in `lib/node_modules/@stdlib/blas/ext/base/zwxmy/README.md`, consistent with the `zxmy`/`zany` sibling docs.
-   `blas/ext/base/zwxmy`: Fixes the C "Examples" section in `blas/ext/base/zwxmy/README.md` (introduced in 451c6c8) to match `examples/c/example.c`: drops the erroneous `f` suffixes from all twelve `stdlib_complex128` literals and switches the `printf` format specifier from `%f` to `%lf`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 27 commits merged to `develop` in the last 24 hours were reviewed for typos, bugs, and stdlib style-guide compliance: two independent style-compliance passes (checked against `docs/style-guides` and established sibling packages such as `gtriu`, `zxmy`, `dindex-of`), plus two independent bug-scan passes over the union diff (strided-loop index arithmetic, native addon marshalling, C benchmark refactors, README/repl example outputs, ULP tolerance translations in the migrated `math/base/special` tests). Only issues that were objective, independently re-verifiable from the diff, and fixable without touching code outside the diff window were retained. Deliberately excluded: subjective suggestions, style preferences not mandated by the style guides, and missing entries in the auto-generated `blas/ext/base` aggregate README/TypeScript declarations (the regeneration commits simply predate the namespace wiring; the next regeneration run will pick them up).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by a scheduled automated review: Claude Code reviewed the last 24 hours of commits merged to `develop` and authored the fixes. A human maintainer will audit before promoting this draft.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UN61jV6C144EpKHXKNXsG4)_