### PR TITLE
test: migrate `stats/base/dists/pareto-type1/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/test/test.cdf.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var cdf = require( './../lib' );
 
 
@@ -129,10 +128,8 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function evaluates the cdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -143,23 +140,15 @@ tape( 'the function evaluates the cdf for `x` given large `alpha` and `beta`', f
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large `alpha` parameter', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -170,23 +159,15 @@ tape( 'the function evaluates the cdf for `x` given large `alpha` parameter', fu
 	beta = largeAlpha.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large rate parameter `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -197,13 +178,7 @@ tape( 'the function evaluates the cdf for `x` given large rate parameter `beta`'
 	beta = largeBeta.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/test/test.factory.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -188,11 +187,9 @@ tape( 'if provided a nonpositive `beta`, the created function always returns `Na
 
 tape( 'the created function evaluates the cdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var cdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -204,24 +201,16 @@ tape( 'the created function evaluates the cdf for `x` given large `alpha` and `b
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( alpha[i], beta[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large `alpha` parameter', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var cdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -233,24 +222,16 @@ tape( 'the created function evaluates the cdf for `x` given large `alpha` parame
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( alpha[i], beta[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large `beta` parameter', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
 	var cdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -262,13 +243,7 @@ tape( 'the created function evaluates the cdf for `x` given large `beta` paramet
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( alpha[i], beta[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/test/test.native.js
@@ -24,10 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 
 
 // VARIABLES //
@@ -138,10 +137,8 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 
 tape( 'the function evaluates the cdf for `x` given large `alpha` and `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -152,23 +149,15 @@ tape( 'the function evaluates the cdf for `x` given large `alpha` and `beta`', o
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large `alpha` parameter', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -179,23 +168,15 @@ tape( 'the function evaluates the cdf for `x` given large `alpha` parameter', op
 	beta = largeAlpha.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large rate parameter `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -206,13 +187,7 @@ tape( 'the function evaluates the cdf for `x` given large rate parameter `beta`'
 	beta = largeBeta.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the `stats/base/dists/pareto-type1/cdf` test suite from the old computed-tolerance idiom (`delta`/`tol` derived from `EPS`) to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   Converted files: `test/test.cdf.js`, `test/test.factory.js`, `test/test.native.js`. `test/test.js` was left untouched (it only contains the exports smoke test; no tolerance comparisons).
-   **ULP bound: `isAlmostSameValue( y, expected[i], 1 )`** across all three converted files.
-   The bound was found by computing the exact ULP difference (`@stdlib/number/float64/base/ulp-difference`) between actual and expected values across the full fixture set (`large_alpha.json`, `large_beta.json`, `both_large.json`; 3000 evaluations total, checked against both the direct `cdf()` export and the `factory()`-created function). The measured maximum ULP difference was **0** (every case is bit-exact against the Julia-generated fixtures in this environment). A bound of `1` was used rather than `0` to match the convention used throughout every other converted package in the codebase (no precedent package uses a bound of `0` for fixture-loop assertions) and to leave a minimal safety margin for the native (C) code path, which was not exercised in this sandboxed environment (see Other, below).
-   The full JS test suite was run twice at this bound to confirm deterministic results (no FMA/arch flakiness): 6055/6055 assertions passing both runs.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   `test/test.native.js` was converted to mirror the JS test files exactly, but the native addon could not be built in this sandboxed session, so the (skip-gated) native tests did not execute here.
-   Only test files were changed; `package.json` did not need updates, as `@stdlib/assert/is-almost-same-value` resolves via existing monorepo module resolution (consistent with other converted packages, none of which added an explicit `devDependencies` entry for it either).
-   `npx eslint` is clean on all three changed files.
-   The local pre-commit hook's EditorConfig check (`make lint-editorconfig-files`) could not run in this sandboxed session: it attempts to download the `editorconfig-checker` binary from `github.com/editorconfig-checker/editorconfig-checker`, a repository outside this session's permitted GitHub access scope, and fails with a 403. This is an environment/tooling limitation unrelated to this diff's content (reproduces identically for an unmodified file). The diff was manually checked for indentation (tabs, no space-indentation) and trailing-whitespace/EOF-newline consistency with the surrounding unmodified code.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored end-to-end by an automated Claude Code agent running as a scheduled task on behalf of the repository owner, following the conventions established in prior merged ULP-migration PRs for this issue (e.g. #13847, #13868).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGCnEeR5cADWKNrnyiPfAB)_