### PR TITLE
test: migrate `math/base/special/asec` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/asec/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asec/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var asec = require( './../lib' );
 
 
@@ -49,8 +48,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-3.0,-1.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -60,21 +57,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-3.0,-1.
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[1.0,3.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -84,21 +73,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[1.0,3.0]
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[3.0,100.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -108,21 +89,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[3.0,100.
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-100.0,-3.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -132,21 +105,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-100.0,-
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[100.0,1000.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -156,21 +121,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[100.0,10
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-1000.0,-100.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -180,21 +137,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-1000.0,
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-1e200,-1e208]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -204,21 +153,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-1e200,-
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[1e300,1e308]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -228,13 +169,7 @@ tape( 'the function computes the inverse (arc) secant on the interval `[1e300,1e
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asec/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asec/test/test.native.js
@@ -22,9 +22,8 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-3.0,-1.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -69,21 +66,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-3.0,-1.
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[1.0,3.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -93,21 +82,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[1.0,3.0]
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[3.0,100.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -117,21 +98,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[3.0,100.
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-100.0,-3.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -141,21 +114,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-100.0,-
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[100.0,1000.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -165,21 +130,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[100.0,10
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-1000.0,-100.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -189,21 +146,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-1000.0,
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-1e200,-1e208]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -213,21 +162,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-1e200,-
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[1e300,1e308]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -237,13 +178,7 @@ tape( 'the function computes the inverse (arc) secant on the interval `[1e300,1e
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asec( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/asec` from relative tolerance comparisons (`delta <= tol`, where `tol = 1.0 * EPS * abs( expected[i] )`) to ULP difference assertions using `@stdlib/assert/is-almost-same-value`, per the idiom established in #11352.
-   removes the now unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` requires, along with the `delta`/`tol` locals and the `y === expected[i]` exact-match branch, in both `test/test.js` and `test/test.native.js`.

The ULP bounds were measured against the full fixture set (4006 fixture values across 8 Julia fixture files) and tightened to the minimum integer which still passes:

| Fixture | Interval | ULP |
| ------- | -------- | --- |
| `medium_negative` | `[-3.0,-1.0]` | 1 |
| `medium_positive` | `[1.0,3.0]` | 1 |
| `large_positive` | `[3.0,100.0]` | 1 |
| `large_negative` | `[-100.0,-3.0]` | 1 |
| `larger_positive` | `[100.0,1000.0]` | 1 |
| `larger_negative` | `[-1000.0,-100.0]` | 1 |
| `huge_negative` | `[-1e200,-1e208]` | 0 |
| `huge_positive` | `[1e300,1e308]` | 0 |

The measured maximum ULP difference over each fixture equals the value used, so each bound is minimal (e.g., the `huge_*` fixtures are bit-for-bit exact, and lowering any `1` to `0` fails). The JavaScript and native C implementations were measured independently and agree exactly, so `test/test.js` and `test/test.native.js` use identical ULP values. Both suites were run twice at the final values to confirm determinism (4013 assertions passing per file, native add-on built locally).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only the two test files are changed; no source, fixture, or documentation changes.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code, which studied the prior conversions in this tracking issue, applied the same idiom to `math/base/special/asec`, and measured the minimum ULP bounds empirically against the fixture data.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_0145dbvojq8U5TjsoiKPEbxm)_