### PR TITLE
test: migrate `math/base/special/fast/acosh` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fast/acosh/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/acosh/test/test.js
@@ -24,7 +24,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var acosh = require( './../lib' );
 
 
@@ -46,8 +46,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the hyperbolic arccosine on the interval `[1.0,3.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -57,21 +55,13 @@ tape( 'the function computes the hyperbolic arccosine on the interval `[1.0,3.0]
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 6.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arccosine on the interval `[3.0,28.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -81,21 +71,13 @@ tape( 'the function computes the hyperbolic arccosine on the interval `[3.0,28.0
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arccosine on the interval `[28.0,100.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -105,21 +87,13 @@ tape( 'the function computes the hyperbolic arccosine on the interval `[28.0,100
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arccosine for huge values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -129,13 +103,7 @@ tape( 'the function computes the hyperbolic arccosine for huge values', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/fast/acosh/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/acosh/test/test.native.js
@@ -25,7 +25,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -55,8 +55,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the hyperbolic arccosine on the interval `[1.0,3.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -66,21 +64,13 @@ tape( 'the function computes the hyperbolic arccosine on the interval `[1.0,3.0]
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 6.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 8 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arccosine on the interval `[3.0,28.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -90,21 +80,13 @@ tape( 'the function computes the hyperbolic arccosine on the interval `[3.0,28.0
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arccosine on the interval `[28.0,100.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -114,21 +96,13 @@ tape( 'the function computes the hyperbolic arccosine on the interval `[28.0,100
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arccosine for huge values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -138,13 +112,7 @@ tape( 'the function computes the hyperbolic arccosine for huge values', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = acosh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/fast/acosh` from computed relative tolerance comparisons (`delta = abs( y - expected[i] ); tol = N * EPS * abs( expected[i] ); t.ok( delta <= tol, ... )`) to ULP difference assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   applies the change to both `test/test.js` and `test/test.native.js`.

Only the two test files are modified; no implementation or fixture changes.

### ULP bounds

Bounds were tightened agentically: starting from `64` and lowering to the minimum integer which still passes over the **full** fixture set. The measured maximum ULP difference per fixture set is:

| Fixture set | Test | Previous tolerance | Final ULP bound | Measured max ULP |
| ----------- | ---- | ------------------ | --------------- | ---------------- |
| `medium_positive` (`[1.0,3.0]`, n=507) | `[1.0,3.0]` | `6.0 * EPS` | `8` | 8 |
| `large_positive` (`[3.0,28.0]`, n=507) | `[3.0,28.0]` | `1.0 * EPS` | `1` | 1 |
| `larger_positive` (`[28.0,100.0]`, n=507) | `[28.0,100.0]` | `1.0 * EPS` | `1` | 1 |
| `huge_positive` (n=1003) | huge values | `1.0 * EPS` | `1` | 1 |

The bounds are minimal: lowering the `[1.0,3.0]` bound to `7` fails, and lowering any of the `1` bounds to `0` (exact equality) fails.

The larger bound on `[1.0,3.0]` is expected for this package: `fast/acosh` evaluates `ln( x + sqrt(x+1)*sqrt(x-1) )` directly, so cancellation in `x-1` near `x = 1` dominates the error there. This mirrors the previous `6.0 * EPS` relative tolerance, which was already loosened for that interval.

The JavaScript and native implementations were measured independently and produce **identical** maximum ULP differences (8 / 1 / 1 / 1), so `test.js` and `test.native.js` use the same bounds.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `test/test.js`: 3527 assertions passing; run twice at the final bounds with identical results (no FMA/arch nondeterminism observed).
-   `test/test.native.js`: native addon was built locally via `node-gyp rebuild`, so these tests ran for real rather than being skipped — 3527 assertions passing, also run twice.
-   ESLint clean against `etc/eslint/.eslintrc.tests.js` (the config the `eslint-tests` target uses for test files).
-   `git diff --check` clean; tab indentation and trailing-newline conventions preserved.

Environment note: the editorconfig pre-commit hook could not run in this environment because downloading the `editorconfig-checker` binary is blocked, so the relevant checks (indentation style, trailing whitespace, final newline, line endings) were verified manually instead.

Opened as a draft pending CI.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied prior converted packages (including the already-migrated sibling `math/base/special/acosh`) to match the established idiom, applied the conversion, and empirically searched for the minimum passing ULP bound for each fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01UViLFYQZDZTmUPew8Kdh85)_