### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/lib/cindex_of_column.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/lib/cindex_of_column.native.js
@@ -34,6 +34,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first column in a single-precision complex floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-column/lib/ndarray.native.js
@@ -31,6 +31,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first column in a single-precision complex floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Complex64Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/lib/cindex_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/lib/cindex_of_row.native.js
@@ -34,6 +34,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first row in a single-precision complex floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/cindex-of-row/lib/ndarray.native.js
@@ -31,6 +31,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first row in a single-precision complex floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Complex64Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/lib/clast_index_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/lib/clast_index_of_row.native.js
@@ -34,6 +34,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last row in a single-precision complex floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/clast-index-of-row/lib/ndarray.native.js
@@ -31,6 +31,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last row in a single-precision complex floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Complex64Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/dcartesian-power/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcartesian-power/benchmark/c/benchmark.length.c
@@ -192,14 +192,14 @@ int main( void ) {
 		iter = ITERATIONS / (int)pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
 		}
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/dcartesian-product/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcartesian-product/benchmark/c/benchmark.length.c
@@ -189,14 +189,14 @@ int main( void ) {
 		iter = ITERATIONS / (int) pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
 		}
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/dcartesian-square/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcartesian-square/benchmark/c/benchmark.length.c
@@ -181,14 +181,14 @@ int main( void ) {
 		iter = ITERATIONS / (int)pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
 		}
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/dcartesian-square/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcartesian-square/lib/ndarray.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Computes the Cartesian square for a double-precision floating-point strided array using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   Pairs are stored as rows in the output matrix, where the first column contains the first element of each pair and the second column contains the second element.
+*
 * @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float64Array} x - input array
 * @param {integer} strideX - stride length for `x`

--- a/lib/node_modules/@stdlib/blas/ext/base/dcircshift/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcircshift/lib/ndarray.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Circularly shifts the elements of a double-precision floating-point strided array by a specified number of positions using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   This implementation is based on the "trinity rotation" (a.k.a., conjoined triple reversal) algorithm introduced in <https://github.com/scandum/rotate/tree/6d0d2d56d10454def027e35921890200b45fe82c>, by Igor van den Hoven.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {integer} k - number of positions to shift
 * @param {Float64Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-column/lib/dindex_of_column.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-column/lib/dindex_of_column.native.js
@@ -33,6 +33,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first column in a double-precision floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-column/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-column/lib/ndarray.native.js
@@ -30,6 +30,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first column in a double-precision floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Float64Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/lib/dindex_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/lib/dindex_of_row.native.js
@@ -33,6 +33,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first row in a double-precision floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dindex-of-row/lib/ndarray.native.js
@@ -30,6 +30,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first row in a double-precision floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Float64Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/lib/dlast_index_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/lib/dlast_index_of_row.native.js
@@ -33,6 +33,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last row in a double-precision floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dlast-index-of-row/lib/ndarray.native.js
@@ -30,6 +30,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last row in a double-precision floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Float64Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/dminheap-sift-down/lib/dminheap_sift_down.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dminheap-sift-down/lib/dminheap_sift_down.native.js
@@ -28,6 +28,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Sifts a value down from a specified index in a double-precision floating-point strided min-heap until the heap property is restored.
 *
+* ## Notes
+*
+* -   The function assumes that the subtrees rooted at the children of `index` already satisfy the min-heap property and only the value being sifted may violate the min-heap invariant.
+* -   The min-heap algorithm is sensitive to the presence of `NaN` values. Since `NaN` comparisons always return `false`, if `NaN` values are present in the input array, the results may be unpredictable.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NonNegativeInteger} index - logical index at which to begin sifting
 * @param {number} value - value to place into the heap

--- a/lib/node_modules/@stdlib/blas/ext/base/dminheap-sift-down/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dminheap-sift-down/lib/ndarray.native.js
@@ -28,6 +28,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Sifts a value down from a specified index in a double-precision floating-point strided min-heap until the heap property is restored using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   The function assumes that the subtrees rooted at the children of `index` already satisfy the min-heap property and only the value being sifted may violate the min-heap invariant.
+* -   The min-heap algorithm is sensitive to the presence of `NaN` values. Since `NaN` comparisons always return `false`, if `NaN` values are present in the input array, the results may be unpredictable.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NonNegativeInteger} index - logical index at which to begin sifting
 * @param {number} value - value to place into the heap

