### PR TITLE
test: add native add-on tests to `math/base/special/log1pmx`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/test/test.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/test/test.native.js
@@ -1,0 +1,95 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var linspace = require( '@stdlib/array/linspace' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var ln = require( '@stdlib/math/base/special/ln' );
+var log1p = require( '@stdlib/math/base/special/log1p' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var log1pmx = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( log1pmx instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof log1pmx, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if input is less than or equal to -1', opts, function test( t ) {
+	var values = linspace( -1.0, -50.0, 100 );
+	var i;
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( isnan( log1pmx( values[ i ] ) ), true, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function computes ln(1+x) - x if |x| > 0.95', opts, function test( t ) {
+	var values = linspace( 0.951, 100.0, 100 );
+	var i;
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( log1pmx( values[i] ), ln( 1.0 + values[i] ) - values[i], 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function returns -x*x/2 if |x| < FLOAT_EPS', opts, function test( t ) {
+	var values = [ 0.0, EPS / 2.0 ];
+	var i;
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( log1pmx( values[i] ), -pow( values[i], 2 ) / 2.0, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function returns a Taylor series expansion otherwise', opts, function test( t ) {
+	var expected;
+	var values;
+	var actual;
+	var i;
+
+	values = linspace( 0.1, 0.95, 100 );
+	for ( i = 0; i < values.length; i++ ) {
+		actual = log1pmx( values[ i ] );
+		expected = log1p( values[ i ] ) - values[ i ];
+		if ( actual === expected ) {
+			t.strictEqual( actual, expected, 'returns '+expected+' when provided '+values[ i ] );
+		} else {
+			t.strictEqual( isAlmostSameValue( actual, expected, 9 ), true, 'returns expected value' );
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves part of #11352

## Description

> What is the purpose of this pull request?

This pull request:

- Adds `test.native.js` to `@stdlib/math/base/special/log1pmx` to execute unit tests for the package's C native addon implementation, mirroring the test assertions in the primary `test.js` file.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #13979 (Follow-up)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
