### PR TITLE
test: migrate `math/base/special/rad2degf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rad2degf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2degf/test/test.js
@@ -24,9 +24,8 @@ var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var PI = require( '@stdlib/constants/float32/pi' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var rad2degf = require( './../lib' );
 
@@ -64,8 +63,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function converts an angle from radians to degrees', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var r;
 	var i;
@@ -77,21 +74,13 @@ tape( 'the function converts an angle from radians to degrees', function test( t
 	for ( i = 0; i < x.length; i++ ) {
 		r = rad2degf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( r === e ) {
-			t.strictEqual( r, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( r - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+r+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( r, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function converts an angle from radians to degrees (canonical values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var er;
 	var x;
 	var r;
@@ -134,26 +123,16 @@ tape( 'the function converts an angle from radians to degrees (canonical values)
 		330.0,
 		360.0
 	];
+
 	for ( i = 0; i < x.length; i++ ) {
 		r = rad2degf( x[ i ] );
 		er = float64ToFloat32( expected[ i ] );
-		if ( r === er ) {
-			t.strictEqual( r, er, 'x: '+x[ i ]+'. r: '+r+'. expected: '+er+'.' );
-		} else {
-			delta = abs( r - er );
-			tol = EPS * abs( er );
-			t.strictEqual( delta <= tol, true, 'x: '+x[ i ]+'. r: '+r+'. expected: '+er+'. delta: '+delta+'. tol: '+ tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( r, er, 1 ), true, 'returns expected value' );
+
 		// Negative `x`:
 		r = rad2degf( -x[ i ] );
 		er = float64ToFloat32( -expected[ i ] );
-		if ( r === er ) {
-			t.strictEqual( r, er, 'x: '+x[ i ]+'. r: '+r+'. expected: '+er+'.' );
-		} else {
-			delta = abs( r - er );
-			tol = EPS * abs( er );
-			t.strictEqual( delta <= tol, true, 'x: '+x[ i ]+'. r: '+r+'. expected: '+er+'. delta: '+delta+'. tol: '+ tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( r, er, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/rad2degf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2degf/test/test.native.js
@@ -25,9 +25,8 @@ var tape = require( 'tape' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var PI = require( '@stdlib/constants/float32/pi' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValuef = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -73,8 +72,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) 
 
 tape( 'the function converts an angle from radians to degrees', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var r;
 	var i;
@@ -86,21 +83,13 @@ tape( 'the function converts an angle from radians to degrees', opts, function t
 	for ( i = 0; i < x.length; i++ ) {
 		r = rad2degf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( r === e ) {
-			t.strictEqual( r, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( r - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+r+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( r, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function converts an angle from radians to degrees (canonical values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var er;
 	var x;
 	var r;
@@ -143,26 +132,16 @@ tape( 'the function converts an angle from radians to degrees (canonical values)
 		330.0,
 		360.0
 	];
+
 	for ( i = 0; i < x.length; i++ ) {
 		r = rad2degf( x[ i ] );
 		er = float64ToFloat32( expected[ i ] );
-		if ( r === er ) {
-			t.strictEqual( r, er, 'x: '+x[ i ]+'. r: '+r+'. expected: '+er+'.' );
-		} else {
-			delta = abs( r - er );
-			tol = EPS * abs( er );
-			t.strictEqual( delta <= tol, true, 'x: '+x[ i ]+'. r: '+r+'. expected: '+er+'. delta: '+delta+'. tol: '+ tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( r, er, 1 ), true, 'returns expected value' );
+
 		// Negative `x`:
 		r = rad2degf( -x[ i ] );
 		er = float64ToFloat32( -expected[ i ] );
-		if ( r === er ) {
-			t.strictEqual( r, er, 'x: '+x[ i ]+'. r: '+r+'. expected: '+er+'.' );
-		} else {
-			delta = abs( r - er );
-			tol = EPS * abs( er );
-			t.strictEqual( delta <= tol, true, 'x: '+x[ i ]+'. r: '+r+'. expected: '+er+'. delta: '+delta+'. tol: '+ tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValuef( r, er, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/rad2degf` from relative tolerance (`EPS`-scaled) assertions to ULP-based assertions using [`@stdlib/number/float32/base/assert/is-almost-same-value`][is-almost-same-valuef], matching the idiom already used by other single-precision packages (e.g., `acotdf`, `asecdf`, `atanf`, `hypotf`).
-   updates both `test/test.js` and `test/test.native.js`, removing the `EPS`/`abs` imports and the `delta`/`tol` computations in favor of `t.strictEqual( isAlmostSameValuef( r, e, 1 ), true, 'returns expected value' );`.

**Final ULP constant: `1`** for every converted assertion, in both the JavaScript and native test files.

The bound was tightened empirically rather than guessed. Starting from a high bound and lowering it, the measured maximum ULP distance over the full fixture set (2003 points in `test/fixtures/julia/data.json`) plus the 32 canonical angle cases (16 positive and 16 negative) is **1 ULP** for both the JavaScript and the C implementation. `1` is therefore the minimum: at `N = 0` the suite fails with 620 failing assertions (both files), and at `N = 1` all 2041 assertions pass.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no implementation, fixture, or documentation changes.
-   The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN=rad2degf`) so that `test/test.native.js` genuinely executed rather than being skipped. Both files report 2041/2041 passing, and the suite was run twice at the final bound to confirm the result is deterministic (no FMA/architecture-dependent flakiness).
-   The JavaScript and C implementations agree exactly on the worst case, so a single ULP constant is used for both test files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated, unattended run: it selected the package, studied the idiom used in previously merged conversions, applied the test edits, and measured the minimum passing ULP bound by running the suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-valuef]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/float32/base/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajs9WTBd63xXHqB6RJzGjL)_