### PR TITLE
build: avoid `Argument list too long` in workflows

### DIFF
--- a/.github/workflows/markdown_links.yml
+++ b/.github/workflows/markdown_links.yml
@@ -119,8 +119,6 @@ jobs:
 
       # Check whether links are included in `docs/links/database.json` and use the correct identifier:
       - name: 'Check links against database'
-        env:
-          ALL_LINKS: ${{ steps.results.outputs.all_links }}
         run: |
           # Determine root directory:
           root=$(git rev-parse --show-toplevel)
@@ -128,9 +126,15 @@ jobs:
           # Define the path to a utility for validating links:
           validate="${root}/lib/node_modules/@stdlib/_tools/links/validate/bin/cli"
 
+          # Write the discovered links to a file, as the list may be too large to pass via an environment variable:
+          all_links_file="${RUNNER_TEMP}/all_links.json"
+          cat > "${all_links_file}" <<'STDLIB_ALL_LINKS_EOF'
+          ${{ steps.results.outputs.all_links }}
+          STDLIB_ALL_LINKS_EOF
+
           echo "## Link Validation" >> $GITHUB_STEP_SUMMARY
 
-          output=$(echo "$ALL_LINKS" | ${validate})
+          output=$(${validate} < "${all_links_file}")
           if [[ "${output}" != "All links are valid." ]]; then
             echo "| URL | ID | Error |" >> $GITHUB_STEP_SUMMARY
             echo "| --- | -- | ----- |" >> $GITHUB_STEP_SUMMARY
@@ -144,12 +148,13 @@ jobs:
 
       # Log the results:
       - name: 'Log results'
-        env:
-          FAILURES: ${{ steps.results.outputs.failures }}
-          WARNINGS: ${{ steps.results.outputs.warnings }}
         run: |
-          echo "$FAILURES" >> "${{ env.LOG_FILE_FAILURES }}"
-          echo "$WARNINGS" >> "${{ env.LOG_FILE_WARNINGS }}"
+          cat >> "${{ env.LOG_FILE_FAILURES }}" <<'STDLIB_FAILURES_EOF'
+          ${{ steps.results.outputs.failures }}
+          STDLIB_FAILURES_EOF
+          cat >> "${{ env.LOG_FILE_WARNINGS }}" <<'STDLIB_WARNINGS_EOF'
+          ${{ steps.results.outputs.warnings }}
+          STDLIB_WARNINGS_EOF
         timeout-minutes: 2
 
       # Fail the workflow if the status is not "success":
@@ -172,10 +177,15 @@ jobs:
         if: failure() && contains(steps.check-status.outcome, 'failure')
         env:
           GITHUB_TOKEN: ${{ secrets.STDLIB_BOT_PAT_REPO_WRITE }}
-          FAILURES: ${{ steps.results.outputs.failures }}
         run: |
+          # Write the failures list to a file, as it may be too large to pass via an environment variable or command-line argument:
+          failures_file="${RUNNER_TEMP}/failures.json"
+          cat > "${failures_file}" <<'STDLIB_FAILURES_EOF'
+          ${{ steps.results.outputs.failures }}
+          STDLIB_FAILURES_EOF
+
           "$GITHUB_WORKSPACE/.github/workflows/scripts/markdown_links/create_broken_link_issues" \
-            "$FAILURES" \
+            "${failures_file}" \
             "9112"
         timeout-minutes: 30
 

--- a/.github/workflows/markdown_src_attributes.yml
+++ b/.github/workflows/markdown_src_attributes.yml
@@ -97,17 +97,18 @@ jobs:
 
       # Log the results:
       - name: 'Log results'
-        env:
-          FAILURES: ${{ steps.results.outputs.failures }}
-          WARNINGS: ${{ steps.results.outputs.warnings }}
         run: |
-          echo "$FAILURES" >> "${{ env.LOG_FILE_FAILURES }}"
-          echo "$WARNINGS" >> "${{ env.LOG_FILE_WARNINGS }}"
+          cat >> "${{ env.LOG_FILE_FAILURES }}" <<'STDLIB_FAILURES_EOF'
+          ${{ steps.results.outputs.failures }}
+          STDLIB_FAILURES_EOF
+          cat >> "${{ env.LOG_FILE_WARNINGS }}" <<'STDLIB_WARNINGS_EOF'
+          ${{ steps.results.outputs.warnings }}
+          STDLIB_WARNINGS_EOF
         timeout-minutes: 2
 
       # Fail the workflow if the status is not "success":
       - name: 'Check status'
-        if: ${{ steps.results.outputs.status }} != 'success'
+        if: ${{ steps.results.outputs.status != 'success' }}
         run: |
           exit 1
 

--- a/.github/workflows/scripts/markdown_links/create_broken_link_issues
+++ b/.github/workflows/scripts/markdown_links/create_broken_link_issues
@@ -18,11 +18,11 @@
 
 # Script to create sub-issues for broken Markdown links.
 #
-# Usage: create_broken_link_issues <failures-json> <parent-issue-number>
+# Usage: create_broken_link_issues <failures-json-file> <parent-issue-number>
 #
 # Arguments:
 #
