### PR TITLE
test: migrate `math/base/special/ahavercos` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ahavercos/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ahavercos/test/test.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var ahavercos = require( './../lib' );
 
@@ -44,8 +44,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse half-value versed cosine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -55,21 +53,13 @@ tape( 'the function computes the inverse half-value versed cosine', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahavercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse half-value versed cosine (small positive numbers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -79,13 +69,7 @@ tape( 'the function computes the inverse half-value versed cosine (small positiv
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahavercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ahavercos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ahavercos/test/test.native.js
@@ -22,9 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -53,8 +53,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse half-value versed cosine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -64,21 +62,13 @@ tape( 'the function computes the inverse half-value versed cosine', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahavercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse half-value versed cosine (small positive numbers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -88,13 +78,7 @@ tape( 'the function computes the inverse half-value versed cosine (small positiv
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = ahavercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/ahavercos` from relative tolerance testing (`delta = abs( y - expected[i] )`, `tol = EPS * abs( expected[i] )`, `t.ok( delta <= tol, ... )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates both `test/test.js` and `test/test.native.js`, which mirror one another.
-   removes the now unused `@stdlib/math/base/special/abs` import from both test files (`@stdlib/constants/float64/eps` is retained, as `EPS` is still used by the out-of-domain test cases).

The ULP bounds were tightened to the measured minimum which passes over the full fixture set, for both the JavaScript and the C implementations:

| Fixture file | Test case | ULP bound | Measured maximum ULP difference |
| --- | --- | --- | --- |
| `fixtures/julia/data.json` | the function computes the inverse half-value versed cosine | `1` | 1 (JS and native) |
| `fixtures/julia/small_positive.json` | the function computes the inverse half-value versed cosine (small positive numbers) | `0` | 0 (JS and native) |

Notes on how the bounds were determined:

-   Each bound is the minimum non-negative integer for which every fixture value passes. Lowering the `data.json` bound from `1` to `0` fails for 446 of 2003 fixture values, so `1` is tight. All 2003 `small_positive.json` values are bit-for-bit exact, hence a bound of `0`.
-   The JavaScript and C implementations agree exactly on both fixture sets, so `test.js` and `test.native.js` use identical bounds.
-   The native add-on was compiled locally, so `test/test.native.js` was exercised against the actual C implementation rather than skipped. Both test files were run twice at the final bounds, with identical results (24009 assertions passing per file, per run).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.
-   Verified with `make test TESTS_FILTER=".*/math/base/special/ahavercos/.*"` and by running `test/test.native.js` directly against the compiled add-on. Linting is clean via ESLint using `etc/eslint/.eslintrc.tests.js`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. The test migration follows the idiom established by previously merged conversions, and the ULP bounds were measured empirically against both the JavaScript and compiled C implementations rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNpXjKH6vjcS68tbWubp1g)_