### PR TITLE
test: migrate `math/base/special/sech` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sech/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/sech/test/test.js
@@ -24,8 +24,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var sech = require( './../lib' );
 
 
@@ -46,8 +45,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the hyperbolic secant', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -60,9 +57,7 @@ tape( 'the function computes the hyperbolic secant', function test( t ) {
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -70,8 +65,6 @@ tape( 'the function computes the hyperbolic secant', function test( t ) {
 
 tape( 'the function computes the hyperbolic secant (tiny values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -84,9 +77,7 @@ tape( 'the function computes the hyperbolic secant (tiny values)', function test
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -94,8 +85,6 @@ tape( 'the function computes the hyperbolic secant (tiny values)', function test
 
 tape( 'the function computes the hyperbolic secant (large values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -108,9 +97,7 @@ tape( 'the function computes the hyperbolic secant (large values)', function tes
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/sech/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sech/test/test.native.js
@@ -25,8 +25,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -55,8 +54,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the hyperbolic secant', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -69,9 +66,7 @@ tape( 'the function computes the hyperbolic secant', opts, function test( t ) {
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -79,8 +74,6 @@ tape( 'the function computes the hyperbolic secant', opts, function test( t ) {
 
 tape( 'the function computes the hyperbolic secant (tiny values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -93,9 +86,7 @@ tape( 'the function computes the hyperbolic secant (tiny values)', opts, functio
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -103,8 +94,6 @@ tape( 'the function computes the hyperbolic secant (tiny values)', opts, functio
 
 tape( 'the function computes the hyperbolic secant (large values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -117,9 +106,7 @@ tape( 'the function computes the hyperbolic secant (large values)', opts, functi
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description
> What is the purpose of this pull request?

This pull request:

Migrates the unit tests for `math/base/special/sech` (`test.js` and `test.native.js`) from relative tolerance testing to ULP difference testing using `@stdlib/assert/is-almost-same-value`.

## Related Issues
> Does this pull request have any related issues?

This pull request has the following related issues:

- #11352

## Questions
> Any questions for reviewers of this pull request?

No.

## Other
> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Implementation Note on ULP Tolerances:**
When evaluating the 3 test loops against their corresponding Julia test fixtures (`data`, `tiny`, and `large`), the minimum required ULP tolerances were determined as follows per Instruction #4 of RFC #11352 ("Make sure that you put the minimum required ULP value possible"):

Across all three test suites, the maximum ULP difference between the computed float64 values and reference fixtures was measured as: `data`: 2, `tiny`: 1, `large`: 2.
Therefore, all test loops were set to these precise baseline tolerances (2, 1, and 2 respectively).

## Checklist
> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance
> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Disclosure
> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
