### PR TITLE
test: migrate `math/base/special/coshf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/coshf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/coshf/test/test.js
@@ -21,14 +21,13 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var randu = require( '@stdlib/random/base/randu' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var MAXLOGF = require( '@stdlib/constants/float32/max-ln' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var coshf = require( './../lib' );
 
 
@@ -49,72 +48,54 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the hyperbolic cosine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	x = data.x;
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coshf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 2.0 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cosine (tiny values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	x = tiny.x;
 	expected = tiny.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coshf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cosine (large values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	x = large.x;
 	expected = large.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coshf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 10.0 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/coshf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/coshf/test/test.native.js
@@ -22,14 +22,13 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var randu = require( '@stdlib/random/base/randu' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var MAXLOGF = require( '@stdlib/constants/float32/max-ln' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,72 +57,54 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the hyperbolic cosine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	x = data.x;
 	expected = data.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coshf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 2.0 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cosine (tiny values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	x = tiny.x;
 	expected = tiny.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coshf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic cosine (large values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
+	var e;
 
 	x = large.x;
 	expected = large.expected;
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coshf( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 10.0 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/coshf` from relative tolerance (`EPS`-scaled) comparisons to ULP-based assertions using `@stdlib/number/float32/base/assert/is-almost-same-value`.
-   converts expected fixture values to single-precision (via `@stdlib/number/float64/base/to-float32`) prior to comparison, as the Julia fixtures are serialized as double-precision decimals.
-   standardizes the assertion messages to `'returns expected value'` and removes the now unused `@stdlib/constants/float32/eps` and `@stdlib/math/base/special/absf` requires.

Final ULP bounds, tightened to the measured minimum over the full fixture set (2003 values each):

| Fixture | Previous tolerance | ULP bound | Measured max ULP difference |
| ------- | ------------------ | --------- | --------------------------- |
| `data.json` | `2.0 * EPS` | `1` | 1 |
| `tiny.json` | `1.0 * EPS` | `0` | 0 |
| `large.json` | `10.0 * EPS` | `1` | 1 |

The same bounds are used in `test.js` and `test.native.js`; the measured maximum ULP differences were identical for the JavaScript and C implementations, so no divergence between the two was observed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally:

-   `make test TESTS_FILTER=".*/math/base/special/coshf/.*"` — 7016 passing in both `test/test.js` and `test/test.native.js`, run twice with identical results (the native add-on was built locally via `make install-node-addons NODE_ADDONS_PATTERN=coshf`, so the native tests were not skipped).
-   Minimality check: lowering the `data` and `large` bounds from `1` to `0` yields 261 failing assertions, confirming `1` is the tightest passing bound. `0` is already the tightest possible bound for `tiny`.
-   `make lint-javascript-tests TESTS_FILTER=".*/math/base/special/coshf/.*"` — clean.

Only the two test files are modified.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled task. The agent selected the package, studied prior ULP migrations in the repository to mirror the established idiom, applied the test conversion, measured the ULP bounds empirically, and verified the tests and linting locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01XAFcfQHbF5cECtsopHZ8cF)_