### PR TITLE
test: migrate `math/base/special/asech` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/asech/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asech/test/test.js
@@ -21,12 +21,17 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var asech = require( './../lib' );
+
+
+// VARIABLES //
+
+var ULP_TOL = 1;
 
 
 // FIXTURES //
@@ -44,8 +49,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the hyperbolic arcsecant on the interval (0, 1]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -55,13 +58,7 @@ tape( 'the function computes the hyperbolic arcsecant on the interval (0, 1]', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asech( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP_TOL ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asech/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asech/test/test.js
@@ -29,11 +29,6 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 var asech = require( './../lib' );
 
 
-// VARIABLES //
-
-var ULP_TOL = 1;
-
-
 // FIXTURES //
 
 var data = require( './fixtures/julia/data.json' );
@@ -58,7 +53,7 @@ tape( 'the function computes the hyperbolic arcsecant on the interval (0, 1]', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asech( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP_TOL ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asech/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asech/test/test.native.js
@@ -36,7 +36,6 @@ var asech = tryRequire( resolve( __dirname, './../lib/native.js' ) );
 var opts = {
 	'skip': ( asech instanceof Error )
 };
-var ULP_TOL = 1;
 
 
 // FIXTURES //
@@ -63,7 +62,7 @@ tape( 'the function computes the hyperbolic arcsecant on the interval (0, 1]', o
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asech( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP_TOL ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asech/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asech/test/test.native.js
@@ -22,17 +22,12 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-
-
-// FIXTURES //
-
-var data = require( './fixtures/julia/data.json' );
 
 
 // VARIABLES //
@@ -41,6 +36,12 @@ var asech = tryRequire( resolve( __dirname, './../lib/native.js' ) );
 var opts = {
 	'skip': ( asech instanceof Error )
 };
+var ULP_TOL = 1;
+
+
+// FIXTURES //
+
+var data = require( './fixtures/julia/data.json' );
 
 
 // TESTS //
@@ -53,8 +54,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the hyperbolic arcsecant on the interval (0, 1]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -64,13 +63,7 @@ tape( 'the function computes the hyperbolic arcsecant on the interval (0, 1]', o
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asech( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], ULP_TOL ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `math/base/special/asech` from relative tolerance testing to ULP (unit in the last place) difference testing, per the tracking issue.
-   replaces the `delta`/`tol`-based tolerance checks in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' )`, using `@stdlib/assert/is-almost-same-value`.
-   removes the now-unused `abs` import from both test files (the `EPS` import is retained, as it is still used elsewhere in the tests for domain-boundary checks).
-   the ULP bound (`1`) was determined empirically: starting from a high bound (64) and lowering it until the minimum integer value that still passes over the full fixture set (2003 assertions) was found. A bound of `0` (exact equality) fails 155 of 4008 total assertions, confirming `1` ULP is the tightest passing bound. The test suite was run twice at this bound to confirm deterministic results.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. It searched the repository for a candidate package not yet converted and without a colliding PR, studied several already-merged conversions in the same tracking issue to mirror the exact idiom used, and empirically determined the minimum ULP bound by running the test suite locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJNm47UayTwgvhS8FigYFp)_