### PR TITLE
test: migrate `math/base/special/sqrtpif` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sqrtpif/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtpif/test/test.js
@@ -26,8 +26,8 @@ var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var sqrtpif = require( './../lib' );
 
 
@@ -53,184 +53,136 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[50,500]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = veryLargePositive.expected;
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[20,50]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = largePositive.expected;
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[3,20]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = mediumPositive.expected;
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[0.8,3]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = smallPositive.expected;
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates principal square root when `x` is on the interval `[0.0,0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = smaller.expected;
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[1e-300,1e-308]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = tinyPositive.expected;
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is subnormal', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = subnormal.expected;
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root for huge positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = hugePositive.expected;
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sqrtpif/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtpif/test/test.native.js
@@ -27,9 +27,9 @@ var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 
 
 // FIXTURES //
@@ -62,184 +62,136 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[50,500]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = veryLargePositive.expected;
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[20,50]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = largePositive.expected;
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[3,20]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = mediumPositive.expected;
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[0.8,3]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = smallPositive.expected;
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates principal square root when `x` is on the interval `[0.0,0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = smaller.expected;
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is on the interval `[1e-300,1e-308]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = tinyPositive.expected;
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root when `x` is subnormal', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = subnormal.expected;
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the principal square root for huge positive numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
+	var e;
 	var i;
 
 	expected = hugePositive.expected;
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
+		e = float64ToFloat32( expected[i] );
 		y = sqrtpif( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `@stdlib/math/base/special/sqrtpif` to use precise ULP-based bounds for floating-point comparisons rather than relative epsilon tolerances.
-   Replaces absolute differences and epsilon logic with `@stdlib/number/float32/base/assert/is-almost-same-value`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md