### PR TITLE
build: guard against binary download failures

### DIFF
--- a/.github/workflows/lint_random_files.yml
+++ b/.github/workflows/lint_random_files.yml
@@ -206,6 +206,9 @@ jobs:
         id: lint-editorconfig
         env:
           FILES: ${{ steps.random-files.outputs.files }}
+
+          # Provide a token so that the editorconfig-checker binary download is authenticated, thus avoiding rate limiting:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -o pipefail
           files=$(echo "$FILES" | tr ',' ' ')
@@ -217,6 +220,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.STDLIB_BOT_PAT_REPO_WRITE }}
         run: |
+          # Guard against creating spurious issues when the lint step failed due to an infrastructure error (e.g., failing to download the editorconfig-checker binary due to rate limiting) rather than actual lint errors:
+          if grep -q 'Failed to download binary' lint_editorconfig_errors.txt 2>/dev/null; then
+            echo 'EditorConfig lint step failed due to an infrastructure error (e.g., failed binary download). Skipping issue creation.'
+            exit 0
+          fi
+
           strip_ansi() {
             sed -r 's/\x1B\[[0-9;]*[mK]//g'
           }


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/869.

## Description

> What is the purpose of this pull request?

This pull request:

-   guards against creating spurious "good first issue" issues when the `lint_random_files` workflow's EditorConfig lint step fails due to an infrastructure error (e.g., failing to download the `editorconfig-checker` binary due to rate limiting) rather than actual lint errors. Before creating a sub-issue, the workflow now checks the captured lint output for the wrapper's definitive download-failure marker (`Failed to download binary`) and skips issue creation when present.
-   sets `GITHUB_TOKEN` on the EditorConfig lint step so that the `editorconfig-checker` npm wrapper authenticates its GitHub releases API request when downloading its binary, avoiding unauthenticated rate limits (the root cause of the spurious issues).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The `editorconfig-checker` npm wrapper routes every download-phase failure (HTTP errors, network errors, extraction errors) through a single `Failed to download binary:` message before exiting non-zero, so matching on that one marker suffices and avoids false negatives from broader patterns.
-   The job still fails when the download fails (the guard only skips issue creation), so transient infrastructure failures remain visible in the workflow run history.
-   A follow-up PR will add `node_modules` caching (as already done in `lint_changed_files.yml`) so that the binary download is skipped entirely on cache hits.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, including inspecting the `editorconfig-checker` wrapper source to determine its failure behavior; the changes were reviewed and directed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
