### PR TITLE
docs: fix descriptions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/logcdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/logcdf/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the natural logarithm of the cumulative density function (CDF) for a uniform distribution with minimum support `a` and maximum support `b` at a value `x`.
+* Evaluates the natural logarithm of the cumulative distribution function (CDF) for a Kumaraswamy's double bounded distribution with first shape parameter `a` and second shape parameter `b` at a value `x`.
 *
 * @private
 * @param {number} x - input value

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/logcdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/logcdf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/base/dists/kumaraswamy/logcdf",
   "version": "0.0.0",
-  "description": "Natural logarithm of the cumulative distribution function (CDF)for a Kumaraswamy's double bounded distribution.",
+  "description": "Natural logarithm of the cumulative distribution function (CDF) for a Kumaraswamy's double bounded distribution.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/logpdf/README.md
@@ -198,7 +198,7 @@ logEachMap( 'x: %0.4f, a: %0.4f, b: %0.4f, ln(f(x;a,b)): %0.4f', x, a, b, logpdf
 
 #### stdlib_base_dists_kumaraswamy_logpdf( x, a, b )
 
-Evaluates the natural logarithm of the probability distribution function (PDF) for a Kumaraswamy's double bounded distribution.
+Evaluates the natural logarithm of the probability density function (PDF) for a Kumaraswamy's double bounded distribution.
 
 ```c
 double out = stdlib_base_dists_kumaraswamy_logpdf( 0.5, 1.0, 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/logpdf/include/stdlib/stats/base/dists/kumaraswamy/logpdf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/kumaraswamy/logpdf/include/stdlib/stats/base/dists/kumaraswamy/logpdf.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the natural logarithm of the probability distribution function (CDF) for a Kumaraswamy's double bounded distribution with parameters `a` (first shape parameter) and `b` (second shape parameter).
+* Evaluates the natural logarithm of the probability density function (PDF) for a Kumaraswamy's double bounded distribution with parameters `a` (first shape parameter) and `b` (second shape parameter).
 */
 double stdlib_base_dists_kumaraswamy_logpdf( const double x, const double a, const double b );
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects copy-paste documentation errors in two members of `@stdlib/stats/base/dists/kumaraswamy` that described the wrong distribution or the wrong function type. No behavior, signatures, or test expectations change; the edits are documentation-only and bring the two outliers in line with wording already used by their own source files and their sibling packages.

The namespace was analyzed for cross-package documentation drift. Every member except these two was already consistent; the corrections below are the only deviations that are both unambiguous errors and mechanically fixable without touching public behavior.

### Namespace summary

-   **Member packages analyzed:** 13 (`cdf`, `ctor`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `median`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`).
-   **Features examined:** file trees, `package.json`/`manifest.json`/`directories` shape, README section structure, `lib/` layout, public signatures, error construction, validation prologues, JSDoc/Doxygen shape, and `require` dependency sets.
-   **Features with a clear majority (≥75%):** package layout and metadata are uniform across the namespace; the only structural variation tracks three legitimate axes — the `ctor` constructor class, measure functions (`cdf`/`logcdf`/`logpdf`/`pdf`/`quantile`) versus moment functions, and C-implemented versus JS-only packages.
-   **Features excluded (no clear majority or semantic split):** presence of a C implementation (11/13; `pdf` and `ctor` legitimately differ) and presence of `lib/factory.js` (measure-function-only). These are not treated as drift.

### `logcdf`

The native-addon JSDoc description was carried over verbatim from the uniform distribution package, describing a distribution with `minimum support` and `maximum support` rather than the two Kumaraswamy shape parameters. It now matches the package's own `main.js` and all eleven C-backed sibling `native.js` files in the namespace (100% conformance among peers). The `package.json` description also dropped the space in `(CDF)for`; it is restored to match the other twelve members.

### `logpdf`

Both the C header doc comment and the README C-API summary labeled the log-density as a `probability distribution function`, with the header additionally tagging it `(CDF)`. Both are corrected to `probability density function (PDF)`, matching `main.js`, `src/main.c`, and the package's own JS-API description, and consistent with `logcdf.h` naming its own function.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Corrections were derived from a structural extraction (filesystem and string features across all 13 members), a semantic extraction (public signatures, error construction, validation, JSDoc/Doxygen shape, dependencies), and an adversarial drift-validation pass. Only errors that are unambiguous, mechanical, and behavior-preserving advanced.

Deliberately excluded from this PR:

-   **`pdf` lacking a C implementation** (present in 11/13 members). Adding a native addon is authored C math, not a mechanical fix, and a maintainer-reviewed attempt (#10067) was previously closed unmerged.
-   **`kurtosis` and `skewness` lacking `test/fixtures/julia/`** (present for five of seven moment functions). Generating reference data requires a Julia runtime and would rewrite the test assertions from a type check to a tolerance comparison; both files carry an explicit `// TODO: Add fixtures` marker. Out of scope.
-   Any feature without a clear ≥75% majority, and any deviation reflecting a genuine semantic difference (e.g., the `ctor` constructor shape, measure-vs-moment signatures).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was prepared by Claude Code running an automated cross-package documentation-drift analysis over the `stats/base/dists/kumaraswamy` namespace. AI extracted structural and semantic features from every member, identified the majority documentation wording per feature, flagged deviating packages, and applied the four documentation corrections above. Each edit was verified against the package's own source files and its sibling packages before committing. A human should review before this draft is marked ready.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRxSyo1FZDWJu5Tiu1PmUi)_