### PR TITLE
docs: add asm type annotation

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/num-significand-bits/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/num-significand-bits/lib/index.js
@@ -39,7 +39,7 @@
 * @type {integer32}
 * @default 23
 */
-var FLOAT32_NUM_SIGNIFICAND_BITS = 23|0;
+var FLOAT32_NUM_SIGNIFICAND_BITS = 23|0; // asm type annotation
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

This pull request adds the `// asm type annotation` trailing comment to the `|0` coercion in `constants/float32/num-significand-bits`. It was the sole package in the namespace applying the asm.js `|0` idiom without the annotation carried by 90% (18/20) of its `|0`-idiom siblings.

### `constants/float32/num-significand-bits`

The `|0` coercion on the exported `integer32` constant lacked the `// asm type annotation` comment used across the namespace's integer constants. This aligns the single outlier with the established convention. The change is comment-only; the exported value (`23`), the `integer32` type, and the tests are unchanged.

## Related Issues

No.

## Questions

No.

## Other

The correction was surfaced by structural and semantic feature extraction across the 68-member `constants/float32` namespace, then cross-referenced against the parallel `constants/float64` namespace to separate intentional per-constant curation (e.g. `@see` and keyword differences, which mirror float64) from genuine drift. The missing annotation was the only high-signal, mechanical, non-behavioral correction to survive filtering, and it is not mirrored in float64 (which has no `num-significand-bits` package).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated cross-package drift-detection routine. The routine extracted structural and semantic features across the namespace, computed the majority convention per feature, cross-referenced the `constants/float64` sibling namespace to reject intentional deviations, and applied the single surviving one-line comment correction. The change was reviewed against sibling-package conventions before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4c2XThBy9A3uLkcBot3yp)_