### PR TITLE
test: migrate `math/base/special/csc` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/csc/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/test/test.js
@@ -22,11 +22,10 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var csc = require( './../lib' );
 
 
@@ -57,8 +56,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the cosecant (huge negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -67,22 +64,14 @@ tape( 'the function computes the cosecant (huge negative values)', function test
 	expected = hugeNegative.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (huge positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -91,22 +80,14 @@ tape( 'the function computes the cosecant (huge positive values)', function test
 	expected = hugePositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (very large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -115,22 +96,14 @@ tape( 'the function computes the cosecant (very large positive values)', functio
 	expected = veryLargePositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (very large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -139,22 +112,14 @@ tape( 'the function computes the cosecant (very large negative values)', functio
 	expected = veryLargeNegative.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -163,22 +128,14 @@ tape( 'the function computes the cosecant (large positive values)', function tes
 	expected = largePositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -187,22 +144,14 @@ tape( 'the function computes the cosecant (large negative values)', function tes
 	expected = largeNegative.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -211,22 +160,14 @@ tape( 'the function computes the cosecant (medium positive values)', function te
 	expected = mediumPositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (medium negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -235,22 +176,14 @@ tape( 'the function computes the cosecant (medium negative values)', function te
 	expected = mediumNegative.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -259,22 +192,14 @@ tape( 'the function computes the cosecant (small positive values)', function tes
 	expected = smallPositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (small negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -283,22 +208,14 @@ tape( 'the function computes the cosecant (small negative values)', function tes
 	expected = smallNegative.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (smaller values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -307,22 +224,14 @@ tape( 'the function computes the cosecant (smaller values)', function test( t ) 
 	expected = smaller.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (tiny positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -331,22 +240,14 @@ tape( 'the function computes the cosecant (tiny positive values)', function test
 	expected = tinyPositive.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (tiny negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -355,14 +256,8 @@ tape( 'the function computes the cosecant (tiny negative values)', function test
 	expected = tinyNegative.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
-		y = csc(x[i]);
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[i], 'x: ' + x[i] + '. E: ' + expected[i]);
-		} else {
-			delta = abs(y - expected[i]);
-			tol = 1.4 * EPS * abs(expected[i]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[i] + '. y: ' + y + '. E: ' + expected[i] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		y = csc( x[ i ] );
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/csc/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -66,8 +65,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the cosecant (huge negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -77,21 +74,13 @@ tape( 'the function computes the cosecant (huge negative values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (huge positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -101,21 +90,13 @@ tape( 'the function computes the cosecant (huge positive values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (very large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -125,21 +106,13 @@ tape( 'the function computes the cosecant (very large positive values)', opts, f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (very large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -149,21 +122,13 @@ tape( 'the function computes the cosecant (very large negative values)', opts, f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -173,21 +138,13 @@ tape( 'the function computes the cosecant (large positive values)', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -197,21 +154,13 @@ tape( 'the function computes the cosecant (large negative values)', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -221,21 +170,13 @@ tape( 'the function computes the cosecant (medium positive values)', opts, funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (medium negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -245,21 +186,13 @@ tape( 'the function computes the cosecant (medium negative values)', opts, funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -269,21 +202,13 @@ tape( 'the function computes the cosecant (small positive values)', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (small negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -293,21 +218,13 @@ tape( 'the function computes the cosecant (small negative values)', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (smaller values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -317,21 +234,13 @@ tape( 'the function computes the cosecant (smaller values)', opts, function test
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (tiny positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -341,21 +250,13 @@ tape( 'the function computes the cosecant (tiny positive values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant (tiny negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -365,13 +266,7 @@ tape( 'the function computes the cosecant (tiny negative values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = csc( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
-		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `math/base/special/csc` testing from EPS-based relative tolerance assertions to `@stdlib/assert/is-almost-same-value` ULP difference assertions.
-   Tightens each fixture range to the minimum required ULP tolerance, measured by running the fixture set against the implementation:
    -   `huge_negative` / `huge_positive`: 2 ULP
    -   `very_large_negative` / `very_large_positive`: 1 ULP
    -   `large`, `medium`, `small`, `smaller`, `tiny` (negative/positive): exact match (`0` ULP), so these now use plain `t.strictEqual`, matching the convention used in already-migrated sibling packages (e.g. `coth`, `havercos`) for ranges that never require tolerance.
-   Applied the identical change to `test.native.js`, keeping the same ULP bounds as `test.js`.
-   Measured minimums were confirmed deterministic by running the full fixture set twice.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, run as a scheduled/autonomous task. It studied issue #11352 and several already-merged sibling PRs (`coth`, `tanh`, `besselj0`) to mirror the settled idiom, then measured the minimum passing ULP bound per fixture range directly against the implementation.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeLecApUxretH11SrzxudS)_