### PR TITLE
feat: add `no-single-property-require` ESLint rule

### DIFF
--- a/etc/eslint/.eslintrc.tests.js
+++ b/etc/eslint/.eslintrc.tests.js
@@ -129,7 +129,7 @@ eslint.rules[ 'stdlib/jsdoc-private-annotation' ] = 'off';
 eslint.rules[ 'stdlib/jsdoc-doctest' ] = 'off';
 
 /**
-* Allow requiring the package under test as a whole when only a single property is used.
+* When testing, allow requiring the package as a whole even though only a single property is used.
 *
 * @private
 */

--- a/etc/eslint/.eslintrc.tests.js
+++ b/etc/eslint/.eslintrc.tests.js
@@ -129,6 +129,13 @@ eslint.rules[ 'stdlib/jsdoc-private-annotation' ] = 'off';
 eslint.rules[ 'stdlib/jsdoc-doctest' ] = 'off';
 
 /**
+* Allow requiring the package under test as a whole when only a single property is used.
+*
+* @private
+*/
+eslint.rules[ 'stdlib/no-single-property-require' ] = 'off';
+
+/**
 * Do not enforce nested function elevation.
 *
 * @private

--- a/etc/eslint/overrides/index.js
+++ b/etc/eslint/overrides/index.js
@@ -122,6 +122,7 @@ var overrides = [
 			'require-jsdoc': 'off',
 			'stdlib/jsdoc-private-annotation': 'off',
 			'stdlib/jsdoc-doctest': 'off',
+			'stdlib/no-single-property-require': 'off',
 			'stdlib/no-unnecessary-nested-functions': 'off',
 			'no-undefined': 'off'
 		}
@@ -158,6 +159,7 @@ var overrides = [
 			'require-jsdoc': 'off',
 			'stdlib/jsdoc-private-annotation': 'off',
 			'stdlib/jsdoc-return-annotations-values': 'off',
+			'stdlib/no-single-property-require': 'off',
 			'stdlib/no-unnecessary-nested-functions': 'off',
 			'stdlib/return-annotations-values': 'off',
 			'strict': 'off',

--- a/etc/eslint/rules/stdlib.js
+++ b/etc/eslint/rules/stdlib.js
@@ -4590,7 +4590,11 @@ rules[ 'stdlib/no-require-index' ] = 'error';
 rules[ 'stdlib/no-self-require' ] = 'error';
 
 /**
-* Enforce that a property is required directly when only a single property of a required module is used. Requiring a property directly reduces bundle sizes during ESM tree-shaking via named imports.
+* Enforce that a property is required directly when only a single property of a required module is used.
+*
+* ## Notes
+*
+* -   Requiring a property directly reduces bundle sizes during ESM tree-shaking via named imports.
 *
 * @name no-single-property-require
 * @memberof rules

--- a/etc/eslint/rules/stdlib.js
+++ b/etc/eslint/rules/stdlib.js
@@ -4590,6 +4590,30 @@ rules[ 'stdlib/no-require-index' ] = 'error';
 rules[ 'stdlib/no-self-require' ] = 'error';
 
 /**
+* Enforce that a property is required directly when only a single property of a required module is used. Requiring a property directly reduces bundle sizes during ESM tree-shaking via named imports.
+*
+* @name no-single-property-require
+* @memberof rules
+* @type {string}
+* @default 'warn'
+*
+* @example
+* // Bad...
+* var dcopy = require( '@stdlib/blas/base/dcopy' );
+*
+* dcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );
+* dcopy.ndarray( y.length, y, 1, 0, z, 1, 0 );
+*
+* @example
+* // Good...
+* var dcopy = require( '@stdlib/blas/base/dcopy' ).ndarray;
+*
+* dcopy( x.length, x, 1, 0, y, 1, 0 );
+* dcopy( y.length, y, 1, 0, z, 1, 0 );
+*/
+rules[ 'stdlib/no-single-property-require' ] = 'warn';
+
+/**
 * Never allow unassigned `require()` calls.
 *
 * @name no-unassigned-require

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/README.md
@@ -83,6 +83,7 @@ var eslint = rules;
 -   <span class="signature">[`no-require-absolute-path`][@stdlib/_tools/eslint/rules/no-require-absolute-path]</span><span class="delimiter">: </span><span class="description">ESLint rule disallowing `require()` statements containing absolute file paths.</span>
 -   <span class="signature">[`no-require-index`][@stdlib/_tools/eslint/rules/no-require-index]</span><span class="delimiter">: </span><span class="description">ESLint rule disallowing `require()` calls which explicitly require `index.<ext>` files.</span>
 -   <span class="signature">[`no-self-require`][@stdlib/_tools/eslint/rules/no-self-require]</span><span class="delimiter">: </span><span class="description">ESLint rule enforcing that modules do not require themselves.</span>
+-   <span class="signature">[`no-single-property-require`][@stdlib/_tools/eslint/rules/no-single-property-require]</span><span class="delimiter">: </span><span class="description">ESLint rule enforcing that a property is required directly when only a single property of a required module is used.</span>
 -   <span class="signature">[`no-unassigned-require`][@stdlib/_tools/eslint/rules/no-unassigned-require]</span><span class="delimiter">: </span><span class="description">ESLint rule forbidding unassigned require statements.</span>
 -   <span class="signature">[`no-unnecessary-nested-functions`][@stdlib/_tools/eslint/rules/no-unnecessary-nested-functions]</span><span class="delimiter">: </span><span class="description">ESLint rule to prevent unnecessary function nesting when inner functions don't depend on outer scope variables.</span>
 -   <span class="signature">[`repl-namespace-order`][@stdlib/_tools/eslint/rules/repl-namespace-order]</span><span class="delimiter">: </span><span class="description">ESLint rule to enforce that packages are added to a REPL namespace object in alphabetical order according to alias (namespace key).</span>
@@ -439,6 +440,8 @@ console.log( getKeys( rules ) );
 [@stdlib/_tools/eslint/rules/no-require-index]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/_tools/eslint/rules/no-require-index
 
 [@stdlib/_tools/eslint/rules/no-self-require]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/_tools/eslint/rules/no-self-require
+
+[@stdlib/_tools/eslint/rules/no-single-property-require]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/_tools/eslint/rules/no-single-property-require
 
 [@stdlib/_tools/eslint/rules/no-unassigned-require]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/_tools/eslint/rules/no-unassigned-require
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/README.md
@@ -83,7 +83,6 @@ var eslint = rules;
 -   <span class="signature">[`no-require-absolute-path`][@stdlib/_tools/eslint/rules/no-require-absolute-path]</span><span class="delimiter">: </span><span class="description">ESLint rule disallowing `require()` statements containing absolute file paths.</span>
 -   <span class="signature">[`no-require-index`][@stdlib/_tools/eslint/rules/no-require-index]</span><span class="delimiter">: </span><span class="description">ESLint rule disallowing `require()` calls which explicitly require `index.<ext>` files.</span>
 -   <span class="signature">[`no-self-require`][@stdlib/_tools/eslint/rules/no-self-require]</span><span class="delimiter">: </span><span class="description">ESLint rule enforcing that modules do not require themselves.</span>
--   <span class="signature">[`no-single-property-require`][@stdlib/_tools/eslint/rules/no-single-property-require]</span><span class="delimiter">: </span><span class="description">ESLint rule enforcing that a property is required directly when only a single property of a required module is used.</span>
 -   <span class="signature">[`no-unassigned-require`][@stdlib/_tools/eslint/rules/no-unassigned-require]</span><span class="delimiter">: </span><span class="description">ESLint rule forbidding unassigned require statements.</span>
 -   <span class="signature">[`no-unnecessary-nested-functions`][@stdlib/_tools/eslint/rules/no-unnecessary-nested-functions]</span><span class="delimiter">: </span><span class="description">ESLint rule to prevent unnecessary function nesting when inner functions don't depend on outer scope variables.</span>
 -   <span class="signature">[`repl-namespace-order`][@stdlib/_tools/eslint/rules/repl-namespace-order]</span><span class="delimiter">: </span><span class="description">ESLint rule to enforce that packages are added to a REPL namespace object in alphabetical order according to alias (namespace key).</span>
@@ -440,8 +439,6 @@ console.log( getKeys( rules ) );
 [@stdlib/_tools/eslint/rules/no-require-index]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/_tools/eslint/rules/no-require-index
 
 [@stdlib/_tools/eslint/rules/no-self-require]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/_tools/eslint/rules/no-self-require
-
-[@stdlib/_tools/eslint/rules/no-single-property-require]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/_tools/eslint/rules/no-single-property-require
 
 [@stdlib/_tools/eslint/rules/no-unassigned-require]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/_tools/eslint/rules/no-unassigned-require
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/lib/index.js
@@ -1000,6 +1000,15 @@ setReadOnly( rules, 'no-require-index', require( '@stdlib/_tools/eslint/rules/no
 setReadOnly( rules, 'no-self-require', require( '@stdlib/_tools/eslint/rules/no-self-require' ) );
 
 /**
+* @name no-single-property-require
+* @memberof rules
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/_tools/eslint/rules/no-single-property-require}
+*/
+setReadOnly( rules, 'no-single-property-require', require( '@stdlib/_tools/eslint/rules/no-single-property-require' ) );
+
+/**
 * @name no-unassigned-require
 * @memberof rules
 * @readonly

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # no-single-property-require
 
-> [ESLint rule][eslint-rules] to enforce requiring a property directly when only a single property of a required module is used.
+> [ESLint rule][eslint-rules] disallowing requiring an entire module when only a single property of the module is used.
 
 <section class="intro">
 
@@ -40,7 +40,7 @@ var rule = require( '@stdlib/_tools/eslint/rules/no-single-property-require' );
 
 #### rule
 
-[ESLint rule][eslint-rules] to enforce requiring a property directly when only a single property of a required module is used.
+[ESLint rule][eslint-rules] disallowing requiring an entire module when only a single property of the module is used.
 
 **Bad**:
 
@@ -49,7 +49,9 @@ var rule = require( '@stdlib/_tools/eslint/rules/no-single-property-require' );
 ```javascript
 var dcopy = require( '@stdlib/blas/base/dcopy' );
 
-// ...
+var x = [ 1.0, 2.0, 3.0 ];
+var y = [ 0.0, 0.0, 0.0 ];
+var z = [ 0.0, 0.0, 0.0 ];
 
 dcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );
 
@@ -63,7 +65,9 @@ dcopy.ndarray( y.length, y, 1, 0, z, 1, 0 );
 ```javascript
 var dcopy = require( '@stdlib/blas/base/dcopy' ).ndarray;
 
-// ...
+var x = [ 1.0, 2.0, 3.0 ];
+var y = [ 0.0, 0.0, 0.0 ];
+var z = [ 0.0, 0.0, 0.0 ];
 
 dcopy( x.length, x, 1, 0, y, 1, 0 );
 
@@ -77,7 +81,9 @@ dcopy( y.length, y, 1, 0, z, 1, 0 );
 ```javascript
 var dcopy = require( '@stdlib/blas/base/dcopy' );
 
-// ...
+var x = [ 1.0, 2.0, 3.0 ];
+var y = [ 0.0, 0.0, 0.0 ];
+var z = [ 0.0, 0.0, 0.0 ];
 
 dcopy( x.length, x, 1, y, 1 );
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/README.md
@@ -1,0 +1,176 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# no-single-property-require
+
+> [ESLint rule][eslint-rules] to enforce requiring a property directly when only a single property of a required module is used.
+
+<section class="intro">
+
+This rule enforces that, when only a single property of a required module is ever used within a module, the property is required directly (e.g., `var dcopy = require( '@stdlib/blas/base/dcopy' ).ndarray;`). Requiring a property directly reduces bundle sizes during ESM tree-shaking via named imports.
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var rule = require( '@stdlib/_tools/eslint/rules/no-single-property-require' );
+```
+
+#### rule
+
+[ESLint rule][eslint-rules] to enforce requiring a property directly when only a single property of a required module is used.
+
+**Bad**:
+
+<!-- eslint-disable stdlib/no-single-property-require -->
+
+```javascript
+var dcopy = require( '@stdlib/blas/base/dcopy' );
+
+// ...
+
+dcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );
+
+// ...
+
+dcopy.ndarray( y.length, y, 1, 0, z, 1, 0 );
+```
+
+**Good**:
+
+```javascript
+var dcopy = require( '@stdlib/blas/base/dcopy' ).ndarray;
+
+// ...
+
+dcopy( x.length, x, 1, 0, y, 1, 0 );
+
+// ...
+
+dcopy( y.length, y, 1, 0, z, 1, 0 );
+```
+
+**Good** (multiple properties are used):
+
+```javascript
+var dcopy = require( '@stdlib/blas/base/dcopy' );
+
+// ...
+
+dcopy( x.length, x, 1, y, 1 );
+
+// ...
+
+dcopy.ndarray( y.length, y, 1, 0, z, 1, 0 );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The rule only checks module-scope (top-level) variable declarations, as `stdlib` convention is to place `require` statements at the top of a module.
+-   Bindings which are used "bare" anywhere (e.g., called directly, passed as an argument, returned, exported, or interrogated via `typeof`) are not flagged.
+-   Computed property access (e.g., `x[ key ]`) is not flagged, as the accessed property cannot be statically determined.
+-   Bindings which are re-assigned or whose properties are mutated (e.g., assigned, deleted, or updated) are not flagged.
+-   The rule does not resolve whether `require` refers to the global CommonJS function or a shadowing local binding.
+-   When converting a method-style call (e.g., `x.ndarray( ... )`) to a direct call, the `this` context within the called function changes; for `stdlib` packages, exported methods do not rely on `this` binding, and, hence, the transformation is safe.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Linter = require( 'eslint' ).Linter;
+var rule = require( '@stdlib/_tools/eslint/rules/no-single-property-require' );
+
+var linter = new Linter();
+
+// Generate source code in which only a single property of a required module is used:
+var code = [
+    'var dcopy = require( \'@stdlib/blas/base/dcopy\' );',
+    'dcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );',
+    'dcopy.ndarray( y.length, y, 1, 0, z, 1, 0 );'
+].join( '\n' );
+
+// Define the ESLint configuration:
+var config = {
+    'rules': {
+        'no-single-property-require': 'error'
+    }
+};
+
+// Register the rule:
+linter.defineRule( 'no-single-property-require', rule );
+
+// Lint the code:
+var out = linter.verify( code, config );
+console.log( out );
+/* =>
+    [
+        {
+            'ruleId': 'no-single-property-require',
+            'severity': 2,
+            'message': 'only the `ndarray` property of the required module is used; require the property directly',
+            'line': 1,
+            'column': 5,
+            'nodeType': 'VariableDeclarator',
+            'endLine': 1,
+            'endColumn': 50
+        }
+    ]
+*/
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[eslint-rules]: https://eslint.org/docs/developer-guide/working-with-rules
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/README.md
@@ -153,7 +153,7 @@ console.log( out );
             'column': 5,
             'nodeType': 'VariableDeclarator',
             'endLine': 1,
