### PR TITLE
test: migrate `math/base/special/log1pexp` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/test/test.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var log1pexp = require( './../lib' );
@@ -79,8 +79,6 @@ tape( 'the function computes the natural logarithm of `1+exp(x)` (`x > 33.3`)', 
 
 tape( 'the function accurately computes the natural logarithm of `1+exp(x)`', function test( t ) {
 	var actual;
-	var delta;
-	var tol;
 	var i;
 
 	for ( i = 0; i < data.length; i++ ) {
@@ -88,9 +86,7 @@ tape( 'the function accurately computes the natural logarithm of `1+exp(x)`', fu
 		if ( actual === expected[ i ] ) {
 			t.strictEqual( actual, expected[ i ], 'returns '+actual+' when provided ' + data[ i ]);
 		} else {
-			delta = abs( actual - expected[ i ] );
-			tol = 85.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+data[ i ]+'. actual: '+actual+'. expected: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/test/test.native.js
@@ -22,9 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -88,8 +88,6 @@ tape( 'the function computes the natural logarithm of `1+exp(x)` (`x > 33.3`)', 
 
 tape( 'the function accurately computes the natural logarithm of `1+exp(x)`', opts, function test( t ) {
 	var actual;
-	var delta;
-	var tol;
 	var i;
 
 	for ( i = 0; i < data.length; i++ ) {
@@ -97,9 +95,7 @@ tape( 'the function accurately computes the natural logarithm of `1+exp(x)`', op
 		if ( actual === expected[ i ] ) {
 			t.strictEqual( actual, expected[ i ], 'returns '+actual+' when provided ' + data[ i ]);
 		} else {
-			delta = abs( actual - expected[ i ] );
-			tol = 85.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+data[ i ]+'. actual: '+actual+'. expected: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of https://github.com/stdlib-js/stdlib/issues/11352.

## Description

> What is the purpose of this pull request?

This pull request:

-  Migrates the `math/base/special/log1pexp` test files from relative tolerance testing to ULP difference testing.
-  Adds the `@stdlib/assert/is-almost-same-value` assertion and replaces the `delta = abs( y - expected[ i ] )`, `tol = 85.0 * EPS * abs( expected[ i ] )` tolerance checks with `t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' )` using the minimum required ULP value of `2`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md