### PR TITLE
docs: add Git note

### DIFF
--- a/docs/git-notes/321bbd80199d4fc09e59e5d00bd0996fed349005.txt
+++ b/docs/git-notes/321bbd80199d4fc09e59e5d00bd0996fed349005.txt
@@ -1,0 +1,9 @@
+---
+type: amend-message
+---
+feat: add `blas/ext/base/ndarray/sindex-of-not-equal`
+
+PR-URL: https://github.com/stdlib-js/stdlib/pull/13560
+Co-authored-by: Athan Reines <kgryte@gmail.com>
+Reviewed-by: Athan Reines <kgryte@gmail.com>
+Closes: https://github.com/stdlib-js/metr-issue-tracker/issues/1034


### PR DESCRIPTION
## Description

This pull request:

-   Adds a `docs/git-notes/` amendment note for a commit merged to `develop` in the last 24 hours whose message contains a factual trailer error, for future use when rewriting history.

Flagged commit:

-   `321bbd8` — wrong `Closes:` trailer — commit says `Closes: .../metr-issue-tracker/issues/945`, but the merging PR (#13560) description states "Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1034"; the note corrects `Closes:` to point to issue 1034 instead of 945 (945 is actually closed by the sibling PR #13535 for `zlast-index-of-falsy`, suggesting a copy-paste error).

## Related Issues

This pull request has the following related issues:

-   None

## Other

This PR was generated by an automated routine that audits commits merged to `develop` over the last 24 hours for clear, verifiable errors in commit trailers (bad `PR-URL`/`Closes`/`Ref` references, malformed trailers, etc.) and records corrected messages as notes under `docs/git-notes/` rather than rewriting history directly. 24 commits were reviewed in this window; all `PR-URL` references and stdlib-internal `Ref:` issue references were cross-checked against the actual merged PRs/issues via the GitHub API and found correct. `Closes:` references pointing to the external `stdlib-js/metr-issue-tracker` repository could not be directly verified (out of scope for this session's GitHub access), but this one discrepancy was caught by cross-checking against the merging PR's own description, which is authoritative and in-scope.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_014Kqhy6c8ppVpLEjvLhJRdr)_