### PR TITLE
bench: update benchmarks to use decimal literals

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/csum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/csum/benchmark/benchmark.js
@@ -49,7 +49,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex64Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex64Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/csum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/csum/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex64Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex64Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/csum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/csum/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex64Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex64Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/csum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/csum/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex64Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex64Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/csumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/csumkbn/benchmark/benchmark.js
@@ -49,7 +49,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex64Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex64Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/csumkbn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/csumkbn/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex64Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex64Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/csumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/csumkbn/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex64Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex64Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/csumkbn/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/csumkbn/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex64Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex64Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/ddiff/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ddiff/benchmark/benchmark.js
@@ -64,9 +64,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = new Float64Array( N+N1+N2-1 );
 	o = new Float64Array( ol );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/ddiff/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ddiff/benchmark/benchmark.native.js
@@ -69,9 +69,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = new Float64Array( N+N1+N2-1 );
 	o = new Float64Array( ol );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/ddiff/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ddiff/benchmark/benchmark.ndarray.js
@@ -64,9 +64,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = new Float64Array( N+N1+N2-1 );
 	o = new Float64Array( ol );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/ddiff/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ddiff/benchmark/benchmark.ndarray.native.js
@@ -69,9 +69,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = new Float64Array( N+N1+N2-1 );
 	o = new Float64Array( ol );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/benchmark/benchmark.js
@@ -61,9 +61,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = new Float64Array( ol );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/benchmark/benchmark.native.js
@@ -66,9 +66,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = new Float64Array( ol );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/benchmark/benchmark.ndarray.js
@@ -61,9 +61,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = new Float64Array( ol );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dediff/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dediff/benchmark/benchmark.ndarray.native.js
@@ -66,9 +66,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = new Float64Array( ol );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/gdiff/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gdiff/benchmark/benchmark.js
@@ -64,9 +64,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = zeros( N+N1+N2-1, options.dtype );
 	o = zeros( ol, options.dtype );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/gdiff/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gdiff/benchmark/benchmark.ndarray.js
@@ -64,9 +64,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = zeros( N+N1+N2-1, options.dtype );
 	o = zeros( ol, options.dtype );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/gediff/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gediff/benchmark/benchmark.js
@@ -61,9 +61,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = zeros( ol, options.dtype );
 
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/gediff/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/gediff/benchmark/benchmark.ndarray.js
@@ -61,9 +61,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = zeros( ol, options.dtype );
 
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/sdiff/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdiff/benchmark/benchmark.js
@@ -64,9 +64,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = new Float32Array( N+N1+N2-1 );
 	o = new Float32Array( ol );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/sdiff/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdiff/benchmark/benchmark.native.js
@@ -69,9 +69,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = new Float32Array( N+N1+N2-1 );
 	o = new Float32Array( ol );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/sdiff/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdiff/benchmark/benchmark.ndarray.js
@@ -64,9 +64,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = new Float32Array( N+N1+N2-1 );
 	o = new Float32Array( ol );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/sdiff/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sdiff/benchmark/benchmark.ndarray.native.js
