### PR TITLE
test: migrate `stats/base/dists/erlang/skewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/skewness/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
 
@@ -106,8 +105,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', function test( t 
 tape( 'the function returns the skewness of an Erlang distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -117,13 +114,7 @@ tape( 'the function returns the skewness of an Erlang distribution', function te
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/skewness/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -109,8 +108,6 @@ tape( 'if provided `lambda <= 0`, the function returns `NaN`', opts, function te
 tape( 'the function returns the skewness of an Erlang distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var k;
 	var i;
 	var y;
@@ -120,13 +117,7 @@ tape( 'the function returns the skewness of an Erlang distribution', opts, funct
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/erlang/skewness` from relative tolerance testing (`delta = abs( y - expected[i] )`, `tol = 1.0 * EPS * abs( expected[i] )`, `t.ok( delta <= tol, ... )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates both `test/test.js` and `test/test.native.js`, which mirror one another.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports from both test files (unlike some other conversions, `EPS` is not used anywhere else in these files).

The ULP bounds were tightened to the measured minimum which passes over the full fixture set, for both the JavaScript and the C implementations:

| Fixture file | Test case | ULP bound | Measured maximum ULP difference |
| --- | --- | --- | --- |
| `fixtures/julia/data.json` | the function returns the skewness of an Erlang distribution | `0` | 0 (JS and native) |

Notes on how the bound was determined:

-   Each bound is the minimum non-negative integer for which every fixture value passes. All 200 fixture values are bit-for-bit exact against the Julia reference values, for both implementations, so `0` is both the measured maximum and the tightest possible bound.
-   This is expected: the skewness of an Erlang distribution is `2 / sqrt( k )`, and both the JavaScript and C implementations evaluate exactly that expression. `sqrt` is correctly rounded under IEEE 754 and the subsequent division is a single correctly rounded operation, so there is no room for the two implementations, or the reference values, to diverge.
-   Because the results are exact, the old `y === expected[i]` fast path was taken for every fixture value and the tolerance branch was never exercised.
-   The JavaScript and C implementations agree exactly, so `test.js` and `test.native.js` use identical bounds.
-   The native add-on was compiled locally, so `test/test.native.js` was exercised against the actual C implementation rather than skipped. Both test files were run twice at the final bounds, with identical results (217 assertions for `test.js`, 215 for `test.native.js`, all passing, per run).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

Given that every fixture value is bit-for-bit exact, a bound of `0` is equivalent to a strict equality check. Reviewers may prefer plain `t.strictEqual( y, expected[ i ], ... )` here instead; `isAlmostSameValue( ..., 0 )` was chosen for consistency with the other converted packages, which already use a `0` bound in 300+ places.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.
-   Verified with `make test TESTS_FILTER=".*/stats/base/dists/erlang/skewness/.*"` and by running `test/test.native.js` directly against the compiled add-on. Linting is clean via ESLint using `etc/eslint/.eslintrc.tests.js`.
-   The `editorconfig` pre-commit hook could not run in this environment, as it downloads its binary from a GitHub repository that this session cannot reach. The two files were instead checked manually against `.editorconfig` (LF endings, tab indentation, final newline, UTF-8); the diff introduces no new violations.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. The test migration follows the idiom established by previously merged conversions, and the ULP bound was measured empirically against both the JavaScript and compiled C implementations rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1qAkJFoiG9eerDmaEhcUC)_