### PR TITLE
test: migrate `math/base/special/fresnel` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fresnel/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/test/test.assign.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var Float64Array = require( '@stdlib/array/float64' );
 var fresnel = require( './../lib/assign.js' );
@@ -48,8 +47,6 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function computes Fresnel integrals (small positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -65,27 +62,13 @@ tape( 'the function computes Fresnel integrals (small positive values)', functio
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns expected value' );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 4.0 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 4.0 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 4 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes Fresnel integrals (medium positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -101,27 +84,13 @@ tape( 'the function computes Fresnel integrals (medium positive values)', functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns expected value' );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes Fresnel integrals (large positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -137,27 +106,13 @@ tape( 'the function computes Fresnel integrals (large positive values)', functio
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns expected value' );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes Fresnel integrals (very large positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -173,20 +128,8 @@ tape( 'the function computes Fresnel integrals (very large positive values)', fu
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i], z, 1, 0 );
 		t.strictEqual( y, z, 'returns expected value' );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/test/test.main.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var fresnel = require( './../lib/main.js' );
 
@@ -47,8 +46,6 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function computes Fresnel integrals (small positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -61,27 +58,13 @@ tape( 'the function computes Fresnel integrals (small positive values)', functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i] );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 4.0 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 4.0 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 4 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes Fresnel integrals (medium positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -94,27 +77,13 @@ tape( 'the function computes Fresnel integrals (medium positive values)', functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i] );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes Fresnel integrals (large positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -127,27 +96,13 @@ tape( 'the function computes Fresnel integrals (large positive values)', functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i] );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes Fresnel integrals (very large positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -160,20 +115,8 @@ tape( 'the function computes Fresnel integrals (very large positive values)', fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i] );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -56,8 +55,6 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function computes Fresnel integrals (small positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -70,27 +67,13 @@ tape( 'the function computes Fresnel integrals (small positive values)', opts, f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i] );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 4.0 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 4.0 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 4 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes Fresnel integrals (medium positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -103,27 +86,13 @@ tape( 'the function computes Fresnel integrals (medium positive values)', opts, 
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i] );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes Fresnel integrals (large positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -136,27 +105,13 @@ tape( 'the function computes Fresnel integrals (large positive values)', opts, f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i] );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes Fresnel integrals (very large positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var S;
 	var x;
@@ -169,20 +124,8 @@ tape( 'the function computes Fresnel integrals (very large positive values)', op
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnel( x[i] );
-		if ( y[0] === S[i] ) {
-			t.strictEqual( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
-		} else {
-			delta = abs( y[0] - S[i] );
-			tol = 1.5 * EPS * abs( S[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
-		if ( y[1] === C[i] ) {
-			t.strictEqual( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y[1] - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y[0], S[i], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y[1], C[i], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `test/test.main.js`, `test/test.assign.js`, and `test/test.native.js` in `math/base/special/fresnel` from relative-tolerance (EPS-based) assertions to ULP-difference assertions via `@stdlib/assert/is-almost-same-value`, using the minimum required ULP values (verified by direct ULP-difference computation over the test fixtures).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Each of the three files has four tolerance blocks (small/medium/large/very-large-positive-value fixtures), each asserting both the `S` and `C` Fresnel integral components.
-   Measured minimum ULP differences (identical across `test.main.js`, `test.assign.js`, and the native addon):
    -   small positive values: `S` → 4 ULP, `C` → 3 ULP
    -   medium/large/very-large positive values: `S` → 0 ULP, `C` → 0 ULP (exact match)
-   Minimality was verified by sweeping `N` from `0` upward against all 1000 fixtures per range and recording the smallest `N` at which every case passed; the full suite was then run twice at the final values to confirm determinism.
-   The native addon was built locally with `node-gyp rebuild` to compute and verify its ULP differences directly; results were identical to the JS implementation, so no compiler-divergence note was needed.
-   `test/test.js` was left unchanged, as it contains only structural checks (no tolerance-based assertions).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, which performed the test migration, computed and verified the minimum ULP tolerances (including via the native addon), and ran the JavaScript and native test suites.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_0186HksJzLJgRFVss8p9KCQV)_