### PR TITLE
build: use blobless full clone to prevent incorrect markdown equation updates

### DIFF
--- a/.github/workflows/markdown_equations.yml
+++ b/.github/workflows/markdown_equations.yml
@@ -59,8 +59,11 @@ jobs:
           # Specify whether to remove untracked files before checking out the repository:
           clean: true
 
-          # Limit clone depth to the most recent 100 commits:
-          fetch-depth: 100
+          # Fetch full history to find when SVGs were last modified:
+          fetch-depth: 0
+
+          # Use a blobless clone to speed up the checkout:
+          filter: blob:none
 
           # Specify whether to download Git-LFS files:
           lfs: false


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: na
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves the problem described here https://github.com/stdlib-js/stdlib/pull/13606#pullrequestreview-4753871162.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes the problem of updating the SHA anytime a README having an equation gets updated. 
Currently, the workflow uses fetch-depth: 100. When the remark-img-equations-src-urls plugin runs, it uses `git rev-list -1 HEAD <path-to-svg>` to find the exact commit where an SVG was last modified, and use it to generate a CDN URL pinned to that specific commit.
However, if an equation SVG hasn't been modified in the last 100 commits (e.g. it was created a year ago), git rev-list in a shallow clone hits its depth boundary and just returns the oldest available commit in the shallow history (I could not find it very well documented, but it does happen when I try to reproduce it).
<img width="2162" height="204" alt="image" src="https://github.com/user-attachments/assets/49068cb2-ffd4-42e3-991f-c9f1677d053b" />
<img width="2794" height="918" alt="image" src="https://github.com/user-attachments/assets/1a7942cb-7be8-483d-b960-53d641310001" />
<img width="1978" height="114" alt="image" src="https://github.com/user-attachments/assets/8af032cd-0524-434b-b0ed-b4c9160f085a" />
It's 101 because of my recent commit.

This PR updates the actions/checkout step to use a Blobless Full Clone:
`fetch-depth: 0`: Fetches the entire commit history so that git rev-list can trace all the way back to the true original commit of the SVG file. This allows the plugin to see that the SVG's SHA matches the URL already in the README.md, resulting in zero file changes.
`filter: blob:none`: Prevents Git from downloading the historical file contents (blobs). It only downloads the commit and tree metadata. This fixes the problem that occurred with shallow clone while remaining relatively fast.

Also here, there is some amount of comparison between partial clones v/s shallow clones : https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
and how some commit history related commands work with shallow clones:
> Since the commit history is truncated, commands such as git merge-base or git log show different results than they would in a full clone! In general, you cannot count on them to work as expected. Recall that these commands work as expectedly in partial clones. Even in blobless clones, commands like git blame -- <path> will work correctly, if only a little slower than in full clones. Shallow clones don’t even make that a possibility


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
