### PR TITLE
test: migrate `math/base/special/logitf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/logitf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/logitf/test/test.js
@@ -24,9 +24,13 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var logitf = require( './../lib' );
+
+
+// VARIABLES //
+
+var ULP = 1;
 
 
 // FIXTURES //
@@ -72,8 +76,6 @@ tape( 'the function returns `+Infinity` when provided `1`', function test( t ) {
 
 tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -82,21 +84,13 @@ tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', fun
 	x = small.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -105,21 +99,13 @@ tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', 
 	x = medium.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -128,13 +114,7 @@ tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', fun
 	x = large.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/logitf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/logitf/test/test.native.js
@@ -25,16 +25,8 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-
-
-// FIXTURES //
-
-var small = require( './fixtures/python/small.json' );
-var medium = require( './fixtures/python/medium.json' );
-var large = require( './fixtures/python/large.json' );
 
 
 // VARIABLES //
@@ -43,6 +35,14 @@ var logitf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
 var opts = {
 	'skip': ( logitf instanceof Error )
 };
+var ULP = 1;
+
+
+// FIXTURES //
+
+var small = require( './fixtures/python/small.json' );
+var medium = require( './fixtures/python/medium.json' );
+var large = require( './fixtures/python/large.json' );
 
 
 // TESTS //
@@ -81,8 +81,6 @@ tape( 'the function returns `+Infinity` when provided `1`', opts, function test(
 
 tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -91,21 +89,13 @@ tape( 'the function evaluates the logit of `x` for the interval `(0,0.25]`', opt
 	x = small.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -114,21 +104,13 @@ tape( 'the function evaluates the logit of `x` for the interval `[0.25,0.75]`', 
 	x = medium.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -137,13 +119,7 @@ tape( 'the function evaluates the logit of `x` for the interval `[0.75,1)`', opt
 	x = large.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logitf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], ULP ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Summary

Resolves a part of #11352.

Migrates `math/base/special/logitf` test cases from the relative tolerance idiom (`delta`/`tol` computed via `EPS`) to ULP-difference-based assertions using `@stdlib/number/float32/base/assert/is-almost-same-value`, per the RFC in #11352.

- `test/test.js` and `test/test.native.js` updated.
- A single named `ULP` constant (`1`) is used in each test file.
- **Measured minimum**: computed the actual ULP difference between `logitf` output and the fixture-provided expected values (via `@stdlib/number/float32/base/ulp-difference`) across all three fixtures (`small`, `medium`, `large`); the maximum observed difference was `1` ULP, so `ULP = 1` is the tightest bound that still passes.
- No conversion of `expected` values was needed since the Python fixture generator already stores `expected` as `float32`-rounded values (`.astype(np.float32)`), unlike some other `f`-suffixed packages whose fixtures store float64 expected values requiring `float64ToFloat32`.

## Test plan

- [x] Ran `test/test.js` directly (`NODE_PATH=lib/node_modules node .../test.js`) — 1507/1507 assertions pass.
- [x] Re-ran twice to confirm determinism at `ULP = 1` (no FMA/arch flakiness).
- [x] `test/test.native.js` runs cleanly and skips (native addon not built in this environment), consistent with existing behavior.
- [x] Confirmed only the two test files changed (no `package.json` changes needed — no new dependency declarations required in this repo's convention).
- [x] Verified basic ESLint checks (unused vars, undefined vars) pass on the changed files; the repository's full custom `eslint-plugin-stdlib` config (which pulls in the `remark-lint` doc-linting toolchain) could not be fully provisioned in this sandbox, but the diff mirrors the exact style/idiom of already-converted sibling packages (e.g. `math/base/special/logit`, `math/base/special/acosf`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GF2e2dwFE3pSb2u2JdoxZU)_