### PR TITLE
fix: add check if xMin changed before emitting change event

### DIFF
--- a/lib/node_modules/@stdlib/plot/ctor/lib/props/x-min/set.js
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/props/x-min/set.js
@@ -49,16 +49,18 @@ function set( min ) {
 		!isNull( min ) &&
 		!isNumber( min ) // FIXME: finite number
 
-		// TODO: Date
+	// TODO: Date
 	) {
 		throw new TypeError( format( 'invalid assignment. `%s` must be a finite number, Date, or null. Value: `%s`.', 'xMin', min ) );
 	}
-	debug( 'Current value: %s.', this._xMin );
+	if ( min !== this._xMin ) {
+		debug( 'Current value: %s.', this._xMin );
 
-	this._xMin = min;
-	debug( 'New value: %s.', this._xMin );
+		this._xMin = min;
+		debug( 'New value: %s.', this._xMin );
 
-	this.emit( 'change' );
+		this.emit( 'change' );
+	}
 }
 
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: na
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---



## Description

> What is the purpose of this pull request?

This pull request:

-   Add a check in x-min setter to see if xMin changed before emitting a change event like the other setters do.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
