### PR TITLE
feat: add `string/base/truncate-code-point`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/README.md
@@ -1,0 +1,104 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# truncate
+
+> Truncate a string to a specified length in code points.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var truncate = require( '@stdlib/string/base/truncate-code-point' );
+```
+
+#### truncate( str, len, ending )
+
+Truncates a string to a specified length in code points.
+
+```javascript
+var out = truncate( 'beep boop', 7, '...' );
+// returns 'beep...'
+
+out = truncate( 'beep boop', 5, '>>>' );
+// returns 'be>>>'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   This function assumes that the input arguments are valid. For input validation, use the top-level [`@stdlib/string/truncate`][@stdlib/string/truncate].
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var truncate = require( '@stdlib/string/base/truncate-code-point' );
+
+console.log( truncate( 'beep boop', 7, '...' ) );
+// => 'beep...'
+
+console.log( truncate( 'beep boop', 5, '>>>' ) );
+// => 'be>>>'
+
+console.log( truncate( '🐺 Wolf Brothers 🐺', 7, '...' ) );
+// => '🐺 Wo...'
+
+console.log( truncate( '🐶🐮🐷🐰🐸', 2, '...' ) );
+// => '..'
+
+console.log( truncate( '🐶🐮🐷🐰🐸', 10, '...' ) );
+// => '🐶🐮🐷🐰🐸'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/string/truncate]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/truncate
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/benchmark/benchmark.js
@@ -1,0 +1,57 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var pkg = require( './../package.json' ).name;
+var truncate = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var strings;
+	var out;
+	var i;
+
+	strings = [
+		'beep boop',
+		'foo bar',
+		'hello world',
+		'🐺 Wolf Brothers 🐺',
+		'🐶🐮🐷🐰🐸'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = truncate( strings[ i % strings.length ], (randu() * 10)|0, '...' );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( typeof out !== 'string' ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/docs/repl.txt
@@ -1,0 +1,32 @@
+{{alias}}( str, len, ending )
+    Truncates a string to a specified length in code points (i.e.,
+    user-perceived characters).
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    len: NonNegativeInteger
+        Output string length (including ending).
+
+    ending: string
+        Custom ending.
+
+    Returns
+    -------
+    out: string
+        Output string.
+
+    Examples
+    --------
+    > var out = {{alias}}( 'beep boop', 7, '...' )
+    'beep...'
+    > out = {{alias}}( 'beep boop', 5, '>>>' )
+    'be>>>'
+    > out = {{alias}}( 'foo bar', 10, '...' )
+    'foo bar'
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/docs/types/index.d.ts
@@ -1,0 +1,42 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Truncates a string to a specified length in code points.
+*
+* @param str - input string
+* @param len - output string length
+* @param ending - custom ending
+* @returns truncated string
+*
+* @example
+* var out = truncate( 'beep boop', 7, '...' );
+* // returns 'beep...'
+*
+* @example
+* var out = truncate( 'beep boop', 5, '>>>' );
+* // returns 'be>>>'
+*/
+declare function truncate( str: string, len: number, ending: string ): string;
+
+
+// EXPORTS //
+
+export = truncate;

--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/docs/types/test.ts
@@ -1,0 +1,71 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import truncate = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	truncate( 'beep boop', 5, '...' ); // $ExpectType string
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string...
+{
+	truncate( 5, 5, '...' ); // $ExpectError
+	truncate( false, 5, '...' ); // $ExpectError
+	truncate( true, 5, '...' ); // $ExpectError
+	truncate( null, 5, '...' ); // $ExpectError
+	truncate( undefined, 5, '...' ); // $ExpectError
+	truncate( [], 5, '...' ); // $ExpectError
+	truncate( {}, 5, '...' ); // $ExpectError
+	truncate( ( x: number ): number => x, 5, '...' ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a number...
+{
+	truncate( 'beep boop', '5', '...' ); // $ExpectError
+	truncate( 'beep boop', false, '...' ); // $ExpectError
+	truncate( 'beep boop', true, '...' ); // $ExpectError
+	truncate( 'beep boop', null, '...' ); // $ExpectError
+	truncate( 'beep boop', undefined, '...' ); // $ExpectError
+	truncate( 'beep boop', [], '...' ); // $ExpectError
+	truncate( 'beep boop', {}, '...' ); // $ExpectError
+	truncate( 'beep boop', ( x: number ): number => x, '...' ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a string...
+{
+	truncate( 'beep boop', 5, 5 ); // $ExpectError
+	truncate( 'beep boop', 5, false ); // $ExpectError
+	truncate( 'beep boop', 5, true ); // $ExpectError
+	truncate( 'beep boop', 5, null ); // $ExpectError
+	truncate( 'beep boop', 5, undefined ); // $ExpectError
+	truncate( 'beep boop', 5, [] ); // $ExpectError
+	truncate( 'beep boop', 5, {} ); // $ExpectError
+	truncate( 'beep boop', 5, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	truncate(); // $ExpectError
+	truncate( 'beep boop' ); // $ExpectError
+	truncate( 'beep boop', 5 ); // $ExpectError
+	truncate( 'beep boop', 5, '...', 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var truncate = require( './../lib' );
+
+console.log( truncate( 'beep boop', 7, '...' ) );
+// => 'beep...'
+
+console.log( truncate( 'beep boop', 5, '>>>' ) );
+// => 'be>>>'
+
+console.log( truncate( '🐺 Wolf Brothers 🐺', 7, '...' ) );
+// => '🐺 Wo...'
+
+console.log( truncate( '🐶🐮🐷🐰🐸', 2, '...' ) );
+// => '..'
+
+console.log( truncate( '🐶🐮🐷🐰🐸', 10, '...' ) );
+// => '🐶🐮🐷🐰🐸'

--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Truncate a string to a specified length in code points.
+*
+* @module @stdlib/string/base/truncate-code-point
+*
+* @example
+* var truncate = require( '@stdlib/string/base/truncate-code-point' );
+*
+* var str = truncate( 'beep boop', 7, '...' );
+* // returns 'beep...'
+*
+* str = truncate( 'beep boop', 5, '>>>' );
+* // returns 'be>>>'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/lib/main.js
@@ -1,0 +1,99 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var numCodePoints = require( '@stdlib/string/num-code-points' );
+var nextCodePointIndex = require( '@stdlib/string/next-code-point-index' );
+
+
+// MAIN //
+
+/**
+* Truncates a string to a specified length in code points.
+*
+* @param {string} str - input string
+* @param {NonNegativeInteger} len - output string length (including ending)
+* @param {string} ending - custom ending
+* @returns {string} truncated string
+*
+* @example
+* var out = truncate( 'beep boop', 7, '...' );
+* // returns 'beep...'
+*
+* @example
+* var out = truncate( 'beep boop', 5, '>>>' );
+* // returns 'be>>>'
+*
+* @example
+* var out = truncate( 'beep boop', 10, '...' );
+* // returns 'beep boop'
+*
+* @example
+* var out = truncate( 'beep boop', 0, '...' );
+* // returns ''
+*
+* @example
+* var out = truncate( 'beep boop', 2, '...' );
+* // returns '..'
+*
+* @example
+* var out = truncate( '🐺 Wolf Brothers 🐺', 7, '...' );
+* // returns '🐺 Wo...'
+*/
+function truncate( str, len, ending ) {
+	var endingLength;
+	var nVisual;
+	var idx;
+
+	endingLength = numCodePoints( ending );
+	if ( len >= numCodePoints( str ) ) {
+		return str;
+	}
+	if ( len - endingLength <= 0 ) {
+		idx = 0;
+		nVisual = 0;
+		while ( nVisual < len ) {
+			idx = nextCodePointIndex( ending, idx );
+			if ( idx === -1 ) {
+				idx = ending.length;
+				break;
+			}
+			nVisual += 1;
+		}
+		return ending.substring( 0, idx );
+	}
+	idx = 0;
+	nVisual = 0;
+	while ( nVisual < len - endingLength ) {
+		idx = nextCodePointIndex( str, idx );
+		if ( idx === -1 ) {
+			idx = str.length;
+			break;
+		}
+		nVisual += 1;
+	}
+	return str.substring( 0, idx ) + ending;
+}
+
+
+// EXPORTS //
+
+module.exports = truncate;

--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/package.json
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/string/base/truncate-code-point",
+  "version": "0.0.0",
+  "description": "Truncate a string to a specified length in code points.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {
+    "@stdlib/string/next-code-point-index": "^0.2.1",
+    "@stdlib/string/num-code-points": "^0.2.1"
+  },
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "truncate",
+    "trunc",
+    "shorten",
+    "short",
+    "code",
+    "point"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-code-point/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-code-point/test/test.js
@@ -1,0 +1,143 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var truncate = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof truncate, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified ' +
+	'length', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'be...';
+	actual = truncate( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 10;
+	expected = 'beep boop';
+	actual = truncate( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 0;
+	expected = '';
+	actual = truncate( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 1;
+	expected = '.';
+	actual = truncate( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 3;
+	expected = '...';
+	actual = truncate( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 9;
+	expected = 'beep boop';
+	actual = truncate( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = '🐺 Wolf Brothers 🐺';
+	len = 6;
+	expected = '🐺 W...';
+	actual = truncate( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = '🐶🐮🐷🐰🐸';
+	len = 2;
+	expected = '..';
+	actual = truncate( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = '🐶🐮🐷🐰🐸';
+	len = 10;
+	expected = '🐶🐮🐷🐰🐸';
+	actual = truncate( str, len, '...' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length (custom ' +
+	'ending)', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'beep|';
+	actual = truncate( str, len, '|' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 10;
+	expected = 'beep boop';
+	actual = truncate( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 3;
+	expected = 'be!';
+	actual = truncate( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'beep😃';
+	actual = truncate( str, len, '😃' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop foo bar';
+	len = 10;
+	expected = 'beep 🙃 🙃 🙃';
+	actual = truncate( str, len, ' 🙃 🙃 🙃' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = '🐺 Wolf Brothers 🐺';
+	len = 8;
+	expected = '🐺 Wolf 🐺';
+	actual = truncate( str, len, '🐺' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Progresses #1062

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds `@stdlib/string/base/truncate-code-point`, a new base package that truncates strings to a specified length in code points.
-   Provides a foundational utility necessary for refactoring the top-level `@stdlib/string/truncate` package.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #1062

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This is the second of several PRs to address the `string/truncate` refactor. The implementation utilizes `@stdlib/string/num-code-points` and `@stdlib/string/next-code-point-index`. It strictly checks for `-1` indices when at the end of the code point iteration to avoid negative `slice` offsets. 

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I utilized an AI coding assistant to help scaffold the boilerplate, test cases, and benchmark structure for this package. The core truncation implementation and edge case handling were verified manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
