### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.get.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.get.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var isBoolean = require( '@stdlib/assert/is-boolean' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var BooleanArray = require( './../lib' );

--- a/tools/git/scripts/median_commits_per_day
+++ b/tools/git/scripts/median_commits_per_day
@@ -30,12 +30,14 @@ median="${root}/tools/awk/median.awk"
 #   - Extract the line which begins with `Date` from each log.
 # * `awk '{}'`
 #   - From each date line, extract the month (`$3`), day (`$4`), and year (`$6`).
+# * `sort`
+#   - Sort in lexicographic order.
 # * `uniq -c`
-#   - Given that same day commits are on consecutive lines, we can remove repeated lines and count the repeats to compute daily totals.
+#   - Remove repeated lines and count the repeats to compute daily totals.
 # * `awk '{}'`
 #   - Extract the total from each line.
 # * `awk '{}'`
 #   - Compute the median number of commits per day.
-git log | grep Date | awk '{print $3 OFS $4 OFS $6}' | uniq -c | awk '{print $1}' | "${median}"
+git log | grep Date | awk '{print $3 OFS $4 OFS $6}' | sort | uniq -c | awk '{print $1}' | "${median}"
 
 # FIXME: does not include days in which no commits are made!

--- a/tools/git/scripts/mode_commits_per_day
+++ b/tools/git/scripts/mode_commits_per_day
@@ -30,12 +30,14 @@ mode="${root}/tools/awk/mode.awk"
 #   - Extract the line which begins with `Date` from each log.
 # * `awk '{}'`
 #   - From each date line, extract the month (`$3`), day (`$4`), and year (`$6`).
+# * `sort`
+#   - Sort in lexicographic order.
 # * `uniq -c`
-#   - Given that same day commits are on consecutive lines, we can remove repeated lines and count the repeats to compute daily totals.
+#   - Remove repeated lines and count the repeats to compute daily totals.
 # * `awk '{}'`
 #   - Extract the total from each line.
 # * `awk '{}'`
 #   - Compute the most frequent number of commits per day.
-git log | grep Date | awk '{print $3 OFS $4 OFS $6}' | uniq -c | awk '{print $1}' | "${mode}"
+git log | grep Date | awk '{print $3 OFS $4 OFS $6}' | sort | uniq -c | awk '{print $1}' | "${mode}"
 
 # FIXME: does not include days in which no commits are made!

--- a/tools/git/scripts/tabulate_total_commits_per_day
+++ b/tools/git/scripts/tabulate_total_commits_per_day
@@ -30,14 +30,16 @@ tabulate="${root}/tools/awk/tabulate.awk"
 #   - Extract the line which begins with `Date` from each log.
 # * `awk '{}'`
 #   - From each date line, extract the month (`$3`), day (`$4`), and year (`$6`).
+# * `sort`
+#   - Sort in lexicographic order.
 # * `uniq -c`
-#   - Given that same day commits are on consecutive lines, we can remove repeated lines and count the repeats to compute daily totals.
+#   - Remove repeated lines and count the repeats to compute daily totals.
 # * `awk '{}'`
 #   - Extract the total from each line.
 # * `awk '{}'`
 #   - Generate a frequency table.
 # * `sort -n`
 #   - Sort in numeric order.
-git log | grep Date | awk '{print $3 OFS $4 OFS $6}' | uniq -c | awk '{print $1}' | "${tabulate}" | sort -n
+git log | grep Date | awk '{print $3 OFS $4 OFS $6}' | sort | uniq -c | awk '{print $1}' | "${tabulate}" | sort -n
 
 # FIXME: does not include days in which no commits are made!


### PR DESCRIPTION
Propagating fixes merged to `develop` between 2026-08-04 and 2026-08-05 (window ending `b9396e354`) to sibling packages.

## Description

> What is the purpose of this pull request?

This pull request:

-   propagates cf6c136 ("test: update import") to the last remaining `array/bool` benchmark using the permissive `is-boolean` import
-   propagates e7c2c09 ("build: replace `uniq` with `sort -u` to deduplicate directories in CI workflows") to `tools/git/scripts` relying on the same adjacency assumption

### cf6c136 → `array/bool` benchmark

cf6c136 ("test: update import") swapped the permissive `@stdlib/assert/is-boolean` import for `.isPrimitive` in `array/bool`'s `test.entries.js`, since the bare export accepts boxed `Boolean` objects while the assertion targets a primitive value. The same defect was the last holdout in `array/bool/benchmark`: `benchmark.get.js` still imported the bare `is-boolean` check against `BooleanArray#get`'s primitive return, while every other benchmark in the directory already used `.isPrimitive`. Applied the identical one-line import fix.

Target:

-   `@stdlib/array/bool` (`benchmark/benchmark.get.js`)

### e7c2c09 → `tools/git/scripts`

`uniq` only collapses adjacent duplicate lines, and e7c2c09 fixed this in `.github/` workflows by sorting before deduplicating; the same assumption holds latently in `tools/git/scripts`, where `git log` author dates are non-monotonic and fragment daily totals across multiple `uniq -c` rows (5 distinct days yielded 11 rows on this repo's history). `sort` is inserted before `uniq -c` in the scripts whose consumers are order-insensitive, and the pipeline comments are updated accordingly.

Targets:

-   `tools/git/scripts/median_commits_per_day`
-   `tools/git/scripts/mode_commits_per_day`
-   `tools/git/scripts/tabulate_total_commits_per_day`

`merges_per_day` and `merged_pull_requests_per_day` are deliberately excluded: their per-day rows are user-visible output in chronological order (via `git log --reverse`), and a plain `sort` would reorder them lexicographically.

## Related Issues

> Does this pull request have any related issues?

This pull request does not have any related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All fix commits merged to `develop` in the 24-hour window were pattern-specified and searched repo-wide. Each candidate site was reviewed by two independent validation passes (defect confirmation with full-file reads), an adaptation pass, and a style-consistency pass against sibling conventions; only sites unanimously confirmed were included.

Deliberately excluded:

-   `merges_per_day` / `merged_pull_requests_per_day` (both validation passes rejected: the fix would reorder user-visible chronological output)
-   nine `constants/**` sites missing `// asm type annotation` (from 46e0a1a: all conflict with a trailing `// eslint-disable-line id-length` pragma; the repo has no convention for combining the two comments — maintainer decision required)
-   the wrong-distribution copy-paste JSDoc class from 075cabdc (no reliable search signature; candidate regex has an extreme false-positive rate)
-   ULP-assertion test migrations (tracked campaign, see #11352 — not defect fixes)

The remaining defect classes from the window's fix commits (075cabdc description typos, 3d19e26 missing `.js` require extensions) have zero remaining sites repo-wide; those source commits fixed the last stragglers.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated fix-propagation routine: candidate sites were located by pattern search and each proposed patch was independently validated by multiple review passes before inclusion.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QgequPdX81fkqyxWXaLB6

---
_Generated by [Claude Code](https://claude.ai/code/session_019QgequPdX81fkqyxWXaLB6)_