### PR TITLE
test: migrate `math/base/special/hypot` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/hypot/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypot/test/test.js
@@ -23,12 +23,11 @@
 var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var hypot = require( './../lib' );
 
 
@@ -122,8 +121,6 @@ tape( 'the function returns `+0` if both arguments are `+-0`', function test( t 
 
 tape( 'the function computes the hypotenuse', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var h;
 	var x;
 	var y;
@@ -135,13 +132,7 @@ tape( 'the function computes the hypotenuse', function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		h = hypot( x[ i ], y[ i ] );
-		if ( h === expected[ i ] ) {
-			t.ok( true, 'x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'.' );
-		} else {
-			delta = abs( h - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( h, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/hypot/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypot/test/test.native.js
@@ -24,12 +24,11 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -131,8 +130,6 @@ tape( 'the function returns `+0` if both arguments are `+-0`', opts, function te
 
 tape( 'the function computes the hypotenuse', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var h;
 	var x;
 	var y;
@@ -144,13 +141,7 @@ tape( 'the function computes the hypotenuse', opts, function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		h = hypot( x[ i ], y[ i ] );
-		if ( h === expected[ i ] ) {
-			t.ok( true, 'x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'.' );
-		} else {
-			delta = abs( h - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( h, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.js` and `test/test.native.js` of `math/base/special/hypot` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP value.
-   the only tolerance-based block in either file is the `'the function computes the hypotenuse'` test, which iterates over the `./fixtures/julia/data.json` fixture (2003 cases). Direct ULP-difference computation over the fixture (via `@stdlib/number/float64/base/ulp-difference`), using both the JavaScript implementation and a locally built native add-on, shows a maximum measured difference of `2` ULPs for both. `N = 1` was confirmed to fail (16 of 2003 fixture cases), so `2` is the minimum integer bound for which all cases pass.
-   the `'the function computes the hypotenuse (canonical inputs)'` block and all other test blocks in both files already use exact `t.strictEqual` comparisons on exactly-representable values and are left unchanged, per the demonstrated idiom in the tracking issue.
-   removes the now-unused `EPS` and `abs` requires and `delta`/`tol` variables.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Both the JavaScript and native (`test.native.js`, run against a locally built add-on) test suites pass in full (2031 assertions each), run twice at the final ULP bound to confirm determinism (no FMA/arch flakiness observed).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by an automated Claude Code agent running as a scheduled routine: it selected an unconverted package, studied the merged prior art for this migration (e.g. `math/base/special/hypotf`, `math/base/special/pow`, `math/base/special/acosh`), performed the ULP-difference migration, and empirically determined the minimum ULP bound by direct measurement against the fixture data (including building and testing against a native add-on), with the bound and its determinism independently re-verified before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01TZVm4J9LGntULPhd3YUZR4)_