### PR TITLE
test: migrate `math/base/special/sec` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sec/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/sec/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var sec = require( './../lib' );
@@ -57,8 +56,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the secant (huge negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -71,9 +68,7 @@ tape( 'the function computes the secant (huge negative values)', function test( 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -81,8 +76,6 @@ tape( 'the function computes the secant (huge negative values)', function test( 
 
 tape( 'the function computes the secant (huge positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,9 +88,7 @@ tape( 'the function computes the secant (huge positive values)', function test( 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -105,8 +96,6 @@ tape( 'the function computes the secant (huge positive values)', function test( 
 
 tape( 'the function computes the secant (very large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -119,9 +108,7 @@ tape( 'the function computes the secant (very large positive values)', function 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -129,8 +116,6 @@ tape( 'the function computes the secant (very large positive values)', function 
 
 tape( 'the function computes the secant (very large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -143,9 +128,7 @@ tape( 'the function computes the secant (very large negative values)', function 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -153,8 +136,6 @@ tape( 'the function computes the secant (very large negative values)', function 
 
 tape( 'the function computes the secant (large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -167,9 +148,7 @@ tape( 'the function computes the secant (large positive values)', function test(
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -177,8 +156,6 @@ tape( 'the function computes the secant (large positive values)', function test(
 
 tape( 'the function computes the secant (large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -191,9 +168,7 @@ tape( 'the function computes the secant (large negative values)', function test(
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -201,8 +176,6 @@ tape( 'the function computes the secant (large negative values)', function test(
 
 tape( 'the function computes the secant (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -215,9 +188,7 @@ tape( 'the function computes the secant (medium positive values)', function test
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -225,8 +196,6 @@ tape( 'the function computes the secant (medium positive values)', function test
 
 tape( 'the function computes the secant (medium negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -239,9 +208,7 @@ tape( 'the function computes the secant (medium negative values)', function test
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -249,8 +216,6 @@ tape( 'the function computes the secant (medium negative values)', function test
 
 tape( 'the function computes the secant (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -263,9 +228,7 @@ tape( 'the function computes the secant (small positive values)', function test(
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -273,8 +236,6 @@ tape( 'the function computes the secant (small positive values)', function test(
 
 tape( 'the function computes the secant (small negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -287,9 +248,7 @@ tape( 'the function computes the secant (small negative values)', function test(
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -297,8 +256,6 @@ tape( 'the function computes the secant (small negative values)', function test(
 
 tape( 'the function computes the secant (smaller values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -311,9 +268,7 @@ tape( 'the function computes the secant (smaller values)', function test( t ) {
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -321,8 +276,6 @@ tape( 'the function computes the secant (smaller values)', function test( t ) {
 
 tape( 'the function computes the secant (tiny positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -335,9 +288,7 @@ tape( 'the function computes the secant (tiny positive values)', function test( 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -345,8 +296,6 @@ tape( 'the function computes the secant (tiny positive values)', function test( 
 
 tape( 'the function computes the secant (tiny negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -359,9 +308,7 @@ tape( 'the function computes the secant (tiny negative values)', function test( 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/sec/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sec/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -66,8 +65,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the secant (huge negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -80,9 +77,7 @@ tape( 'the function computes the secant (huge negative values)', opts, function 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -90,8 +85,6 @@ tape( 'the function computes the secant (huge negative values)', opts, function 
 
 tape( 'the function computes the secant (huge positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -104,9 +97,7 @@ tape( 'the function computes the secant (huge positive values)', opts, function 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -114,8 +105,6 @@ tape( 'the function computes the secant (huge positive values)', opts, function 
 
 tape( 'the function computes the secant (very large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -128,9 +117,7 @@ tape( 'the function computes the secant (very large positive values)', opts, fun
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -138,8 +125,6 @@ tape( 'the function computes the secant (very large positive values)', opts, fun
 
 tape( 'the function computes the secant (very large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -152,9 +137,7 @@ tape( 'the function computes the secant (very large negative values)', opts, fun
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs(y - expected[ i ]);
-			tol = 1.4 * EPS * abs(expected[ i ]);
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -162,8 +145,6 @@ tape( 'the function computes the secant (very large negative values)', opts, fun
 
 tape( 'the function computes the secant (large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -176,9 +157,7 @@ tape( 'the function computes the secant (large positive values)', opts, function
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -186,8 +165,6 @@ tape( 'the function computes the secant (large positive values)', opts, function
 
 tape( 'the function computes the secant (large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -200,9 +177,7 @@ tape( 'the function computes the secant (large negative values)', opts, function
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -210,8 +185,6 @@ tape( 'the function computes the secant (large negative values)', opts, function
 
 tape( 'the function computes the secant (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -224,9 +197,7 @@ tape( 'the function computes the secant (medium positive values)', opts, functio
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -234,8 +205,6 @@ tape( 'the function computes the secant (medium positive values)', opts, functio
 
 tape( 'the function computes the secant (medium negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -248,9 +217,7 @@ tape( 'the function computes the secant (medium negative values)', opts, functio
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -258,8 +225,6 @@ tape( 'the function computes the secant (medium negative values)', opts, functio
 
 tape( 'the function computes the secant (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -272,9 +237,7 @@ tape( 'the function computes the secant (small positive values)', opts, function
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -282,8 +245,6 @@ tape( 'the function computes the secant (small positive values)', opts, function
 
 tape( 'the function computes the secant (small negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -296,9 +257,7 @@ tape( 'the function computes the secant (small negative values)', opts, function
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -306,8 +265,6 @@ tape( 'the function computes the secant (small negative values)', opts, function
 
 tape( 'the function computes the secant (smaller values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -320,9 +277,7 @@ tape( 'the function computes the secant (smaller values)', opts, function test( 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -330,8 +285,6 @@ tape( 'the function computes the secant (smaller values)', opts, function test( 
 
 tape( 'the function computes the secant (tiny positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -344,9 +297,7 @@ tape( 'the function computes the secant (tiny positive values)', opts, function 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -354,8 +305,6 @@ tape( 'the function computes the secant (tiny positive values)', opts, function 
 
 tape( 'the function computes the secant (tiny negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -368,9 +317,7 @@ tape( 'the function computes the secant (tiny negative values)', opts, function 
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ] );
 		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests in `math/base/special/sec` to use ULP-based testing via `isAlmostSameValue`, replacing the old relative tolerance checks. The ULP bound has been tightly calibrated to the minimum required value.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