@@ -69,9 +69,9 @@ function createBenchmark( len ) {
 	k = 1;
 	ol = N + N1 + N2 - k;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	w = new Float32Array( N+N1+N2-1 );
 	o = new Float32Array( ol );
 	return benchmark;

--- a/lib/node_modules/@stdlib/blas/ext/base/sediff/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sediff/benchmark/benchmark.js
@@ -61,9 +61,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = new Float32Array( ol );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/sediff/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sediff/benchmark/benchmark.native.js
@@ -66,9 +66,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = new Float32Array( ol );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/sediff/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sediff/benchmark/benchmark.ndarray.js
@@ -61,9 +61,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = new Float32Array( ol );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/sediff/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/sediff/benchmark/benchmark.ndarray.native.js
@@ -66,9 +66,9 @@ function createBenchmark( len ) {
 	N2 = 1;
 	ol = N + N1 + N2 - 1;
 
-	x = uniform( N, -100, 100, options );
-	p = uniform( N1, -100, 100, options );
-	a = uniform( N2, -100, 100, options );
+	x = uniform( N, -100.0, 100.0, options );
+	p = uniform( N1, -100.0, 100.0, options );
+	a = uniform( N2, -100.0, 100.0, options );
 	o = new Float32Array( ol );
 	return benchmark;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/zsum/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zsum/benchmark/benchmark.js
@@ -49,7 +49,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex128Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex128Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/zsum/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zsum/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex128Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex128Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/zsum/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zsum/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex128Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex128Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/zsum/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zsum/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex128Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex128Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/zsumkbn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zsumkbn/benchmark/benchmark.js
@@ -49,7 +49,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex128Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex128Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/zsumkbn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zsumkbn/benchmark/benchmark.native.js
@@ -54,7 +54,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex128Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex128Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/zsumkbn/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zsumkbn/benchmark/benchmark.ndarray.js
@@ -49,7 +49,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex128Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex128Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/blas/ext/base/zsumkbn/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zsumkbn/benchmark/benchmark.ndarray.native.js
@@ -54,7 +54,7 @@ var options = {
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x = new Complex128Array( uniform( len*2, -100, 100, options ) );
+	var x = new Complex128Array( uniform( len*2, -100.0, 100.0, options ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/lapack/base/disnan/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/disnan/benchmark/benchmark.js
@@ -36,7 +36,7 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = uniform( len, -50, 50 );
+	x = uniform( len, -50.0, 50.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/lapack/base/dlaisnan/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/dlaisnan/benchmark/benchmark.js
@@ -37,8 +37,8 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = uniform( len, -50, 50 );
-	y = uniform( len, -50, 50 );
+	x = uniform( len, -50.0, 50.0 );
+	y = uniform( len, -50.0, 50.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/lapack/base/dlapy2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/dlapy2/benchmark/benchmark.js
@@ -37,8 +37,8 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = uniform( len, -50, 50 );
-	y = uniform( len, -50, 50 );
+	x = uniform( len, -50.0, 50.0 );
+	y = uniform( len, -50.0, 50.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/lapack/base/dlapy3/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/dlapy3/benchmark/benchmark.js
@@ -38,9 +38,9 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = uniform( len, -50, 50 );
-	y = uniform( len, -50, 50 );
-	z = uniform( len, -50, 50 );
+	x = uniform( len, -50.0, 50.0 );
+	y = uniform( len, -50.0, 50.0 );
+	z = uniform( len, -50.0, 50.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/hypot/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypot/benchmark/benchmark.js
@@ -45,8 +45,8 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = uniform( len, -50, 50 );
-	y = uniform( len, -50, 50 );
+	x = uniform( len, -50.0, 50.0 );
+	y = uniform( len, -50.0, 50.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -71,8 +71,8 @@ bench( format( '%s::built-in', pkg ), opts, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = uniform( len, -50, 50 );
-	y = uniform( len, -50, 50 );
+	x = uniform( len, -50.0, 50.0 );
+	y = uniform( len, -50.0, 50.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/hypot/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypot/benchmark/benchmark.native.js
@@ -47,8 +47,8 @@ bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = uniform( len, -50, 50 );
-	y = uniform( len, -50, 50 );
+	x = uniform( len, -50.0, 50.0 );
+	y = uniform( len, -50.0, 50.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-08-01T13:55:59-07:00 (`5b3b59d5e`) and 2026-08-02T03:50:29-07:00 (`ca056bafc`) to sibling packages.

Fixes benchmark call sites in `blas/ext/base/{sdiff,sediff,ddiff,dediff,gdiff,gediff,csum,csumkbn,zsum,zsumkbn}`, `lapack/base/{disnan,dlaisnan,dlapy2,dlapy3}`, and `math/base/special/hypot` that 22fe7a64a missed: floating-point bounds passed to `uniform` from `@stdlib/random/array/uniform` now use decimal literals (e.g., `-100` → `-100.0`, `100` → `100.0`), matching project convention. `hypotf` already received this treatment in the original commit; `hypot` did not. Same transformation, 42 files, 90 call sites, no other changes.

Source commit: 22fe7a64a ("bench: update benchmarks to use decimal literals", #13849). Target packages:

-   `blas/ext/base/csum`
-   `blas/ext/base/csumkbn`
-   `blas/ext/base/ddiff`
-   `blas/ext/base/dediff`
-   `blas/ext/base/gdiff`
-   `blas/ext/base/gediff`
-   `blas/ext/base/sdiff`
-   `blas/ext/base/sediff`
-   `blas/ext/base/zsum`
-   `blas/ext/base/zsumkbn`
-   `lapack/base/disnan`
-   `lapack/base/dlaisnan`
-   `lapack/base/dlapy2`
-   `lapack/base/dlapy3`
-   `math/base/special/hypot`

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed:

-   Pattern search scoped to `benchmark/*.js` files repo-wide, anchored to calls of `uniform` from `@stdlib/random/array/uniform` with integer literal bounds; `discreteUniform` call sites (where integer literals are intentional) excluded by anchoring.
-   Two independent validation passes confirmed the defect at all 42 files (correct import, floating-point dtype consumers, no intentional integer semantics, no autogenerated files).
-   An adaptation pass confirmed the source transformation applies verbatim (no per-site tailoring) and found no cascade risk: no README, example, or test files embed the changed lines.
-   A style-consistency pass confirmed the patched lines match surrounding conventions (tab indentation, paren spacing, decimal-literal form identical to the source commit).
-   Deliberately excluded: doctest modernization for complex number instances (tracked in a Good First Issue with one-package-per-PR guidance), ULP-based test migrations (require per-package test authoring), and single-site workflow fixes.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated fix-propagation routine: candidate sites were located by pattern search and each site was verified by independent validation passes before the mechanical transformation was applied.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01SG3DpFXMZe3ceVZ7cQeLT6)_