### PR TITLE
test: migrate `math/base/special/ellipk` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ellipk/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipk/test/test.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var HALF_PI = require( '@stdlib/constants/float64/half-pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var ellipk = require( './../lib' );
 
 
@@ -48,92 +47,64 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the complete elliptic integral of the first kind (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = mediumPositive.expected;
 	x = mediumPositive.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 25.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 25 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the complete elliptic integral of the first kind (values close to positive unity)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = closeToUnity.expected;
 	x = closeToUnity.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 8000.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12065 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the complete elliptic integral of the first kind (medium negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = mediumNegative.expected;
 	x = mediumNegative.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the complete elliptic integral of the first kind (large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = largeNegative.expected;
 	x = largeNegative.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1e9 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 204773163 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ellipk/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipk/test/test.js
@@ -72,7 +72,7 @@ tape( 'the function evaluates the complete elliptic integral of the first kind (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12065 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12065 ), true, 'returns expected value' ); // FIXME: investigate the reason for this large discrepancy
 	}
 	t.end();
 });
@@ -104,7 +104,7 @@ tape( 'the function evaluates the complete elliptic integral of the first kind (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[ i ], 204773163 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 204773163 ), true, 'returns expected value' ); // FIXME: investigate the reason for this large discrepancy
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ellipk/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipk/test/test.native.js
@@ -81,7 +81,7 @@ tape( 'the function evaluates the complete elliptic integral of the first kind (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12065 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12065 ), true, 'returns expected value' ); // FIXME: investigate the reason for this large discrepancy
 	}
 	t.end();
 });
@@ -113,7 +113,7 @@ tape( 'the function evaluates the complete elliptic integral of the first kind (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[ i ], 204773163 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 204773163 ), true, 'returns expected value' ); // FIXME: investigate the reason for this large discrepancy
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ellipk/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipk/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var HALF_PI = require( '@stdlib/constants/float64/half-pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -57,92 +56,64 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the complete elliptic integral of the first kind (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = mediumPositive.expected;
 	x = mediumPositive.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 25.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 25 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the complete elliptic integral of the first kind (values close to positive unity)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = closeToUnity.expected;
 	x = closeToUnity.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 8000.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 12065 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the complete elliptic integral of the first kind (medium negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = mediumNegative.expected;
 	x = mediumNegative.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the complete elliptic integral of the first kind (large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = largeNegative.expected;
 	x = largeNegative.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = ellipk( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1e9 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 204773163 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/ellipk` from relative tolerance testing (`delta <= tol`, where `tol = C * EPS * abs( expected[ i ] )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   applies the migration to both `test/test.js` and `test/test.native.js`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from both test files.

Each assertion uses the `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' )` shape, where `N` is inlined per test body, matching the idiom used in previously merged conversions.

The ULP bounds are the **measured minimum** over each full fixture set (4000 cases per fixture):

| Test body | Fixture | Previous tolerance | ULP bound |
| --- | --- | --- | --- |
| medium positive values | `fixtures/cpp/medium_positive.json` | `25.0 * EPS` | `25` |
| values close to positive unity | `fixtures/cpp/close_to_unity.json` | `8000.0 * EPS` | `12065` |
| medium negative values | `fixtures/cpp/medium_negative.json` | `1.5 * EPS` | `2` |
| large negative values | `fixtures/cpp/large_negative.json` | `1e9 * EPS` | `204773163` |

Notes on how the bounds were determined:

-   The ULP difference was computed for every fixture value using `@stdlib/number/float64/base/ulp-difference`, taking the per-fixture maximum.
-   The bounds were measured independently for the JavaScript implementation (`lib/main.js`) and the native implementation (`lib/native.js`, built via `make install-node-addons`). Both implementations yield identical maxima, so `test.js` and `test.native.js` use the same values.
-   Tightness was confirmed by re-checking each fixture set with the bound decremented by one, which leaves exactly one failing case for `medium_positive`, `close_to_unity`, and `large_negative`, and three failing cases for `medium_negative`.
-   The suite was run twice at the final bounds to confirm determinism; `test.js` and `test.native.js` each report 16007/16007 passing on both runs, and the native add-on was built locally so that `test.native.js` was exercised rather than skipped.
-   The large bound for `large_negative` reflects the pre-existing `1e9 * EPS` relative tolerance for that fixture; the measured maximum is roughly a factor of five tighter.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only the two test files are changed; no `package.json` or source changes were required.

One environment note: the `lint-editorconfig-files` step could not run locally, as downloading the `editorconfig-checker` binary is blocked in this environment. The relevant EditorConfig rules (LF line endings, UTF-8, tab indentation, no trailing whitespace, final newline) were instead verified manually, and `make lint-javascript-tests TESTS_FILTER=".*/math/base/special/ellipk/.*"` passes cleanly.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied the migration idiom from previously merged conversions, applied the migration, measured the minimum ULP bounds for both the JavaScript and native implementations, and verified tightness and determinism locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value