### PR TITLE
docs: improve doctests for complex number instances

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ccis/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/docs/types/index.d.ts
@@ -30,37 +30,21 @@ import { Complex128 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var z = new Complex128( 0.0, 0.0 );
 * // returns <Complex128>
 *
 * var out = ccis( z );
-* // returns <Complex128>
-*
-* var re = real( out );
-* // returns 1.0
-*
-* var im = imag( out );
-* // returns 0.0
+* // returns <Complex128>[ 1.0, 0.0 ]
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var z = new Complex128( 1.0, 0.0 );
 * // returns <Complex128>
 *
 * var out = ccis( z );
-* // returns <Complex128>
-*
-* var re = real( out );
-* // returns ~0.540
-*
-* var im = imag( out );
-* // returns ~0.841
+* // returns <Complex128>[ ~0.540, ~0.841 ]
 */
 declare function ccis( z: Complex128 ): Complex128;
 

--- a/lib/node_modules/@stdlib/math/base/special/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/docs/types/index.d.ts
@@ -2602,37 +2602,21 @@ interface Namespace {
 	*
 	* @example
 	* var Complex128 = require( '@stdlib/complex/float64/ctor' );
-	* var real = require( '@stdlib/complex/float64/real' );
-	* var imag = require( '@stdlib/complex/float64/imag' );
 	*
 	* var z = new Complex128( 0.0, 0.0 );
 	* // returns <Complex128>
 	*
 	* var out = ns.ccis( z );
-	* // returns <Complex128>
-	*
-	* var re = real( out );
-	* // returns 1.0
-	*
-	* var im = imag( out );
-	* // returns 0.0
+	* // returns <Complex128>[ 1.0, 0.0 ]
 	*
 	* @example
 	* var Complex128 = require( '@stdlib/complex/float64/ctor' );
-	* var real = require( '@stdlib/complex/float64/real' );
-	* var imag = require( '@stdlib/complex/float64/imag' );
 	*
 	* var z = new Complex128( 1.0, 0.0 );
 	* // returns <Complex128>
 	*
 	* var out = ns.ccis( z );
-	* // returns <Complex128>
-	*
-	* var re = real( out );
-	* // returns ~0.540
-	*
-	* var im = imag( out );
-	* // returns ~0.841
+	* // returns <Complex128>[ ~0.540, ~0.841 ]
 	*/
 	ccis: typeof ccis;
 


### PR DESCRIPTION

Resolves a part of #8641.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates the documentation examples in the `math/base/special` namespace to use the new compact complex instance doctest notation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8641.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

n/a

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
