### PR TITLE
build(workflows): don't fail `process_metadata` on non-YAML comments

### DIFF
--- a/.github/workflows/process_metadata.yml
+++ b/.github/workflows/process_metadata.yml
@@ -92,11 +92,14 @@ jobs:
         # Pin action to full length commit SHA
         uses: stdlib-js/metadata-action@3ccf68f24c51ae23470319e8e5619d539df8212b # v3.0.0
 
+        # Continue with subsequent steps even when this step fails (e.g., due to a non-YAML comment body) in order to "pass" the job and not trigger failure e-mails/notifications:
+        continue-on-error: true
+
       # Check the metadata for directives to send tweets:
       - name: 'Send tweets'
 
-        # Only run this step if a user has write access:
-        if: steps.assert-write-access.outcome == 'success'
+        # Only run this step if a user has write access and metadata was successfully extracted:
+        if: steps.assert-write-access.outcome == 'success' && steps.extract-metadata.outcome == 'success'
 
         # Pin action to full length commit SHA
         uses: stdlib-js/metadata-tweet-action@8e9b688c86150797c1c7f60bc8f7c9a9a30e10fe # v2.0.0
@@ -111,8 +114,8 @@ jobs:
       - name: 'Check metadata for workflow dispatch directives'
         id: check-workflow-dispatch
 
-        # Only run this step if a user has write access:
-        if: steps.assert-write-access.outcome == 'success'
+        # Only run this step if a user has write access and metadata was successfully extracted:
+        if: steps.assert-write-access.outcome == 'success' && steps.extract-metadata.outcome == 'success'
 
         env:
           METADATA: ${{ steps.extract-metadata.outputs.metadata }}


### PR DESCRIPTION
Resolves .

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes the `process_metadata` GitHub Actions workflow to no longer fail when the external `stdlib-js/metadata-action` step throws on a non-YAML comment body.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/30747267016 (also 30747264440, 30747262422 — same signature, same commit, 2026-08-02 12:10:17-12:10:24 UTC).

**Symptom:** The `Extract metadata` step crashes with `YAMLException: end of the stream or a document separator is expected`, failing the job.

**Root cause:** `stdlib-js/metadata-action` tries to parse the triggering issue/PR comment body as YAML. Any comment that isn't YAML-shaped (e.g., an ordinary markdown/prose bot comment) throws an uncaught exception. We don't control that action's source, so the fix lives entirely in our own workflow YAML.

**Fix:** Adds `continue-on-error: true` to `Extract metadata`, mirroring the identical pattern already used on `assert-write-access` in the same file (same rationale: don't fail the job/spam failure e-mails over an expected, benign case). Gates the two downstream steps that consume `steps.extract-metadata.outputs.metadata` (`Send tweets`, `Check metadata for workflow dispatch directives`) on `steps.extract-metadata.outcome == 'success'` so they no longer execute against an empty/unset value. `Dispatch workflow with inputs` needs no change — it's already transitively gated on `check-workflow-dispatch`'s output.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation:** YAML syntax validated (`yaml.safe_load`). Reviewed by three independent passes:
-   Correctness (opus): approve. Confirmed the fix uses step `outcome` (not `conclusion`) in the new gates, which is the detail that determines whether the fix actually works; traced the empty-`METADATA` path through `jq` and confirmed it exits cleanly.
-   Regression scope (opus): approve. Confirmed the happy path (~90% of runs) is a strict no-op, searched `.github/workflows/` for any workflow depending on this job's pass/fail via `workflow_run`/`needs` (none found), confirmed the diff touches only the intended 3 lines.
-   Style/conventions (sonnet): approve. Confirmed comment wording, indentation, and quoting match the file's existing `assert-write-access` precedent exactly.

**Reviewer notes:** Two independent, non-blocking observations from reviewers A and B: `continue-on-error` is unconditional, so it also applies to the `push`-triggered runs of this workflow (which parse commit-message metadata, not comment bodies) — a genuinely malformed metadata block in a commit message would now silently no-op instead of failing loudly, an observability trade-off. Also, the step now conflates "expected non-YAML comment" with "a real regression in `metadata-action`" — both go green. Left as-is to keep this fix minimal and targeted at the actually-observed failure mode; a maintainer may want a follow-up `::warning` step or scoping `continue-on-error` to `issue_comment` only if either trade-off matters.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by an automated CI-fix routine running Claude Code. The routine identified the failure cluster from live GitHub Actions job logs, traced the root cause to the external `metadata-action`'s lack of YAML-parse error handling, applied the minimal in-repo workflow fix, and validated it via three independent automated review passes (correctness, regression scope, style) before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPH9AML3yi7AJuK7mwXCm4)_