### PR TITLE
test: migrate `math/base/special/sincosd` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincosd/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincosd/test/test.assign.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var Float64Array = require( '@stdlib/array/float64' );
 var sincosd = require( './../lib/assign.js' );
 
@@ -50,9 +49,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -66,29 +63,15 @@ tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', func
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = 1.01 * EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -102,29 +85,15 @@ tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', func
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = 1.01 * EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -138,29 +107,15 @@ tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', funct
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = 1.01 * EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2**20 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -174,29 +129,15 @@ tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2*
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -210,29 +151,15 @@ tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**6
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -246,29 +173,15 @@ tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', f
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -282,20 +195,8 @@ tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', fu
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns output array' );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sincosd/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincosd/test/test.main.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var sincosd = require( './../lib/main.js' );
 
 
@@ -49,9 +48,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -62,29 +59,15 @@ tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', func
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = 1.01 * EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,29 +78,15 @@ tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = 1.01 * EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2**20 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -128,29 +97,15 @@ tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2*
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -161,29 +116,15 @@ tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**6
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -194,29 +135,15 @@ tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -227,20 +154,8 @@ tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/sincosd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincosd/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,9 +57,7 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -71,29 +68,15 @@ tape( 'the function computes the sine and cosine (for -256*180.0 < x < 0)', opts
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = 1.01 * EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -104,29 +87,15 @@ tape( 'the function computes the sine and cosine (for 0 < x < 256*180.0)', opts,
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = 1.01 * EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2**20 (180.0/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -137,29 +106,15 @@ tape( 'the function computes the sine and cosine (for -2**60 (180.0/2) < x < -2*
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**60 (180.0/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -170,29 +125,15 @@ tape( 'the function computes the sine and cosine (for 2**20 (180.0/2) < x < 2**6
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -203,29 +144,15 @@ tape( 'the function computes the sine and cosine (for x <= -2**60 (180.0/2))', o
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', opts, function test( t ) {
 	var cosine;
-	var delta;
 	var sine;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -236,20 +163,8 @@ tape( 'the function computes the sine and cosine (for x >= 2**60 (180.0/2))', op
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = sincosd( x[i] );
-		if ( y[0] === sine[ i ] ) {
-			t.strictEqual( y[0], sine[ i ], 'x: '+x[i]+'. Expected: '+sine[i] );
-		} else {
-			delta = abs( y[0] - sine[i] );
-			tol = EPS * abs( sine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[0]+'. Expected: '+sine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === cosine[ i ] ) {
-			t.strictEqual( y[1], cosine[ i ], 'x: '+x[i]+'. Expected: '+cosine[i] );
-		} else {
-			delta = abs( y[1] - cosine[i] );
-			tol = EPS * abs( cosine[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y[1]+'. Expected: '+cosine[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[ 1 ], cosine[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/sincosd` from relative tolerance (`EPS`-scaled) assertions to ULP-based assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value], matching the idiom used by previously converted double-precision packages (e.g., `expit`, `ellipk`, `factorialln`, `falling-factorial`).
-   updates `test/test.main.js`, `test/test.assign.js`, and `test/test.native.js`, removing the `EPS`/`abs` imports and the `delta`/`tol` computations in favor of `t.strictEqual( isAlmostSameValue( y[ 0 ], sine[ i ], N ), true, 'returns expected value' );`.

**Final ULP constants:**

| Fixture set | `sine` | `cosine` |
| ----------- | ------ | -------- |
| `medium_negative` | `1` | `2` |
| `medium_positive` | `1` | `2` |
| `large_negative` | `1` | `1` |
| `large_positive` | `1` | `1` |
| `huge_negative` | `1` | `1` |
| `huge_positive` | `1` | `1` |

The same constants are used in all three test files.

The bounds were tightened empirically rather than guessed. Starting from a high bound and lowering it, the measured maximum ULP distance over the full fixture set (6 fixture files &times; 4000 points = 24000 points, each contributing a `sine` and a `cosine` assertion) is:

-   `1` ULP for `sine` across every fixture set.
-   `2` ULP for `cosine` on the two `medium` fixture sets, and `1` ULP elsewhere.

These are minimal:

-   Lowering `sine` from `1` to `0` produces 8260 failing assertions in `test/test.main.js`.
-   Lowering the `medium` `cosine` bound from `2` to `1` produces 2 failing assertions.
-   Lowering the `large`/`huge` `cosine` bound from `1` to `0` produces 3472 failing assertions.

At the final bounds, `test/test.main.js` passes all 48008 assertions and `test/test.assign.js` passes all 84024 assertions.

Note that the previous relative tolerances already encoded this same split: the `medium` fixture sets used `tol = 1.01 * EPS * abs( cosine[i] )` for the cosine while every other assertion used `tol = EPS * abs( ... )`. The measured ULP bounds reproduce that structure exactly.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

Yes &mdash; one:

-   The native add-on could **not** be built in the environment used to author this PR (`node-gyp` was unavailable), so `test/test.native.js` was skipped rather than executed, and its ULP constants mirror the measured JavaScript bounds rather than being independently measured against the C implementation. Please confirm the native tests pass at these bounds in CI. If the C implementation is fractionally less accurate at any point, the corresponding constant in `test/test.native.js` may need to be raised.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the three test files are modified; no implementation, fixture, or documentation changes.
-   `test/test.js` contains no tolerance-based assertions (it only checks the exports), so it is unchanged.
-   The suites were run twice at the final bounds to confirm the result is deterministic (no FMA/architecture-dependent flakiness).
-   ESLint (`etc/eslint/.eslintrc.tests.js`) is clean on all four test files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated, unattended run: it selected the package, studied the idiom used in previously merged conversions, applied the test edits, and measured the minimum passing ULP bounds by running the suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMycrGkFdDy3nbXTV8wzFD)_