### PR TITLE
docs: prevent write-after-end crash in `repl/presentation` example

### DIFF
--- a/lib/node_modules/@stdlib/repl/presentation/examples/index.js
+++ b/lib/node_modules/@stdlib/repl/presentation/examples/index.js
@@ -22,7 +22,11 @@ var join = require( 'path' ).join;
 var REPL = require( '@stdlib/repl' );
 var Presentation = require( './../lib' ); // eslint-disable-line stdlib/no-redeclare
 
+var timer;
+
 function onExit() {
+	// Cancel any pending slide timeout:
+	clearTimeout( timer );
 	console.log( '' );
 	console.log( 'REPL closed.' );
 }
@@ -46,7 +50,7 @@ var len = pres.length;
 pres.show();
 
 // Automate the slide show:
-setTimeout( next, 2000 );
+timer = setTimeout( next, 2000 );
 
 function next() {
 	// If we are finished with the slide show, close the REPL...
@@ -54,5 +58,5 @@ function next() {
 		return repl.close();
 	}
 	pres.next().show();
-	setTimeout( next, 2000 );
+	timer = setTimeout( next, 2000 );
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a crash in the `@stdlib/repl/presentation` example (`examples/index.js`) that was failing the nightly `random_examples` CI workflow.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/30775007749 (workflow `random_examples`, step "Run JavaScript examples", develop HEAD `15f2e10394448024fff2a039f952c7bfce36dee4`).

**Symptom:** `Error: write after end` thrown from `Presentation.show` (`lib/main.js:1199`), called from the example's `next()` timeout callback, crashing the process with exit code 2.

**Root cause:** The example drives an automated slide show via a recursive `setTimeout( next, 2000 )` chain. In CI, stdin is non-interactive and hits EOF almost immediately, so the REPL emits `exit` well before the slide show would naturally finish. The already-scheduled `next()` timeout still fires ~2s later and calls `pres.next().show()`, which writes to the REPL's output stream after it has already ended.

**Fix:** Track the pending timeout in a `timer` variable and `clearTimeout( timer )` in the `exit` handler, so no further slide writes are attempted once the REPL has closed, whether by reaching the last slide or by early stdin EOF. Single-file change, 6 insertions / 2 deletions, no behavior change on the normal completion path.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation:
-   `node --check` passes on the modified file.
-   Reviewed independently by three agents (correctness, regression scope, style/conventions); all three approved. Regression-scope review confirmed `repl/presentation` has no `test/` directory and this example file is not referenced elsewhere in the repo. Style review confirmed the fix matches this file's existing variable-declaration idiom and flagged (non-blocking) that the added comment could be terser, which was trimmed before this PR.
-   Could not run the full `make test-javascript`/`make lint-javascript-files` suite in this environment (no `node_modules` installed / no network access for `npm install`); relied on manual review plus the three-agent validation above.

Commit type: this change is confined entirely to an `examples/index.js` file, which `docs/style-guides/git/README.md` classifies as documentation-only (`docs:`), even though the underlying motivation is a crash fix.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was investigated, written, and validated by an automated Claude Code CI-triage routine, in response to a nightly CI failure. Root cause was identified by tracing the job logs and REPL/Presentation source; the fix was reviewed by three independent Claude Code review passes (correctness, regression scope, style) before being opened here.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbnYv6Xs1uztD8KvP8NBas)_