### PR TITLE
docs: improve doctests for complex number instances

### DIFF
--- a/lib/node_modules/@stdlib/complex/base/wrap-function/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/complex/base/wrap-function/docs/types/index.d.ts
@@ -281,13 +281,7 @@ declare function wrap( fcn: Binary, nargs: 2, ctor: Constructor ): WrappedBinary
 * // ...
 *
 * var z = f( 3.0, 4.0, 5.0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 12.0
-*
-* var im = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 12.0, 0.0 ]
 */
 declare function wrap( fcn: Ternary, nargs: 3, ctor: Constructor ): WrappedTernary;
 
@@ -321,13 +315,7 @@ declare function wrap( fcn: Ternary, nargs: 3, ctor: Constructor ): WrappedTerna
 * // ...
 *
 * var z = f( 3.0, 4.0, 5.0, 6.0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 18.0
-*
-* var im = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 18.0, 0.0 ]
 */
 declare function wrap( fcn: Quaternary, nargs: 4, ctor: Constructor ): WrappedQuaternary;
 
@@ -361,13 +349,7 @@ declare function wrap( fcn: Quaternary, nargs: 4, ctor: Constructor ): WrappedQu
 * // ...
 *
 * var z = f( 3.0, 4.0, 5.0, 6.0, 7.0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 25.0
-*
-* var im = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 25.0, 0.0 ]
 */
 declare function wrap( fcn: Quinary, nargs: 5, ctor: Constructor ): WrappedQuinary;
 
@@ -401,13 +383,7 @@ declare function wrap( fcn: Quinary, nargs: 5, ctor: Constructor ): WrappedQuina
 * // ...
 *
 * var z = f( 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 33.0
-*
-* var im = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 33.0, 0.0 ]
 */
 declare function wrap( fcn: Nary, nargs: number, ctor: Constructor ): WrappedNary;
 


### PR DESCRIPTION

Resolves a part of #8641.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates the documentation examples for the `complex/base/wrap-function` package to use the new compact complex instance doctest notation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8641

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

n/a

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
