### PR TITLE
bench: update benchmarks to use decimal literals

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn2/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn2/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn2/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn2/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn2/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumpw/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dasumpw/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/benchmark.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/benchmark.native.js
@@ -52,7 +52,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/benchmark.ndarray.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusum/benchmark/benchmark.ndarray.native.js
@@ -52,7 +52,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn/benchmark/benchmark.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn/benchmark/benchmark.native.js
@@ -52,7 +52,7 @@ var opts = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn/benchmark/benchmark.ndarray.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn/benchmark/benchmark.ndarray.native.js
@@ -52,7 +52,7 @@ var opts = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn2/benchmark/benchmark.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn2/benchmark/benchmark.native.js
@@ -52,7 +52,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn2/benchmark/benchmark.ndarray.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn2/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumkbn2/benchmark/benchmark.ndarray.native.js
@@ -52,7 +52,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumors/benchmark/benchmark.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumors/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumors/benchmark/benchmark.native.js
@@ -52,7 +52,7 @@ var opts = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumors/benchmark/benchmark.ndarray.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumors/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumors/benchmark/benchmark.ndarray.native.js
@@ -52,7 +52,7 @@ var opts = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumpw/benchmark/benchmark.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumpw/benchmark/benchmark.native.js
@@ -52,7 +52,7 @@ var opts = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumpw/benchmark/benchmark.ndarray.js
@@ -47,7 +47,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumpw/benchmark/benchmark.ndarray.native.js
@@ -52,7 +52,7 @@ var opts = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-equal/benchmark/benchmark.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-equal/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-equal/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-equal/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-equal/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-equal/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-equal/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/benchmark/benchmark.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-nan/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/benchmark/benchmark.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill-not-equal/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/dreplicate/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dreplicate/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dreplicate/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dreplicate/benchmark/benchmark.native.js
@@ -53,7 +53,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dreplicate/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dreplicate/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dreplicate/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dreplicate/benchmark/benchmark.ndarray.native.js
@@ -53,7 +53,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dssumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumors/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dssumors/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumors/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dssumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumors/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dssumors/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumors/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dssumpw/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsum/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsum/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsum/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsum/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var	x = uniform( len, -100, 100, options );
+	var	x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumkbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumkbn2/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumkbn2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumkbn2/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumkbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumkbn2/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumkbn2/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumkbn2/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumors/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumors/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumors/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumors/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumors/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumors/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumpw/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dsumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumpw/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/benchmark.native.js
@@ -53,7 +53,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dvander/benchmark/benchmark.ndarray.native.js
@@ -53,7 +53,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwapx/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwapx/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwapx/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwapx/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwapx/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwapx/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwapx/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwapx/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwax/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwax/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwax/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwax/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwax/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwax/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwax/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxmy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxmy/benchmark/benchmark.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxmy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxmy/benchmark/benchmark.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxmy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxmy/benchmark/benchmark.ndarray.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxmy/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxmy/benchmark/benchmark.ndarray.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxpy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxpy/benchmark/benchmark.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxpy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxpy/benchmark/benchmark.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxpy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxpy/benchmark/benchmark.ndarray.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxpy/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxpy/benchmark/benchmark.ndarray.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxsa/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxsa/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxsa/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxsa/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxsa/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxsa/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxsa/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxsa/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxsy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxsy/benchmark/benchmark.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxsy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxsy/benchmark/benchmark.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxsy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxsy/benchmark/benchmark.ndarray.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/dwxsy/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dwxsy/benchmark/benchmark.ndarray.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapx/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapx/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapx/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapx/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsum/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsum/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsumkbn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsumkbn/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsumkbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsumkbn2/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsumkbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsumkbn2/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsumors/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsumors/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gapxsumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gapxsumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gasumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gasumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gasumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gasumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gaxpb/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gaxpb/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gaxpb/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gaxpb/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gaxpby/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gaxpby/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gaxpby/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gaxpby/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusum/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusum/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = new Float64Array( len );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn2/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumkbn2/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumors/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumors/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumpw/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gcusumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gcusumpw/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gfill-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfill-equal/benchmark/benchmark.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/gfill-equal/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfill-equal/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/gfill-nan/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfill-nan/benchmark/benchmark.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/gfill-nan/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfill-nan/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/gfill-not-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfill-not-equal/benchmark/benchmark.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/gfill-not-equal/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfill-not-equal/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/gfill/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfill/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gfill/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gfill/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gone-to/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gone-to/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gone-to/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gone-to/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/greplicate/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/greplicate/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/greplicate/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/greplicate/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsum/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsum/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumkbn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumkbn/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsumkbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumkbn2/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsumkbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumkbn2/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumors/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumors/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gsumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gunitspace/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gunitspace/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gunitspace/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gunitspace/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gvander/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gvander/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gvander/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gvander/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwapx/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwapx/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwapx/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwapx/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwax/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwax/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwax/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwaxpb/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwaxpb/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwaxpb/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwaxpb/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwhere/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwhere/benchmark/benchmark.js
@@ -50,8 +50,8 @@ var options = {
 function createBenchmark( len ) {
 	var condition = bernoulli( len, 0.5, options );
 	var out = zeros( len, options.dtype );
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwhere/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwhere/benchmark/benchmark.ndarray.js
@@ -50,8 +50,8 @@ var options = {
 function createBenchmark( len ) {
 	var condition = bernoulli( len, 0.5, options );
 	var out = zeros( len, options.dtype );
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxmy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxmy/benchmark/benchmark.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxmy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxmy/benchmark/benchmark.ndarray.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxpy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxpy/benchmark/benchmark.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxpy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxpy/benchmark/benchmark.ndarray.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsa/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsa/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsy/benchmark/benchmark.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gwxsy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gwxsy/benchmark/benchmark.ndarray.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxdy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxdy/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, 1, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, 1.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxdy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxdy/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, 1, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, 1.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxmy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxmy/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxmy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxmy/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxpy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxpy/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxpy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxpy/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxsa/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxsa/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxsa/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxsa/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxsy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxsy/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gxsy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gxsy/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gzero-to/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gzero-to/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/gzero-to/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gzero-to/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapx/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapx/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapx/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapx/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapx/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapx/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapx/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapx/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsum/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsum/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsum/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsum/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn2/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn2/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn2/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn2/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumkbn2/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumors/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumors/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumors/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumors/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumors/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumors/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumpw/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sapxsumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sapxsumpw/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sasumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sasumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sasumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sasumpw/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sasumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sasumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sasumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sasumpw/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusum/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusum/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusum/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusum/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumkbn/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumkbn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumkbn/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumkbn/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumkbn/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumkbn/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumkbn2/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumors/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumors/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumors/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumors/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumors/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumors/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumpw/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumpw/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumpw/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/scusumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/scusumpw/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
 
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/sdsapxsum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdsapxsum/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdsapxsum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdsapxsum/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdsapxsum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdsapxsum/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdsapxsum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdsapxsum/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdsapxsumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdsapxsumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdsapxsumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdsapxsumpw/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdsapxsumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdsapxsumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdsapxsumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdsapxsumpw/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdssum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdssum/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdssum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdssum/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdssum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdssum/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdssum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdssum/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdssumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdssumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdssumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdssumpw/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdssumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdssumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sdssumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdssumpw/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-equal/benchmark/benchmark.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-equal/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-equal/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-equal/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-equal/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-equal/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-equal/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/benchmark/benchmark.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-nan/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = NaN;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/benchmark/benchmark.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sfill-not-equal/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ function createBenchmark( len ) {
 	var x;
 	var i;
 
-	x = uniform( len, -100, 100, options );
+	x = uniform( len, -100.0, 100.0, options );
 	for ( i = 0; i < x.length; i += 3 ) {
 		x[ i ] = 0.0;
 	}

--- a/lib/node_modules/@stdlib/blas/ext/base/sreplicate/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sreplicate/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sreplicate/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sreplicate/benchmark/benchmark.native.js
@@ -53,7 +53,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sreplicate/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sreplicate/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sreplicate/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sreplicate/benchmark/benchmark.ndarray.native.js
@@ -53,7 +53,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * 2, options.dtype );
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/srev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/srev/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/srev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/srev/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/srev/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/srev/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/srev/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/srev/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssum/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssum/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssum/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssum/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumkbn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumkbn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumkbn/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumkbn/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumkbn/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumkbn/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumkbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumkbn2/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumkbn2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumkbn2/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumkbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumkbn2/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumkbn2/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumkbn2/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumors/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumors/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumors/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumors/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumors/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumors/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/benchmark.native.js
@@ -53,7 +53,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/svander/benchmark/benchmark.ndarray.native.js
@@ -53,7 +53,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var out = zeros( len * len, options.dtype );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swapx/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swapx/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swapx/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swapx/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swapx/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swapx/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swapx/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swapx/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swax/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swax/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swax/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swax/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swax/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swax/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swax/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxmy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxmy/benchmark/benchmark.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxmy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxmy/benchmark/benchmark.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxmy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxmy/benchmark/benchmark.ndarray.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxmy/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxmy/benchmark/benchmark.ndarray.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxpy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxpy/benchmark/benchmark.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxpy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxpy/benchmark/benchmark.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxpy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxpy/benchmark/benchmark.ndarray.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxpy/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxpy/benchmark/benchmark.ndarray.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxsa/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxsa/benchmark/benchmark.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxsa/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxsa/benchmark/benchmark.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxsa/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxsa/benchmark/benchmark.ndarray.js
@@ -46,8 +46,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxsa/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxsa/benchmark/benchmark.ndarray.native.js
@@ -51,8 +51,8 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxsy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxsy/benchmark/benchmark.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxsy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxsy/benchmark/benchmark.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxsy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxsy/benchmark/benchmark.ndarray.js
@@ -46,9 +46,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/swxsy/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/swxsy/benchmark/benchmark.ndarray.native.js
@@ -51,9 +51,9 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
-	var y = uniform( len, -100, 100, options );
-	var w = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	var w = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sxsa/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sxsa/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sxsa/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sxsa/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sxsa/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sxsa/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/sxsa/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sxsa/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -100, 100, options );
+	var x = uniform( len, -100.0, 100.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/benchmark.js
@@ -50,8 +50,8 @@ bench( pkg, function benchmark( b ) {
 	};
 
 	len = 100;
-	x = uniform( len, -50, 50, opts );
-	y = uniform( len, -50, 50, opts );
+	x = uniform( len, -50.0, 50.0, opts );
+	y = uniform( len, -50.0, 50.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -81,8 +81,8 @@ bench( format( '%s::built-in', pkg ), opts, function benchmark( b ) {
 	};
 
 	len = 100;
-	x = uniform( len, -50, 50, opts );
-	y = uniform( len, -50, 50, opts );
+	x = uniform( len, -50.0, 50.0, opts );
+	y = uniform( len, -50.0, 50.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/benchmark.native.js
@@ -52,8 +52,8 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	};
 
 	len = 100;
-	x = uniform( len, -50, 50, opts );
-	y = uniform( len, -50, 50, opts );
+	x = uniform( len, -50.0, 50.0, opts );
+	y = uniform( len, -50.0, 50.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/array/max-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/max-by/benchmark/benchmark.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/max/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/max/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/maxabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/maxabs/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/mean/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/meankbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/meankbn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/meankbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/meankbn2/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/meanors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/meanors/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/meanpn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/meanpn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/meanpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/meanpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/meanwd/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/meanwd/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/midrange-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/midrange-by/benchmark/benchmark.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/midrange/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/midrange/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/min-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/min-by/benchmark/benchmark.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/min/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/min/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/minabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/minabs/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/mskmax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/mskmax/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var mask = bernoulli( len, 0.2, options );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/mskmaxabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/mskmaxabs/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var mask = bernoulli( len, 0.2, options );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/mskmidrange/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/mskmidrange/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var mask = bernoulli( len, 0.2, options );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/mskmin/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/mskmin/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var mask = bernoulli( len, 0.2, options );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/mskminabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/mskminabs/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var mask = bernoulli( len, 0.2, options );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/mskrange/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/mskrange/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 */
 function createBenchmark( len ) {
 	var mask = bernoulli( len, 0.2, options );
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/range-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/range-by/benchmark/benchmark.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/range/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/range/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/rangeabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/rangeabs/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/stdev/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/stdevch/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/stdevch/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/stdevpn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/stdevpn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/stdevtk/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/stdevtk/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/stdevwd/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/stdevwd/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/stdevyc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/stdevyc/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/variance/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/variancech/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/variancech/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/variancepn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/variancepn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/variancetk/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/variancetk/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/variancewd/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/variancewd/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/array/varianceyc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/array/varianceyc/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/base/cumax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/cumax/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/stats/base/cumax/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cumax/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/stats/base/cumaxabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/cumaxabs/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/stats/base/cumaxabs/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cumaxabs/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/stats/base/cumin/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/cumin/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/stats/base/cumin/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cumin/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.ndarray.js
@@ -48,7 +48,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	var y = zeros( len, options.dtype );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/stats/strided/max-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/max-by/benchmark/benchmark.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/max-by/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/max-by/benchmark/benchmark.ndarray.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/max/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/max/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/max/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/max/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/maxabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/maxabs/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/maxabs/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/maxabs/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/mean/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/mean/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/mean/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meankbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/meankbn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meankbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/meankbn/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meankbn2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/meankbn2/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meankbn2/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/meankbn2/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meanors/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/meanors/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meanors/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/meanors/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meanpn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/meanpn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meanpw/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/meanpw/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meanpw/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/meanpw/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meanwd/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/meanwd/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/meanwd/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/meanwd/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/midrange-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/midrange-by/benchmark/benchmark.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/midrange-by/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/midrange-by/benchmark/benchmark.ndarray.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/midrange/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/midrange/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/midrange/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/midrange/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/midrangeabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/midrangeabs/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/midrangeabs/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/midrangeabs/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/min-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/min-by/benchmark/benchmark.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/min-by/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/min-by/benchmark/benchmark.ndarray.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/min/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/min/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/min/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/min/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/minabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/minabs/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/minabs/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/minabs/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/nanmidrange-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/nanmidrange-by/benchmark/benchmark.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/nanmidrange-by/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/nanmidrange-by/benchmark/benchmark.ndarray.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/range-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/range-by/benchmark/benchmark.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/range-by/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/range-by/benchmark/benchmark.ndarray.js
@@ -57,7 +57,7 @@ function accessor( value ) {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/range/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/range/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/range/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/range/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/rangeabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/rangeabs/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/rangeabs/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/rangeabs/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdev/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdev/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdev/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevch/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevch/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevch/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevch/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevpn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevpn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevpn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevpn/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevtk/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevtk/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevtk/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevtk/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevwd/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevwd/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevwd/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevwd/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevyc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevyc/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/stdevyc/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/stdevyc/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svariance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/svariance/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svariance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/svariance/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svariance/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/svariance/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svariance/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/svariance/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svariancewd/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/svariancewd/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svariancewd/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/svariancewd/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svariancewd/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/svariancewd/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svariancewd/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/svariancewd/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svarianceyc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/svarianceyc/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svarianceyc/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/svarianceyc/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svarianceyc/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/svarianceyc/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/svarianceyc/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/svarianceyc/benchmark/benchmark.ndarray.native.js
@@ -51,7 +51,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/variance/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variance/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/variance/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variancech/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/variancech/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variancech/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/variancech/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variancepn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/variancepn/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variancepn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/variancepn/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variancetk/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/variancetk/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variancetk/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/variancetk/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variancewd/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/strided/variancewd/benchmark/benchmark.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/stats/strided/variancewd/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/variancewd/benchmark/benchmark.ndarray.js
@@ -46,7 +46,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = uniform( len, -10, 10, options );
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	/**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

- updates benchmarks across `blas/ext/base`, `stats/array`, `stats/strided`, `stats/base`, and `math/base` to use decimal literals when generating random decimal values via `@stdlib/random/array/uniform` (e.g., `uniform( len, -100, 100, options )` => `uniform( len, -100.0, 100.0, options )`). Decimal values out, decimal values in.

This follows up on review feedback in https://github.com/stdlib-js/stdlib/pull/13845#discussion. Only benchmark files requiring the continuous `@stdlib/random/array/uniform` generator were updated; `discreteUniform` usage (integer values out, integer values in) was intentionally left unchanged.

## Related Issues

> Does this pull request have any related issues?

https://github.com/stdlib-js/metr-issue-tracker/issues/1098

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The change was applied mechanically and verified: all 453 updated files bind `uniform` to `@stdlib/random/array/uniform`, the diff contains only `uniform( len, ... )` range-argument literal changes, and no examples, tests, or source files were modified.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used Claude Code to scan for affected files and apply the mechanical literal updates.

* * *

@stdlib-js/reviewers