### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dtriu2tril/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dtriu2tril/src/main.c
@@ -88,7 +88,7 @@ void API_SUFFIX(stdlib_strided_dtriu2tril_ndarray)( const CBLAS_INT M, const CBL
 		// Read A row-by-row (upper triangle); write the transpose into B...
 		for ( i1 = 0; i1 < M; i1++ ) {
 			for ( i0 = MAX( 0, i1+k ); i0 < N; i0++ ) {
-				B[ ib + ( i0*strideB1 ) ] = A[ ia + ( i0*strideA2 ) ];
+				B[ ib+(i0*strideB1) ] = A[ ia+(i0*strideA2) ];
 			}
 			ia += strideA1;
 			ib += strideB2;
@@ -98,7 +98,7 @@ void API_SUFFIX(stdlib_strided_dtriu2tril_ndarray)( const CBLAS_INT M, const CBL
 	// Read A column-by-column (upper triangle); write the transpose into B...
 	for ( i1 = 0; i1 < N; i1++ ) {
 		for ( i0 = 0; i0 <= MIN( i1-k, M-1 ); i0++ ) {
-			B[ ib + ( i0*strideB2 ) ] = A[ ia + ( i0*strideA1 ) ];
+			B[ ib+(i0*strideB2) ] = A[ ia+(i0*strideA1) ];
 		}
 		ia += strideA2;
 		ib += strideB1;

--- a/lib/node_modules/@stdlib/math/base/special/frexpf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/frexpf/test/test.native.js
@@ -168,7 +168,7 @@ tape( 'the absolute value of the normalized fraction is on the interval `[1/2,1)
 		}
 		frac = f32( randu()*10.0 );
 		exp = roundf( randu()*74.0 ) - 37;
-		x = f32( sign * frac * f32( powf( 10.0, exp ) ) );
+		x = f32( sign * frac * powf( 10.0, exp ) );
 		f = frexpf( x );
 
 		// Compute the absolute value of the normalized fraction:


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-08-05 21:23 (-0500) and 2026-08-06 04:04 (-0700) (`1d04bde84..e1cc737f7`, 26 commits).

This pull request:

-   `blas/ext/base/dtriu2tril`: Tighten pointer-offset spacing in `dtriu2tril/src/main.c` (5968644): `B[ ib + ( i0*strideB1 ) ]` → `B[ ib+(i0*strideB1) ]` on the two ndarray-loop lines in `lib/node_modules/@stdlib/blas/ext/base/dtriu2tril/src/main.c`, matching `striu2tril` and the rest of `blas/ext/base`.
-   `math/base/special/frexpf`: Fix leftover redundant `f32()` wrapping in `math/base/special/frexpf/test/test.native.js:171` that 37facc3 missed — `x = f32( sign * frac * f32( powf( 10.0, exp ) ) )` becomes `x = f32( sign * frac * powf( 10.0, exp ) )`, matching the five sites already migrated in that commit. No behavior change, `powf` already returns single precision.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed on the 24-hour commit window:

-   Style-guide compliance audit of the five new packages (`blas/ext/base/dtriu2tril`, `blas/ext/base/striu2tril`, `ml/base/loss/float64/huber-gradient`, `ml/base/loss/float64/log-gradient`, `stats/base/dists/wald/mgf`) against established sibling packages.
-   Bug scan of all changed code: triangular-copy index arithmetic in `dtriu2tril`/`striu2tril` (`lib/base.js` and `src/main.c`) brute-force verified against an independent reference over both memory layouts and diagonal offsets; Huber/log-loss gradient formulas and the Wald MGF (incl. domain guard) recomputed against their documented definitions and Julia fixtures; ULP-based test migrations spot-checked against prior tolerances. No runtime bugs found.
-   Deliberately excluded: anything subjective, anything requiring interpretation, and mechanical changes (ULP tolerance constants, bot-driven equation URL bumps).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by a scheduled Claude Code review of commits merged to `develop` in the last 24 hours; Claude identified the issues and authored the fixes, which await human audit (hence draft status).

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDTnN9SGCH168sPZU4kXan

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDTnN9SGCH168sPZU4kXan)_