### PR TITLE
test: migrate `math/base/special/cabsf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cabsf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cabsf/test/test.js
@@ -21,11 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var cabsf = require( './../lib' );
 
@@ -45,12 +45,11 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the absolute value of a complex number', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var y;
 	var i;
+	var e;
 
 	re = data.re;
 	im = data.im;
@@ -58,13 +57,8 @@ tape( 'the function computes the absolute value of a complex number', function t
 
 	for ( i = 0; i < re.length; i++ ) {
 		y = cabsf( new Complex64( re[ i ], im[ i ] ) );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 're: '+re[i]+'. im: '+im[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 1.5 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[i]+'. im: '+im[i]+' y: '+y+'. Expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cabsf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cabsf/test/test.native.js
@@ -22,11 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -54,12 +54,11 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the absolute value of a complex number', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var y;
 	var i;
+	var e;
 
 	re = data.re;
 	im = data.im;
@@ -67,13 +66,8 @@ tape( 'the function computes the absolute value of a complex number', opts, func
 
 	for ( i = 0; i < re.length; i++ ) {
 		y = cabsf( new Complex64( re[ i ], im[ i ] ) );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 're: '+re[i]+'. im: '+im[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = absf( y - expected[i] );
-			tol = 1.5 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[i]+'. im: '+im[i]+' y: '+y+'. Expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		e = f32( expected[ i ] );
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/cabsf` from computed relative tolerance (`EPS`-scaled `delta <= tol`) checks to ULP-based assertions, per the RFC in #11352.
-   replaces the `@stdlib/constants/float32/eps` and `@stdlib/math/base/special/absf` requires with `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, as `cabsf` returns a single-precision result), together with `@stdlib/number/float64/base/to-float32` in order to round the JSON fixture values back to their exact `float32` representation before comparison.
-   applies the same change to both `test/test.js` and `test/test.native.js`.

**ULP bound: `1`** (both `test/test.js` and `test/test.native.js`).

This was tightened to the measured minimum. Starting from `64` and lowering, `1` is the smallest integer for which all fixtures pass:

-   at `1`: 2018/2018 assertions pass (2003 fixture comparisons).
-   at `0`: 382 assertions fail.

Each suite was run twice at the final bound with identical results, so the bound is not sensitive to FMA/contraction differences on this machine. The native add-on was built locally so that `test/test.native.js` was actually exercised (rather than skipped) while measuring the bound; the JavaScript and native implementations agree on the same 1 ULP maximum.

Only the two test files are modified.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The idiom follows the previously merged conversions in this family, in particular `math/base/special/coshf` (#14036) for the single-precision `f32( expected[ i ] )` handling and `math/base/special/cinv` (#14042) for complex input.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which performed the test migration and empirically determined the minimum ULP bound by running the test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01EB2BWzktoc9L1cAUXGUUVT)_