### PR TITLE
test: migrate `math/base/special/asind` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/asind/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asind/test/test.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
@@ -46,8 +46,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the arcsine in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -57,21 +55,13 @@ tape( 'the function computes the arcsine in degrees (negative values)', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asind( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsine in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -81,13 +71,7 @@ tape( 'the function computes the arcsine in degrees (positive values)', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asind( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asind/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asind/test/test.native.js
@@ -22,9 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
@@ -55,8 +55,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the arcsine in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -66,21 +64,13 @@ tape( 'the function computes the arcsine in degrees (negative values)', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asind( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsine in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -90,13 +80,7 @@ tape( 'the function computes the arcsine in degrees (positive values)', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asind( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[ i ]+'. E: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `math/base/special/asind` from relative tolerance testing to ULP (unit in the last place) difference testing, per the tracking issue.
-   replaces the `delta`/`tol`-based tolerance checks in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' )`, using `@stdlib/assert/is-almost-same-value`.
-   removes the now-unused `abs` import from both test files (the `EPS` import is retained, as it is still used elsewhere in the tests for domain-boundary checks).
-   the ULP bound (`2`) was determined empirically: starting from a high bound (64) and lowering it until the minimum integer value that still passes over the full fixture set (6011 assertions across both the negative- and positive-value fixtures) was found. The test suite was run twice at this bound to confirm deterministic results.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, which searched the repository for a candidate package, studied several already-merged conversions in the same tracking issue to mirror the exact idiom used, and empirically determined the minimum ULP bound by running the test suite locally.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7T5SJET3Y2okwZpKzmpGm)_