### PR TITLE
test: migrate `math/base/special/gamma-lanczos-sum` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum/test/test.js
@@ -24,11 +24,10 @@ var tape = require( 'tape' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var G = require( '@stdlib/constants/float64/gamma-lanczos-g' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var gammaLanczosSum = require( './../lib' );
 
 
@@ -48,8 +47,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function evaluates the Lanczos sum', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -59,13 +56,7 @@ tape( 'the function evaluates the Lanczos sum', function test( t ) {
 		y = gammaLanczosSum( x[i] );
 		expected = gamma( x[i] );
 		expected /= pow( x[i]+G-0.5, x[i]-0.5 ) / ( exp( x[i]+G-0.5 ) );
-		if ( y === expected ) {
-			t.strictEqual( y, expected, 'x: '+x[i]+', y: '+y+', expected: '+expected );
-		} else {
-			delta = abs( y - expected );
-			tol = 10.0 * EPS * abs( expected );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected, 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum/test/test.native.js
@@ -25,11 +25,10 @@ var tape = require( 'tape' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var exp = require( '@stdlib/math/base/special/exp' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var G = require( '@stdlib/constants/float64/gamma-lanczos-g' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -57,8 +56,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) 
 
 tape( 'the function evaluates the Lanczos sum', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -68,13 +65,7 @@ tape( 'the function evaluates the Lanczos sum', opts, function test( t ) {
 		y = gammaLanczosSum( x[ i ] );
 		expected = gamma( x[ i ] );
 		expected /= pow( x[ i ] + G - 0.5, x[ i ] - 0.5 ) / ( exp( x[ i ] + G - 0.5 ) ); // eslint-disable-line max-len
-		if ( y === expected ) {
-			t.strictEqual( y, expected, 'x: '+x[ i ]+', y: '+y+', expected: '+expected );
-		} else {
-			delta = abs( y - expected );
-			tol = 10.0 * EPS * abs( expected );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+expected+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected, 12 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/gamma-lanczos-sum` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` computation and the `y === expected` special case in `test/test.js` and `test/test.native.js` with a single `t.strictEqual( isAlmostSameValue( y, expected, 12 ), true, 'returns expected value' );` assertion.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires and adds `@stdlib/assert/is-almost-same-value`.

**ULP bound:** `12` for both `test/test.js` and `test/test.native.js`.

This is the measured minimum. Over the full `linspace( 1.0, 100.0, 500 )` fixture set, the worst-case ULP difference is 12, occurring at `x = 8.935871743486974`. Starting from a high bound and tightening, `12` passes all 503 assertions and `11` fails exactly one, for both the JavaScript and the native (C) implementation. Each suite was run twice at the final bound with identical results, so the bound is not sensitive to FMA/arch variation on this machine.

The previous tolerance was `10.0 * EPS * abs( expected )`, i.e. roughly 40 ULP, so the new bound is strictly tighter than what it replaces.

Only the two test files are changed; no source, documentation, or `package.json` changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally:

-   `make test TESTS_FILTER=".*/math/base/special/gamma-lanczos-sum/.*"` — 503 passing, 0 failing.
-   `test/test.native.js` run directly against a locally built addon (`make install-node-addons NODE_ADDONS_PATTERN="gamma-lanczos-sum"`) — 503 passing, 0 failing (not skipped).
-   `make lint-javascript-tests TESTS_FILTER=".*/math/base/special/gamma-lanczos-sum/.*"` — clean.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. The test migration and the ULP bound search (start high, tighten to the minimum that still passes, then re-run to confirm determinism) were performed by the agent, following the idiom established in already-migrated packages in `math/base/special`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013TDMGvGmQyZ8R7hPZVMHMX)_