### PR TITLE
chore: fix C lint errors

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-contiguous/include/stdlib/ndarray/base/assert/is_contiguous.h
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-contiguous/include/stdlib/ndarray/base/assert/is_contiguous.h
@@ -32,7 +32,7 @@ extern "C" {
 /**
 * Determines if an array is contiguous.
 */
-int8_t stdlib_ndarray_is_contiguous( enum STDLIB_NDARRAY_DTYPE dtype, int64_t ndims, int64_t *shape, int64_t *strides, int64_t offset );
+int8_t stdlib_ndarray_is_contiguous( enum STDLIB_NDARRAY_DTYPE dtype, int64_t ndims, const int64_t *shape, const int64_t *strides, int64_t offset );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-contiguous/src/main.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-contiguous/src/main.c
@@ -48,7 +48,7 @@
 * int8_t b = stdlib_ndarray_is_contiguous( STDLIB_NDARRAY_UINT8, ndims, shape, strides, offset );
 * // returns 1
 */
-int8_t stdlib_ndarray_is_contiguous( enum STDLIB_NDARRAY_DTYPE dtype, int64_t ndims, int64_t *shape, int64_t *strides, int64_t offset ) {
+int8_t stdlib_ndarray_is_contiguous( enum STDLIB_NDARRAY_DTYPE dtype, int64_t ndims, const int64_t *shape, const int64_t *strides, int64_t offset ) {
 	if (
 		stdlib_ndarray_iteration_order( ndims, strides ) != 0 &&
 		stdlib_ndarray_is_single_segment_compatible( dtype, ndims, shape, strides, offset ) != 0


### PR DESCRIPTION
Resolves #13417.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds `const` qualifiers to the `shape` and `strides` pointer parameters in `stdlib_ndarray_is_contiguous` since they are not modified within the function, resolving `constParameterPointer` lint warnings reported by cppcheck.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #13417 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No


* * *

@stdlib-js/reviewers

