### PR TITLE
test: migrate `math/base/special/xlogyf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/xlogyf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/xlogyf/test/test.js
@@ -22,8 +22,7 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var xlogyf = require( './../lib' );
 
@@ -74,9 +73,7 @@ tape( 'the function returns `0` when `x = 0` and `y` is a number', function test
 
 tape( 'the function evaluates `x * ln(y)` for small `x` and `y`', function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -88,22 +85,14 @@ tape( 'the function evaluates `x * ln(y)` for small `x` and `y`', function test(
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		out = xlogyf( x[ i ], y[ i ] );
-		if ( out === e ) {
-			t.strictEqual( out, e, 'x: '+x[ i ]+', out: '+out+', expected: '+e );
-		} else {
-			delta = absf( out - e );
-			tol = 17.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+out+'. E: '+e+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValuef( out, e, 22 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates `x * ln(y)` for small `x` and large `y`', function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -115,22 +104,14 @@ tape( 'the function evaluates `x * ln(y)` for small `x` and large `y`', function
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		out = xlogyf( x[ i ], y[ i ] );
-		if ( out === e ) {
-			t.strictEqual( out, e, 'x: '+x[ i ]+', out: '+out+', expected: '+e );
-		} else {
-			delta = absf( out - e );
-			tol = 2.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+out+'. E: '+e+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValuef( out, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates `x * ln(y)` for large `x` and small `y`', function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -142,22 +123,14 @@ tape( 'the function evaluates `x * ln(y)` for large `x` and small `y`', function
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		out = xlogyf( x[ i ], y[ i ] );
-		if ( out === e ) {
-			t.strictEqual( out, e, 'x: '+x[ i ]+', out: '+out+', expected: '+e );
-		} else {
-			delta = absf( out - e );
-			tol = 83.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+out+'. E: '+e+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValuef( out, e, 101 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates `x * ln(y)` for large `x` and `y`', function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -169,13 +142,7 @@ tape( 'the function evaluates `x * ln(y)` for large `x` and `y`', function test(
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		out = xlogyf( x[ i ], y[ i ] );
-		if ( out === e ) {
-			t.strictEqual( out, e, 'x: '+x[ i ]+', out: '+out+', expected: '+e );
-		} else {
-			delta = absf( out - e );
-			tol = 2.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+out+'. E: '+e+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValuef( out, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/xlogyf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/xlogyf/test/test.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -83,9 +82,7 @@ tape( 'the function returns `0` when `x = 0` and `y` is a number', opts, functio
 
 tape( 'the function evaluates `x * ln(y)` for small `x` and `y`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -97,22 +94,14 @@ tape( 'the function evaluates `x * ln(y)` for small `x` and `y`', opts, function
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		out = xlogyf( x[ i ], y[ i ] );
-		if ( out === e ) {
-			t.strictEqual( out, e, 'x: '+x[ i ]+', out: '+out+', expected: '+e );
-		} else {
-			delta = absf( out - e );
-			tol = 17.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+out+'. E: '+e+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValuef( out, e, 22 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates `x * ln(y)` for small `x` and large `y`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -124,22 +113,14 @@ tape( 'the function evaluates `x * ln(y)` for small `x` and large `y`', opts, fu
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		out = xlogyf( x[ i ], y[ i ] );
-		if ( out === e ) {
-			t.strictEqual( out, e, 'x: '+x[ i ]+', out: '+out+', expected: '+e );
-		} else {
-			delta = absf( out - e );
-			tol = 2.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+out+'. E: '+e+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValuef( out, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates `x * ln(y)` for large `x` and small `y`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -151,22 +132,14 @@ tape( 'the function evaluates `x * ln(y)` for large `x` and small `y`', opts, fu
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		out = xlogyf( x[ i ], y[ i ] );
-		if ( out === e ) {
-			t.strictEqual( out, e, 'x: '+x[ i ]+', out: '+out+', expected: '+e );
-		} else {
-			delta = absf( out - e );
-			tol = 83.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+out+'. E: '+e+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValuef( out, e, 101 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates `x * ln(y)` for large `x` and `y`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var out;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -178,13 +151,7 @@ tape( 'the function evaluates `x * ln(y)` for large `x` and `y`', opts, function
 	for ( i = 0; i < x.length; i++ ) {
 		e = float64ToFloat32( expected[ i ] );
 		out = xlogyf( x[ i ], y[ i ] );
-		if ( out === e ) {
-			t.strictEqual( out, e, 'x: '+x[ i ]+', out: '+out+', expected: '+e );
-		} else {
-			delta = absf( out - e );
-			tol = 2.0 * EPS * absf( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. v: '+out+'. E: '+e+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValuef( out, e, 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description
> What is the purpose of this pull request?

This pull request:

Migrates the unit tests for `math/base/special/xlogyf` (`test.js` and `test.native.js`) from relative tolerance testing to ULP difference testing using `@stdlib/assert/is-almost-same-value`.

## Related Issues
> Does this pull request have any related issues?

This pull request has the following related issues:

- #11352

## Questions
> Any questions for reviewers of this pull request?

No.

## Other
> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Implementation Note on ULP Tolerances:**
When evaluating the 4 test loops against their corresponding Python test fixtures (`small_small`, `small_large`, `large_small`, and `large_large`), the minimum required ULP tolerances were determined as follows per Instruction #4 of RFC #11352 ("Make sure that you put the minimum required ULP value possible"):

Across all four test suites, the maximum ULP difference between the computed values and reference fixtures was measured as: `small_small`: 22, `small_large`: 3, `large_small`: 101, `large_large`: 2.
Therefore, all test loops were set to these baseline tolerances (22, 3, 101, and 2 respectively).
These thresholds achieve a 100% pass rate across all test suites while establishing the exact mathematical floor required for precision validation.

## Checklist
> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance
> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Disclosure
> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
