### PR TITLE
bench: replace `pow` with `powf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fibonaccif/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/fibonaccif/benchmark/benchmark.js
@@ -23,12 +23,11 @@
 var bench = require( '@stdlib/bench' );
 var Int32Array = require( '@stdlib/array/int32' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var powf = require( '@stdlib/math/base/special/powf' );
 var roundf = require( '@stdlib/math/base/special/roundf' );
 var sqrtf = require( '@stdlib/math/base/special/sqrtf' );
-var pow = require( '@stdlib/math/base/special/pow' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var PHI = require( '@stdlib/constants/float32/phi' );
-var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var FIBONACCI = require( './../lib/fibonacci.json' );
@@ -70,8 +69,7 @@ bench( format( '%s::analytic', pkg ), function benchmark( b ) {
 	var i;
 
 	function fibonaccif( n ) {
-		// TODO: replace with powf once implemented
-		return roundf( float64ToFloat32( pow( PHI, n ) ) / SQRT_5 );
+		return roundf( powf( PHI, n ) / SQRT_5 );
 	}
 
 	x = discreteUniform( 100, 0, 36 );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: na
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---


## Description

> What is the purpose of this pull request?

This pull request:

-   Use single precision `powf` in place of double precision `pow` with rounding in benchmark.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
