### PR TITLE
test: migrate `math/base/special/gamma1pm1` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gamma1pm1/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma1pm1/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var gamma1pm1 = require( './../lib' );
 
 
@@ -78,8 +77,6 @@ tape( 'the function computes `gamma(x+1) - 1` for most `x` (positive)', function
 
 tape( 'the function accurately computes `gamma(x+1) - 1` for small negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -89,17 +86,13 @@ tape( 'the function accurately computes `gamma(x+1) - 1` for small negative numb
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = gamma1pm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 5.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `gamma(x+1) - 1` for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -109,9 +102,7 @@ tape( 'the function accurately computes `gamma(x+1) - 1` for small positive numb
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = gamma1pm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 2.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/gamma1pm1/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma1pm1/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -87,8 +86,6 @@ tape( 'the function computes `gamma(x+1) - 1` for most `x` (positive)', opts, fu
 
 tape( 'the function accurately computes `gamma(x+1) - 1` for small negative numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -98,17 +95,13 @@ tape( 'the function accurately computes `gamma(x+1) - 1` for small negative numb
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = gamma1pm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 5.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function accurately computes `gamma(x+1) - 1` for small positive numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -118,9 +111,7 @@ tape( 'the function accurately computes `gamma(x+1) - 1` for small positive numb
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = gamma1pm1( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 2.0 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/gamma1pm1` from relative tolerance (`EPS`-based) assertions to ULP difference assertions using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates both `test/test.js` and `test/test.native.js`, removing the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

The ULP bounds were tightened to the measured minimum which still passes over the full fixture sets:

| Test case | Fixtures | Previous tolerance | ULP bound |
| --- | --- | --- | --- |
| small negative numbers | `fixtures/cpp/small_negative.json` (1000 values) | `5.0 * EPS * abs( expected )` | **3** |
| small positive numbers | `fixtures/cpp/small_positive.json` (1000 values) | `2.0 * EPS * abs( expected )` | **2** |

The same bounds apply to both the JavaScript and the native (C) implementations, so `test.js` and `test.native.js` use identical values.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Notes on how the bounds were determined and verified:

-   For each fixture value, the minimum `N` for which `isAlmostSameValue( actual, expected, N )` returns `true` was computed; the bound above is the maximum such `N` over the full fixture set.
-   The bounds are tight: lowering the small negative bound to `2` produces 1 failing assertion, and lowering the small positive bound to `1` produces 29 failing assertions.
-   The native add-on was built locally (`make install-node-addons NODE_ADDONS_PATTERN=gamma1pm1`) so that `test/test.native.js` actually ran rather than being skipped.
-   `make test TESTS_FILTER=".*/math/base/special/gamma1pm1/.*"` was run twice at the final bounds, with identical results each time (2691 passing in `test.js`, 2680 passing in `test.native.js`, 0 failing).
-   `make lint-javascript-tests TESTS_FILTER=".*/math/base/special/gamma1pm1/.*"` is clean.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, following the idiom established in previously merged conversions (e.g., `math/base/special/sqrt1pm1`, `math/base/special/asec`, `math/base/special/powm1`). The ULP bounds were measured empirically against the fixture sets rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8y1oQRpySabKgjBMumaWs)_