### PR TITLE
build: disambiguate path in `changelog/parse-commits` `git log`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/changelog/parse-commits/scripts/commits.sh
+++ b/lib/node_modules/@stdlib/_tools/changelog/parse-commits/scripts/commits.sh
@@ -38,4 +38,4 @@ if [ -z "$GIT_COMMIT_SEP" ]; then
 	GIT_COMMIT_SEP="^---^"; # Default separator
 fi
 
-git log "${@:2}" --name-only --no-merges --notes --pretty=format:"%H|%ad|%aN <%aE>|%B|%N|" "$1" | awk -v sep="$GIT_COMMIT_SEP" '/^$/{p=1;next} /^[0-9a-f]{40}\|/{if (p==1) print sep; p=0} {print}';
+git log "${@:2}" --name-only --no-merges --notes --pretty=format:"%H|%ad|%aN <%aE>|%B|%N|" -- "$1" | awk -v sep="$GIT_COMMIT_SEP" '/^$/{p=1;next} /^[0-9a-f]{40}\|/{if (p==1) print sep; p=0} {print}';


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a `git log` pathspec-disambiguation bug in `@stdlib/_tools/changelog/parse-commits` that crashed the `standalone_push_changes` CI workflow.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/30804159359 (workflow `standalone_push_changes`, job "Push changes", develop commit `b7a8f64e`).

**Symptom:**
```
Publishing 19 `stdlib` packages...
Starting by processing the following package: ml/base/sgd-classification/learning-rate-enum2str
Error: invalid argument. Unable to parse commits for package: `ml/base/sgd-classification/learning-rate-enum2str`.
    at generate (.../changelog/generate/lib/main.js:313:9)
```
An uncaught throw with no surrounding `try`/`catch`, so the entire Node.js process exited and all 19 packages in the batch failed to publish, not just the one package.

**Root cause:** `ml/base/sgd-classification/learning-rate-enum2str` was created and then deleted from the monorepo in an earlier commit. `lib/node_modules/@stdlib/_tools/changelog/parse-commits/scripts/commits.sh` runs `git log ... "$dir"` without a `--` pathspec separator. When `$dir` no longer exists in the working tree, `git log` fails hard (`fatal: ambiguous argument ... unknown revision or path not in the working tree`) instead of returning the directory's commit history. The Node.js wrapper (`commits.js`) discards stderr and never checks the exit code, so this silently returns zero commits, which then throws `Unable to parse commits for package` uncaught.

**Fix:** Add `--` before the path argument in the `git log` invocation, so it is always treated as a pathspec, never as a revision. One-line change, single file.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation:**
-   Reproduced the exact failure and fix against the real repository history: `git log` without `--` against the deleted package directory fails with the documented "ambiguous argument" error (exit 128, empty stdout); with `--` it correctly returns the package's 2 historical commits.
-   Confirmed byte-identical output with vs. without `--` for existing package directories, including the root `lib/node_modules/@stdlib` changelog case, and for the "unresolvable directory" test case (`dir: 'beepboop'` in `parse-commits/test/test.js`), which still returns an empty array.
-   Could not run the full `tape` test suite in this environment (no `node_modules` installed / no network for `npm install`); relied on direct `git`/`bash` reproduction of both the failing and fixed behavior, plus three independent reviewer passes (correctness, regression scope, style/conventions) — all three approved.

**Reviewer notes:**
-   This fix resolves the specific documented crash, but does not guarantee the entire 19-package batch survives if a genuinely deleted package is included: `publish_packages.js` still has no `try`/`catch` around `generateChangelog()`, and downstream steps (e.g. `rsync` from a non-existent source directory) could still fail for a deleted package. A maintainer may want a follow-up to either skip already-deleted packages earlier in the pipeline, or harden `publish()` with a try/catch per package so one failure doesn't abort the whole batch. Left out of this PR to keep the fix minimal and scoped to the one root cause.
-   `commits.js` also silently swallows the spawned script's exit code (masking failures like this one). Fixing that more foundational gap is a separate, larger change and was intentionally left out of scope here.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was investigated, written, and validated by an automated Claude Code CI-triage routine, in response to a nightly CI failure. Root cause was identified and independently reproduced against the actual repository history; the fix was reviewed by three independent Claude Code review passes (correctness, regression scope, style) before being opened here.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbnYv6Xs1uztD8KvP8NBas)_