### PR TITLE
test: migrate `math/base/special/expit` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/expit/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/expit/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var expit = require( './../lib' );
 
 
@@ -69,46 +68,32 @@ tape( 'the function returns `0.0` when provided `-Infinity`', function test( t )
 
 tape( 'the function evaluates the standard logistic function for negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = negative.expected;
 	x = negative.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = expit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the standard logistic function for positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = positive.expected;
 	x = positive.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = expit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/expit/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/expit/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 
 
 // FIXTURES //
@@ -78,46 +77,32 @@ tape( 'the function returns `0.0` when provided `-Infinity`', opts, function tes
 
 tape( 'the function evaluates the standard logistic function for negative numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = negative.expected;
 	x = negative.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = expit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the standard logistic function for positive numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
 
 	expected = positive.expected;
 	x = positive.x;
+
 	for ( i = 0; i < x.length; i++ ) {
 		y = expit( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+y+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/expit` from relative tolerance (`EPS`-scaled) assertions to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value], matching the idiom used by previously converted double-precision packages (e.g., `ellipk`, `factorialln`, `falling-factorial`, `cphase`).
-   updates both `test/test.js` and `test/test.native.js`, removing the `EPS`/`abs` imports and the `delta`/`tol` computations in favor of `t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );`.

**Final ULP constant: `2`** for every converted assertion, in both the JavaScript and native test files.

The bound was tightened empirically rather than guessed. Starting from a high bound and lowering it, the measured maximum ULP distance over the full fixture set (5000 points in `test/fixtures/python/positive.json` and 5000 points in `test/fixtures/python/negative.json`) is **2 ULP** for both the JavaScript and the C implementation, so `2` is the minimum: at `N = 1`, each test file reports 34 failing assertions; at `N = 2`, all 10006 assertions pass in each file.

The worst cases are:

-   negative: `x = -0.01604874543074996`, `y = 0.4959878997557333`, expected `0.4959878997557332`
-   positive: `x = 1.0563425188994806`, `y = 0.7419909757291605`, expected `0.7419909757291603`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no implementation, fixture, or documentation changes.
-   The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN=expit`) so that `test/test.native.js` genuinely executed rather than being skipped.
-   The suite was run twice at the final bound to confirm the result is deterministic (no FMA/architecture-dependent flakiness).
-   The JavaScript and C implementations agree exactly on the worst case, so a single ULP constant is used for both test files.
-   `make lint-javascript-tests TESTS_FILTER=".*/math/base/special/expit/.*"` is clean.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated, unattended run: it selected the package, studied the idiom used in previously merged conversions, applied the test edits, and measured the minimum passing ULP bound by running the suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_014zrHEc6Qt61uPr8oo1zWcM)_