### PR TITLE
build: replace `uniq` with `sort -u` to deduplicate directories in CI workflows

### DIFF
--- a/.github/workflows/run_affected_benchmarks.yml
+++ b/.github/workflows/run_affected_benchmarks.yml
@@ -131,7 +131,7 @@ jobs:
               files=$(git diff --diff-filter=AM --name-only ${{ github.event.before }} ${{ github.event.after }})
             fi
           fi
-          directories=$(for file in $files; do dirname $file; done | uniq | tr '\n' ' ' | sed 's/ $//')
+          directories=$(for file in $files; do dirname $file; done | sort -u | tr '\n' ' ' | sed 's/ $//')
           echo "directories=${directories}" >> $GITHUB_OUTPUT
 
       # Get list of changed directories from workflow dispatch event:

--- a/.github/workflows/run_affected_tests.yml
+++ b/.github/workflows/run_affected_tests.yml
@@ -163,7 +163,7 @@ jobs:
               files=$(git diff --diff-filter=AM --name-only ${{ github.event.before }} ${{ github.event.after }})
             fi
           fi
-          directories=$(for file in $files; do dirname $file; done | uniq | tr '\n' ' ' | sed 's/ $//')
+          directories=$(for file in $files; do dirname $file; done | sort -u | tr '\n' ' ' | sed 's/ $//')
           echo "directories=${directories}" >> $GITHUB_OUTPUT
 
       # Get list of changed directories from workflow dispatch event:

--- a/.github/workflows/run_tests_coverage.yml
+++ b/.github/workflows/run_tests_coverage.yml
@@ -134,7 +134,7 @@ jobs:
           else
             files=$(git diff --diff-filter=AM --name-only ${{ github.event.before }} ${{ github.event.after }})
           fi
-          directories=$(for file in $files; do dirname $file; done | uniq | tr '\n' ' ' | sed 's/ $//')
+          directories=$(for file in $files; do dirname $file; done | sort -u | tr '\n' ' ' | sed 's/ $//')
           echo "directories=${directories}" >> $GITHUB_OUTPUT
 
       # Get list of changed directories from workflow dispatch event:

--- a/.github/workflows/run_tests_coverage_pr.yml
+++ b/.github/workflows/run_tests_coverage_pr.yml
@@ -123,7 +123,7 @@ jobs:
           # Get changed files using git diff against base branch:
           git fetch origin ${{ github.base_ref }} --depth=1
           files=$(git diff --diff-filter=AM --name-only origin/${{ github.base_ref }}...HEAD)
-          directories=$(for file in $files; do dirname $file; done | uniq | tr '\n' ' ' | sed 's/ $//')
+          directories=$(for file in $files; do dirname $file; done | sort -u | tr '\n' ' ' | sed 's/ $//')
           echo "directories=${directories}" >> $GITHUB_OUTPUT
 
       # Exit early if non-package directories are changed:

--- a/.github/workflows/scripts/run_affected_benchmarks/run
+++ b/.github/workflows/scripts/run_affected_benchmarks/run
@@ -110,7 +110,7 @@ main() {
 	changed=$(echo "${changed}" | tr ' ' '\n' | grep '^lib/node_modules/@stdlib') || true
 
 	# Find unique package directories:
-	directories=$(echo "${changed}" | tr ' ' '\n' | sed -E 's/\/(benchmark|bin|data|docs|etc|examples|include|lib|scripts|src|test)(\/.*)?$//' | uniq)
+	directories=$(echo "${changed}" | tr ' ' '\n' | sed -E 's/\/(benchmark|bin|data|docs|etc|examples|include|lib|scripts|src|test)(\/.*)?$//' | sort -u)
 
 	if [ -z "${directories}" ]; then
 		echo 'No packages to run benchmarks for.' >&2

--- a/.github/workflows/scripts/run_affected_tests/run
+++ b/.github/workflows/scripts/run_affected_tests/run
@@ -110,7 +110,7 @@ main() {
 	changed=$(echo "${changed}" | tr ' ' '\n' | grep '^lib/node_modules/@stdlib') || true
 
 	# Find unique package directories:
-	directories=$(echo "${changed}" | tr ' ' '\n' | sed -E 's/\/(benchmark|bin|data|docs|etc|examples|include|lib|scripts|src|test)(\/.*)?$//' | uniq)
+	directories=$(echo "${changed}" | tr ' ' '\n' | sed -E 's/\/(benchmark|bin|data|docs|etc|examples|include|lib|scripts|src|test)(\/.*)?$//' | sort -u)
 
 	if [ -z "${directories}" ]; then
 		echo 'No packages to test.' >&2
@@ -140,6 +140,9 @@ main() {
 	if [ -n "${required_by}" ]; then
 		directories="${directories} ${required_by}"
 	fi
+
+	# Deduplicate the merged list of directories:
+	directories=$(echo "${directories}" | tr ' ' '\n' | sort -u)
 
 	# Build native add-ons for packages (if applicable):
 	for pkg in ${packages}; do

--- a/.github/workflows/scripts/run_tests_coverage/run
+++ b/.github/workflows/scripts/run_tests_coverage/run
@@ -129,7 +129,7 @@ main() {
 	  grep -v '^lib/node_modules/@stdlib/_tools') || true
 
 	# Find unique package directories:
-	directories=$(echo "${changed}" | tr ' ' '\n' | sed -E 's/\/(benchmark|bin|data|docs|etc|examples|include|lib|scripts|src|test)(\/.*)?\/?$//' | uniq)
+	directories=$(echo "${changed}" | tr ' ' '\n' | sed -E 's/\/(benchmark|bin|data|docs|etc|examples|include|lib|scripts|src|test)(\/.*)?\/?$//' | sort -u)
 
 	if [ -z "${directories}" ]; then
 		echo 'No packages to test.' >&2


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1113.

## Description

> What is the purpose of this pull request?

This pull request:

-   Replaces `uniq` with `sort -u` in all CI workflow YAML files and their companion shell scripts to properly deduplicate directory lists.
-   Adds a deduplication step after merging changed directories with dependent directories in the affected tests script.

The `uniq` command only removes adjacent duplicates, so when `git diff` output produces the same parent directory in non-adjacent positions (e.g., files in root interleaved with subdirectory files), duplicate directory entries survive. This causes test files, benchmarks, and coverage runs to execute multiple times for the same package. For example, in [this run](https://github.com/stdlib-js/stdlib/actions/runs/30885996120/job/91917222062), every test file for `@stdlib/complex/float32/base/div` ran **twice**.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   https://github.com/stdlib-js/metr-issue-tracker/issues/1113

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code under my direction. Claude identified the root cause by analyzing the workflow scripts and a failing CI run, and authored the `uniq` → `sort -u` replacements.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md