### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/time/minutes-in-month/lib/index.js
+++ b/lib/node_modules/@stdlib/time/minutes-in-month/lib/index.js
@@ -41,9 +41,9 @@
 
 // MODULES //
 
-var minutesInMonth = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = minutesInMonth;
+module.exports = main;

--- a/lib/node_modules/@stdlib/time/minutes-in-year/lib/index.js
+++ b/lib/node_modules/@stdlib/time/minutes-in-year/lib/index.js
@@ -38,9 +38,9 @@
 
 // MODULES //
 
-var minutesInYear = require( './main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //
 
-module.exports = minutesInYear;
+module.exports = main;

--- a/lib/node_modules/@stdlib/time/ms2duration/lib/main.js
+++ b/lib/node_modules/@stdlib/time/ms2duration/lib/main.js
@@ -52,19 +52,19 @@ function ms2duration( ms ) {
 	}
 	out = '';
 	if ( ms >= 86400000 ) {
-		out += floor(ms/86400000) + 'd';
+		out += floor( ms/86400000 ) + 'd';
 		ms %= 86400000;
 	}
 	if ( ms >= 3600000 ) {
-		out += floor(ms/3600000) + 'h';
+		out += floor( ms/3600000 ) + 'h';
 		ms %= 3600000;
 	}
 	if ( ms >= 60000 ) {
-		out += floor(ms/60000) + 'm';
+		out += floor( ms/60000 ) + 'm';
 		ms %= 60000;
 	}
 	if ( ms >= 1000 ) {
-		out += floor(ms/1000) + 's';
+		out += floor( ms/1000 ) + 's';
 		ms %= 1000;
 	}
 	if ( ms > 0 ) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request normalizes three source-file convention deviations in the `@stdlib/time` namespace to the pattern used by the overwhelming majority of sibling packages. All changes are internal and behavior-neutral; no public API, signature, or test expectation is affected.

**Namespace summary.** `@stdlib/time` has 19 direct members; the `base` namespace-aggregator package was excluded, leaving 18 leaf function packages voted at a 75% majority threshold (≥14/18). Structural features (file tree, `package.json` shape, README section structure, test/benchmark/example file naming) and semantic features (public signatures, return kind, validation prologue, error construction, JSDoc shape, dependencies) were extracted per package. Features with a clear majority: error construction (uniform `@stdlib/string/format`), validation prologues (consistent within signature families), JSDoc tag shape, `package.json` key set, and core file layout. Features excluded for lacking a clear majority: `benchmark/benchmark.js` presence (2/18) and per-function `@example` count. The namespace is unusually consistent — the only corrections below are convention drift in three outliers.

### `@stdlib/time/minutes-in-month`

The `lib/index.js` re-export bound `require( './main.js' )` to a package-named variable (`minutesInMonth`) rather than `main`. 16 of 18 namespace members (89%) use `main` for this binding. Renamed the binding and its `module.exports` assignment to `main`. Internal only; the `require`d public API is untouched.

### `@stdlib/time/minutes-in-year`

Same deviation as `minutes-in-month`: `lib/index.js` bound `require( './main.js' )` to `minutesInYear` instead of `main` (89% conformance to `main` across the namespace). Renamed the binding and its `module.exports` assignment. Internal only.

### `@stdlib/time/ms2duration`

The four `floor()` calls in `lib/main.js` omitted the interior parenthesis spacing required by the `space-in-parens` lint rule (`floor(ms/…)` rather than `floor( ms/… )`). All 17 other `floor()` call sites in the namespace already conform. Added the spacing. Whitespace-only.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Structural features were extracted from the filesystem; semantic features were extracted per package from `lib/main.js`/`lib/index.js`; candidate drift was cross-checked by three independent reviewers (structural, semantic, and fresh-eyes). Deliberately excluded from this PR: `tic`/`toc` lacking CLI scaffolding (`bin/cli`, `etc/cli_opts.json`, `test.cli.js`) — intentional, since neither is a standalone CLI primitive; missing `## See Also` sections in four READMEs — generator-owned; benchmark-directory absence — below the majority threshold and not a mechanical fix. Each change here was verified to preserve behavior via direct invocation (e.g. `minutesInMonth( 2, 2017 ) === 40320`, `ms2duration( 1030 ) === '1s30ms'`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was generated by an automated cross-package drift-detection routine run via Claude Code: it extracted structural and semantic features from every `@stdlib/time` package, identified the majority convention per feature, flagged the three outliers above, and applied the mechanical corrections. Each correction was validated by independent review passes and verified behavior-neutral before commit.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_012yDjoVfndcioeuohxziAw3)_