### PR TITLE
fix: pass const qualified views

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
@@ -144,7 +144,6 @@ import dsumkbn2 = require( '@stdlib/blas/ext/base/dsumkbn2' );
 import dsumors = require( '@stdlib/blas/ext/base/dsumors' );
 import dsumpw = require( '@stdlib/blas/ext/base/dsumpw' );
 import dtril = require( '@stdlib/blas/ext/base/dtril' );
-import dtril2triu = require( '@stdlib/blas/ext/base/dtril2triu' );
 import dtriu = require( '@stdlib/blas/ext/base/dtriu' );
 import dtriu2tril = require( '@stdlib/blas/ext/base/dtriu2tril' );
 import dunitspace = require( '@stdlib/blas/ext/base/dunitspace' );
@@ -4332,39 +4331,6 @@ interface Namespace {
 	* // B => <Float64Array>[ 1.0, 0.0, 3.0, 4.0 ]
 	*/
 	dtril: typeof dtril;
-
-	/**
-	* Reflects the lower triangular part of a double-precision floating-point matrix `A` into the upper triangular part of another matrix `B`.
-	*
-	* @param order - storage layout of `A` and `B`
-	* @param M - number of rows in matrix `A`
-	* @param N - number of columns in matrix `A`
-	* @param k - diagonal above which to ignore
-	* @param A - input matrix
-	* @param LDA - stride of the first dimension of `A` (a.k.a., leading dimension of the matrix `A`)
-	* @param B - output matrix
-	* @param LDB - stride of the first dimension of `B` (a.k.a., leading dimension of the matrix `B`)
-	* @returns `B`
-	*
-	* @example
-	* var Float64Array = require( '@stdlib/array/float64' );
-	*
-	* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
-	* var B = new Float64Array( [ 0.0, 0.0, 0.0, 0.0 ] );
-	*
-	* ns.dtril2triu( 'row-major', 2, 2, 0, A, 2, B, 2 );
-	* // B => <Float64Array>[ 1.0, 3.0, 0.0, 4.0 ]
-	*
-	* @example
-	* var Float64Array = require( '@stdlib/array/float64' );
-	*
-	* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
-	* var B = new Float64Array( [ 0.0, 0.0, 0.0, 0.0 ] );
-	*
-	* ns.dtril2triu.ndarray( 2, 2, 0, A, 2, 1, 0, B, 2, 1, 0 );
-	* // B => <Float64Array>[ 1.0, 3.0, 0.0, 4.0 ]
-	*/
-	dtril2triu: typeof dtril2triu;
 
 	/**
 	* Copies the upper triangular part of a double-precision floating-point matrix `A` to another matrix `B`.

--- a/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/docs/types/index.d.ts
@@ -144,6 +144,7 @@ import dsumkbn2 = require( '@stdlib/blas/ext/base/dsumkbn2' );
 import dsumors = require( '@stdlib/blas/ext/base/dsumors' );
 import dsumpw = require( '@stdlib/blas/ext/base/dsumpw' );
 import dtril = require( '@stdlib/blas/ext/base/dtril' );
+import dtril2triu = require( '@stdlib/blas/ext/base/dtril2triu' );
 import dtriu = require( '@stdlib/blas/ext/base/dtriu' );
 import dtriu2tril = require( '@stdlib/blas/ext/base/dtriu2tril' );
 import dunitspace = require( '@stdlib/blas/ext/base/dunitspace' );
@@ -4331,6 +4332,39 @@ interface Namespace {
 	* // B => <Float64Array>[ 1.0, 0.0, 3.0, 4.0 ]
 	*/
 	dtril: typeof dtril;
+
+	/**
+	* Reflects the lower triangular part of a double-precision floating-point matrix `A` into the upper triangular part of another matrix `B`.
+	*
+	* @param order - storage layout of `A` and `B`
+	* @param M - number of rows in matrix `A`
+	* @param N - number of columns in matrix `A`
+	* @param k - diagonal above which to ignore
+	* @param A - input matrix
+	* @param LDA - stride of the first dimension of `A` (a.k.a., leading dimension of the matrix `A`)
+	* @param B - output matrix
+	* @param LDB - stride of the first dimension of `B` (a.k.a., leading dimension of the matrix `B`)
+	* @returns `B`
+	*
+	* @example
+	* var Float64Array = require( '@stdlib/array/float64' );
+	*
+	* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	* var B = new Float64Array( [ 0.0, 0.0, 0.0, 0.0 ] );
+	*
+	* ns.dtril2triu( 'row-major', 2, 2, 0, A, 2, B, 2 );
+	* // B => <Float64Array>[ 1.0, 3.0, 0.0, 4.0 ]
+	*
+	* @example
+	* var Float64Array = require( '@stdlib/array/float64' );
+	*
+	* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	* var B = new Float64Array( [ 0.0, 0.0, 0.0, 0.0 ] );
+	*
+	* ns.dtril2triu.ndarray( 2, 2, 0, A, 2, 1, 0, B, 2, 1, 0 );
+	* // B => <Float64Array>[ 1.0, 3.0, 0.0, 4.0 ]
+	*/
+	dtril2triu: typeof dtril2triu;
 
 	/**
 	* Copies the upper triangular part of a double-precision floating-point matrix `A` to another matrix `B`.

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumkbn/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansumkbn/src/addon.c
@@ -45,8 +45,12 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 		assert( status == napi_ok );
 		return NULL;
 	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 1 ] = {
+		arrays[ 0 ]
+	};
 	// Perform computation:
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_blas_ext_snansumkbn( arrays ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_blas_ext_snansumkbn( arr ), v );
 
 	// Free allocated memory:
 	stdlib_ndarray_free( arrays[ 0 ] );

--- a/lib/node_modules/@stdlib/stats/base/ndarray/smean/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/smean/src/addon.c
@@ -45,8 +45,12 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 		assert( status == napi_ok );
 		return NULL;
 	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 1 ] = {
+		arrays[ 0 ]
+	};
 	// Perform computation:
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_stats_smean( arrays ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_stats_smean( arr ), v );
 
 	// Free allocated memory:
 	stdlib_ndarray_free( arrays[ 0 ] );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-08-07 15:36 PT (`ccacbf9`) and 2026-08-08 03:51 PT (`b56e927`).

This pull request:

-   **`stats/base/ndarray/smean`**: `src/addon.c` in `smean` passed non-const `arrays` straight to `stdlib_stats_smean()`, which takes `const struct ndarray *arrays[]`; `struct ndarray **` doesn't implicitly convert to `const struct ndarray **`, so it broke under `-Wincompatible-pointer-types` (error by default on GCC>=14/Clang>=16). Introduced in 5ca7350; fixed by adding the const-qualified view `arr`, matching smeankbn2/smeanli/dmediansorted from the same window.
-   **`blas/ext/base/ndarray/snansumkbn`**: Fix `-Wincompatible-pointer-types` in `ndarray/snansumkbn/src/addon.c` (introduced in 5b355d1): build a `const struct ndarray *arr[ 1 ] = { arrays[ 0 ] };` view before calling `stdlib_blas_ext_snansumkbn()`, matching the pattern used by sibling addons.
-   **`blas/ext/base`**: Fix `blas/ext/base` TS declarations: 268ae62 added `dtril2triu` to the namespace `lib/index.js`, but 31eafd1's declaration update missed it — `docs/types/index.d.ts` lacked both the `import dtril2triu = require(...)` line and the `dtril2triu: typeof dtril2triu;` interface member, so `ns.dtril2triu` failed TS2339 despite existing at runtime. Added both, alphabetically ordered, JSDoc ported from the package's own `docs/types/index.d.ts` with examples rewritten to `ns.` form.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** The 35 commits merged to `develop` in the window were reviewed by four independent review passes: two auditing stdlib style-guide compliance (`docs/style-guides`) against established reference packages, and two scanning for bugs/security/logic errors in the introduced code. Findings were merged, de-duplicated, and each surviving issue was re-verified directly against the working tree (header prototypes checked for const qualification; namespace `lib/index.js` cross-checked against `docs/types/index.d.ts`). Deliberately excluded: subjective suggestions, style preferences not mandated by the style guides, and anything requiring interpretation or changes outside the window's diff. No other issues survived filtering.

This PR is a **draft** for maintainer audit; each fix is a separate commit grouped by package.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored end-to-end by Claude Code as part of an automated 24-hour commit-review routine: AI agents reviewed the window's diffs, validated findings against the working tree, and applied the fixes. A human maintainer will audit before promoting from draft.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQ3tFyqhydxb2Fp34o5oUE)_