### PR TITLE
docs: add asm type annotations

### DIFF
--- a/lib/node_modules/@stdlib/constants/float16/abs-mask/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/abs-mask/lib/index.js
@@ -48,7 +48,7 @@
 * @default 0x7fff
 * @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
 */
-var FLOAT16_ABS_MASK = 0x7fff>>>0;
+var FLOAT16_ABS_MASK = 0x7fff>>>0; // asm type annotation
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/constants/float16/num-exponent-bits/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/num-exponent-bits/lib/index.js
@@ -39,7 +39,7 @@
 * @type {integer16}
 * @default 5
 */
-var FLOAT16_NUM_EXPONENT_BITS = 5|0;
+var FLOAT16_NUM_EXPONENT_BITS = 5|0; // asm type annotation
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/constants/float16/num-significand-bits/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/num-significand-bits/lib/index.js
@@ -39,7 +39,7 @@
 * @type {integer16}
 * @default 10
 */
-var FLOAT16_NUM_SIGNIFICAND_BITS = 10|0;
+var FLOAT16_NUM_SIGNIFICAND_BITS = 10|0; // asm type annotation
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/constants/float16/sign-mask/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/sign-mask/lib/index.js
@@ -48,7 +48,7 @@
 * @default 0x8000
 * @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
 */
-var FLOAT16_SIGN_MASK = 0x8000>>>0;
+var FLOAT16_SIGN_MASK = 0x8000>>>0; // asm type annotation
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/constants/float32/abs-mask/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/abs-mask/lib/index.js
@@ -48,7 +48,7 @@
 * @default 0x7fffffff
 * @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
 */
-var FLOAT32_ABS_MASK = 0x7fffffff>>>0;
+var FLOAT32_ABS_MASK = 0x7fffffff>>>0; // asm type annotation
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/constants/float32/sign-mask/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sign-mask/lib/index.js
@@ -48,7 +48,7 @@
 * @default 0x80000000
 * @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
 */
-var FLOAT32_SIGN_MASK = 0x80000000>>>0;
+var FLOAT32_SIGN_MASK = 0x80000000>>>0; // asm type annotation
 
 
 // EXPORTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-08-03T17:46-07:00 and 2026-08-04T00:05-07:00 to sibling packages.

Adds the `// asm type annotation` trailing comment to the six remaining coerced-integer constants that lacked it, bringing the `constants` namespace to full coverage (77 of 77 non-`eslint-disable-line` sites). Purely mechanical: appends the existing convention established in ab689bf1 (#13905) to lines it missed on first pass; no coercion logic changes.

-   `constants/float16/abs-mask`
-   `constants/float16/num-exponent-bits`
-   `constants/float16/num-significand-bits`
-   `constants/float16/sign-mask`
-   `constants/float32/abs-mask`
-   `constants/float32/sign-mask`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation: candidate sites were enumerated by searching `lib/node_modules/@stdlib/constants/**/lib/*.js` for bare `|0`/`>>>0` coercions (92 total coercion sites: 77 annotated, 9 carrying `// eslint-disable-line id-length`, 6 bare). Each of the six sites was independently confirmed by two validation passes, an adaptation pass (verbatim applicability, ESLint `max-len`/`id-length` interaction ruled out), and a style-consistency pass against the existing 77 annotated sites. Deliberately excluded: the nine sites whose trailing-comment slot is occupied by `// eslint-disable-line id-length` (identifiers longer than 25 characters), and uncoerced plain hex-literal constants (e.g. `constants/float16/exponent-mask`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated fix-propagation routine: candidate sites were enumerated via search and validated by independent review passes before the changes were applied.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPpEJXtCEJjRk6CrC8bZv9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPpEJXtCEJjRk6CrC8bZv9)_