### PR TITLE
test: migrate `math/base/special/besselj1` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/besselj1/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/test/test.js
@@ -25,8 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var j1 = require( './../lib' );
 
 
@@ -55,8 +54,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (very large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -65,21 +62,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 600.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 885 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -88,21 +77,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 300.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 302 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -111,21 +92,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2600.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2870 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -134,21 +107,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 5.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (small negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -157,21 +122,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = smallNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 5.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates Bessel function of the first kind of order one (J_1) (smaller positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -180,21 +137,13 @@ tape( 'the function evaluates Bessel function of the first kind of order one (J_
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 3.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (tiny positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -203,21 +152,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (subnormal values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -226,21 +167,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 5.0e-324;
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (huge positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -249,21 +182,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 3000.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4054 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) for positive x over a wide range of magnitudes', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -272,21 +197,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = positiveGamut.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 18.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 31 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) for negative x over a wide range of magnitudes', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -295,13 +212,7 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = negativeGamut.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 18.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 31 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/besselj1/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/test/test.native.js
@@ -26,8 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -64,8 +63,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (very large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -74,21 +71,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = veryLargePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 600.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 885 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -97,21 +86,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = largePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 300.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 302 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -120,21 +101,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = mediumPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2600.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2870 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -143,21 +116,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = smallPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 5.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (small negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -166,21 +131,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = smallNegative.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 5.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates Bessel function of the first kind of order one (J_1) (smaller positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -189,21 +146,13 @@ tape( 'the function evaluates Bessel function of the first kind of order one (J_
 	x = smaller.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 3.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (tiny positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -212,21 +161,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = tinyPositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (subnormal values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -235,21 +176,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = subnormal.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 5.0e-324;
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) (huge positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -258,21 +191,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = hugePositive.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 3000.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4054 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) for positive x over a wide range of magnitudes', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -281,21 +206,13 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = positiveGamut.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 18.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 31 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the Bessel function of the first kind of order one (J_1) for negative x over a wide range of magnitudes', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -304,13 +221,7 @@ tape( 'the function evaluates the Bessel function of the first kind of order one
 	x = negativeGamut.x;
 	for ( i = 0; i < x.length; i++ ) {
 		y = j1( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 18.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 31 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `math/base/special/besselj1` test cases from relative-tolerance testing (`delta <= EPS * multiplier * abs(expected)`) to ULP-difference testing using `@stdlib/assert/is-almost-same-value`, per the conventions established in #11352 (mirroring the already-converted sibling package `math/base/special/besselj0`).
-   applies the same conversion to both `test/test.js` and `test/test.native.js`.
-   for each fixture set, the minimum required ULP bound was determined empirically using `@stdlib/number/float64/base/ulp-difference` to compute the exact maximum ULP distance between actual and expected values across the full fixture, for both the JavaScript and native (C addon) implementations (which produced identical bounds):
    -   `veryLargePositive`: 885
    -   `largePositive`: 302
    -   `mediumPositive`: 2870
    -   `smallPositive` / `smallNegative`: 8
    -   `smaller`: 5
    -   `tinyPositive` / `subnormal`: 1
    -   `hugePositive`: 4054
    -   `positiveGamut` / `negativeGamut`: 31
-   the full test suite (`test.js` and `test.native.js`, 46,666 assertions each) was run twice at these bounds to confirm deterministic behavior (no FMA/arch-related flakiness).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored autonomously by Claude Code (running as a scheduled task on behalf of the repository account owner), including package discovery, studying prior-art conversions, computing the minimum ULP bounds via `@stdlib/number/float64/base/ulp-difference`, and rewriting the test files. Opened as a draft for maintainer review given issue #11352 requests this task be done manually by first-time contributors where possible.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR9JdQG3BpzVybaTpDJpNq)_