### PR TITLE
test: migrate `math/base/special/cinv` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cinv/test/test.js
@@ -23,9 +23,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
@@ -65,10 +64,8 @@ tape( 'the function computes the inverse of a double-precision complex floating-
 });
 
 tape( 'the function computes a complex inverse', function test( t ) {
-	var delta;
 	var qre;
 	var qim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -81,28 +78,13 @@ tape( 'the function computes a complex inverse', function test( t ) {
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (large negative imaginary components)', function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -117,28 +99,13 @@ tape( 'the function computes a complex inverse (large negative imaginary compone
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (large negative real components)', function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -153,28 +120,13 @@ tape( 'the function computes a complex inverse (large negative real components)'
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (large positive imaginary components)', function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -189,28 +141,13 @@ tape( 'the function computes a complex inverse (large positive imaginary compone
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (large positive real components)', function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -225,28 +162,13 @@ tape( 'the function computes a complex inverse (large positive real components)'
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (tiny negative imaginary components)', function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -261,28 +183,13 @@ tape( 'the function computes a complex inverse (tiny negative imaginary componen
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (tiny negative real components)', function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -297,28 +204,13 @@ tape( 'the function computes a complex inverse (tiny negative real components)',
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (tiny positive imaginary components)', function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -333,28 +225,13 @@ tape( 'the function computes a complex inverse (tiny positive imaginary componen
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (tiny positive real components)', function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -369,21 +246,8 @@ tape( 'the function computes a complex inverse (tiny positive real components)',
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cinv/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cinv/test/test.native.js
@@ -24,9 +24,8 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
@@ -74,10 +73,8 @@ tape( 'the function computes the inverse of a double-precision complex floating-
 });
 
 tape( 'the function computes a complex inverse', opts, function test( t ) {
-	var delta;
 	var qre;
 	var qim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -91,31 +88,14 @@ tape( 'the function computes a complex inverse', opts, function test( t ) {
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
 
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			tol = 1.8 * EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-
-			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			tol = 1.7 * EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		// NOTE: the ULP threshold here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 2 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (large negative imaginary components)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -130,28 +110,13 @@ tape( 'the function computes a complex inverse (large negative imaginary compone
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (large negative real components)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -166,28 +131,13 @@ tape( 'the function computes a complex inverse (large negative real components)'
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (large positive imaginary components)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -202,28 +152,13 @@ tape( 'the function computes a complex inverse (large positive imaginary compone
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (large positive real components)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -238,28 +173,13 @@ tape( 'the function computes a complex inverse (large positive real components)'
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (tiny negative imaginary components)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -274,28 +194,13 @@ tape( 'the function computes a complex inverse (tiny negative imaginary componen
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (tiny negative real components)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -310,28 +215,13 @@ tape( 'the function computes a complex inverse (tiny negative real components)',
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (tiny positive imaginary components)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -346,28 +236,13 @@ tape( 'the function computes a complex inverse (tiny positive imaginary componen
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a complex inverse (tiny positive real components)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var qre;
 	var qim;
 	var re;
@@ -382,21 +257,8 @@ tape( 'the function computes a complex inverse (tiny positive real components)',
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cinv( new Complex128( re[ i ], im[ i ] ) );
-
-		if ( real( q ) === qre[ i ] ) {
-			t.strictEqual( real( q ), qre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - qre[ i ] );
-			tol = EPS * abs( qre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+qre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === qim[ i ] ) {
-			t.strictEqual( imag( q ), qim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - qim[ i ] );
-			tol = EPS * abs( qim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+qim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), qre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), qim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Progresses #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suites for `math/base/special/cinv` from computed `EPS`-based relative tolerances to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the idiom described in #11352.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta`/`tol` locals and the `if ( actual === expected ) { ... } else { ... }` branching, in both `test/test.js` and `test/test.native.js`.

### ULP constants

All nine Julia fixture blocks (9 × 500 values × 2 components = 9000 comparisons) were measured directly against `@stdlib/number/float64/base/ulp-difference`:

| File | Fixture block | ULP constant used | Measured minimum |
| ---- | ------------- | ----------------- | ---------------- |
| `test/test.js` | all nine blocks | `0` | `0` |
| `test/test.native.js` | `data` | `2` | `0` |
| `test/test.native.js` | remaining eight blocks | `1` | `0` |

**Measured minimum was `0` for every block, for both the JavaScript and native implementations** — every fixture value matched bit-for-bit on this machine (linux/x86_64, gcc). `test/test.js` therefore uses `0`.

For `test/test.native.js`, the ULP constants intentionally retain headroom above the measured minimum rather than dropping to `0`. The C implementation computes `re + (im * r)`, which is an FMA contraction candidate, and the pre-existing `NOTE` in that file (referencing https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205) documents exactly this divergence. The chosen constants mirror the tolerances the file already carried: the `data` block previously used `1.8 * EPS` / `1.7 * EPS` with the `NOTE` (now `2` ULP, `NOTE` retained), and the remaining blocks previously used `1.0 * EPS` (now `1` ULP). Happy to tighten these to `0` if reviewers would rather have the measured minimum and rely on CI across architectures to catch any divergence.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

Yes — see the note above regarding the `test/test.native.js` constants: should they be tightened to the measured minimum of `0`, or is the headroom above the documented FMA-contraction `NOTE` preferred?

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only `test/test.js` and `test/test.native.js` are modified; no fixtures, source, or documentation changed.
-   The native addon was built locally so that `test/test.native.js` actually executed rather than being skipped. Both suites pass (9026 assertions each), and both were run twice at the final constants with identical results.
-   `make lint-javascript-files` against `etc/eslint/.eslintrc.tests.js` reports zero problems for both files.
-   `make lint-editorconfig-files` could not run in this environment (the `editorconfig-checker` binary download is blocked); formatting was instead verified manually against `.editorconfig` (LF endings, tab indentation, no trailing whitespace, final newline).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task on my account. It surveyed already-merged ULP migrations to match the established idiom, applied the mechanical test conversion, measured the per-block ULP distances empirically, and drafted this description. Opened as a draft pending my own review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbT2zTKdHUN6aGoh5P6S3c)_