### PR TITLE
test: migrate `math/base/special/factorialln` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/factorialln/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorialln/test/test.js
@@ -21,14 +21,13 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var factorial = require( '@stdlib/math/base/special/factorial' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factorialln = require( './../lib' );
 
 
@@ -81,8 +80,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function evaluates the natural logarithm of the factorial of `x` (very large positive integers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -92,21 +89,13 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (ver
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = factorialln( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the natural logarithm of the factorial of `x` (large positive integers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -116,21 +105,13 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (lar
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = factorialln( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the natural logarithm of the factorial of `x` (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -139,21 +120,13 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (med
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = factorialln( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the natural logarithm of the factorial of `x` (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -162,13 +135,7 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (sma
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = factorialln( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -176,8 +143,6 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (sma
 tape( 'the function returns a value almost equal to `ln( factorial( x )` for `x` in `[0,171]', function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var v;
 	var i;
 
@@ -185,9 +150,7 @@ tape( 'the function returns a value almost equal to `ln( factorial( x )` for `x`
 	for ( i = 0; i < values.length; i++ ) {
 		v = factorialln( values[ i ] );
 		expected = ln( factorial( values[ i ] ) );
-		delta = abs( v - expected );
-		tol = 4.0 * EPS * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. x: ' + values[ i ] + '. Value: ' + v + '. Expected: ' + expected + '. Tolerance: ' + tol + '. Delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected, 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/factorialln/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorialln/test/test.native.js
@@ -22,14 +22,13 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var factorial = require( '@stdlib/math/base/special/factorial' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -90,8 +89,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) 
 
 tape( 'the function evaluates the natural logarithm of the factorial of `x` (very large positive integers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -101,21 +98,13 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (ver
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = factorialln( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the natural logarithm of the factorial of `x` (large positive integers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -125,21 +114,13 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (lar
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = factorialln( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the natural logarithm of the factorial of `x` (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -148,23 +129,15 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (med
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = factorialln( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
 
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2774#discussion_r1712904184
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2774#discussion_r1712904184
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the natural logarithm of the factorial of `x` (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -173,13 +146,7 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (sma
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = factorialln( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -187,8 +154,6 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (sma
 tape( 'the function returns a value almost equal to `ln( factorial( x )` for `x` in `[0,171]', opts, function test( t ) {
 	var expected;
 	var values;
-	var delta;
-	var tol;
 	var v;
 	var i;
 
@@ -196,9 +161,7 @@ tape( 'the function returns a value almost equal to `ln( factorial( x )` for `x`
 	for ( i = 0; i < values.length; i++ ) {
 		v = factorialln( values[ i ] );
 		expected = ln( factorial( values[ i ] ) );
-		delta = abs( v - expected );
-		tol = 4.0 * EPS * abs( expected );
-		t.ok( delta <= tol, 'within tolerance. x: ' + values[ i ] + '. Value: ' + v + '. Expected: ' + expected + '. Tolerance: ' + tol + '. Delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected, 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/factorialln` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` computations (and the `y === expected[i]` / `else` branching) in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' );`.
-   adds the `@stdlib/assert/is-almost-same-value` require and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

Only the two test files are modified; no source, fixtures, or package metadata changed.

### ULP bounds

Each bound was measured against the full fixture set (and, for the native tests, against a locally built addon) by computing `@stdlib/number/float64/base/ulp-difference` for every test case, and then tightened to the minimum integer which still passes.

`test/test.js`:

| Test case | ULP | Measured max ULP difference |
| --- | --- | --- |
| very large positive integers (101 values) | 1 | 0 |
| large positive integers (181 values) | 1 | 0 |
| medium positive values (1001 values) | 1 | 0 |
| small positive values (1001 values) | 1 | 0 |
| `ln( factorial( x ) )` for `x` in `[0,171]` (342 values) | 6 | 6 |

`test/test.native.js`: same values, except the medium positive test case uses `2` in order to preserve the existing note in that file that a wider tolerance (`1.5*EPS` versus `EPS`) is required due to compiler optimizations which may result in divergence (see [#2774 (comment)](https://github.com/stdlib-js/stdlib/pull/2774#discussion_r1712904184)). The note is retained alongside the assertion.

Notes on the measurements:

-   The four Julia fixture test cases match bit-for-bit (0 ULP), for both the JavaScript and native implementations. `1` is used rather than `0`, as `0` is not used anywhere in the already-migrated packages and `isAlmostSameValue( a, b, 0 )` degenerates to a `SameValue` comparison.
-   `6` is tight for the `ln( factorial( x ) )` test case: lowering it to `5` produces exactly one failure (`x = 0.5`). The previous tolerance there was `4.0 * EPS * abs( expected )`.
-   `test/test.js` and `test/test.native.js` were each run twice at the final bounds; 3130 assertions pass in each file on every run, with no variation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

-   For the four Julia fixture test cases, the measured ULP difference is `0`. This PR uses `1` to match the floor used throughout the already-migrated packages, but please let me know if `0` is preferred where results match exactly.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The native addon was built locally so that `test/test.native.js` ran for real rather than being skipped; both files report 3130 passing assertions.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled task. The test edits, the ULP measurements, and this description were produced by Claude Code.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao7hXUMsdLjwftNgNKvJHr)_