### PR TITLE
test: migrate `stats/base/dists/chisquare/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/cdf/test/test.cdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var cdf = require( './../lib' );
 
 
@@ -103,8 +102,6 @@ tape( 'if provided a `k` equal to `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the cdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -115,13 +112,7 @@ tape( 'the function evaluates the cdf for `x` given degrees of freedom `k`', fun
 	k = decimalDecimal.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 76 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/cdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -129,9 +128,7 @@ tape( 'if `k` equals `0`, the created function evaluates a degenerate distributi
 
 tape( 'the created function evaluates the cdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -143,13 +140,7 @@ tape( 'the created function evaluates the cdf for `x` given degrees of freedom `
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( k[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 76 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/cdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 
 
 // FIXTURES //
@@ -92,8 +91,6 @@ tape( 'if provided a negative `k`, the function returns `NaN`', opts, function t
 
 tape( 'the function evaluates the cdf for `x` given `k`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -104,13 +101,7 @@ tape( 'the function evaluates the cdf for `x` given `k`', opts, function test( t
 	k = decimalDecimal.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 40.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 76 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

Migrates the `stats/base/dists/chisquare/cdf` test suite from the old computed-tolerance idiom (`delta`/`tol` derived from `EPS`) to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.

Converted files:
- `test/test.cdf.js`
- `test/test.factory.js`
- `test/test.native.js`

`test/test.js` was left untouched (it only contains the exports smoke test; no tolerance comparisons).

## ULP bound

All three files share the same fixture set (`test/fixtures/julia/decimal_decimal.json`) and the same underlying computation, so a single ULP constant was used across all of them:

- **`isAlmostSameValue( y, expected[i], 76 )`**

The bound of `76` was found by computing the exact ULP difference between actual and expected values across the full fixture (5015 cases) using `@stdlib/number/float64/base/ulp-difference`; the maximum observed difference was `76` ULPs. The full test suite was run twice at this bound to confirm deterministic results (no FMA/arch flakiness).

## Verification

- `test/test.cdf.js`: 5015/5015 passing (run twice)
- `test/test.factory.js`: 5015/5015 passing (run twice)
- `test/test.js`: 3/3 passing
- `test/test.native.js`: no native binding available in this environment, so the (skip-gated) tests did not execute; the conversion mirrors the JS test files exactly.
- Only test files were changed; `package.json` did not need updates since `@stdlib/assert/is-almost-same-value` resolves via the existing monorepo module resolution (no explicit `devDependencies` entries are used elsewhere in this package either).
- `eslint` could not be run to completion in this sandboxed session due to an unrelated dependency-resolution issue in the reconstructed lint toolchain (reproduces identically on an already-merged, unmodified test file, so it is an environment/tooling issue, not something introduced by this diff). The diff was manually checked against the exact conventions used in prior merged conversions (e.g. #13828, #13857, #13847) — require ordering, removal of now-unused `abs`/`EPS`/`delta`/`tol`, and the `t.strictEqual( isAlmostSameValue( actual, expected, N ), true, 'returns expected value' )` shape.

Ref: #11352


---
_Generated by [Claude Code](https://claude.ai/code/session_01HGxMTnuL9mP1QcXXngVUo8)_