### PR TITLE
test: migrate `math/base/special/secd` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/secd/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/secd/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var secd = require( './../lib' );
 
@@ -44,8 +43,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the secant of an angle measured in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -58,9 +55,7 @@ tape( 'the function computes the secant of an angle measured in degrees (negativ
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -68,8 +63,6 @@ tape( 'the function computes the secant of an angle measured in degrees (negativ
 
 tape( 'the function computes the secant of an angle measured in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -82,9 +75,7 @@ tape( 'the function computes the secant of an angle measured in degrees (positiv
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/secd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/secd/test/test.native.js
@@ -22,9 +22,8 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -53,8 +52,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the secant of an angle measured in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -67,9 +64,7 @@ tape( 'the function computes the secant of an angle measured in degrees (negativ
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -77,8 +72,6 @@ tape( 'the function computes the secant of an angle measured in degrees (negativ
 
 tape( 'the function computes the secant of an angle measured in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -91,9 +84,7 @@ tape( 'the function computes the secant of an angle measured in degrees (positiv
 		if ( y === expected[ i ] ) {
 			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
 		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests in `math/base/special/secd` to use ULP-based testing via `isAlmostSameValue`, replacing the old relative tolerance checks. The ULP bound has been tightly calibrated to the minimum required value.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
