### PR TITLE
test: migrate `math/base/special/fast/pow-int` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/test/test.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
@@ -56,8 +55,6 @@ tape( 'the function accepts two parameters: a base and an exponent', function te
 tape( 'the function evaluates the exponential function (decimal `x`, integer `y`)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -70,9 +67,7 @@ tape( 'the function evaluates the exponential function (decimal `x`, integer `y`
 		if ( actual === expected[ i ] ) {
 			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
 		} else {
-			delta = abs( actual - expected[i] );
-			tol = 70.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. v: '+actual+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 126 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -81,8 +76,6 @@ tape( 'the function evaluates the exponential function (decimal `x`, integer `y`
 tape( 'the function evaluates the exponential function (integer `x`, integer `y`)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -100,9 +93,7 @@ tape( 'the function evaluates the exponential function (integer `x`, integer `y`
 			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
 		}
 		else {
-			delta = abs( actual - expected[i] );
-			tol = 61.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. v: '+actual+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 113 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -111,8 +102,6 @@ tape( 'the function evaluates the exponential function (integer `x`, integer `y`
 tape( 'the function evaluates the exponential function (multiples of ten)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -125,9 +114,7 @@ tape( 'the function evaluates the exponential function (multiples of ten)', func
 		if ( actual === expected[ i ] ) {
 			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
 		} else {
-			delta = abs( actual - expected[i] );
-			tol = 3.75 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. v: '+actual+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 6 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
@@ -65,8 +64,6 @@ tape( 'the function accepts two parameters: a base and an exponent', opts, funct
 tape( 'the function evaluates the exponential function (decimal `x`, integer `y`)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -79,9 +76,7 @@ tape( 'the function evaluates the exponential function (decimal `x`, integer `y`
 		if ( actual === expected[ i ] ) {
 			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
 		} else {
-			delta = abs( actual - expected[i] );
-			tol = 70.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. v: '+actual+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 126 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -90,8 +85,6 @@ tape( 'the function evaluates the exponential function (decimal `x`, integer `y`
 tape( 'the function evaluates the exponential function (integer `x`, integer `y`)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -109,9 +102,7 @@ tape( 'the function evaluates the exponential function (integer `x`, integer `y`
 			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
 		}
 		else {
-			delta = abs( actual - expected[i] );
-			tol = 61.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. v: '+actual+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 113 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -120,8 +111,6 @@ tape( 'the function evaluates the exponential function (integer `x`, integer `y`
 tape( 'the function evaluates the exponential function (multiples of ten)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -134,9 +123,7 @@ tape( 'the function evaluates the exponential function (multiples of ten)', opts
 		if ( actual === expected[ i ] ) {
 			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
 		} else {
-			delta = abs( actual - expected[i] );
-			tol = 3.75 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. v: '+actual+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 6 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves part of #11352 

## Description

> What is the purpose of this pull request?

This pull request:

- Migrates tests in `@stdlib/math/base/special/fast/pow-int` to use ULP-based testing assertions. Specifically, both `test.js` and `test.native.js` were updated to replace absolute tolerance checks with exact ULP assertions using `@stdlib/assert/is-almost-same-value`.

### ULP Tolerance Explanation
The ULP tolerance values used (`126`, `113`, and `6`) represent the exact, tightest minimums required to pass the test fixtures:
- **`decimalInteger`:** `126` ULP 
- **`integerInteger`:** `113` ULP
- **`multiplesOfTen`:** `6` ULP

Previously, the tests used relative absolute tolerances of `70.0 * EPS * abs(expected)`, `61.0 * EPS * abs(expected)`, and `3.75 * EPS * abs(expected)`. Because the absolute value can scale up to almost `2` within a floating-point exponent bin, those older tolerances effectively allowed for up to `~140` ULP, `~122` ULP, and `~7.5` ULP differences in the worst-case scenarios. 

By programmatically computing the exact maximum ULP differences against the expected Julia outputs, we were able to successfully tighten these thresholds to the absolute minimum bounds required to pass all edge cases.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
