### PR TITLE
fix(plot): validate finite number in y, x axis domain setters

### DIFF
--- a/lib/node_modules/@stdlib/plot/ctor/lib/props/x-max/set.js
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/props/x-max/set.js
@@ -22,7 +22,7 @@
 
 var logger = require( 'debug' );
 var isNull = require( '@stdlib/assert/is-null' );
-var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var isFiniteNumber = require( '@stdlib/assert/is-finite' ).isPrimitive;
 var format = require( '@stdlib/string/format' );
 
 
@@ -46,9 +46,9 @@ function set( max ) {
 	// TODO: add test to determine if evaluates to valid date?
 	if (
 		!isNull( max ) &&
-		!isNumber( max ) // FIXME: finite number
+		!isFiniteNumber( max )
 
-		// TODO: Date
+	// TODO: Date
 	) {
 		throw new TypeError( format( 'invalid assignment. `%s` must be a finite number, Date, or null. Value: `%s`.', 'xMax', max ) );
 	}

--- a/lib/node_modules/@stdlib/plot/ctor/lib/props/x-min/set.js
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/props/x-min/set.js
@@ -22,7 +22,7 @@
 
 var logger = require( 'debug' );
 var isNull = require( '@stdlib/assert/is-null' );
-var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var isFiniteNumber = require( '@stdlib/assert/is-finite' ).isPrimitive;
 var format = require( '@stdlib/string/format' );
 
 
@@ -47,9 +47,9 @@ function set( min ) {
 	// TODO: add test to determine if evaluates to valid date?
 	if (
 		!isNull( min ) &&
-		!isNumber( min ) // FIXME: finite number
+		!isFiniteNumber( min )
 
-		// TODO: Date
+	// TODO: Date
 	) {
 		throw new TypeError( format( 'invalid assignment. `%s` must be a finite number, Date, or null. Value: `%s`.', 'xMin', min ) );
 	}

--- a/lib/node_modules/@stdlib/plot/ctor/lib/props/y-max/set.js
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/props/y-max/set.js
@@ -22,7 +22,7 @@
 
 var logger = require( 'debug' );
 var isNull = require( '@stdlib/assert/is-null' );
-var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var isFiniteNumber = require( '@stdlib/assert/is-finite' ).isPrimitive;
 var format = require( '@stdlib/string/format' );
 
 
@@ -45,9 +45,9 @@ function set( max ) {
 	/* eslint-disable no-invalid-this */
 	if (
 		!isNull( max ) &&
-		!isNumber( max ) // FIXME: finite number
+		!isFiniteNumber( max )
 	) {
-		throw new TypeError( format( 'invalid assignment. `%s` must be a number or null. Value: `%s`.', 'yMax', max ) );
+		throw new TypeError( format( 'invalid assignment. `%s` must be a finite number or null. Value: `%s`.', 'yMax', max ) );
 	}
 	if ( max !== this._yMax ) {
 		debug( 'Current value: %d.', this._yMax );

--- a/lib/node_modules/@stdlib/plot/ctor/lib/props/y-min/set.js
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/props/y-min/set.js
@@ -22,7 +22,7 @@
 
 var logger = require( 'debug' );
 var isNull = require( '@stdlib/assert/is-null' );
-var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var isFiniteNumber = require( '@stdlib/assert/is-finite' ).isPrimitive;
 var format = require( '@stdlib/string/format' );
 
 
@@ -45,9 +45,9 @@ function set( min ) {
 	/* eslint-disable no-invalid-this */
 	if (
 		!isNull( min ) &&
-		!isNumber( min ) // FIXME: finite number
+		!isFiniteNumber( min )
 	) {
-		throw new TypeError( format( 'invalid assignment. `%s` must be a number or null. Value: `%s`.', 'yMin', min ) );
+		throw new TypeError( format( 'invalid assignment. `%s` must be a finite number or null. Value: `%s`.', 'yMin', min ) );
 	}
 	if ( min !== this._yMin ) {
 		debug( 'Current value: %d.', this._yMin );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: na
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   Replaces `isNumber` with `isFinite` assertion in  y, x axis domain setters

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
