### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/assert/deep-equal/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/deep-equal/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Number = require( '@stdlib/number/ctor' );
-var isBoolean = require( '@stdlib/assert/is-boolean' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var string2buffer = require( '@stdlib/buffer/from-string' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape/include/stdlib/ndarray/base/assert/is_buffer_length_compatible_shape.h
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape/include/stdlib/ndarray/base/assert/is_buffer_length_compatible_shape.h
@@ -31,7 +31,7 @@ extern "C" {
 /**
 * Determines if a buffer length is compatible with a provided shape array.
 */
-int8_t stdlib_ndarray_is_buffer_length_compatible_shape( int64_t len, int64_t ndims, int64_t *shape );
+int8_t stdlib_ndarray_is_buffer_length_compatible_shape( const int64_t len, const int64_t ndims, const int64_t *shape );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape/src/main.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape/src/main.c
@@ -44,7 +44,7 @@
 * int8_t b = stdlib_ndarray_is_buffer_length_compatible_shape( 10, ndims, shape );
 * // returns 0
 */
-int8_t stdlib_ndarray_is_buffer_length_compatible_shape( int64_t len, int64_t ndims, int64_t *shape ) {
+int8_t stdlib_ndarray_is_buffer_length_compatible_shape( const int64_t len, const int64_t ndims, const int64_t *shape ) {
 	if ( len > stdlib_ndarray_numel( ndims, shape ) ) {
 		return 1;
 	}

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible/include/stdlib/ndarray/base/assert/is_buffer_length_compatible.h
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible/include/stdlib/ndarray/base/assert/is_buffer_length_compatible.h
@@ -32,7 +32,7 @@ extern "C" {
 /**
 * Determines if a buffer length is compatible with provided ndarray meta data.
 */
-int8_t stdlib_ndarray_is_buffer_length_compatible( enum STDLIB_NDARRAY_DTYPE dtype, int64_t len, int64_t ndims, int64_t *shape, int64_t *strides, int64_t offset );
+int8_t stdlib_ndarray_is_buffer_length_compatible( const enum STDLIB_NDARRAY_DTYPE dtype, const int64_t len, const int64_t ndims, const int64_t *shape, const int64_t *strides, const int64_t offset );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible/src/main.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-buffer-length-compatible/src/main.c
@@ -52,7 +52,7 @@
 * int8_t b = stdlib_ndarray_is_buffer_length_compatible( STDLIB_NDARRAY_UINT8, 10, ndims, shape, strides, offset );
 * // returns 0
 */
-int8_t stdlib_ndarray_is_buffer_length_compatible( enum STDLIB_NDARRAY_DTYPE dtype, int64_t len, int64_t ndims, int64_t *shape, int64_t *strides, int64_t offset ) {
+int8_t stdlib_ndarray_is_buffer_length_compatible( const enum STDLIB_NDARRAY_DTYPE dtype, const int64_t len, const int64_t ndims, const int64_t *shape, const int64_t *strides, const int64_t offset ) {
 	int64_t tmp[ 2 ];
 	int64_t nbytes;
 

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major-contiguous/include/stdlib/ndarray/base/assert/is_column_major_contiguous.h
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major-contiguous/include/stdlib/ndarray/base/assert/is_column_major_contiguous.h
@@ -32,7 +32,7 @@ extern "C" {
 /**
 * Determines if an array is column-major contiguous.
 */
-int8_t stdlib_ndarray_is_column_major_contiguous( enum STDLIB_NDARRAY_DTYPE dtype, int64_t ndims, int64_t *shape, int64_t *strides, int64_t offset );
+int8_t stdlib_ndarray_is_column_major_contiguous( const enum STDLIB_NDARRAY_DTYPE dtype, const int64_t ndims, const int64_t *shape, const int64_t *strides, const int64_t offset );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major-contiguous/src/main.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-column-major-contiguous/src/main.c
@@ -49,7 +49,7 @@
 * int8_t b = stdlib_ndarray_is_column_major_contiguous( STDLIB_NDARRAY_UINT8, ndims, shape, strides, offset );
 * // returns 1
 */
-int8_t stdlib_ndarray_is_column_major_contiguous( enum STDLIB_NDARRAY_DTYPE dtype, int64_t ndims, int64_t *shape, int64_t *strides, int64_t offset ) {
+int8_t stdlib_ndarray_is_column_major_contiguous( const enum STDLIB_NDARRAY_DTYPE dtype, const int64_t ndims, const int64_t *shape, const int64_t *strides, const int64_t offset ) {
 	if (
 		stdlib_ndarray_iteration_order( ndims, strides ) != 0 &&
 		stdlib_ndarray_is_column_major( ndims, strides ) != 0 &&

--- a/lib/node_modules/@stdlib/number/uint64/base/number2words/README.md
+++ b/lib/node_modules/@stdlib/number/uint64/base/number2words/README.md
@@ -78,7 +78,7 @@ var bool = ( w === out );
 
 ## Notes
 
--   For accurate results, the input value should be an integer in the range \[`0`, `2^53-1`\].
+-   For accurate results, the input value should be an integer in the range \[`0`, `2^53-1`].
 
 </section>
 

--- a/lib/node_modules/@stdlib/random/base/minstd-shuffle/lib/main.js
+++ b/lib/node_modules/@stdlib/random/base/minstd-shuffle/lib/main.js
@@ -87,7 +87,7 @@ var randint32 = require( './rand_int32.js' );
 * -   Herzog, T.N., and G. Lord. 2002. _Applications of Monte Carlo Methods to Finance and Insurance_. ACTEX Publications. [https://books.google.com/books?id=vC7I\\\_gdX-A0C](https://books.google.com/books?id=vC7I\_gdX-A0C).
 * -   Press, William H., Brian P. Flannery, Saul A. Teukolsky, and William T. Vetterling. 1992. _Numerical Recipes in C: The Art of Scientific Computing, Second Edition_. Cambridge University Press.
 *
-* @function minstd
+* @name minstd
 * @type {PRNG}
 * @returns {PositiveInteger} pseudorandom integer
 *

--- a/lib/node_modules/@stdlib/random/base/minstd/lib/main.js
+++ b/lib/node_modules/@stdlib/random/base/minstd/lib/main.js
@@ -84,7 +84,7 @@ var randint32 = require( './rand_int32.js' );
 * -   Park, S. K., and K. W. Miller. 1988. "Random Number Generators: Good Ones Are Hard to Find." _Communications of the ACM_ 31 (10). New York, NY, USA: ACM: 1192–1201. doi:[10.1145/63039.63042](http://dx.doi.org/10.1145/63039.63042).
 * -   Press, William H., Brian P. Flannery, Saul A. Teukolsky, and William T. Vetterling. 1992. _Numerical Recipes in C: The Art of Scientific Computing, Second Edition_. Cambridge University Press.
 *
-* @function minstd
+* @name minstd
 * @type {PRNG}
 * @returns {PositiveInteger} pseudorandom integer
 *

--- a/lib/node_modules/@stdlib/random/base/mt19937/lib/main.js
+++ b/lib/node_modules/@stdlib/random/base/mt19937/lib/main.js
@@ -86,7 +86,7 @@ var randuint32 = require( './rand_uint32.js' );
 *
 * [@matsumoto:1998a]: https://doi.org/10.1145/272991.272995
 *
-* @function mt19937
+* @name mt19937
 * @type {PRNG}
 * @returns {PositiveInteger} pseudorandom integer
 *


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request propagates fixes merged to `develop` between 2026-08-05 and 2026-08-06 to sibling packages with the same defects.

**JSDoc `@function` → `@name` (source: 4db26c0)**

4db26c0 fixed `@stdlib/random/base/chisquare`'s `@function chisquare` tag to `@name chisquare`, since the documented export is a factory-produced PRNG value, not a function declaration. This propagates the same fix to the three remaining outliers in `random/base`, bringing all 43 packages into consistency:

-   `@stdlib/random/base/minstd`
-   `@stdlib/random/base/minstd-shuffle`
-   `@stdlib/random/base/mt19937`

**C `const` qualifiers (sources: 8ef56c4, ed2034b)**

Applies the `const` qualification from 8ef56c4 and ed2034b to the remaining sibling assert packages that lacked it. Every helper invoked by these functions already declares `const`-qualified parameters, so no downstream signature changes are required.

-   `@stdlib/ndarray/base/assert/is-buffer-length-compatible`
-   `@stdlib/ndarray/base/assert/is-buffer-length-compatible-shape`
-   `@stdlib/ndarray/base/assert/is-column-major-contiguous`

`is-contiguous` is excluded. PR #13874 already const-qualifies it.

**Benchmark boolean assertion (source: 1935a5f)**

Propagates the fix from 1935a5f to `@stdlib/assert/deep-equal`'s `benchmark/benchmark.js`, replacing `require( '@stdlib/assert/is-boolean' )` with `require( '@stdlib/assert/is-boolean' ).isPrimitive`. The sole `isBoolean` call site checks `deepEqual`'s return value, which is always a primitive boolean.

**README escaped bracket (source: 51e6c83)**

Propagates the same README cleanup to the `number2words` README, the last remaining occurrence of the unnecessary escaped-bracket form in the `uint64/base` namespace: `` \[`0`, `2^53-1`\] `` becomes `` \[`0`, `2^53-1`] ``, matching the fix already applied to `bigint2words` in 51e6c83.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed per pattern: signatures were derived from the source commits and searched across the in-scope namespaces; two independent validation passes confirmed each defect in full-file context; an adaptation pass confirmed each patch is self-contained within its target package (all C helpers called by the modified functions already declare `const`-qualified parameters, and no external callers reference the three C symbols); and a style-consistency pass confirmed each patch matches the merged precedents.

Deliberately excluded: `ndarray/base/assert/is-contiguous` (covered by open PR #13874); double-precision `pow` usage in other `*f` package fixtures (intentional reference computations, not the 37facc3 defect); `shape parameter` descriptions in `random/base/*` validators (all verified correct); and the remaining escaped-bracket occurrences repo-wide (literal regexp output and CLI-syntax contexts where the escape is intended).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated fix-propagation routine: candidate sites were located by pattern search over the last 24 hours of `develop` commits, and every applied patch was confirmed by two independent validation passes plus adaptation and style-consistency passes before committing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_014AQwLfUnMjo4hyfgxsZRg2)_