### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/org-repos/lib/validate.js
+++ b/lib/node_modules/@stdlib/_tools/github/org-repos/lib/validate.js
@@ -56,13 +56,13 @@ function validate( opts, options ) {
 	if ( hasOwnProp( options, 'token' ) ) {
 		opts.token = options.token;
 		if ( !isString( opts.token ) ) {
-			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'token',  opts.token ) );
+			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'token', opts.token ) );
 		}
 	}
 	if ( hasOwnProp( options, 'useragent' ) ) {
 		opts.useragent = options.useragent;
 		if ( !isString( opts.useragent ) ) {
-			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'useragent',  opts.useragent ) );
+			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'useragent', opts.useragent ) );
 		}
 	}
 	return null;

--- a/lib/node_modules/@stdlib/_tools/scripts/transform.js
+++ b/lib/node_modules/@stdlib/_tools/scripts/transform.js
@@ -59,10 +59,12 @@ var ERROR_NAMES = [
 */
 function onStringFormat( path ) {
 	var node = path.node;
-	return node.init &&
+	return (
+		node.init &&
 		node.init.type === 'CallExpression' &&
 		node.init.callee.name === 'require' &&
-		node.init.arguments[0].value === '@stdlib/string-format';
+		node.init.arguments[0].value === '@stdlib/string-format'
+	);
 }
 
 /**
@@ -103,8 +105,8 @@ function deleteComment( path ) {
 * @returns {void}
 */
 function rewriteRequire( path ) {
-	if ( startsWith( path.value.arguments[0].value, '@stdlib' ) ) {
-		path.value.arguments[0].value += '/dist';
+	if ( startsWith( path.value.arguments[ 0 ].value, '@stdlib' ) ) {
+		path.value.arguments[ 0 ].value += '/dist';
 	}
 }
 
@@ -116,8 +118,10 @@ function rewriteRequire( path ) {
 * @returns {boolean} boolean indicating whether a path is a require call for `@stdlib/error-tools-fmtprodmsg`
 */
 function hasRequire( path ) {
-	return path.value.callee.name === 'require' &&
-		path.value.arguments[ 0 ].value === '@stdlib/error-tools-fmtprodmsg';
+	return (
+		path.value.callee.name === 'require' &&
+		path.value.arguments[ 0 ].value === '@stdlib/error-tools-fmtprodmsg'
+	);
 }
 
 

--- a/lib/node_modules/@stdlib/_tools/scripts/transform.js
+++ b/lib/node_modules/@stdlib/_tools/scripts/transform.js
@@ -48,6 +48,79 @@ var ERROR_NAMES = [
 ];
 
 
+// FUNCTIONS //
+
+/**
+* Tests whether a variable declaration is for the `@stdlib/string-format` require.
+*
+* @private
+* @param {Object} path - AST node path
+* @returns {boolean} boolean indicating whether a variable declaration is for the `@stdlib/string-format` require
+*/
+function onStringFormat( path ) {
+	var node = path.node;
+	return node.init &&
+		node.init.type === 'CallExpression' &&
+		node.init.callee.name === 'require' &&
+		node.init.arguments[0].value === '@stdlib/string-format';
+}
+
+/**
+* Returns false if the node index is equal to zero and true otherwise.
+*
+* @private
+* @param {Object} path - AST node path
+* @param {number} idx - node index
+* @returns {boolean} boolean indicating whether to keep the node
+*/
+function dropFirst( path, idx ) {
+	return idx !== 0;
+}
+
+/**
+* Deletes the comments associated with a given node.
+*
+* @private
+* @param {Object} path - AST node path
+* @returns {void}
+*/
+function deleteComment( path ) {
+	var i;
+	if ( path.node.comments ) {
+		for ( i = 0; i < path.node.comments.length; i++ ) {
+			if ( contains( path.node.comments[ i ].value, '@license Apache-2.0' ) ) {
+				path.node.comments[ i ].value = '* @license Apache-2.0 ';
+			}
+		}
+	}
+}
+
+/**
+* Rewrites a `require` statement to include the `/dist` directory if the module being required starts with `@stdlib`.
+*
+* @private
+* @param {Object} path - AST node path
+* @returns {void}
+*/
+function rewriteRequire( path ) {
+	if ( startsWith( path.value.arguments[0].value, '@stdlib' ) ) {
+		path.value.arguments[0].value += '/dist';
+	}
+}
+
+/**
+* Tests whether a path is a require call for `@stdlib/error-tools-fmtprodmsg`.
+*
+* @private
+* @param {Object} path - AST node path
+* @returns {boolean} boolean indicating whether a path is a require call for `@stdlib/error-tools-fmtprodmsg`
+*/
+function hasRequire( path ) {
+	return path.value.callee.name === 'require' &&
+		path.value.arguments[ 0 ].value === '@stdlib/error-tools-fmtprodmsg';
+}
+
+
 // MAIN //
 
 /**
@@ -122,21 +195,6 @@ function transformer( fileInfo, api ) {
 	return replace( out, RE_INDENT, '\n' );
 
 	/**
-	* Tests whether a variable declaration is for the `@stdlib/string-format` require.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @returns {boolean} boolean indicating whether a variable declaration is for the `@stdlib/string-format` require
-	*/
-	function onStringFormat( path ) {
-		var node = path.node;
-		return node.init &&
-			node.init.type === 'CallExpression' &&
-			node.init.callee.name === 'require' &&
-			node.init.arguments[0].value === '@stdlib/string-format';
-	}
-
-	/**
 	* Assigns the variable name for the `@stdlib/string-format` require.
 	*
 	* @private
@@ -145,49 +203,6 @@ function transformer( fileInfo, api ) {
 	*/
 	function assignFormatVar( path ) {
 		formatVar = path.node.id.name;
-	}
-
-	/**
-	* Returns false if the node index is equal to zero and true otherwise.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @param {number} idx - node index
-	* @returns {boolean} boolean indicating whether to keep the node
-	*/
-	function dropFirst( path, idx ) {
-		return idx !== 0;
-	}
-
-	/**
-	* Deletes the comments associated with a given node.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @returns {void}
-	*/
-	function deleteComment( path ) {
-		var i;
-		if ( path.node.comments ) {
-			for ( i = 0; i < path.node.comments.length; i++ ) {
-				if ( contains( path.node.comments[ i ].value, '@license Apache-2.0' ) ) {
-					path.node.comments[ i ].value = '* @license Apache-2.0 ';
-				}
-			}
-		}
-	}
-
-	/**
-	* Rewrites a `require` statement to include the `/dist` directory if the module being required starts with `@stdlib`.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @returns {void}
-	*/
-	function rewriteRequire( path ) {
-		if ( startsWith( path.value.arguments[0].value, '@stdlib' ) ) {
-			path.value.arguments[0].value += '/dist';
-		}
 	}
 
 	/**
@@ -247,18 +262,6 @@ function transformer( fileInfo, api ) {
 				}
 			}
 		}
-	}
-
-	/**
-	* Tests whether a path is a require call for `@stdlib/error-tools-fmtprodmsg`.
-	*
-	* @private
-	* @param {Object} path - AST node path
-	* @returns {boolean} boolean indicating whether a path is a require call for `@stdlib/error-tools-fmtprodmsg`
-	*/
-	function hasRequire( path ) {
-		return path.value.callee.name === 'require' &&
-			path.value.arguments[ 0 ].value === '@stdlib/error-tools-fmtprodmsg';
 	}
 }
 


### PR DESCRIPTION
Resolves #11147.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes 5 `stdlib/no-unnecessary-nested-functions` lint errors in `lib/node_modules/@stdlib/_tools/scripts/transform.js` by moving the `onStringFormat`, `dropFirst`, `deleteComment`, `rewriteRequire`, and `hasRequire` helper functions to module scope (a new `FUNCTIONS` section), as they do not depend on any closure variables. The `assignFormatVar` and `onStringLiteral` functions are intentionally left nested, as they rely on variables scoped to `transformer`.
-   fixes 2 `no-multi-spaces` lint errors in `lib/node_modules/@stdlib/_tools/github/org-repos/lib/validate.js` by collapsing the extra spaces in the `format` calls for the `token` and `useragent` options.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   resolves #11147

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   While making these changes, I noticed a pre-existing typo in `transform.js`: `ERROR_NAMES.indexof` (lowercase `o`) in the second `NewExpression` branch of `onStringLiteral`. It is left unchanged here, as it is outside the scope of this lint fix, but I am happy to open a separate issue/PR for it.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by an AI assistant, which verified the reported lint errors against `develop`, analyzed the closure dependencies of the nested functions, and generated the changes. I reviewed the diff before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md