### PR TITLE
fix: replace `pow` with `powf` in `math/base/special/frexpf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/frexpf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/frexpf/examples/index.js
@@ -20,7 +20,7 @@
 
 var randu = require( '@stdlib/random/base/randu' );
 var roundf = require( '@stdlib/math/base/special/roundf' );
-var pow = require( '@stdlib/math/base/special/pow' ); // TODO: replace with `powf` when available
+var powf = require( '@stdlib/math/base/special/powf' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var BIAS = require( '@stdlib/constants/float32/exponent-bias' );
 var frexpf = require( './../lib' );
@@ -42,12 +42,12 @@ for ( i = 0; i < 100; i++ ) {
 	}
 	frac = f32( randu()*10.0 );
 	exp = roundf( randu()*76.0 ) - 38;
-	x = f32( sign * frac * f32( pow( 10.0, exp ) ) );
+	x = f32( sign * frac * powf( 10.0, exp ) );
 	f = frexpf( x );
 	if ( f[ 1 ] > BIAS ) {
-		v = f32( f[ 0 ] * f32( pow(2.0, f[1]-BIAS) ) * f32( pow(2.0, BIAS) ) );
+		v = f32( f[ 0 ] * powf(2.0, f[1]-BIAS) * powf(2.0, BIAS) );
 	} else {
-		v = f32( f[ 0 ] * f32( pow( 2.0, f[ 1 ] ) ) );
+		v = f32( f[ 0 ] * powf( 2.0, f[ 1 ] ) );
 	}
 	console.log( '%d = %d * 2^%d = %d', x, f[ 0 ], f[ 1 ], v );
 }

--- a/lib/node_modules/@stdlib/math/base/special/frexpf/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/frexpf/test/test.assign.js
@@ -26,7 +26,7 @@ var PINF = require( '@stdlib/constants/float32/pinf' );
 var BIAS = require( '@stdlib/constants/float32/exponent-bias' );
 var randu = require( '@stdlib/random/base/randu' );
 var roundf = require( '@stdlib/math/base/special/roundf' );
-var pow = require( '@stdlib/math/base/special/pow' ); // TODO: replace with `powf` when available
+var powf = require( '@stdlib/math/base/special/powf' );
 var absf = require( '@stdlib/math/base/special/absf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
@@ -144,15 +144,15 @@ tape( 'the returned normalized fraction and exponent satisfy the relation `x = f
 		}
 		frac = f32( randu()*10.0 );
 		exp = roundf( randu()*76.0 ) - 38;
-		x = f32( sign * frac * f32( pow( 10.0, exp ) ) );
+		x = f32( sign * frac * powf( 10.0, exp ) );
 		out = new Float32Array( 2 );
 		f = frexpf( x, out, 1, 0 );
 		t.strictEqual( f, out, 'returns output array' );
 
 		if ( f[ 1 ] > BIAS ) {
-			f = f32( f[ 0 ] * pow( 2.0, BIAS ) * pow( 2.0, f[1]-BIAS ) );
+			f = f32( f[ 0 ] * powf( 2.0, BIAS ) * powf( 2.0, f[1]-BIAS ) );
 		} else {
-			f = f32( f[ 0 ] * pow( 2.0, f[ 1 ] ) );
+			f = f32( f[ 0 ] * powf( 2.0, f[ 1 ] ) );
 		}
 		t.strictEqual( f, x, 'returns expected value' );
 	}
@@ -176,7 +176,7 @@ tape( 'the absolute value of the normalized fraction is on the interval `[1/2,1)
 		}
 		frac = f32( randu()*10.0 );
 		exp = roundf( randu()*74.0 ) - 37;
-		x = f32( sign * frac * f32( pow( 10.0, exp ) ) );
+		x = f32( sign * frac * powf( 10.0, exp ) );
 		out = new Float32Array( 2 );
 		f = frexpf( x, out, 1, 0 );
 		t.strictEqual( f, out, 'returns output array' );

--- a/lib/node_modules/@stdlib/math/base/special/frexpf/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/frexpf/test/test.main.js
@@ -26,7 +26,7 @@ var PINF = require( '@stdlib/constants/float32/pinf' );
 var BIAS = require( '@stdlib/constants/float32/exponent-bias' );
 var randu = require( '@stdlib/random/base/randu' );
 var roundf = require( '@stdlib/math/base/special/roundf' );
