### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dsort2hp/lib/dsort2hp.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsort2hp/lib/dsort2hp.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Simultaneously sorts two double-precision floating-point strided arrays based on the sort order of the first array using heapsort.
 *
+* ## Notes
+*
+* -   This implementation uses an in-place algorithm derived from the work of Floyd (1964).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float64Array} x - first input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dsort2hp/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsort2hp/lib/ndarray.native.js
@@ -29,6 +29,10 @@ var addon = require( './dsort2hp.native.js' );
 /**
 * Simultaneously sorts two double-precision floating-point strided arrays based on the sort order of the first array using heapsort.
 *
+* ## Notes
+*
+* -   This implementation uses an in-place algorithm derived from the work of Floyd (1964).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float64Array} x - first input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dsort2sh/lib/dsort2sh.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsort2sh/lib/dsort2sh.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Simultaneously sorts two double-precision floating-point strided arrays based on the sort order of the first array using Shellsort.
 *
+* ## Notes
+*
+* -   This implementation uses the gap sequence proposed by Ciura (2001).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float64Array} x - first input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dsort2sh/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsort2sh/lib/ndarray.native.js
@@ -29,6 +29,10 @@ var addon = require( './dsort2sh.native.js' );
 /**
 * Simultaneously sorts two double-precision floating-point strided arrays based on the sort order of the first array using Shellsort.
 *
+* ## Notes
+*
+* -   This implementation uses the gap sequence proposed by Ciura (2001).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float64Array} x - first input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dsorthp/lib/dsorthp.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsorthp/lib/dsorthp.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Sorts a double-precision floating-point strided array using heapsort.
 *
+* ## Notes
+*
+* -   This implementation uses an in-place algorithm derived from the work of Floyd (1964).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float64Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dsorthp/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsorthp/lib/ndarray.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Sorts a double-precision floating-point strided array using heapsort.
 *
+* ## Notes
+*
+* -   This implementation uses an in-place algorithm derived from the work of Floyd (1964).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float64Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dsortsh/lib/dsortsh.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsortsh/lib/dsortsh.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Sorts a double-precision floating-point strided array using Shellsort.
 *
+* ## Notes
+*
+* -   This implementation uses the gap sequence proposed by Ciura (2001).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float64Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/dsortsh/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsortsh/lib/ndarray.native.js
@@ -29,6 +29,10 @@ var addon = require( './dsortsh.native.js' );
 /**
 * Sorts a double-precision floating-point strided array using Shellsort.
 *
+* ## Notes
+*
+* -   This implementation uses the gap sequence proposed by Ciura (2001).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float64Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/ssort2hp/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssort2hp/lib/ndarray.native.js
@@ -29,6 +29,10 @@ var addon = require( './ssort2hp.native.js' );
 /**
 * Simultaneously sorts two single-precision floating-point strided arrays based on the sort order of the first array using heapsort.
 *
+* ## Notes
+*
+* -   This implementation uses an in-place algorithm derived from the work of Floyd (1964).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float32Array} x - first input array

--- a/lib/node_modules/@stdlib/blas/ext/base/ssort2hp/lib/ssort2hp.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssort2hp/lib/ssort2hp.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Simultaneously sorts two single-precision floating-point strided arrays based on the sort order of the first array using heapsort.
 *
+* ## Notes
+*
+* -   This implementation uses an in-place algorithm derived from the work of Floyd (1964).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float32Array} x - first input array

--- a/lib/node_modules/@stdlib/blas/ext/base/ssort2sh/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssort2sh/lib/ndarray.native.js
@@ -29,6 +29,10 @@ var addon = require( './ssort2sh.native.js' );
 /**
 * Simultaneously sorts two single-precision floating-point strided arrays based on the sort order of the first array using Shellsort.
 *
+* ## Notes
+*
+* -   This implementation uses the gap sequence proposed by Ciura (2001).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float32Array} x - first input array

--- a/lib/node_modules/@stdlib/blas/ext/base/ssort2sh/lib/ssort2sh.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssort2sh/lib/ssort2sh.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Simultaneously sorts two single-precision floating-point strided arrays based on the sort order of the first array using Shellsort.
 *
+* ## Notes
+*
+* -   This implementation uses the gap sequence proposed by Ciura (2001).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float32Array} x - first input array

--- a/lib/node_modules/@stdlib/blas/ext/base/ssorthp/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssorthp/lib/ndarray.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Sorts a single-precision floating-point strided array using heapsort.
 *
+* ## Notes
+*
+* -   This implementation uses an in-place algorithm derived from the work of Floyd (1964).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float32Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/ssorthp/lib/ssorthp.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssorthp/lib/ssorthp.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Sorts a single-precision floating-point strided array using heapsort.
 *
+* ## Notes
+*
+* -   This implementation uses an in-place algorithm derived from the work of Floyd (1964).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float32Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/ssortsh/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssortsh/lib/ndarray.native.js
@@ -30,6 +30,10 @@ var addon = require( './ssortsh.native.js' );
 /**
 * Sorts a single-precision floating-point strided array using Shellsort.
 *
+* ## Notes
+*
+* -   This implementation uses the gap sequence proposed by Ciura (2001).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float32Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/ssortsh/lib/ssortsh.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssortsh/lib/ssortsh.native.js
@@ -28,6 +28,10 @@ var addon = require( './../src/addon.node' );
 /**
 * Sorts a single-precision floating-point strided array using Shellsort.
 *
+* ## Notes
+*
+* -   This implementation uses the gap sequence proposed by Ciura (2001).
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} order - sort order
 * @param {Float32Array} x - input array

--- a/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-falsy/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-falsy/lib/ndarray.native.js
@@ -29,6 +29,12 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last falsy element in a double-precision complex floating-point strided array using alternative indexing semantics.
 *
+* ## Notes
+*
+* -   A complex number is falsy when both its real and imaginary components are falsy.
+* -   If unable to find a falsy element, the function returns `-1`.
+* -   The function explicitly treats `NaN` values as falsy.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Complex128Array} x - input array
 * @param {integer} strideX - stride length

--- a/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-falsy/lib/zlast_index_of_falsy.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zlast-index-of-falsy/lib/zlast_index_of_falsy.native.js
@@ -29,6 +29,12 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the index of the last falsy element in a double-precision complex floating-point strided array.
 *
+* ## Notes
+*
+* -   A complex number is falsy when both its real and imaginary components are falsy.
+* -   If unable to find a falsy element, the function returns `-1`.
+* -   The function explicitly treats `NaN` values as falsy.
+*
 * @param {PositiveInteger} N - number of indexed elements
 * @param {Complex128Array} x - input array
 * @param {integer} strideX - stride length

--- a/lib/node_modules/@stdlib/complex/float32/reim/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/complex/float32/reim/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/complex/float64/reim/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/complex/float64/reim/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/math/base/special/cceil/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cceil/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/math/base/special/hyp2f1/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/hyp2f1/benchmark/c/benchmark.c
@@ -133,7 +133,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-allowed-data-type-cast/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-allowed-data-type-cast/benchmark/c/benchmark.c
@@ -125,7 +125,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape/benchmark/c/benchmark.c
@@ -127,7 +127,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major-contiguous/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major-contiguous/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major/benchmark/c/benchmark.c
@@ -127,7 +127,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-contiguous/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-contiguous/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-mostly-safe-data-type-cast/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-mostly-safe-data-type-cast/benchmark/c/benchmark.c
@@ -124,7 +124,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major-contiguous/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major-contiguous/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major/benchmark/c/benchmark.c
@@ -127,7 +127,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-safe-data-type-cast/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-safe-data-type-cast/benchmark/c/benchmark.c
@@ -124,7 +124,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-same-kind-data-type-cast/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-same-kind-data-type-cast/benchmark/c/benchmark.c
@@ -124,7 +124,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-single-segment-compatible/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-single-segment-compatible/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/bind2vind/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/bind2vind/benchmark/c/benchmark.c
@@ -647,112 +647,112 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=row-major\n", NAME );
+		printf( "# c::%s:mode=error,order=row-major\n", NAME );
 		elapsed = benchmark1();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=column-major\n", NAME );
+		printf( "# c::%s:mode=error,order=column-major\n", NAME );
 		elapsed = benchmark2();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=error,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark3();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=error,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark4();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=row-major\n", NAME );
+		printf( "# c::%s:mode=wrap,order=row-major\n", NAME );
 		elapsed = benchmark5();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=column-major\n", NAME );
+		printf( "# c::%s:mode=wrap,order=column-major\n", NAME );
 		elapsed = benchmark6();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=wrap,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark7();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=wrap,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark8();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=row-major\n", NAME );
+		printf( "# c::%s:mode=clamp,order=row-major\n", NAME );
 		elapsed = benchmark9();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=column-major\n", NAME );
+		printf( "# c::%s:mode=clamp,order=column-major\n", NAME );
 		elapsed = benchmark10();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=clamp,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark11();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=clamp,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark12();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=row-major\n", NAME );
+		printf( "# c::%s:mode=normalize,order=row-major\n", NAME );
 		elapsed = benchmark13();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=column-major\n", NAME );
+		printf( "# c::%s:mode=normalize,order=column-major\n", NAME );
 		elapsed = benchmark14();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=normalize,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark15();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=normalize,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark16();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/broadcast-shapes/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/broadcast-shapes/benchmark/c/benchmark.c
@@ -140,7 +140,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s::two_arrays\n", NAME );
+		printf( "# c::%s::two_arrays\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/bytes-per-element/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/bytes-per-element/benchmark/c/benchmark.c
@@ -137,7 +137,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/clamp-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/clamp-index/benchmark/c/benchmark.c
@@ -126,7 +126,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/dtype-alignment/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/dtype-alignment/benchmark/c/benchmark.c
@@ -137,7 +137,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/dtype-char/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/dtype-char/benchmark/c/benchmark.c
@@ -137,7 +137,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/flatten-shape-from/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/flatten-shape-from/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/flatten-shape/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/flatten-shape/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/ind/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/ind/benchmark/c/benchmark.c
@@ -210,28 +210,28 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error\n", NAME );
+		printf( "# c::%s:mode=error\n", NAME );
 		elapsed = benchmark1();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp\n", NAME );
+		printf( "# c::%s:mode=clamp\n", NAME );
 		elapsed = benchmark2();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap\n", NAME );
+		printf( "# c::%s:mode=wrap\n", NAME );
 		elapsed = benchmark3();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize\n", NAME );
+		printf( "# c::%s:mode=normalize\n", NAME );
 		elapsed = benchmark4();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/ind2sub/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/ind2sub/benchmark/c/benchmark.c
@@ -679,112 +679,112 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=row-major\n", NAME );
+		printf( "# c::%s:mode=error,order=row-major\n", NAME );
 		elapsed = benchmark1();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=column-major\n", NAME );
+		printf( "# c::%s:mode=error,order=column-major\n", NAME );
 		elapsed = benchmark2();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=error,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark3();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=error,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark4();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=row-major\n", NAME );
+		printf( "# c::%s:mode=wrap,order=row-major\n", NAME );
 		elapsed = benchmark5();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=column-major\n", NAME );
+		printf( "# c::%s:mode=wrap,order=column-major\n", NAME );
 		elapsed = benchmark6();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=wrap,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark7();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=wrap,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark8();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=row-major\n", NAME );
+		printf( "# c::%s:mode=clamp,order=row-major\n", NAME );
 		elapsed = benchmark9();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=column-major\n", NAME );
+		printf( "# c::%s:mode=clamp,order=column-major\n", NAME );
 		elapsed = benchmark10();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=clamp,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark11();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=clamp,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark12();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=row-major\n", NAME );
+		printf( "# c::%s:mode=normalize,order=row-major\n", NAME );
 		elapsed = benchmark13();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=column-major\n", NAME );
+		printf( "# c::%s:mode=normalize,order=column-major\n", NAME );
 		elapsed = benchmark14();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=normalize,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark15();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=normalize,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark16();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/iteration-order/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/iteration-order/benchmark/c/benchmark.c
@@ -127,7 +127,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/max-view-buffer-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/max-view-buffer-index/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/min-view-buffer-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/min-view-buffer-index/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/minmax-view-buffer-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/minmax-view-buffer-index/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/nonsingleton-dimensions/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/nonsingleton-dimensions/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/normalize-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/normalize-index/benchmark/c/benchmark.c
@@ -124,7 +124,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/numel/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/numel/benchmark/c/benchmark.c
@@ -127,7 +127,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/shape2strides/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/shape2strides/benchmark/c/benchmark.c
@@ -162,14 +162,14 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:order=row-major\n", NAME );
+		printf( "# c::%s:order=row-major\n", NAME );
 		elapsed = benchmark1();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:order=column-major\n", NAME );
+		printf( "# c::%s:order=column-major\n", NAME );
 		elapsed = benchmark2();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/singleton-dimensions/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/singleton-dimensions/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/strides2offset/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/strides2offset/benchmark/c/benchmark.c
@@ -128,7 +128,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/strides2order/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/strides2order/benchmark/c/benchmark.c
@@ -127,7 +127,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/base/sub2ind/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/sub2ind/benchmark/c/benchmark.c
@@ -576,84 +576,84 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[error]\n", NAME );
+		printf( "# c::%s:mode=[error]\n", NAME );
 		elapsed = benchmark1();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[error],offset=0\n", NAME );
+		printf( "# c::%s:mode=[error],offset=0\n", NAME );
 		elapsed = benchmark2();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[wrap]\n", NAME );
+		printf( "# c::%s:mode=[wrap]\n", NAME );
 		elapsed = benchmark3();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[wrap],offset=0\n", NAME );
+		printf( "# c::%s:mode=[wrap],offset=0\n", NAME );
 		elapsed = benchmark4();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[clamp]\n", NAME );
+		printf( "# c::%s:mode=[clamp]\n", NAME );
 		elapsed = benchmark5();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[clamp],offset=0\n", NAME );
+		printf( "# c::%s:mode=[clamp],offset=0\n", NAME );
 		elapsed = benchmark6();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[wrap,clamp]\n", NAME );
+		printf( "# c::%s:mode=[wrap,clamp]\n", NAME );
 		elapsed = benchmark7();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[wrap,clamp,clamp]\n", NAME );
+		printf( "# c::%s:mode=[wrap,clamp,clamp]\n", NAME );
 		elapsed = benchmark8();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[clamp,wrap]\n", NAME );
+		printf( "# c::%s:mode=[clamp,wrap]\n", NAME );
 		elapsed = benchmark9();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[clamp,wrap,wrap]\n", NAME );
+		printf( "# c::%s:mode=[clamp,wrap,wrap]\n", NAME );
 		elapsed = benchmark10();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[normalize]\n", NAME );
+		printf( "# c::%s:mode=[normalize]\n", NAME );
 		elapsed = benchmark11();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=[normalize],offset=0\n", NAME );
+		printf( "# c::%s:mode=[normalize],offset=0\n", NAME );
 		elapsed = benchmark12();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/sub2ind/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/sub2ind/benchmark/c/benchmark.c
@@ -576,84 +576,84 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[error]\n", NAME );
+		printf( "# c::native::%s:mode=[error]\n", NAME );
 		elapsed = benchmark1();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[error],offset=0\n", NAME );
+		printf( "# c::native::%s:mode=[error],offset=0\n", NAME );
 		elapsed = benchmark2();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[wrap]\n", NAME );
+		printf( "# c::native::%s:mode=[wrap]\n", NAME );
 		elapsed = benchmark3();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[wrap],offset=0\n", NAME );
+		printf( "# c::native::%s:mode=[wrap],offset=0\n", NAME );
 		elapsed = benchmark4();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[clamp]\n", NAME );
+		printf( "# c::native::%s:mode=[clamp]\n", NAME );
 		elapsed = benchmark5();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[clamp],offset=0\n", NAME );
+		printf( "# c::native::%s:mode=[clamp],offset=0\n", NAME );
 		elapsed = benchmark6();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[wrap,clamp]\n", NAME );
+		printf( "# c::native::%s:mode=[wrap,clamp]\n", NAME );
 		elapsed = benchmark7();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[wrap,clamp,clamp]\n", NAME );
+		printf( "# c::native::%s:mode=[wrap,clamp,clamp]\n", NAME );
 		elapsed = benchmark8();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[clamp,wrap]\n", NAME );
+		printf( "# c::native::%s:mode=[clamp,wrap]\n", NAME );
 		elapsed = benchmark9();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[clamp,wrap,wrap]\n", NAME );
+		printf( "# c::native::%s:mode=[clamp,wrap,wrap]\n", NAME );
 		elapsed = benchmark10();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[normalize]\n", NAME );
+		printf( "# c::native::%s:mode=[normalize]\n", NAME );
 		elapsed = benchmark11();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::%s:mode=[normalize],offset=0\n", NAME );
+		printf( "# c::native::%s:mode=[normalize],offset=0\n", NAME );
 		elapsed = benchmark12();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/vind2bind/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/vind2bind/benchmark/c/benchmark.c
@@ -647,112 +647,112 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=row-major\n", NAME );
+		printf( "# c::%s:mode=error,order=row-major\n", NAME );
 		elapsed = benchmark1();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=column-major\n", NAME );
+		printf( "# c::%s:mode=error,order=column-major\n", NAME );
 		elapsed = benchmark2();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=error,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark3();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=error,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=error,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark4();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=row-major\n", NAME );
+		printf( "# c::%s:mode=wrap,order=row-major\n", NAME );
 		elapsed = benchmark5();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=column-major\n", NAME );
+		printf( "# c::%s:mode=wrap,order=column-major\n", NAME );
 		elapsed = benchmark6();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=wrap,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark7();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=wrap,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=wrap,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark8();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=row-major\n", NAME );
+		printf( "# c::%s:mode=clamp,order=row-major\n", NAME );
 		elapsed = benchmark9();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=column-major\n", NAME );
+		printf( "# c::%s:mode=clamp,order=column-major\n", NAME );
 		elapsed = benchmark10();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=clamp,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark11();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=clamp,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=clamp,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark12();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=row-major\n", NAME );
+		printf( "# c::%s:mode=normalize,order=row-major\n", NAME );
 		elapsed = benchmark13();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=column-major\n", NAME );
+		printf( "# c::%s:mode=normalize,order=column-major\n", NAME );
 		elapsed = benchmark14();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=row-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=normalize,order=row-major,offset=0\n", NAME );
 		elapsed = benchmark15();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s:mode=normalize,order=column-major,offset=0\n", NAME );
+		printf( "# c::%s:mode=normalize,order=column-major,offset=0\n", NAME );
 		elapsed = benchmark16();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/ndarray/base/wrap-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/wrap-index/benchmark/c/benchmark.c
@@ -126,7 +126,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/ndarray/ctor/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/ctor/benchmark/c/benchmark.c
@@ -3322,469 +3322,469 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::instantiation\n", NAME );
+		printf( "# c::%s::instantiation\n", NAME );
 		elapsed = benchmark1();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:byteLength\n", NAME );
+		printf( "# c::%s::get:byteLength\n", NAME );
 		elapsed = benchmark2();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:data\n", NAME );
+		printf( "# c::%s::get:data\n", NAME );
 		elapsed = benchmark3();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:dtype\n", NAME );
+		printf( "# c::%s::get:dtype\n", NAME );
 		elapsed = benchmark4();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:flags\n", NAME );
+		printf( "# c::%s::get:flags\n", NAME );
 		elapsed = benchmark5();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:length\n", NAME );
+		printf( "# c::%s::get:length\n", NAME );
 		elapsed = benchmark6();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:ndims\n", NAME );
+		printf( "# c::%s::get:ndims\n", NAME );
 		elapsed = benchmark7();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:offset\n", NAME );
+		printf( "# c::%s::get:offset\n", NAME );
 		elapsed = benchmark8();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:order\n", NAME );
+		printf( "# c::%s::get:order\n", NAME );
 		elapsed = benchmark9();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:shape\n", NAME );
+		printf( "# c::%s::get:shape\n", NAME );
 		elapsed = benchmark10();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:strides\n", NAME );
+		printf( "# c::%s::get:strides\n", NAME );
 		elapsed = benchmark11();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:get:mode=error\n", NAME );
+		printf( "# c::%s::1d:get:mode=error\n", NAME );
 		elapsed = benchmark12();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:get:mode=wrap\n", NAME );
+		printf( "# c::%s::1d:get:mode=wrap\n", NAME );
 		elapsed = benchmark13();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:get:mode=clamp\n", NAME );
+		printf( "# c::%s::1d:get:mode=clamp\n", NAME );
 		elapsed = benchmark14();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d:get:mode=error\n", NAME );
+		printf( "# c::%s::2d:get:mode=error\n", NAME );
 		elapsed = benchmark15();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d:get:mode=wrap\n", NAME );
+		printf( "# c::%s::2d:get:mode=wrap\n", NAME );
 		elapsed = benchmark16();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d:get:mode=clamp\n", NAME );
+		printf( "# c::%s::2d:get:mode=clamp\n", NAME );
 		elapsed = benchmark17();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::3d:get:mode=error\n", NAME );
+		printf( "# c::%s::3d:get:mode=error\n", NAME );
 		elapsed = benchmark18();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::3d:get:mode=wrap\n", NAME );
+		printf( "# c::%s::3d:get:mode=wrap\n", NAME );
 		elapsed = benchmark19();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::3d:get:mode=clamp\n", NAME );
+		printf( "# c::%s::3d:get:mode=clamp\n", NAME );
 		elapsed = benchmark20();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::4d:get:mode=error\n", NAME );
+		printf( "# c::%s::4d:get:mode=error\n", NAME );
 		elapsed = benchmark21();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::4d:get:mode=wrap\n", NAME );
+		printf( "# c::%s::4d:get:mode=wrap\n", NAME );
 		elapsed = benchmark22();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::4d:get:mode=clamp\n", NAME );
+		printf( "# c::%s::4d:get:mode=clamp\n", NAME );
 		elapsed = benchmark23();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::5d:get:mode=error\n", NAME );
+		printf( "# c::%s::5d:get:mode=error\n", NAME );
 		elapsed = benchmark24();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::5d:get:mode=wrap\n", NAME );
+		printf( "# c::%s::5d:get:mode=wrap\n", NAME );
 		elapsed = benchmark25();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::5d:get:mode=clamp\n", NAME );
+		printf( "# c::%s::5d:get:mode=clamp\n", NAME );
 		elapsed = benchmark26();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:iget:mode=error\n", NAME );
+		printf( "# c::%s::1d:iget:mode=error\n", NAME );
 		elapsed = benchmark27();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:iget:mode=wrap\n", NAME );
+		printf( "# c::%s::1d:iget:mode=wrap\n", NAME );
 		elapsed = benchmark28();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:iget:mode=clamp\n", NAME );
+		printf( "# c::%s::1d:iget:mode=clamp\n", NAME );
 		elapsed = benchmark29();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,all_positive_strides:iget:mode=error,order=row-major\n", NAME );
+		printf( "# c::%s::2d,all_positive_strides:iget:mode=error,order=row-major\n", NAME );
 		elapsed = benchmark30();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,all_positive_strides:iget:mode=error,order=column-major\n", NAME );
+		printf( "# c::%s::2d,all_positive_strides:iget:mode=error,order=column-major\n", NAME );
 		elapsed = benchmark31();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,all_negative_strides:iget:mode=error,order=row-major\n", NAME );
+		printf( "# c::%s::2d,all_negative_strides:iget:mode=error,order=row-major\n", NAME );
 		elapsed = benchmark32();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,all_negative_strides:iget:mode=error,order=column-major\n", NAME );
+		printf( "# c::%s::2d,all_negative_strides:iget:mode=error,order=column-major\n", NAME );
 		elapsed = benchmark33();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,mixed_sign_strides:iget:mode=error,order=row-major\n", NAME );
+		printf( "# c::%s::2d,mixed_sign_strides:iget:mode=error,order=row-major\n", NAME );
 		elapsed = benchmark34();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,mixed_sign_strides:iget:mode=error,order=column-major\n", NAME );
+		printf( "# c::%s::2d,mixed_sign_strides:iget:mode=error,order=column-major\n", NAME );
 		elapsed = benchmark35();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:set:mode=error\n", NAME );
+		printf( "# c::%s::1d:set:mode=error\n", NAME );
 		elapsed = benchmark36();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:set:mode=wrap\n", NAME );
+		printf( "# c::%s::1d:set:mode=wrap\n", NAME );
 		elapsed = benchmark37();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:set:mode=clamp\n", NAME );
+		printf( "# c::%s::1d:set:mode=clamp\n", NAME );
 		elapsed = benchmark38();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d:set:mode=error\n", NAME );
+		printf( "# c::%s::2d:set:mode=error\n", NAME );
 		elapsed = benchmark39();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d:set:mode=wrap\n", NAME );
+		printf( "# c::%s::2d:set:mode=wrap\n", NAME );
 		elapsed = benchmark40();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d:set:mode=clamp\n", NAME );
+		printf( "# c::%s::2d:set:mode=clamp\n", NAME );
 		elapsed = benchmark41();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::3d:set:mode=error\n", NAME );
+		printf( "# c::%s::3d:set:mode=error\n", NAME );
 		elapsed = benchmark42();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::3d:set:mode=wrap\n", NAME );
+		printf( "# c::%s::3d:set:mode=wrap\n", NAME );
 		elapsed = benchmark43();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::3d:set:mode=clamp\n", NAME );
+		printf( "# c::%s::3d:set:mode=clamp\n", NAME );
 		elapsed = benchmark44();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::4d:set:mode=error\n", NAME );
+		printf( "# c::%s::4d:set:mode=error\n", NAME );
 		elapsed = benchmark45();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::4d:set:mode=wrap\n", NAME );
+		printf( "# c::%s::4d:set:mode=wrap\n", NAME );
 		elapsed = benchmark46();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::4d:set:mode=clamp\n", NAME );
+		printf( "# c::%s::4d:set:mode=clamp\n", NAME );
 		elapsed = benchmark47();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::5d:set:mode=error\n", NAME );
+		printf( "# c::%s::5d:set:mode=error\n", NAME );
 		elapsed = benchmark48();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::5d:set:mode=wrap\n", NAME );
+		printf( "# c::%s::5d:set:mode=wrap\n", NAME );
 		elapsed = benchmark49();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::5d:set:mode=clamp\n", NAME );
+		printf( "# c::%s::5d:set:mode=clamp\n", NAME );
 		elapsed = benchmark50();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:iset:mode=error\n", NAME );
+		printf( "# c::%s::1d:iset:mode=error\n", NAME );
 		elapsed = benchmark51();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:iset:mode=wrap\n", NAME );
+		printf( "# c::%s::1d:iset:mode=wrap\n", NAME );
 		elapsed = benchmark52();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::1d:iset:mode=clamp\n", NAME );
+		printf( "# c::%s::1d:iset:mode=clamp\n", NAME );
 		elapsed = benchmark53();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,all_positive_strides:iset:mode=error,order=row-major\n", NAME );
+		printf( "# c::%s::2d,all_positive_strides:iset:mode=error,order=row-major\n", NAME );
 		elapsed = benchmark54();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,all_positive_strides:iset:mode=error,order=column-major\n", NAME );
+		printf( "# c::%s::2d,all_positive_strides:iset:mode=error,order=column-major\n", NAME );
 		elapsed = benchmark55();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,all_negative_strides:iset:mode=error,order=row-major\n", NAME );
+		printf( "# c::%s::2d,all_negative_strides:iset:mode=error,order=row-major\n", NAME );
 		elapsed = benchmark56();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,all_negative_strides:iset:mode=error,order=column-major\n", NAME );
+		printf( "# c::%s::2d,all_negative_strides:iset:mode=error,order=column-major\n", NAME );
 		elapsed = benchmark57();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,mixed_sign_strides:iset:mode=error,order=row-major\n", NAME );
+		printf( "# c::%s::2d,mixed_sign_strides:iset:mode=error,order=row-major\n", NAME );
 		elapsed = benchmark58();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::2d,mixed_sign_strides:iset:mode=error,order=column-major\n", NAME );
+		printf( "# c::%s::2d,mixed_sign_strides:iset:mode=error,order=column-major\n", NAME );
 		elapsed = benchmark59();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:dimension\n", NAME );
+		printf( "# c::%s::get:dimension\n", NAME );
 		elapsed = benchmark60();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:stride\n", NAME );
+		printf( "# c::%s::get:stride\n", NAME );
 		elapsed = benchmark61();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:index_mode\n", NAME );
+		printf( "# c::%s::get:index_mode\n", NAME );
 		elapsed = benchmark62();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:submodes\n", NAME );
+		printf( "# c::%s::get:submodes\n", NAME );
 		elapsed = benchmark63();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:submode\n", NAME );
+		printf( "# c::%s::get:submode\n", NAME );
 		elapsed = benchmark64();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:byte_length_per_element\n", NAME );
+		printf( "# c::%s::get:byte_length_per_element\n", NAME );
 		elapsed = benchmark65();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:stride_elements\n", NAME );
+		printf( "# c::%s::get:stride_elements\n", NAME );
 		elapsed = benchmark66();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::get:offset_elements\n", NAME );
+		printf( "# c::%s::get:offset_elements\n", NAME );
 		elapsed = benchmark67();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/number/float16/base/exponent/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float16/base/exponent/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main ( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float16/base/from-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float16/base/from-word/benchmark/c/benchmark.c
@@ -114,7 +114,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float16/base/signbit/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float16/base/signbit/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main ( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float16/base/significand/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float16/base/significand/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main ( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float16/base/to-float32/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float16/base/to-float32/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float16/base/to-float64/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float16/base/to-float64/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float16/base/to-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float16/base/to-word/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-same-value-zero/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-same-value-zero/benchmark/c/benchmark.c
@@ -132,7 +132,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-same-value/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-same-value/benchmark/c/benchmark.c
@@ -132,7 +132,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float32/base/exponent/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/exponent/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main ( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float32/base/from-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/from-word/benchmark/c/benchmark.c
@@ -123,7 +123,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float32/base/normalize/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/normalize/benchmark/c/benchmark.c
@@ -132,7 +132,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float32/base/signbit/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/signbit/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main ( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float32/base/significand/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/significand/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main ( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float32/base/to-float16/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/to-float16/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float32/base/to-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float32/base/to-word/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/assert/is-same-value-zero/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/assert/is-same-value-zero/benchmark/c/benchmark.c
@@ -132,7 +132,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/assert/is-same-value/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/assert/is-same-value/benchmark/c/benchmark.c
@@ -132,7 +132,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main ( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/from-words/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/from-words/benchmark/c/benchmark.c
@@ -127,7 +127,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/get-high-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/get-high-word/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/get-low-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/get-low-word/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/normalize/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/normalize/benchmark/c/benchmark.c
@@ -132,7 +132,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/set-high-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/set-high-word/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/set-low-word/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/set-low-word/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/signbit/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/signbit/benchmark/c/benchmark.c
@@ -131,7 +131,7 @@ int main ( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/to-float16/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/to-float16/benchmark/c/benchmark.c
@@ -130,7 +130,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/number/float64/base/to-words/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/to-words/benchmark/c/benchmark.c
@@ -132,7 +132,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/random/base/shared/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/random/base/shared/benchmark/c/benchmark.c
@@ -564,70 +564,70 @@ int main( void ) {
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::next\n", NAME );
+		printf( "# c::%s::next\n", NAME );
 		elapsed = benchmark1();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::normalized\n", NAME );
+		printf( "# c::%s::normalized\n", NAME );
 		elapsed = benchmark2();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::min\n", NAME );
+		printf( "# c::%s::min\n", NAME );
 		elapsed = benchmark3();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::max\n", NAME );
+		printf( "# c::%s::max\n", NAME );
 		elapsed = benchmark4();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::normalized_min\n", NAME );
+		printf( "# c::%s::normalized_min\n", NAME );
 		elapsed = benchmark5();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::normalized_max\n", NAME );
+		printf( "# c::%s::normalized_max\n", NAME );
 		elapsed = benchmark6();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::state_size\n", NAME );
+		printf( "# c::%s::state_size\n", NAME );
 		elapsed = benchmark7();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::copy\n", NAME );
+		printf( "# c::%s::copy\n", NAME );
 		elapsed = benchmark8();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::copy_state\n", NAME );
+		printf( "# c::%s::copy_state\n", NAME );
 		elapsed = benchmark9();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );
 	}
 	for ( i = 0; i < REPEATS; i++ ) {
 		count += 1;
-		printf( "# c::native::%s::set\n", NAME );
+		printf( "# c::%s::set\n", NAME );
 		elapsed = benchmark10();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", count );

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/cdf/benchmark/c/benchmark.c
@@ -139,7 +139,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		printf( "ok %d benchmark finished\n", i+1 );
 		print_results( elapsed );

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/logcdf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/logcdf/benchmark/c/benchmark.c
@@ -141,7 +141,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		printf( "ok %d benchmark finished\n", i+1 );
 		print_results( elapsed );

--- a/lib/node_modules/@stdlib/strided/base/max-view-buffer-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/strided/base/max-view-buffer-index/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/strided/base/min-view-buffer-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/strided/base/min-view-buffer-index/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );

--- a/lib/node_modules/@stdlib/strided/base/stride2offset/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/strided/base/stride2offset/benchmark/c/benchmark.c
@@ -129,7 +129,7 @@ int main( void ) {
 
 	print_version();
 	for ( i = 0; i < REPEATS; i++ ) {
-		printf( "# c::native::%s\n", NAME );
+		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
 		printf( "ok %d benchmark finished\n", i+1 );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-07-31 and 2026-08-01 to sibling packages.

Applies the two clean-up fixes from 430fdea (#13805) to the remaining sites that were missed in the original pass.

-   **`## Notes` JSDoc section**: 18 `*.native.js` files across 9 `blas/ext/base` packages (`dsort2hp`, `dsort2sh`, `dsorthp`, `dsortsh`, `ssort2hp`, `ssort2sh`, `ssorthp`, `ssortsh`, `zlast-index-of-falsy`) were missing the `## Notes` section present in their non-native counterparts. Each main native file and its `ndarray.native.js` sibling now carries the Notes content mirrored from the corresponding non-native file.
-   **TAP benchmark labels**: plain C benchmarks with no add-on linkage (i.e., not under `benchmark/c/native/`) printed names under the `c::native::` label reserved for add-on benchmarks. 198 `printf` lines across 74 files — spanning `ndarray/base`, `number/{float16,float32,float64}/base`, `complex/{float32,float64}/reim`, `strided/base`, `stats/base/dists/{chi/cdf,gamma/logcdf}`, `random/base/shared`, `math/base/special/{cceil,hyp2f1}`, and `ndarray/ctor` — are relabeled to `c::`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation: candidate sites were enumerated by pattern search over the full repository (`## Notes` present in the non-native file but absent in the paired `*.native.js`; `c::native::` labels outside `benchmark/c/native/` directories), then independently confirmed by two validation passes which read each site in full, an adaptation pass which derived each package's Notes content from its non-native counterpart and verified each bullet against the package's C sources, and a style-consistency pass against the conventions of 430fdea. Sites requiring cross-package changes or interpretation were excluded; none were flagged. The label convention was confirmed repo-wide: 1254 plain C benchmarks use `c::`, 432 add-on benchmarks under `benchmark/c/native/` use `c::native::`, and none of the relabeled files link the Node.js add-on.

`ndarray/base/sub2ind/benchmark/c/benchmark.c` also carries the mislabel (12 lines) but is excluded here: the file has pre-existing cppcheck `constVariable` violations which fail the changed-files lint, so its label fix should land together with the lint clean-up.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by an automated Claude Code fix-propagation routine, which identified the source commit, enumerated candidate sites, and validated each change with independent review passes before applying it.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md