### PR TITLE
feat: add `uint64/base/set-low-word`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/README.md
@@ -56,7 +56,7 @@ var w = getLowWord( b );
 
 ## Notes
 
--   The function returns a new [64-bit unsigned integer][@stdlib/number/uint64/ctor] instance without modifying the input.
+-   The function returns a new [64-bit unsigned integer][@stdlib/number/uint64/ctor] instance without modifying the input value.
 
 </section>
 

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/README.md
@@ -1,0 +1,112 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# setLowWord
+
+> Set the low 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var setLowWord = require( '@stdlib/number/uint64/base/set-low-word' );
+```
+
+#### setLowWord( x, low )
+
+Sets the low 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
+
+```javascript
+var getLowWord = require( '@stdlib/number/uint64/base/get-low-word' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+
+var a = new Uint64( 4294967296 );
+// returns <Uint64>[ 4294967296n ]
+
+var b = setLowWord( a, 2 );
+// returns <Uint64>[ 4294967298n ]
+
+var w = getLowWord( b );
+// returns 2
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The function returns a new [64-bit unsigned integer][@stdlib/number/uint64/ctor] instance without modifying the input.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var setLowWord = require( '@stdlib/number/uint64/base/set-low-word' );
+
+var a = new Uint64( 4294967296 );
+// returns <Uint64>
+
+var words = discreteUniform( 100, 0, UINT32_MAX, {
+    'dtype': 'uint32'
+});
+
+logEachMap( 'setLowWord(%s, %s) = %s', a, words, setLowWord );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/number/uint64/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/uint64/ctor
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/benchmark/benchmark.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var pkg = require( './../package.json' ).name;
+var setLowWord = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var N;
+	var a;
+	var i;
+	var z;
+
+	N = 100;
+	values = discreteUniform( N, 0, UINT32_MAX, {
+		'dtype': 'uint32'
+	});
+
+	a = new Uint64( 0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		z = setLowWord( a, values[ i % N ] );
+		if ( typeof z !== 'object' ) {
+			b.fail( 'should return a Uint64 instance' );
+		}
+	}
+	b.toc();
+	if ( !( z instanceof Uint64 ) ) {
+		b.fail( 'should return a Uint64 instance' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/docs/repl.txt
@@ -2,7 +2,8 @@
 {{alias}}( a, low )
     Sets the low 32-bit word of a 64-bit unsigned integer.
 
-    The function returns a new Uint64 instance without modifying the input.
+    The function returns a new Uint64 instance without modifying the input
+    value.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/docs/repl.txt
@@ -1,0 +1,31 @@
+
+{{alias}}( a, low )
+    Sets the low 32-bit word of a 64-bit unsigned integer.
+
+    The function returns a new Uint64 instance without modifying the input.
+
+    Parameters
+    ----------
+    a: Uint64
+        64-bit unsigned integer.
+
+    low: integer
+        32-bit unsigned integer to replace the low 32-bit word.
+
+    Returns
+    -------
+    out: Uint64
+        64-bit unsigned integer.
+
+    Examples
+    --------
+    > var a = new {{alias:@stdlib/number/uint64/ctor}}( 4294967296 )
+    <Uint64>[ 4294967296n ]
+    > var b = {{alias}}( a, 2 )
+    <Uint64>[ 4294967298n ]
+    > var w = {{alias:@stdlib/number/uint64/base/get-low-word}}( b )
+    2
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/docs/types/index.d.ts
@@ -1,0 +1,50 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Uint64 } from '@stdlib/types/number';
+
+/**
+* Sets the low 32-bit word of a 64-bit unsigned integer.
+*
+* @param a - 64-bit unsigned integer
+* @param low - 32-bit unsigned integer to replace the low 32-bit word
+* @returns 64-bit unsigned integer
+*
+* @example
+* var getLowWord = require( '@stdlib/number/uint64/base/get-low-word' );
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 4294967296 );
+* // returns <Uint64>[ 4294967296n ]
+*
+* var b = setLowWord( a, 2 );
+* // returns <Uint64>[ 4294967298n ]
+*
+* var w = getLowWord( b );
+* // returns 2
+*/
+declare function setLowWord( a: Uint64, low: number ): Uint64;
+
+
+// EXPORTS //
+
+export = setLowWord;

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/docs/types/test.ts
@@ -1,0 +1,58 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Uint64 = require( '@stdlib/number/uint64/ctor' );
+import setLowWord = require( './index' );
+
+
+// TESTS //
+
+// The function returns a Uint64 instance...
+{
+	const a = new Uint64( 5 );
+	setLowWord( a, 2 ); // $ExpectType Uint64
+}
+
+// The compiler throws an error if the function is provided a first argument that is not a Uint64 instance...
+{
+	setLowWord( 'abc', 2 ); // $ExpectError
+	setLowWord( true, 2 ); // $ExpectError
+	setLowWord( false, 2 ); // $ExpectError
+	setLowWord( [], 2 ); // $ExpectError
+	setLowWord( {}, 2 ); // $ExpectError
+	setLowWord( ( x: number ): number => x, 2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument that is not a number...
+{
+	const a = new Uint64( 5 );
+	setLowWord( a, 'abc' ); // $ExpectError
+	setLowWord( a, true ); // $ExpectError
+	setLowWord( a, false ); // $ExpectError
+	setLowWord( a, [] ); // $ExpectError
+	setLowWord( a, {} ); // $ExpectError
+	setLowWord( a, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const a = new Uint64( 5 );
+	setLowWord(); // $ExpectError
+	setLowWord( a ); // $ExpectError
+	setLowWord( a, 2, 0 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/examples/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/examples/index.js
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var setLowWord = require( './../lib' );
+
+var a = new Uint64( 4294967296 );
+// returns <Uint64>
+
+var words = discreteUniform( 100, 0, UINT32_MAX, {
+	'dtype': 'uint32'
+});
+
+logEachMap( 'setLowWord(%s, %s) = %s', a, words, setLowWord );

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/lib/index.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/lib/index.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Set the low 32-bit word of a 64-bit unsigned integer.
+*
+* @module @stdlib/number/uint64/base/set-low-word
+*
+* @example
+* var getLowWord = require( '@stdlib/number/uint64/base/get-low-word' );
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+* var setLowWord = require( '@stdlib/number/uint64/base/set-low-word' );
+*
+* var a = new Uint64( 4294967296 );
+* // returns <Uint64>[ 4294967296n ]
+*
+* var b = setLowWord( a, 2 );
+* // returns <Uint64>[ 4294967298n ]
+*
+* var w = getLowWord( b );
+* // returns 2
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/lib/main.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var getHighWord = require( '@stdlib/number/uint64/base/get-high-word' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+
+
+// MAIN //
+
+/**
+* Sets the low 32-bit word of a 64-bit unsigned integer.
+*
+* @param {Uint64} a - 64-bit unsigned integer
+* @param {uinteger32} low - 32-bit unsigned integer to replace the low 32-bit word
+* @returns {Uint64} 64-bit unsigned integer
+*
+* @example
+* var getLowWord = require( '@stdlib/number/uint64/base/get-low-word' );
+* var Uint64 = require( '@stdlib/number/uint64/ctor' );
+*
+* var a = new Uint64( 4294967296 );
+* // returns <Uint64>[ 4294967296n ]
+*
+* var b = setLowWord( a, 2 );
+* // returns <Uint64>[ 4294967298n ]
+*
+* var w = getLowWord( b );
+* // returns 2
+*/
+function setLowWord( a, low ) {
+	return Uint64.of( getHighWord( a ), low );
+}
+
+
+// EXPORTS //
+
+module.exports = setLowWord;

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/package.json
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/number/uint64/base/set-low-word",
+  "version": "0.0.0",
+  "description": "Set the low 32-bit word of a 64-bit unsigned integer.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "base",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "types",
+    "type",
+    "uint64",
+    "unsigned",
+    "64-bit",
+    "integer",
+    "int",
+    "set",
+    "low",
+    "word"
+  ]
+}

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/test/test.js
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/test/test.js
@@ -1,0 +1,83 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isUint64 = require( '@stdlib/assert/is-uint64' );
+var UINT32_MAX = require( '@stdlib/constants/uint32/max' );
+var getHighWord = require( '@stdlib/number/uint64/base/get-high-word' );
+var getLowWord = require( '@stdlib/number/uint64/base/get-low-word' );
+var Uint64 = require( '@stdlib/number/uint64/ctor' );
+var setLowWord = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof setLowWord, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a Uint64 instance', function test( t ) {
+	var a = new Uint64( 0 );
+	var b = setLowWord( a, 2 );
+	t.ok( isUint64( b ), 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function sets the low 32-bit word of a 64-bit unsigned integer', function test( t ) {
+	var values;
+	var a;
+	var b;
+	var v;
+	var w;
+	var i;
+
+	values = [
+		0,
+		1,
+		2,
+		3,
+		4,
+		5,
+		10,
+		99,
+		100,
+		999,
+		1000,
+		999999,
+		1000000,
+		999999999,
+		1000000000,
+		UINT32_MAX
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		v = values[ i ];
+		a = new Uint64( 0 );
+		w = getHighWord( a );
+		b = setLowWord( a, v );
+		t.strictEqual( getHighWord( b ), w, 'returns expected value' );
+		t.strictEqual( getLowWord( b ), v, 'returns expected value' );
+	}
+	t.end();
+});


### PR DESCRIPTION

Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a new package for setting the low 32-bit word of a `Uint64`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

n/a

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