-var pow = require( '@stdlib/math/base/special/pow' ); // TODO: replace with `powf` when available
+var powf = require( '@stdlib/math/base/special/powf' );
 var absf = require( '@stdlib/math/base/special/absf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
@@ -130,13 +130,13 @@ tape( 'the returned normalized fraction and exponent satisfy the relation `x = f
 		}
 		frac = f32( randu()*10.0 );
 		exp = roundf( randu()*76.0 ) - 38;
-		x = f32( sign * frac * f32( pow( 10.0, exp ) ) );
+		x = f32( sign * frac * powf( 10.0, exp ) );
 		f = frexpf( x );
 
 		if ( f[ 1 ] > BIAS ) {
-			f = f32( f[ 0 ] * pow( 2.0, BIAS ) * pow( 2.0, f[1]-BIAS ) );
+			f = f32( f[ 0 ] * powf( 2.0, BIAS ) * powf( 2.0, f[1]-BIAS ) );
 		} else {
-			f = f32( f[ 0 ] * pow( 2.0, f[ 1 ] ) );
+			f = f32( f[ 0 ] * powf( 2.0, f[ 1 ] ) );
 		}
 		t.strictEqual( f, x, 'returns expected value' );
 	}
@@ -159,7 +159,7 @@ tape( 'the absolute value of the normalized fraction is on the interval `[1/2,1)
 		}
 		frac = f32( randu()*10.0 );
 		exp = roundf( randu()*74.0 ) - 37;
-		x = f32( sign * frac * f32( pow( 10.0, exp ) ) );
+		x = f32( sign * frac * powf( 10.0, exp ) );
 		f = frexpf( x );
 
 		// Compute the absolute value of the normalized fraction:

--- a/lib/node_modules/@stdlib/math/base/special/frexpf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/frexpf/test/test.native.js
@@ -27,7 +27,7 @@ var PINF = require( '@stdlib/constants/float32/pinf' );
 var BIAS = require( '@stdlib/constants/float32/exponent-bias' );
 var randu = require( '@stdlib/random/base/randu' );
 var roundf = require( '@stdlib/math/base/special/roundf' );
-var pow = require( '@stdlib/math/base/special/pow' ); // TODO: replace with `powf` when available
+var powf = require( '@stdlib/math/base/special/powf' );
 var absf = require( '@stdlib/math/base/special/absf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
@@ -139,13 +139,13 @@ tape( 'the returned normalized fraction and exponent satisfy the relation `x = f
 		}
 		frac = f32( randu()*10.0 );
 		exp = roundf( randu()*76.0 ) - 38;
-		x = f32( sign * frac * f32( pow( 10.0, exp ) ) );
+		x = f32( sign * frac * powf( 10.0, exp ) );
 		f = frexpf( x );
 
 		if ( f[ 1 ] > BIAS ) {
-			f = f32( f[ 0 ] * pow( 2.0, BIAS ) * pow( 2.0, f[1]-BIAS ) );
+			f = f32( f[ 0 ] * powf( 2.0, BIAS ) * powf( 2.0, f[1]-BIAS ) );
 		} else {
-			f = f32( f[ 0 ] * pow( 2.0, f[ 1 ] ) );
+			f = f32( f[ 0 ] * powf( 2.0, f[ 1 ] ) );
 		}
 		t.strictEqual( f, x, 'returns expected value' );
 	}
@@ -168,7 +168,7 @@ tape( 'the absolute value of the normalized fraction is on the interval `[1/2,1)
 		}
 		frac = f32( randu()*10.0 );
 		exp = roundf( randu()*74.0 ) - 37;
-		x = f32( sign * frac * f32( pow( 10.0, exp ) ) );
+		x = f32( sign * frac * f32( powf( 10.0, exp ) ) );
 		f = frexpf( x );
 
 		// Compute the absolute value of the normalized fraction:


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Replace use of double precision `pow` with rounding to appropriate single precision `powf` in `math/base/special/frexpf`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
