### PR TITLE
test: migrate `math/base/special/expm1rel` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/expm1rel/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/expm1rel/test/test.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -48,8 +48,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -59,17 +57,13 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for negative medium numbe
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -79,17 +73,13 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for positive medium numbe
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for negative small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -99,17 +89,13 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for negative small number
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for positive small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -119,17 +105,13 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for positive small number
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for very small `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -139,9 +121,7 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for very small `x`', func
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/expm1rel/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/expm1rel/test/test.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
@@ -57,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for negative medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -68,17 +66,13 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for negative medium numbe
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for positive medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -88,17 +82,13 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for positive medium numbe
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for negative small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -108,17 +98,13 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for negative small number
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for positive small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -128,17 +114,13 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for positive small number
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `(exp(x)-1)/x` for very small `x`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -148,9 +130,7 @@ tape( 'the function accurately computes `(exp(x)-1)/x` for very small `x`', opts
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = expm1rel( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Delta: ' + delta + '. Tolerance: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/expm1rel` from relative tolerance (`EPS`-scaled) assertions to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value], matching the idiom used by previously converted double-precision packages (e.g., `hypot`, `ellipk`, `expit`, `cphase`).
-   updates both `test/test.js` and `test/test.native.js`, removing the `abs` import and the `delta`/`tol` computations in favor of `t.strictEqual( isAlmostSameValue( v, expected[ i ], N ), true, 'returns expected value' );`. The `EPS` import is retained in both files, as it is still used by the "returns `1.0` near `0.0`" test.

**Final ULP constants** (per fixture set, identical in `test/test.js` and `test/test.native.js`):

| Fixture set | ULP bound | Worst case |
| ----------- | --------- | ---------- |
| `medium_negative.json` | `0` | exact for all 1000 points |
| `medium_positive.json` | `2` | `x = 87.55771771771771`, `y = 1.2121021459952258e+36`, expected `1.2121021459952261e+36` |
| `small_negative.json` | `3` | `x = -0.22922922922922928`, `y = 0.8936633379449439`, expected `0.8936633379449436` |
| `small_positive.json` | `3` | `x = 0.4644644644644645`, `y = 1.2727816274388977`, expected `1.272781627438897` |
| `tiny.json` | `0` | exact for all 1000 points |

The previous tolerance was a uniform `3.0 * EPS * abs( expected[ i ] )` for every fixture set.

The bounds were tightened empirically rather than guessed. Starting from a high bound and lowering it, the measured maximum ULP distance was computed for every one of the 5000 fixture points, and the values above are the minima: lowering the `2` to `1` and the `3`s to `2` produces 21 failing assertions, while at the stated bounds all 5008 assertions pass.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The `medium_negative` and `tiny` fixture sets are reproduced exactly (0 ULP). Reviewers may prefer a floor of `1` there for robustness against future implementation changes; `0` is used here as it is the measured minimum, consistent with the guidance in #11352 and with the ~300 existing `isAlmostSameValue( ..., 0 )` assertions already in the tree.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no implementation, fixture, or documentation changes.
-   The suite was run twice at the final bounds to confirm the result is deterministic (no FMA/architecture-dependent flakiness).
-   The native add-on could not be built in the authoring environment, so `test/test.native.js` skipped locally. To avoid guessing its bounds, the C implementation (`src/main.c`, plus its `expm1`/`abs`/`is_nan` dependencies) was compiled standalone with `gcc -O2` and evaluated over the same fixture points: the C implementation reproduces the JavaScript results bit-for-bit, giving identical per-set bounds of `0`, `2`, `3`, `3`, `0`. The two test files therefore use the same constants. Confirmation from CI (where the add-on is built) would be welcome.
-   ESLint (`etc/eslint/.eslintrc.tests.js`) reports no errors or warnings for either file; the pre-commit JavaScript test lint and filename lint hooks both passed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated, unattended run: it selected the package, studied the idiom used in previously merged conversions, applied the test edits, and measured the minimum passing ULP bounds by running the suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXgZDZZDJZ92eUM4AwD1Cu)_