--- a/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/c/benchmark.length.c
@@ -183,7 +183,7 @@ int main( void ) {
 		iter = ITERATIONS / pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
@@ -194,7 +194,7 @@ int main( void ) {
 		iter = ITERATIONS / pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/scartesian-power/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/scartesian-power/benchmark/c/benchmark.length.c
@@ -192,14 +192,14 @@ int main( void ) {
 		iter = ITERATIONS / (int)pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
 		}
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/scartesian-product/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/scartesian-product/benchmark/c/benchmark.length.c
@@ -189,14 +189,14 @@ int main( void ) {
 		iter = ITERATIONS / (int) pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
 		}
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/scartesian-square/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/scartesian-square/benchmark/c/benchmark.length.c
@@ -181,14 +181,14 @@ int main( void ) {
 		iter = ITERATIONS / (int)pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
 		}
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/scartesian-square/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scartesian-square/lib/ndarray.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Computes the Cartesian square for a single-precision floating-point strided array using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   Pairs are stored as rows in the output matrix, where the first column contains the first element of each pair and the second column contains the second element.
+*
 * @param {NonNegativeInteger} N - number of indexed elements
 * @param {Float32Array} x - input array
 * @param {integer} strideX - stride length for `x`

--- a/lib/node_modules/@stdlib/blas/ext/base/scircshift/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scircshift/lib/ndarray.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Circularly shifts the elements of a single-precision floating-point strided array by a specified number of positions using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   This implementation is based on the "trinity rotation" (a.k.a., conjoined triple reversal) algorithm introduced in <https://github.com/scandum/rotate/tree/6d0d2d56d10454def027e35921890200b45fe82c>, by Igor van den Hoven.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {integer} k - number of positions to shift
 * @param {Float32Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/lib/ndarray.native.js
@@ -30,6 +30,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first column in a single-precision floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Float32Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/lib/sindex_of_column.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-column/lib/sindex_of_column.native.js
@@ -33,6 +33,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first column in a single-precision floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/lib/ndarray.native.js
@@ -30,6 +30,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first row in a single-precision floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Float32Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/lib/sindex_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of-row/lib/sindex_of_row.native.js
@@ -33,6 +33,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first row in a single-precision floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/ndarray.native.js
@@ -30,6 +30,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last row in a single-precision floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Float32Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/slast-index-of-row/lib/slast_index_of_row.native.js
@@ -33,6 +33,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last row in a single-precision floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/sminheap-sift-down/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sminheap-sift-down/lib/ndarray.native.js
@@ -28,6 +28,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Sifts a value down from a specified index in a single-precision floating-point strided min-heap until the heap property is restored using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   The function assumes that the subtrees rooted at the children of `index` already satisfy the min-heap property and only the value being sifted may violate the min-heap invariant.
+* -   The min-heap algorithm is sensitive to the presence of `NaN` values. Since `NaN` comparisons always return `false`, if `NaN` values are present in the input array, the results may be unpredictable.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NonNegativeInteger} index - logical index at which to begin sifting
 * @param {number} value - value to place into the heap

--- a/lib/node_modules/@stdlib/blas/ext/base/sminheap-sift-down/lib/sminheap_sift_down.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sminheap-sift-down/lib/sminheap_sift_down.native.js
@@ -28,6 +28,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Sifts a value down from a specified index in a single-precision floating-point strided min-heap until the heap property is restored.
 *
+* ## Notes
+*
+* -   The function assumes that the subtrees rooted at the children of `index` already satisfy the min-heap property and only the value being sifted may violate the min-heap invariant.
+* -   The min-heap algorithm is sensitive to the presence of `NaN` values. Since `NaN` comparisons always return `false`, if `NaN` values are present in the input array, the results may be unpredictable.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {NonNegativeInteger} index - logical index at which to begin sifting
 * @param {number} value - value to place into the heap

--- a/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/c/benchmark.length.c
@@ -183,7 +183,7 @@ int main( void ) {
 		iter = ITERATIONS / pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
@@ -194,7 +194,7 @@ int main( void ) {
 		iter = ITERATIONS / pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/zcartesian-product/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/zcartesian-product/benchmark/c/benchmark.length.c
@@ -190,14 +190,14 @@ int main( void ) {
 		iter = ITERATIONS / (int) pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
 		}
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/zcartesian-square/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/zcartesian-square/benchmark/c/benchmark.length.c
@@ -192,14 +192,14 @@ int main( void ) {
 		iter = ITERATIONS / (int)pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:len=%d\n", NAME, len );
+			printf( "# c::%s:len=%d\n", NAME, len );
 			elapsed = benchmark1( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );
 		}
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
-			printf( "# c::native::%s:ndarray:len=%d\n", NAME, len );
+			printf( "# c::%s:ndarray:len=%d\n", NAME, len );
 			elapsed = benchmark2( iter, len );
 			print_results( iter, elapsed );
 			printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/blas/ext/base/zcartesian-square/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zcartesian-square/lib/ndarray.native.js
@@ -29,6 +29,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Computes the Cartesian square for a double-precision complex floating-point strided array using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   Pairs are stored as rows in the output matrix, where the first column contains the first element of each pair and the second column contains the second element.
+*
 * @param {NonNegativeInteger} N - number of indexed elements
 * @param {Complex128Array} x - input array
 * @param {integer} strideX - stride length for `x`

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/lib/ndarray.native.js
@@ -31,6 +31,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first column in a double-precision complex floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Complex128Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/lib/zindex_of_column.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-column/lib/zindex_of_column.native.js
@@ -34,6 +34,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first column in a double-precision complex floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching column, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in row-major order. When the matrix is stored in column-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/lib/ndarray.native.js
@@ -31,6 +31,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first row in a double-precision complex floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Complex128Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/lib/zindex_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zindex-of-row/lib/zindex_of_row.native.js
@@ -34,6 +34,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the first row in a double-precision complex floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/lib/ndarray.native.js
@@ -31,6 +31,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last row in a double-precision complex floating-point input matrix which has the same elements as a provided search vector using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`
 * @param {Complex128Array} A - input matrix

--- a/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/lib/zlast_index_of_row.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-row/lib/zlast_index_of_row.native.js
@@ -34,6 +34,11 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last row in a double-precision complex floating-point input matrix which has the same elements as a provided search vector.
 *
+* ## Notes
+*
+* -   If the function is provided an empty matrix or if the function is unable to find a matching row, the function returns `-1` (i.e., an invalid index).
+* -   The `workspace` array is only applicable when an input matrix is stored in column-major order. When the matrix is stored in row-major order, the workspace array is ignored.
+*
 * @param {string} order - storage layout
 * @param {PositiveInteger} M - number of rows in `A`
 * @param {PositiveInteger} N - number of columns in `A`

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-same-value-zero/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-same-value-zero/benchmark/c/benchmark.c
@@ -77,13 +77,15 @@ static double tic( void ) {
 }
 
 /**
-* Generates a random number on the interval [0,1).
+* Generates a random number on the interval [min,max).
 *
-* @return random number
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
 */
-static float rand_float( void ) {
-	int r = rand();
-	return (float)r / ( (float)RAND_MAX + 1.0f );
+static float random_uniform( const float min, const float max ) {
+	float v = (float)rand() / ( (float)RAND_MAX + 1.0f );
+	return min + ( v*( max-min ) );
 }
 
 /**
@@ -94,14 +96,17 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
+	float *x;
 	bool out;
 	int i;
 
+	x = (float *) malloc( 100 * sizeof( float ) );
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( 500.0f, 1500.0f );
+	}
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0f*rand_float() ) + 500.0f;
-		out = stdlib_base_float32_is_same_value_zero( x, x );
+		out = stdlib_base_float32_is_same_value_zero( x[ i%100 ], x[ i%100 ] );
 		if ( out != true ) {
 			printf( "unexpected result\n" );
 			break;
@@ -111,6 +116,7 @@ static double benchmark( void ) {
 	if ( out != true ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-same-value/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-same-value/benchmark/c/benchmark.c
@@ -77,13 +77,15 @@ static double tic( void ) {
 }
 
 /**
-* Generates a random number on the interval [0,1).
+* Generates a random number on the interval [min,max).
 *
-* @return random number
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
 */
-static float rand_float( void ) {
-	int r = rand();
-	return (float)r / ( (float)RAND_MAX + 1.0f );
+static float random_uniform( const float min, const float max ) {
+	float v = (float)rand() / ( (float)RAND_MAX + 1.0f );
+	return min + ( v*( max-min ) );
 }
 
 /**
@@ -94,14 +96,17 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
+	float *x;
 	bool out;
 	int i;
 
+	x = (float *) malloc( 100 * sizeof( float ) );
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( 500.0f, 1500.0f );
+	}
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0f*rand_float() ) + 500.0f;
-		out = stdlib_base_float32_is_same_value( x, x );
+		out = stdlib_base_float32_is_same_value( x[ i%100 ], x[ i%100 ] );
 		if ( out != true ) {
 			printf( "unexpected result\n" );
 			break;
@@ -111,6 +116,7 @@ static double benchmark( void ) {
 	if ( out != true ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/number/float32/base/to-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/to-word/benchmark/c/benchmark.c
@@ -76,13 +76,15 @@ static double tic( void ) {
 }
 
 /**
-* Generates a random number on the interval [0,1).
+* Generates a random number on the interval [min,max).
 *
-* @return random number
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
 */
-static float rand_float( void ) {
-	int r = rand();
-	return (float)r / ( (float)RAND_MAX + 1.0f );
+static float random_uniform( const float min, const float max ) {
+	float v = (float)rand() / ( (float)RAND_MAX + 1.0f );
+	return min + ( v*( max-min ) );
 }
 
 /**
@@ -94,13 +96,16 @@ static double benchmark( void ) {
 	double elapsed;
 	uint32_t w;
 	double t;
-	float x;
+	float *x;
 	int i;
 
+	x = (float *) malloc( 100 * sizeof( float ) );
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( -500.0f, 500.0f );
+	}
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0f*rand_float() ) - 500.0f;
-		stdlib_base_float32_to_word( x, &w );
+		stdlib_base_float32_to_word( x[ i%100 ], &w );
 		if ( w == 1 ) { // Note: should not generate the smallest subnormal
 			printf( "unexpected result\n" );
 			break;
@@ -110,6 +115,7 @@ static double benchmark( void ) {
 	if ( w == 1 ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/number/float64/base/assert/is-same-value-zero/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/assert/is-same-value-zero/benchmark/c/benchmark.c
@@ -77,13 +77,15 @@ static double tic( void ) {
 }
 
 /**
-* Generates a random number on the interval [0,1).
+* Generates a random number on the interval [min,max).
 *
-* @return random number
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
 */
-static double rand_double( void ) {
-	int r = rand();
-	return (double)r / ( (double)RAND_MAX + 1.0 );
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*( max-min ) );
 }
 
 /**
@@ -93,15 +95,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double *x;
 	double t;
 	bool out;
 	int i;
 
+	x = (double *) malloc( 100 * sizeof( double ) );
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( 500.0, 1500.0 );
+	}
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) + 500.0;
-		out = stdlib_base_float64_is_same_value_zero( x, x );
+		out = stdlib_base_float64_is_same_value_zero( x[ i%100 ], x[ i%100 ] );
 		if ( out != true ) {
 			printf( "unexpected result\n" );
 			break;
@@ -111,6 +116,7 @@ static double benchmark( void ) {
 	if ( out != true ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/number/float64/base/assert/is-same-value/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/assert/is-same-value/benchmark/c/benchmark.c
@@ -77,13 +77,15 @@ static double tic( void ) {
 }
 
 /**
-* Generates a random number on the interval [0,1).
+* Generates a random number on the interval [min,max).
 *
-* @return random number
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
 */
-static double rand_double( void ) {
-	int r = rand();
-	return (double)r / ( (double)RAND_MAX + 1.0 );
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*( max-min ) );
 }
 
 /**
@@ -93,15 +95,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double *x;
 	double t;
 	bool out;
 	int i;
 
+	x = (double *) malloc( 100 * sizeof( double ) );
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( 500.0, 1500.0 );
+	}
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) + 500.0;
-		out = stdlib_base_float64_is_same_value( x, x );
+		out = stdlib_base_float64_is_same_value( x[ i%100 ], x[ i%100 ] );
 		if ( out != true ) {
 			printf( "unexpected result\n" );
 			break;
@@ -111,6 +116,7 @@ static double benchmark( void ) {
 	if ( out != true ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/number/float64/base/get-high-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/get-high-word/benchmark/c/benchmark.c
@@ -76,13 +76,15 @@ static double tic( void ) {
 }
 
 /**
-* Generates a random number on the interval [0,1).
+* Generates a random number on the interval [min,max).
 *
-* @return random number
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
 */
-static double rand_double( void ) {
-	int r = rand();
-	return (double)r / ( (double)RAND_MAX + 1.0 );
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*( max-min ) );
 }
 
 /**
@@ -93,14 +95,17 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	uint32_t h;
-	double x;
+	double *x;
 	double t;
 	int i;
 
+	x = (double *) malloc( 100 * sizeof( double ) );
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( 500.0, 1500.0 );
+	}
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) + 500.0;
-		stdlib_base_float64_get_high_word( x, &h );
+		stdlib_base_float64_get_high_word( x[ i%100 ], &h );
 		if ( h == 0 ) {
 			printf( "unexpected result\n" );
 			break;
@@ -110,6 +115,7 @@ static double benchmark( void ) {
 	if ( h == 0 ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/number/float64/base/get-low-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/get-low-word/benchmark/c/benchmark.c
@@ -76,13 +76,15 @@ static double tic( void ) {
 }
 
 /**
-* Generates a random number on the interval [0,1).
+* Generates a random number on the interval [min,max).
 *
-* @return random number
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
 */
-static double rand_double( void ) {
-	int r = rand();
-	return (double)r / ( (double)RAND_MAX + 1.0 );
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*( max-min ) );
 }
 
 /**
@@ -93,14 +95,17 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	uint32_t l;
-	double x;
+	double *x;
 	double t;
 	int i;
 
+	x = (double *) malloc( 100 * sizeof( double ) );
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( 500.0, 1500.0 );
+	}
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) + 500.0;
-		stdlib_base_float64_get_low_word( x, &l );
+		stdlib_base_float64_get_low_word( x[ i%100 ], &l );
 		if ( l == 0 ) {
 			printf( "unexpected result\n" );
 			break;
@@ -110,6 +115,7 @@ static double benchmark( void ) {
 	if ( l == 0 ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/number/float64/base/signbit/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/signbit/benchmark/c/benchmark.c
@@ -76,13 +76,15 @@ static double tic( void ) {
 }
 
 /**
-* Generates a random number on the interval [0,1).
+* Generates a random number on the interval [min,max).
 *
-* @return random number
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
 */
-static double rand_double( void ) {
-	int r = rand();
-	return (double)r / ( (double)RAND_MAX + 1.0 );
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*( max-min ) );
 }
 
 /**
@@ -93,14 +95,17 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	int8_t out;
-	double x;
+	double *x;
 	double t;
 	int i;
 
+	x = (double *) malloc( 100 * sizeof( double ) );
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( -100.0, 100.0 );
+	}
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( rand_double()*200.0 ) - 100.0;
-		out = stdlib_base_float64_signbit( x );
+		out = stdlib_base_float64_signbit( x[ i%100 ] );
 		if ( out != 0 && out != 1 ) {
 			printf( "unexpected result\n" );
 			break;
@@ -110,6 +115,7 @@ static double benchmark( void ) {
 	if ( out != 0 && out != 1 ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/number/float64/base/to-words/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/to-words/benchmark/c/benchmark.c
@@ -76,13 +76,15 @@ static double tic( void ) {
 }
 
 /**
-* Generates a random number on the interval [0,1).
+* Generates a random number on the interval [min,max).
 *
-* @return random number
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
 */
-static double rand_double( void ) {
-	int r = rand();
-	return (double)r / ( (double)RAND_MAX + 1.0 );
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*( max-min ) );
 }
 
 /**
@@ -94,14 +96,17 @@ static double benchmark( void ) {
 	double elapsed;
 	uint32_t h;
 	uint32_t l;
-	double x;
+	double *x;
 	double t;
 	int i;
 
+	x = (double *) malloc( 100 * sizeof( double ) );
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( -500.0, 500.0 );
+	}
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		stdlib_base_float64_to_words( x, &h, &l );
+		stdlib_base_float64_to_words( x[ i%100 ], &h, &l );
 		if ( h != 0 && h == l ) {
 			printf( "unexpected result\n" );
 			break;
@@ -111,6 +116,7 @@ static double benchmark( void ) {
 	if ( h != 0 && h == l ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/strided/base/cmap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/cmap/README.md
@@ -210,10 +210,10 @@ static float complex scale( const float complex x ) {
     return ( re+10.0f ) + ( im+10.0f )*I;
 }
 
-float complex X[] = { 1.0f+1.0f*I, 2.0f+2.0f*I, 3.0f+3.0f*I, 4.0f+4.0f*I, 5.0f+5.0f*I, 6.0f+6.0f*I };
+const float complex X[] = { 1.0f+1.0f*I, 2.0f+2.0f*I, 3.0f+3.0f*I, 4.0f+4.0f*I, 5.0f+5.0f*I, 6.0f+6.0f*I };
 float complex Y[] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
 
-int64_t N = 6;
+const int64_t N = 6;
 
 stdlib_strided_cmap( N, X, 1, Y, 1, scale );
 ```
@@ -265,17 +265,17 @@ static float complex scale( const float complex x ) {
 
 int main( void ) {
     // Create an input strided array:
-    float complex X[] = { 1.0+1.0*I, 2.0+2.0*I, 3.0+3.0*I, 4.0+4.0*I, 5.0+5.0*I, 6.0+6.0*I };
+    const float complex X[] = { 1.0+1.0*I, 2.0+2.0*I, 3.0+3.0*I, 4.0+4.0*I, 5.0+5.0*I, 6.0+6.0*I };
 
     // Create an output strided array:
     float complex Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
     // Specify the number of elements:
-    int64_t N = 6;
+    const int64_t N = 6;
 
     // Define the strides:
-    int64_t strideX = 1;
-    int64_t strideY = -1;
+    const int64_t strideX = 1;
+    const int64_t strideY = -1;
 
     // Apply the callback:
     stdlib_strided_cmap( N, X, strideX, Y, strideY, scale );

--- a/lib/node_modules/@stdlib/strided/base/cmap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/cmap/examples/c/example.c
@@ -37,11 +37,11 @@ int main( void ) {
 	float complex Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
 	// Specify the number of elements:
-	int64_t N = 6;
+	const int64_t N = 6;
 
 	// Define the strides:
-	int64_t strideX = 1;
-	int64_t strideY = -1;
+	const int64_t strideX = 1;
+	const int64_t strideY = -1;
 
 	// Apply the callback:
 	stdlib_strided_cmap( N, X, strideX, Y, strideY, scale );

--- a/lib/node_modules/@stdlib/strided/base/dmap2/README.md
+++ b/lib/node_modules/@stdlib/strided/base/dmap2/README.md
@@ -212,11 +212,11 @@ static double add( const double x, const double y ) {
     return x + y;
 }
 
-double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
-double Y[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+const double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+const double Y[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
 double Z[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
-int64_t N = 6;
+const int64_t N = 6;
 
 stdlib_strided_dmap2( N, X, 1, Y, 1, Z, 1, add );
 ```
@@ -267,19 +267,19 @@ static double add( const double x, const double y ) {
 
 int main( void ) {
     // Create input strided arrays:
-    double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
-    double Y[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+    const double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+    const double Y[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
 
     // Create an output strided array:
     double Z[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
     // Specify the number of elements:
-    int64_t N = 6;
+    const int64_t N = 6;
 
     // Define the strides:
-    int64_t strideX = 1;
-    int64_t strideY = -1;
-    int64_t strideZ = 1;
+    const int64_t strideX = 1;
+    const int64_t strideY = -1;
+    const int64_t strideZ = 1;
 
     // Apply the callback:
     stdlib_strided_dmap2( N, X, strideX, Y, strideY, Z, strideZ, add );

--- a/lib/node_modules/@stdlib/strided/base/dmap2/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/dmap2/examples/c/example.c
@@ -28,19 +28,19 @@ static double add( const double x, const double y ) {
 
 int main( void ) {
 	// Create input strided arrays:
-	double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
-	double Y[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+	const double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+	const double Y[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
 
 	// Create an output strided array:
 	double Z[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
 	// Specify the number of elements:
-	int64_t N = 6;
+	const int64_t N = 6;
 
 	// Define the strides:
-	int64_t strideX = 1;
-	int64_t strideY = -1;
-	int64_t strideZ = 1;
+	const int64_t strideX = 1;
+	const int64_t strideY = -1;
+	const int64_t strideZ = 1;
 
 	// Apply the callback:
 	stdlib_strided_dmap2( N, X, strideX, Y, strideY, Z, strideZ, add );

--- a/lib/node_modules/@stdlib/strided/base/dmskmap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/dmskmap/README.md
@@ -226,11 +226,11 @@ static double scale( const double x ) {
     return x * 10.0;
 }
 
-double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
-uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
+const double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+const uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
 double Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
-int64_t N = 6;
+const int64_t N = 6;
 
 stdlib_strided_dmskmap( N, X, 1, M, 1, Y, 1, scale );
 ```
@@ -281,21 +281,21 @@ static double scale( const double x ) {
 
 int main( void ) {
     // Create an input strided array:
-    double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+    const double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
 
     // Create a mask strided array:
-    uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
+    const uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
 
     // Create an output strided array:
     double Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
     // Specify the number of elements:
-    int64_t N = 6;
+    const int64_t N = 6;
 
     // Define the strides:
-    int64_t strideX = 1;
-    int64_t strideM = 1;
-    int64_t strideY = -1;
+    const int64_t strideX = 1;
+    const int64_t strideM = 1;
+    const int64_t strideY = -1;
 
     // Apply the callback:
     stdlib_strided_dmskmap( N, X, strideX, M, strideM, Y, strideY, scale );

--- a/lib/node_modules/@stdlib/strided/base/dmskmap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/dmskmap/examples/c/example.c
@@ -37,12 +37,12 @@ int main( void ) {
 	double Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
 	// Specify the number of elements:
-	int64_t N = 6;
+	const int64_t N = 6;
 
 	// Define the strides:
-	int64_t strideX = 1;
-	int64_t strideM = 1;
-	int64_t strideY = -1;
+	const int64_t strideX = 1;
+	const int64_t strideM = 1;
+	const int64_t strideY = -1;
 
 	// Apply the callback:
 	stdlib_strided_dmskmap( N, X, strideX, M, strideM, Y, strideY, scale );

--- a/lib/node_modules/@stdlib/strided/base/max-view-buffer-index/README.md
+++ b/lib/node_modules/@stdlib/strided/base/max-view-buffer-index/README.md
@@ -168,13 +168,13 @@ int64_t stdlib_strided_max_view_buffer_index( const int64_t N, const int64_t str
 
 int main( void ) {
     // Specify the number of indexed elements:
-    int64_t N = 6;
+    const int64_t N = 6;
 
     // Define a stride:
-    int64_t stride = 2;
+    const int64_t stride = 2;
 
     // Define an offset:
-    int64_t offset = 100;
+    const int64_t offset = 100;
 
     // Compute the maximum accessible index:
     int64_t idx = stdlib_strided_max_view_buffer_index( N, stride, offset );

--- a/lib/node_modules/@stdlib/strided/base/max-view-buffer-index/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/max-view-buffer-index/examples/c/example.c
@@ -23,13 +23,13 @@
 
 int main( void ) {
 	// Specify the number of indexed elements:
-	int64_t N = 6;
+	const int64_t N = 6;
 
 	// Define a stride:
-	int64_t stride = 2;
+	const int64_t stride = 2;
 
 	// Define an offset:
-	int64_t offset = 100;
+	const int64_t offset = 100;
 
 	// Compute the maximum accessible index:
 	int64_t idx = stdlib_strided_max_view_buffer_index( N, stride, offset );

--- a/lib/node_modules/@stdlib/strided/base/min-view-buffer-index/README.md
+++ b/lib/node_modules/@stdlib/strided/base/min-view-buffer-index/README.md
@@ -168,13 +168,13 @@ int64_t stdlib_strided_min_view_buffer_index( const int64_t N, const int64_t str
 
 int main( void ) {
     // Specify the number of indexed elements:
-    int64_t N = 6;
+    const int64_t N = 6;
 
     // Define a stride:
-    int64_t stride = -2;
+    const int64_t stride = -2;
 
     // Define an offset:
-    int64_t offset = 100;
+    const int64_t offset = 100;
 
     // Compute the minimum accessible index:
     int64_t idx = stdlib_strided_min_view_buffer_index( N, stride, offset );

--- a/lib/node_modules/@stdlib/strided/base/min-view-buffer-index/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/min-view-buffer-index/examples/c/example.c
@@ -23,13 +23,13 @@
 
 int main( void ) {
 	// Specify the number of indexed elements:
-	int64_t N = 6;
+	const int64_t N = 6;
 
 	// Define a stride:
-	int64_t stride = -2;
+	const int64_t stride = -2;
 
 	// Define an offset:
-	int64_t offset = 100;
+	const int64_t offset = 100;
 
 	// Compute the minimum accessible index:
 	int64_t idx = stdlib_strided_min_view_buffer_index( N, stride, offset );

--- a/lib/node_modules/@stdlib/strided/base/smskmap2/README.md
+++ b/lib/node_modules/@stdlib/strided/base/smskmap2/README.md
@@ -232,12 +232,12 @@ static float addf( const float x, const float y ) {
     return x + y;
 }
 
-float X[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
-float Y[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+const float X[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+const float Y[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
 float Z[] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
-uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
+const uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
 
-int64_t N = 6;
+const int64_t N = 6;
 
 stdlib_strided_smskmap2( N, X, 1, Y, 1, M, 1, Z, 1, addf );
 ```
@@ -290,23 +290,23 @@ static float addf( const float x, const float y ) {
 
 int main( void ) {
     // Create input strided arrays:
-    float X[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
-    float Y[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+    const float X[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+    const float Y[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
 
     // Create a mask strided array:
-    uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
+    const uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
 
     // Create an output strided array:
     float Z[] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
 
     // Specify the number of elements:
-    int64_t N = 6;
+    const int64_t N = 6;
 
     // Define the strides:
-    int64_t strideX = 1;
-    int64_t strideY = -1;
-    int64_t strideZ = 1;
-    int64_t strideM = 1;
+    const int64_t strideX = 1;
+    const int64_t strideY = -1;
+    const int64_t strideZ = 1;
+    const int64_t strideM = 1;
 
     // Apply the callback:
     stdlib_strided_smskmap2( N, X, strideX, Y, strideY, M, strideM, Z, strideZ, addf );

--- a/lib/node_modules/@stdlib/strided/base/smskmap2/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/smskmap2/examples/c/example.c
@@ -28,23 +28,23 @@ static float addf( const float x, const float y ) {
 
 int main( void ) {
 	// Create input strided arrays:
-	float X[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
-	float Y[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+	const float X[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+	const float Y[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f };
 
 	// Create a mask strided array:
-	uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
+	const uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
 
 	// Create an output strided array:
 	float Z[] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
 
 	// Specify the number of elements:
-	int64_t N = 6;
+	const int64_t N = 6;
 
 	// Define the strides:
-	int64_t strideX = 1;
-	int64_t strideY = -1;
-	int64_t strideZ = 1;
-	int64_t strideM = 1;
+	const int64_t strideX = 1;
+	const int64_t strideY = -1;
+	const int64_t strideZ = 1;
+	const int64_t strideM = 1;
 
 	// Apply the callback:
 	stdlib_strided_smskmap2( N, X, strideX, Y, strideY, M, strideM, Z, strideZ, addf );

--- a/lib/node_modules/@stdlib/strided/base/stride2offset/README.md
+++ b/lib/node_modules/@stdlib/strided/base/stride2offset/README.md
@@ -176,10 +176,10 @@ int64_t stdlib_strided_stride2offset( int64_t N, int64_t stride );
 
 int main( void ) {
     // Specify the number of indexed elements:
-    int64_t N = 6;
+    const int64_t N = 6;
 
     // Define a stride:
-    int64_t stride = -2;
+    const int64_t stride = -2;
 
     // Compute the offset:
     int64_t offset = stdlib_strided_stride2offset( N, stride );

--- a/lib/node_modules/@stdlib/strided/base/stride2offset/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/stride2offset/examples/c/example.c
@@ -23,10 +23,10 @@
 
 int main( void ) {
 	// Specify the number of indexed elements:
-	int64_t N = 6;
+	const int64_t N = 6;
 
 	// Define a stride:
-	int64_t stride = -2;
+	const int64_t stride = -2;
 
 	// Compute the offset:
 	int64_t offset = stdlib_strided_stride2offset( N, stride );

--- a/lib/node_modules/@stdlib/strided/base/zmap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/zmap/README.md
@@ -210,10 +210,10 @@ static double complex scale( const double complex x ) {
     return ( re+10.0 ) + ( im+10.0 )*I;
 }
 
-double complex X[] = { 1.0+1.0*I, 2.0+2.0*I, 3.0+3.0*I, 4.0+4.0*I, 5.0+5.0*I, 6.0+6.0*I };
+const double complex X[] = { 1.0+1.0*I, 2.0+2.0*I, 3.0+3.0*I, 4.0+4.0*I, 5.0+5.0*I, 6.0+6.0*I };
 double complex Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
-int64_t N = 6;
+const int64_t N = 6;
 
 stdlib_strided_zmap( N, X, 1, Y, 1, scale );
 ```
@@ -265,17 +265,17 @@ static double complex scale( const double complex x ) {
 
 int main( void ) {
     // Create an input strided array:
-    double complex X[] = { 1.0+1.0*I, 2.0+2.0*I, 3.0+3.0*I, 4.0+4.0*I, 5.0+5.0*I, 6.0+6.0*I };
+    const double complex X[] = { 1.0+1.0*I, 2.0+2.0*I, 3.0+3.0*I, 4.0+4.0*I, 5.0+5.0*I, 6.0+6.0*I };
 
     // Create an output strided array:
     double complex Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
     // Specify the number of elements:
-    int64_t N = 6;
+    const int64_t N = 6;
 
     // Define the strides:
-    int64_t strideX = 1;
-    int64_t strideY = -1;
+    const int64_t strideX = 1;
+    const int64_t strideY = -1;
 
     // Apply the callback:
     stdlib_strided_zmap( N, X, strideX, Y, strideY, scale );

--- a/lib/node_modules/@stdlib/strided/base/zmap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/zmap/examples/c/example.c
@@ -37,11 +37,11 @@ int main( void ) {
 	double complex Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
 	// Specify the number of elements:
-	int64_t N = 6;
+	const int64_t N = 6;
 
 	// Define the strides:
-	int64_t strideX = 1;
-	int64_t strideY = -1;
+	const int64_t strideX = 1;
+	const int64_t strideY = -1;
 
 	// Apply the callback:
 	stdlib_strided_zmap( N, X, strideX, Y, strideY, scale );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-07-30 14:56 PDT (`22f4f4679`) and 2026-07-31 04:19 PDT (`a6697506a`) to sibling packages containing the same defects.

#### Propagated benchmark TAP-name fix

The `native::` segment in C benchmark TAP output, corrected upstream in `4da1e5810` for `blas/ext/base`, was carried into 10 sibling packages via copy-paste and is fixed here identically: each `benchmark/c/benchmark.length.c` printf format string is changed from `# c::native::%s:len=%d` to `# c::%s:len=%d` (and the ndarray variant to `# c::%s:ndarray:len=%d`), matching the repo-wide TAP naming convention. 20 lines across 10 files are affected, two per package.

-   `blas/ext/base/scartesian-square`, `blas/ext/base/dcartesian-square`, `blas/ext/base/zcartesian-square`, `blas/ext/base/scartesian-power`, `blas/ext/base/dcartesian-power`, `blas/ext/base/scartesian-product`, `blas/ext/base/dcartesian-product`, `blas/ext/base/zcartesian-product`, `blas/ext/base/svander`, `blas/ext/base/dvander`

#### Native binding docstring parity

The Notes section added to `blas/ext/base/dindex-of-not-equal`'s `*.native.js` in `4c8e34dca` closes a documentation gap that recurs across 33 `*.native.js` files in 19 sibling packages: each is missing a `## Notes` block present in its JS counterpart. The fix propagates identically to each target: the Notes block is copied verbatim from the package's own JS implementation file into its `*.native.js` file(s). The 8 sort-family packages (`d`/`s` × `sort2hp`/`sort2sh`/`sorthp`/`sortsh`) are excluded — their JS siblings pair Notes with a `## References` section, and no `*.native.js` in the repo currently carries References, so extending scope there requires a maintainer decision.

-   `blas/ext/base/cindex-of-column`, `blas/ext/base/cindex-of-row`, `blas/ext/base/clast-index-of-row`, `blas/ext/base/dindex-of-column`, `blas/ext/base/dindex-of-row`, `blas/ext/base/dlast-index-of-row`, `blas/ext/base/sindex-of-column`, `blas/ext/base/sindex-of-row`, `blas/ext/base/slast-index-of-row`, `blas/ext/base/zindex-of-column`, `blas/ext/base/zindex-of-row`, `blas/ext/base/zlast-index-of-row`, `blas/ext/base/dcartesian-square`, `blas/ext/base/scartesian-square`, `blas/ext/base/zcartesian-square`, `blas/ext/base/dcircshift`, `blas/ext/base/scircshift`, `blas/ext/base/dminheap-sift-down`, `blas/ext/base/sminheap-sift-down`

#### Pre-compute RNG inputs outside timed benchmark loops

Nine benchmarks in `number/float32/base` and `number/float64/base` timed random value generation alongside the operation under test, inflating measurements with RNG overhead. Fixed per the template established in `a6697506a`: values are generated into a 100-element array before `tic()`, and the loop indexes with `i % 100`, isolating the timed region to the function under test. All 9 compile clean under `-Wall -Wextra`.

-   `number/float32/base/to-word`, `number/float32/base/assert/is-same-value`, `number/float32/base/assert/is-same-value-zero`, `number/float64/base/get-low-word`, `number/float64/base/get-high-word`, `number/float64/base/to-words`, `number/float64/base/signbit`, `number/float64/base/assert/is-same-value`, `number/float64/base/assert/is-same-value-zero`

#### Const-qualify read-only variables in `strided/base` example code

Commit `d5a00c330` added `const` to read-only, literal-initialized variables in `strided/base/smap`'s C example and README, correcting a lint error; the same omission was present in eight sibling packages. Each addition was verified against the package's own header signature — every input pointer is `const`-qualified in the C API — and every patched example compiles clean under `-Wall -Wextra`; output arrays are left non-const. Packages routing arrays through non-const pointer arrays (`unary`, `binary`, `mskunary`, `nullary`) were excluded, since `const` there breaks compilation.

-   `strided/base/cmap`, `strided/base/zmap`, `strided/base/dmskmap`, `strided/base/dmap2`, `strided/base/smskmap2`, `strided/base/stride2offset`, `strided/base/min-view-buffer-index`, `strided/base/max-view-buffer-index`

#### Withdrawn: invalid ESLint directive in twin fixture

The invalid `/* eslint-ignore no-multiple-empty-lines */` directive fixed upstream in `990d891c1` recurs byte-for-byte in `_tools/lint/license-header-glob/test/fixtures/start-location/file.js`. The propagated correction was initially included and then withdrawn: the fixture is intentionally invalid (its license header deliberately starts at line 6 so the package's tests can assert an error), and the `Lint Changed Files` workflow runs `lint-license-headers-files` over every changed file with no fixture exemption, so any edit to this file fails CI. Landing the one-line fix requires a maintainer either merging over the red check (as with the source commit) or exempting lint-tool fixtures from the license-header lint.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed before inclusion:

-   Candidate sites were enumerated via pattern-signature searches scoped to sibling namespaces of each source commit.
-   Every site was independently verified by two validation passes reading the target files in full, plus an adaptation pass producing exact per-site patches and a style-consistency pass checking JSDoc/C conventions against the source commits and surrounding packages.
-   Deliberately excluded: the 16 sort-family `*.native.js` files (Notes/References scope ambiguity), two bare `eslint-ignore` fixtures (would trip `--report-unused-disable-directives`), `strided/base/smskmap` (incomplete analog flagged during validation), and README-only staleness in `strided/base/dmap` and `strided/base/smap2` (single-pass confirmation only).
-   All C changes (benchmarks and examples) compile clean with `gcc -std=c99 -Wall -Wextra`.

One commit per source fix pattern; each commit body cites the propagated source commit SHA.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated fix-propagation routine: source fixes were extracted from commits merged to `develop` in the last 24 hours, candidate sibling sites were located by pattern search, and every applied patch was verified by multiple independent validation passes (defect presence, per-site adaptation, style consistency) plus compilation checks before inclusion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md