### PR TITLE
test: migrate `math/base/special/floorn` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/floorn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/floorn/test/test.js
@@ -24,14 +24,13 @@ var tape = require( 'tape' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var floorn = require( './../lib' );
 
 
@@ -207,8 +206,6 @@ tape( 'if `n > 308` and `x >= 0`, the function returns `+0` (sign preserving)', 
 
 tape( 'the function supports rounding very small numbers (including subnormals)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;
@@ -242,13 +239,7 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = floorn( x, n[i] );
-		if ( v === expected[i] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
-		} else {
-			delta = abs( v - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/floorn/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/floorn/test/test.native.js
@@ -25,14 +25,13 @@ var tape = require( 'tape' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -198,8 +197,6 @@ tape( 'if `n > 308` and `x >= 0`, the function returns `+0` (sign preserving)', 
 
 tape( 'the function supports rounding very small numbers (including subnormals)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;
@@ -233,13 +230,7 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = floorn( x, n[i] );
-		if ( v === expected[i] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
-		} else {
-			delta = abs( v - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `math/base/special/floorn` from relative tolerance testing (a computed `EPS`-based `delta`/`tol` comparison) to ULP difference testing using `@stdlib/assert/is-almost-same-value`, per the pattern described in #11352.
-   applies the same change to both `test/test.js` and `test/test.native.js`, which contained an identical tolerance block in the "supports rounding very small numbers (including subnormals)" test case.
-   determines the minimum required ULP tolerance agentically: starting from a generous bound (64 ULPs) and lowering it until the full fixture set no longer passed, then confirming the tightest passing value is deterministic (no FMA/architecture flakiness) by re-running the suite. The minimum required ULP difference is **1**.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verified locally:
-   `node_modules/.bin/tape test/test.js` → 450/450 passing, run twice to confirm determinism at ULP=1.
-   `node_modules/.bin/eslint test/test.js test/test.native.js` → clean.
-   `test/test.native.js` test cases are skipped locally (no compiled native addon available in this environment), but the tolerance block was identical in source and was updated identically to `test.js`.
-   Only the two test files changed; no `package.json` update was needed since `@stdlib/assert/is-almost-same-value` is an internal stdlib package.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was written primarily by Claude Code (an AI coding assistant), converting the existing relative-tolerance test case to ULP-based assertions following the established pattern from previously merged conversions in this tracking issue (e.g. `math/base/special/roundn`, `math/base/special/csc`). The minimum ULP bound was determined empirically by running the actual test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y29Yw9EFavQSxJygi88gWS)_