### PR TITLE
docs: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-equal/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-equal/README.md
@@ -75,7 +75,7 @@ The function has the following parameters:
 ## Notes
 
 -   The input ndarray is modified **in-place** (i.e., the input ndarray is **mutated**).
--   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct, and `-0` and `+0` are considered the same.
+-   When comparing elements, the function checks for equality using the strict equality operator `===`. As a consequence, `NaN` values are considered distinct (i.e., as `NaN === NaN` always evaluates to `false`, `NaN` elements are never replaced), and `-0` and `+0` are considered the same.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/sindex-of-not-equal/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/sindex-of-not-equal/lib/main.js
@@ -31,7 +31,7 @@ var strided = require( '@stdlib/blas/ext/base/sindex-of-not-equal' ).ndarray;
 // MAIN //
 
 /**
-* Returns the first index of an element in a one-dimensional ndarray which is not equal to a specified search element.
+* Returns the first index of an element in a one-dimensional single-precision floating-point ndarray which is not equal to a specified search element.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-falsy/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-falsy/lib/ndarray.native.js
@@ -29,6 +29,12 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last falsy element in a double-precision complex floating-point strided array using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   A complex number is falsy when both its real and imaginary components are falsy.
+* -   If unable to find a falsy element, the function returns `-1`.
+* -   The function explicitly treats `NaN` values as falsy.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Complex128Array} x - input array
 * @param {integer} strideX - stride length

--- a/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-falsy/lib/zlast_index_of_falsy.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-falsy/lib/zlast_index_of_falsy.native.js
@@ -29,6 +29,12 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last falsy element in a double-precision complex floating-point strided array.
 *
+* ## Notes
+*
+* -   A complex number is falsy when both its real and imaginary components are falsy.
+* -   If unable to find a falsy element, the function returns `-1`.
+* -   The function explicitly treats `NaN` values as falsy.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Complex128Array} x - input array
 * @param {integer} strideX - stride length

--- a/lib/node_modules/@stdlib/number/uint64/base/set-low-word/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/set-low-word/README.md
@@ -30,7 +30,7 @@ limitations under the License.
 var setLowWord = require( '@stdlib/number/uint64/base/set-low-word' );
 ```
 
-#### setLowWord( x, low )
+#### setLowWord( a, low )
 
 Sets the low 32-bit word of a [64-bit unsigned integer][@stdlib/number/uint64/ctor].
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-07-31 14:47 PDT (`382065db2`) and 2026-08-01 05:06 PDT (`2d0146e71`). An automated review of the 27 commits in this window surfaced five documentation defects, all independently re-verified against sibling packages before committing.

This pull request:

-   **`blas/ext/base/ndarray/sindex-of-not-equal`**: Fixed the `sindex-of-not-equal` main.js JSDoc summary in 321bbd8 — it dropped "single-precision floating-point" that every other doc surface (README, lib/index.js, repl.txt, index.d.ts) and the `dindex-of-not-equal` analog carries. Added the qualifier for consistency.
-   **`blas/ext/base/ndarray/gfill-equal`**: Restored the dropped `NaN === NaN` parenthetical in `lib/node_modules/@stdlib/blas/ext/base/ndarray/gfill-equal/README.md` (regressed in bdd912c) so the Notes section matches `lib/main.js`, `docs/repl.txt`, `docs/types/index.d.ts`, and the `gfill-not-equal` analog README.
-   **`blas/ext/base/zlast-index-of-falsy`**: Missing `## Notes` block in the native wrappers (`lib/zlast_index_of_falsy.native.js`, `lib/ndarray.native.js`) from 35251d8 — complex falsy-both-components, no-match `-1`, and NaN-as-falsy semantics went undocumented there while the non-native siblings had them. Added the block to both, matching the `dlast-index-of-falsy` native analogs.
-   **`number/uint64/base/set-low-word`**: Fixed the heading in `lib/node_modules/@stdlib/number/uint64/base/set-low-word/README.md` (from `f4555c0`): `x` → `a` to match `lib/main.js`, `docs/repl.txt`, `docs/types/index.d.ts`, and the example immediately below it.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 27 commits in the window were reviewed for: stdlib style-guide compliance (compared against established reference packages, e.g. `blas/ext/base/dindex-of-not-equal`, `dlast-index-of-falsy`, `number/uint64/base/set-high-word`), bugs in the diff (logic, loop bounds, complex arithmetic, two's-complement word values — all documented numeric results hand-verified), and copy-paste divergence between the `cwxsy`/`zwxsy` package pair. Deliberately excluded: anything requiring interpretation or judgment (subjective style preferences, ULP-count choices in the test migrations, bot-generated file mechanics, and issues whose fix would require touching code outside the window's diff — e.g. the pre-existing `setHighWord( x, high )` heading in `number/uint64/base/set-high-word`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a scheduled automated review of commits merged to `develop` in the last 24 hours. Findings were produced by independent review agents and each fix was re-verified against the actual repository files and sibling reference packages before committing.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXgfVvS59K2r7HGZQSqnL8)_