### PR TITLE
build: cache node modules to avoid repeated editorconfig-checker downloads

### DIFF
--- a/.github/workflows/lint_random_files.yml
+++ b/.github/workflows/lint_random_files.yml
@@ -113,8 +113,21 @@ jobs:
           node-version: '20' # 'lts/*'
         timeout-minutes: 5
 
+      # Restore cache if up-to-date:
+      - name: 'Restore cache if up-to-date'
+        # Pin action to full length commit SHA
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: cache
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       # Install dependencies (accounting for possible network failures, etc, when installing node module dependencies):
       - name: 'Install dependencies'
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           make install-node-modules || make install-node-modules || make install-node-modules
         timeout-minutes: 15
@@ -213,6 +226,14 @@ jobs:
           set -o pipefail
           files=$(echo "$FILES" | tr ',' ' ')
           make lint-editorconfig-files FILES="${files}" 2>&1 | tee lint_editorconfig_errors.txt
+
+      # Save cache after editorconfig-checker binary has been downloaded:
+      - name: 'Save cache after editorconfig-checker binary has been downloaded'
+        if: always() && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/node_modules
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
       # Create sub-issue for EditorConfig lint failures:
       - name: 'Create sub-issue for EditorConfig lint failures'


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   caches `node_modules` in the `lint_random_files` workflow (mirroring the existing setup in `lint_changed_files.yml`) so that, on cache hits, dependency installation — and, in particular, the `editorconfig-checker` binary download — is skipped entirely, further reducing exposure to download failures and speeding up the daily run.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The `editorconfig-checker` npm wrapper downloads its Go binary into the package directory inside `node_modules` on first invocation, so caching `node_modules` after the EditorConfig lint step also caches the binary.
-   The cache save step runs with `if: always()` so that the binary is cached even when the lint step fails due to lint errors.
-   This PR is stacked on top of #13999, which guards issue creation against binary download failures and authenticates the download.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, mirroring the existing caching setup in `lint_changed_files.yml`; the changes were reviewed and directed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