-            'endColumn': 50
+            'endColumn': 49
         }
     ]
 */

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/examples/index.js
@@ -53,7 +53,7 @@ console.log( out );
 			'column': 5,
 			'nodeType': 'VariableDeclarator',
 			'endLine': 1,
-			'endColumn': 50
+			'endColumn': 49
 		}
 	]
 */

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/examples/index.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Linter = require( 'eslint' ).Linter;
+var rule = require( './../lib' );
+
+var linter = new Linter();
+
+// Generate source code in which only a single property of a required module is used:
+var code = [
+	'var dcopy = require( \'@stdlib/blas/base/dcopy\' );',
+	'dcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );',
+	'dcopy.ndarray( y.length, y, 1, 0, z, 1, 0 );'
+].join( '\n' );
+
+// Define the ESLint configuration:
+var config = {
+	'rules': {
+		'no-single-property-require': 'error'
+	}
+};
+
+// Register the rule:
+linter.defineRule( 'no-single-property-require', rule );
+
+// Lint the code:
+var out = linter.verify( code, config );
+console.log( out );
+/* =>
+	[
+		{
+			'ruleId': 'no-single-property-require',
+			'severity': 2,
+			'message': 'only the `ndarray` property of the required module is used; require the property directly',
+			'line': 1,
+			'column': 5,
+			'nodeType': 'VariableDeclarator',
+			'endLine': 1,
+			'endColumn': 50
+		}
+	]
+*/

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/lib/index.js
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* ESLint rule enforcing that a property is required directly when only a single property of a required module is used.
+*
+* @module @stdlib/_tools/eslint/rules/no-single-property-require
+*
+* @example
+* var rule = require( '@stdlib/_tools/eslint/rules/no-single-property-require' );
+*
+* console.log( rule );
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* ESLint rule enforcing that a property is required directly when only a single property of a required module is used.
+* ESLint rule disallowing requiring an entire module when only a single property of the module is used.
 *
 * @module @stdlib/_tools/eslint/rules/no-single-property-require
 *

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/lib/main.js
@@ -1,0 +1,205 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+
+
+// VARIABLES //
+
+var rule;
+
+
+// FUNCTIONS //
+
+/**
+* Returns the property name accessed by a reference, or `null` if the reference is not a simple non-computed single-property read.
+*
+* @private
+* @param {Object} ref - ESLint reference
+* @returns {(string|null)} property name or null
+*/
+function propertyName( ref ) {
+	var parent;
+	var id;
+	var p2;
+
+	if ( ref.isWrite() ) {
+		// Re-assignment (e.g., `x = other`): binding is mutated...
+		return null;
+	}
+	id = ref.identifier;
+	parent = id.parent;
+	if (
+		!parent ||
+		parent.type !== 'MemberExpression' ||
+		parent.object !== id ||
+		parent.computed ||
+		parent.optional
+	) {
+		// Bare use (e.g., `x()`, `f( x )`, `typeof x`, `module.exports = x`) or computed access (e.g., `x[ key ]`)...
+		return null;
+	}
+	p2 = parent.parent;
+	if ( p2 ) {
+		if ( p2.type === 'AssignmentExpression' && p2.left === parent ) {
+			// Write target (e.g., `x.foo = bar`): mutating the module object...
+			return null;
+		}
+		if ( p2.type === 'UpdateExpression' ) {
+			// Update expression (e.g., `x.count++`)...
+			return null;
+		}
+		if ( p2.type === 'UnaryExpression' && p2.operator === 'delete' ) {
+			// Delete expression (e.g., `delete x.foo`)...
+			return null;
+		}
+	}
+	return parent.property.name;
+}
+
+/**
+* Returns the single property name used across all references of a variable, or `null` if references are absent, mixed, or not simple property reads.
+*
+* @private
+* @param {Object} variable - ESLint scope variable
+* @returns {(string|null)} property name or null
+*/
+function singleProperty( variable ) {
+	var count;
+	var refs;
+	var prop;
+	var name;
+	var i;
+
+	prop = null;
+	count = 0;
+	refs = variable.references;
+	for ( i = 0; i < refs.length; i++ ) {
+		if ( refs[ i ].init ) {
+			// Skip the reference created by the declarator's own initialization...
+			continue;
+		}
+		count += 1;
+		name = propertyName( refs[ i ] );
+		if ( name === null ) {
+			return null;
+		}
+		if ( prop === null ) {
+			prop = name;
+		} else if ( prop !== name ) {
+			// More than one property is used...
+			return null;
+		}
+	}
+	if ( count === 0 ) {
+		// Unused binding: out of scope for this rule...
+		return null;
+	}
+	return prop;
+}
+
+/**
+* Rule for flagging required modules of which only a single property is ever used.
+*
+* @param {Object} context - ESLint context
+* @returns {Object} validators
+*/
+function main( context ) {
+	/**
+	* Checks a variable declaration for required modules of which only a single property is used.
+	*
+	* @private
+	* @param {Node} node - variable declaration node
+	*/
+	function validate( node ) {
+		var variables;
+		var variable;
+		var decl;
+		var init;
+		var prop;
+		var i;
+		var j;
+
+		if ( !node.parent || node.parent.type !== 'Program' ) {
+			// Only consider module-scope declarations:
+			return;
+		}
+		variables = null;
+		for ( i = 0; i < node.declarations.length; i++ ) {
+			decl = node.declarations[ i ];
+			if ( decl.type !== 'VariableDeclarator' || decl.id.type !== 'Identifier' ) {
+				continue;
+			}
+			init = decl.init;
+			if (
+				!init ||
+				init.type !== 'CallExpression' ||
+				!init.callee ||
+				init.callee.type !== 'Identifier' ||
+				init.callee.name !== 'require' ||
+				init.arguments.length !== 1 ||
+				!isString( init.arguments[ 0 ].value )
+			) {
+				continue;
+			}
+			if ( variables === null ) {
+				variables = context.sourceCode.getDeclaredVariables( node );
+			}
+			for ( j = 0; j < variables.length; j++ ) {
+				variable = variables[ j ];
+				if ( variable.name !== decl.id.name ) {
+					continue;
+				}
+				prop = singleProperty( variable );
+				if ( prop !== null ) {
+					context.report({
+						'node': decl,
+						'message': 'only the `' + prop + '` property of the required module is used; require the property directly'
+					});
+				}
+				break;
+			}
+		}
+	}
+	return {
+		'VariableDeclaration': validate
+	};
+}
+
+
+// MAIN //
+
+rule = {
+	'meta': {
+		'type': 'suggestion',
+		'docs': {
+			'description': 'enforce requiring a property directly when only a single property of a required module is used'
+		},
+		'schema': []
+	},
+	'create': main
+};
+
+
+// EXPORTS //
+
+module.exports = rule;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/lib/main.js
@@ -192,7 +192,7 @@ rule = {
 	'meta': {
 		'type': 'suggestion',
 		'docs': {
-			'description': 'enforce requiring a property directly when only a single property of a required module is used'
+			'description': 'disallow requiring an entire module when only a single property is used'
 		},
 		'schema': []
 	},

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/package.json
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@stdlib/_tools/eslint/rules/no-single-property-require",
+  "version": "0.0.0",
+  "description": "ESLint rule enforcing that a property is required directly when only a single property of a required module is used.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {},
+  "main": "./lib",
+  "directories": {
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "tools",
+    "tool",
+    "eslint",
+    "lint",
+    "custom",
+    "rules",
+    "rule",
+    "plugin",
+    "require",
+    "import",
+    "property",
+    "treeshaking",
+    "style"
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/package.json
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/_tools/eslint/rules/no-single-property-require",
   "version": "0.0.0",
-  "description": "ESLint rule enforcing that a property is required directly when only a single property of a required module is used.",
+  "description": "ESLint rule disallowing requiring an entire module when only a single property of the module is used.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/test/fixtures/invalid.js
@@ -1,0 +1,112 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+var invalid = [];
+
+invalid.push({
+	'code': [
+		'var dcopy = require( \'@stdlib/blas/base/dcopy\' );',
+		'dcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );',
+		'dcopy.ndarray( y.length, y, 1, 0, z, 1, 0 );'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'only the `ndarray` property of the required module is used; require the property directly',
+			'type': 'VariableDeclarator'
+		}
+	]
+});
+
+invalid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'var y = x.bar;'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'only the `bar` property of the required module is used; require the property directly',
+			'type': 'VariableDeclarator'
+		}
+	]
+});
+
+invalid.push({
+	'code': [
+		'var dcopy = require( \'@stdlib/blas/base/dcopy\' );',
+		'function copy( x, y ) {',
+		'\treturn dcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );',
+		'}',
+		'dcopy.ndarray( y.length, y, 1, 0, z, 1, 0 );'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'only the `ndarray` property of the required module is used; require the property directly',
+			'type': 'VariableDeclarator'
+		}
+	]
+});
+
+invalid.push({
+	'code': [
+		'var dcopy = require( \'@stdlib/blas/base/dcopy\' );',
+		'var len = dcopy.ndarray.length;',
+		'dcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'only the `ndarray` property of the required module is used; require the property directly',
+			'type': 'VariableDeclarator'
+		}
+	]
+});
+
+invalid.push({
+	'code': [
+		'var a = require( \'a\' ), b = require( \'b\' );',
+		'a();',
+		'b.only();'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'only the `only` property of the required module is used; require the property directly',
+			'type': 'VariableDeclarator'
+		}
+	]
+});
+
+invalid.push({
+	'code': [
+		'var x = require( \'./../lib\' );',
+		'x.method();'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'only the `method` property of the required module is used; require the property directly',
+			'type': 'VariableDeclarator'
+		}
+	]
+});
+
+
+// EXPORTS //
+
+module.exports = invalid;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/test/fixtures/unvalidated.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/test/fixtures/unvalidated.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+var unvalidated = [];
+
+unvalidated.push({
+	'code': [
+		'var x = foo();',
+		'x.bar();',
+		'x.bar();'
+	].join( '\n' )
+});
+
+unvalidated.push({
+	'code': [
+		'var x = require( name );',
+		'x.bar();'
+	].join( '\n' )
+});
+
+unvalidated.push({
+	'code': [
+		'var { a } = require( \'foo\' );',
+		'a();'
+	].join( '\n' ),
+	'parserOptions': {
+		'ecmaVersion': 6
+	}
+});
+
+unvalidated.push({
+	'code': [
+		'var x = require( \'foo\', \'bar\' );',
+		'x.baz();'
+	].join( '\n' )
+});
+
+
+// EXPORTS //
+
+module.exports = unvalidated;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/test/fixtures/valid.js
@@ -1,0 +1,131 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+var valid = [];
+
+valid.push({
+	'code': [
+		'var floor = require( \'@stdlib/math/base/special/floor\' );',
+		'var y = floor( 3.14 );'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var dcopy = require( \'@stdlib/blas/base/dcopy\' );',
+		'var type = typeof dcopy;',
+		'dcopy.ndarray( x.length, x, 1, 0, y, 1, 0 );'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'x.a();',
+		'x.b();'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'x[ k ]();'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'f( x );'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'module.exports = x;'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var dcopy = require( \'@stdlib/blas/base/dcopy\' ).ndarray;',
+		'dcopy( x.length, x, 1, 0, y, 1, 0 );'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'x.foo = 1;',
+		'x.foo();'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'x = other;',
+		'x.foo();'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'var str = \'\' + x;'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'delete x.foo;',
+		'x.foo();'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': [
+		'var x = require( \'foo\' );',
+		'x.count += 1;',
+		'var v = x.count;'
+	].join( '\n' )
+});
+
+valid.push({
+	'code': 'var x = require( \'foo\' );'
+});
+
+valid.push({
+	'code': [
+		'function f() {',
+		'\tvar x = require( \'foo\' );',
+		'\treturn x.bar();',
+		'}'
+	].join( '\n' )
+});
+
+
+// EXPORTS //
+
+module.exports = valid;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-single-property-require/test/test.js
@@ -1,0 +1,86 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var RuleTester = require( 'eslint' ).RuleTester;
+var rule = require( './../lib' );
+
+
+// FIXTURES //
+
+var valid = require( './fixtures/valid.js' );
+var invalid = require( './fixtures/invalid.js' );
+var unvalidated = require( './fixtures/unvalidated.js' );
+
+
+// TESTS //
+
+tape( 'main export is an object', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof rule, 'object', 'main export is an object' );
+	t.end();
+});
+
+tape( 'the function positively validates code in which required modules are not used via only a single property', function test( t ) {
+	var tester = new RuleTester();
+
+	try {
+		tester.run( 'no-single-property-require', rule, {
+			'valid': valid,
+			'invalid': []
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});
+
+tape( 'the function negatively validates code in which only a single property of a required module is used', function test( t ) {
+	var tester = new RuleTester();
+
+	try {
+		tester.run( 'no-single-property-require', rule, {
+			'valid': [],
+			'invalid': invalid
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});
+
+tape( 'the function does not validate other `require` expressions', function test( t ) {
+	var tester = new RuleTester();
+
+	try {
+		tester.run( 'no-single-property-require', rule, {
+			'valid': unvalidated,
+			'invalid': []
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/664.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds a new custom ESLint rule `no-single-property-require` which flags module-scope `var x = require( '...' );` declarations where the required binding is only ever used to access a single property (e.g., `x.ndarray( ... )` everywhere) and suggests requiring the property directly (e.g., `var x = require( '...' ).ndarray;`), which reduces bundle sizes during ESM tree-shaking via named imports.
-   registers the rule in the rules namespace and enables it as `'warn'` in the stdlib ESLint configuration (existing violations exist across the codebase, so enabling as `'error'` would break linting repo-wide; the rule can be promoted to `'error'` in a follow-up once violations are cleaned up).
-   disables the rule for test files (which intentionally require the package under test as a whole) and Markdown code blocks (which deliberately demonstrate namespace-style access).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

-   Is `'warn'` the right initial severity, or should the rule start as `'error'` with overrides?

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The rule uses ESLint scope analysis (`sourceCode.getDeclaredVariables`) to walk all references of a required binding, including references within nested closures.
-   Bindings used "bare" anywhere (called directly, passed as argument, returned, exported, `typeof`), via computed access (`x[ key ]`), re-assigned, or mutated (`x.foo = 1`, `delete x.foo`, `x.count++`) are not flagged.
-   Only module-scope (top-level) declarations are considered, per stdlib convention of placing `require` statements at the top of a module.
-   The rule is report-only (no autofix): converting a method-style call (`x.ndarray()`) to a direct call changes the `this` context within the called function, so automatic rewriting is deliberately avoided.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, modeled on the existing `uppercase-required-constants` and `no-unnecessary-nested-functions` rules; the approach and configuration decisions were reviewed and directed by myself.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
