### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ctriu/test/test.ctriu.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ctriu/test/test.ctriu.js
@@ -23,7 +23,7 @@
 var tape = require( 'tape' );
 var isSameComplex64Array = require( '@stdlib/assert/is-same-complex64array' );
 var Complex64Array = require( '@stdlib/array/complex64' );
-var ctriu = require( './../lib/ctriu' );
+var ctriu = require( './../lib/ctriu.js' );
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/blas/ext/base/ztriu/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ztriu/lib/main.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
-var ztriu = require( './ztriu' );
+var ztriu = require( './ztriu.js' );
 var ndarray = require( './ndarray.js' );
 
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ztriu/test/test.ztriu.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ztriu/test/test.ztriu.js
@@ -23,7 +23,7 @@
 var tape = require( 'tape' );
 var isSameComplex128Array = require( '@stdlib/assert/is-same-complex128array' );
 var Complex128Array = require( '@stdlib/array/complex128' );
-var ztriu = require( './../lib/ztriu' );
+var ztriu = require( './../lib/ztriu.js' );
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/complex/float32/base/div/README.md
+++ b/lib/node_modules/@stdlib/complex/float32/base/div/README.md
@@ -253,20 +253,6 @@ int main( void ) {
 
 <!-- /.c -->
 
-* * *
-
-<section class="references">
-
-## References
-
--   Smith, Robert L. 1962. "Algorithm 116: Complex Division." _Commun. ACM_ 5 (8). New York, NY, USA: ACM: 435. doi:[10.1145/368637.368661][@smith:1962a].
--   Stewart, G. W. 1985. "A Note on Complex Division." _ACM Trans. Math. Softw._ 11 (3). New York, NY, USA: ACM: 238–41. doi:[10.1145/214408.214414][@stewart:1985a].
--   Priest, Douglas M. 2004. "Efficient Scaling for Complex Division." _ACM Trans. Math. Softw._ 30 (4). New York, NY, USA: ACM: 389–401. doi:[10.1145/1039813.1039814][@priest:2004a].
-
-</section>
-
-<!-- /.references -->
-
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">
@@ -278,12 +264,6 @@ int main( void ) {
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
-
-[@smith:1962a]: https://doi.org/10.1145/368637.368661
-
-[@stewart:1985a]: https://doi.org/10.1145/214408.214414
-
-[@priest:2004a]: https://doi.org/10.1145/1039813.1039814
 
 </section>
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-08-03 17:46 (PT) and 2026-08-04 00:05 (PT) (`efa3ea8`…`1f6aa3d`), from an automated review of the last 24 hours of merged commits.

This pull request:

**`blas/ext/base/ztriu`**

-   Fix `.js` extension in two `require()` calls introduced by ee75563 (`blas/ext/base/ztriu`): `lib/main.js`'s `require( './ztriu' )` and `test/test.ztriu.js`'s `require( './../lib/ztriu' )`. Both violate `stdlib/require-file-extensions`; `dtriu`, `striu`, and `ctriu`'s `lib/main.js` already do this correctly.

**`blas/ext/base/ctriu`**

-   Fix `require` path in `test/test.ctriu.js`: commit ed05eba added `blas/ext/base/ctriu` but left the extensionless `require( './../lib/ctriu' )`, tripping the error-level `stdlib/require-file-extensions` rule that `lib/main.js` and the `dtriu`/`striu` siblings already honor. Change to `require( './../lib/ctriu.js' )`.

**`complex/float32/base/div`**

-   Removes the inapplicable References section from `complex/float32/base/div`'s `README.md` (Smith 1962, Stewart 1985, Priest 2004), copied from `complex/float64/base/div` in b423804. Per `lib/assign.js`/`src/main.c`, this package follows Julia's promote-to-double approach and doesn't use those scaling algorithms, so the citations don't apply.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 21 commits in the window were reviewed by two independent style-compliance passes (checked against `docs/style-guides` and established sibling packages: `dtriu`/`striu`, `mprod`/`mvariance`/`wmean` and the `nanm*` family, `complex/float64/base/div`) and two independent bug-scan passes over the diffs (loop bounds, stride/offset arithmetic, complex interleaving, accumulator delegation, namespace wiring). Every fix in this PR was re-verified against the checked-out files before committing; each fix touches only lines added in the window.

**Deliberately excluded** (require interpretation or a maintainer decision, not mechanical fixes):

-   `complex/float32/base/div` returns signed zeros whose signs differ from `complex/float64/base/div` for finite/infinite division (e.g. `(5+3i)/(Inf+1i)` yields `(+0, -0)` in float32 vs `(+0, +0)` in float64, and signed zeros instead of NaNs when both denominator components are infinite). The divergence is reproducible, but the package's own tests assert the current behavior, so this is left as a design question rather than patched here.
-   `stats/incr/nanmprod` docs say values are "calculated from all provided values" without the "(excluding `NaN` values)" qualifier that `nanmvariance`/`nanmrmse` (same batch) use — but established `nanm*` packages (`nanmsum`, `nanmmax`, `nanmmin`) use the same unqualified wording, so which wording is canonical is left to maintainers.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a scheduled automated review of commits merged to `develop` in the last 24 hours; all fixes were machine-proposed, cross-verified by independent review passes, and re-checked against the repository before committing.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNzxG7FaJDiXSfWgnYz8Eh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNzxG7FaJDiXSfWgnYz8Eh)_