-#   failures-json        JSON array of broken link failures.
+#   failures-json-file   Path to a file containing a JSON array of broken link failures.
 #   parent-issue-number  Number of the parent tracking issue.
 #
 # Environment variables:
@@ -43,7 +43,7 @@ set -e
 # VARIABLES #
 
 # Assign command line arguments to variables:
-failures_json="$1"
+failures_file="$1"
 parent_issue_number="$2"
 
 # Repository information:
@@ -252,14 +252,29 @@ create_sub_issue_relationship() {
 # Main execution sequence.
 main() {
 	# Validate inputs:
-	if [ -z "$failures_json" ]; then
-		echo "ERROR: No failures JSON provided." >&2
+	if [ -z "$failures_file" ]; then
+		echo "ERROR: No failures JSON file provided." >&2
+		exit 1
+	fi
+
+	if [ ! -f "$failures_file" ]; then
+		echo "ERROR: Failures JSON file not found: ${failures_file}" >&2
 		exit 1
 	fi
 
 	if [ -z "$parent_issue_number" ]; then
 		echo "ERROR: No parent issue number provided." >&2
 		exit 1
+	fi
+
+	# Read the failures JSON from the file:
+	local failures_json
+	failures_json=$(cat "$failures_file")
+
+	if [ -z "$failures_json" ]; then
+		echo "No broken links found." >&2
+		print_success
+		exit 0
 	fi
 
 	# Parse the failures JSON:


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes `markdown_links` and `markdown_src_attributes` scheduled workflows, which have failed on every `develop` run since 2026-07-01 with `Argument list too long`
-   replaces oversized `env:`-block payloads with quoted heredocs that write directly into the run script, avoiding the exec-time argument/environment size limit while preserving shell-injection protection
-   fixes a malformed `if:` condition in `markdown_src_attributes.yml` that made the "Check status" step always run regardless of actual status

## Related Issues

This pull request does not have any related issues.

## Questions

None.

## Other

Failing runs: [30675870949](https://github.com/stdlib-js/stdlib/actions/runs/30675870949) (`markdown_src_attributes`, step "Log results"), [30675418090](https://github.com/stdlib-js/stdlib/actions/runs/30675418090) (`markdown_links`, step "Check links against database"). Both fail with:

```
An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/stdlib/stdlib'. Argument list too long
```

Root cause: #12741 (shell-injection hardening) moved broken-link/broken-image JSON payloads, sometimes exceeding 200KB, into step-level `env:` blocks. `env:` values are placed into the process environment table when the runner `execve()`s bash for the step. Linux caps individual argv/environ strings at `MAX_ARG_STRLEN` (128KB), so any payload larger than that crashes the spawn before the step body runs.

Fix: replace each `env: VAR: ${{ steps.results.outputs.X }}` + `"$VAR"` pattern in both workflow files with `cat > file <<'DELIM' ... DELIM`, writing the payload into the script body instead of the environment or argv. The heredoc delimiter is quoted, which disables parameter and command substitution on the body — untrusted `$(...)` or backtick content is written literally, never executed, so the injection protection from #12741 is preserved through a size-safe mechanism. Four call sites changed across the two workflow files. `.github/workflows/scripts/markdown_links/create_broken_link_issues` now takes a file path as its first argument instead of an inline JSON string, since passing the payload as a literal argv element hits the same size limit.

Second fix, same file: `markdown_src_attributes.yml`'s "Check status" step had `if: ${{ steps.results.outputs.status }} != 'success'` — only the left-hand side is wrapped in `${{ }}`, so the whole expression evaluates to a non-empty literal string and is always truthy. The step therefore always ran and always failed, but this was masked by the "Log results" crash happening first. Corrected to `${{ steps.results.outputs.status != 'success' }}`, matching the form already used in `markdown_links.yml`.

Validation: YAML syntax checked for both workflow files (`yaml.safe_load`), bash syntax checked for the modified script (`bash -n`). Standalone reproduction confirmed the heredoc write produces byte-identical output to the old `echo "$VAR" >> file` approach across compact JSON, pretty-printed JSON, empty string, empty array, and trailing-newline cases, and confirmed shell metacharacters, `$()`, and backticks embedded in a payload are written literally and never executed.

Two residual items for maintainer attention, neither blocking:

-   a payload line exactly matching the heredoc delimiter would truncate it early; not reachable today since the upstream `stdlib-js/check-markdown-link-definitions-action` always emits single-line JSON. That action is referenced via `@main` rather than a pinned SHA — pre-existing, not introduced here, but worth a separate look
-   `create_broken_link_issues` now treats a genuinely empty failures file as "no broken links" (exit 0) instead of erroring; unreachable in the old code since the upstream action always emits at least `[ ]` for zero failures

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was produced by an automated CI-maintenance routine. Root cause was identified via multi-agent investigation of the failing workflow runs, and the fix was independently validated by three separate reviewer agents (correctness, regression scope, style/conventions) before commit. A maintainer should still review before merging.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEWgcHZtKjhW2UNY8zPRTf)_