### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/zdscal/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/zdscal/benchmark/c/benchmark.length.c
@@ -99,11 +99,12 @@ static double rand_double( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	stdlib_complex128_t x[ len ];
+	stdlib_complex128_t *x;
 	double elapsed;
 	double t;
 	int i;
 
+	x = (stdlib_complex128_t *)malloc( len * sizeof( stdlib_complex128_t ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = stdlib_complex128( (rand_double()*10000.0)-5000.0, (rand_double()*10000.0)-5000.0 );
 	}
@@ -119,6 +120,7 @@ static double benchmark1( int iterations, int len ) {
 	if ( stdlib_base_is_nan( stdlib_complex128_imag( x[ i%len ] ) ) ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
@@ -130,11 +132,12 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	stdlib_complex128_t x[ len ];
+	stdlib_complex128_t *x;
 	double elapsed;
 	double t;
 	int i;
 
+	x = (stdlib_complex128_t *)malloc( len * sizeof( stdlib_complex128_t ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = stdlib_complex128( (rand_double()*10000.0)-5000.0, (rand_double()*10000.0)-5000.0 );
 	}
@@ -150,6 +153,7 @@ static double benchmark2( int iterations, int len ) {
 	if ( stdlib_base_is_nan( stdlib_complex128_real( x[ i%len ] ) ) ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/blas/base/zdscal/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/zdscal/benchmark/c/benchmark.length.c
@@ -99,12 +99,11 @@ static double rand_double( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	stdlib_complex128_t *x;
+	stdlib_complex128_t x[ len ];
 	double elapsed;
 	double t;
 	int i;
 
-	x = (stdlib_complex128_t *)malloc( len * sizeof( stdlib_complex128_t ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = stdlib_complex128( (rand_double()*10000.0)-5000.0, (rand_double()*10000.0)-5000.0 );
 	}
@@ -120,7 +119,6 @@ static double benchmark1( int iterations, int len ) {
 	if ( stdlib_base_is_nan( stdlib_complex128_imag( x[ i%len ] ) ) ) {
 		printf( "should not return NaN\n" );
 	}
-	free( x );
 	return elapsed;
 }
 
@@ -132,12 +130,11 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	stdlib_complex128_t *x;
+	stdlib_complex128_t x[ len ];
 	double elapsed;
 	double t;
 	int i;
 
-	x = (stdlib_complex128_t *)malloc( len * sizeof( stdlib_complex128_t ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = stdlib_complex128( (rand_double()*10000.0)-5000.0, (rand_double()*10000.0)-5000.0 );
 	}
@@ -153,7 +150,6 @@ static double benchmark2( int iterations, int len ) {
 	if ( stdlib_base_is_nan( stdlib_complex128_real( x[ i%len ] ) ) ) {
 		printf( "should not return NaN\n" );
 	}
-	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansum/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dnansum/src/addon.c
@@ -45,8 +45,12 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 		assert( status == napi_ok );
 		return NULL;
 	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 1 ] = {
+		arrays[ 0 ]
+	};
 	// Perform computation:
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_blas_ext_dnansum( arrays ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_blas_ext_dnansum( arr ), v );
 
 	// Free allocated memory:
 	stdlib_ndarray_free( arrays[ 0 ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsum/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsum/src/addon.c
@@ -45,8 +45,12 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 		assert( status == napi_ok );
 		return NULL;
 	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 1 ] = {
+		arrays[ 0 ]
+	};
 	// Perform computation:
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_blas_ext_dsum( arrays ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_blas_ext_dsum( arr ), v );
 
 	// Free allocated memory:
 	stdlib_ndarray_free( arrays[ 0 ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansum/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/snansum/src/addon.c
@@ -45,8 +45,12 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 		assert( status == napi_ok );
 		return NULL;
 	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 1 ] = {
+		arrays[ 0 ]
+	};
 	// Perform computation:
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_blas_ext_snansum( arrays ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_blas_ext_snansum( arr ), v );
 
 	// Free allocated memory:
 	stdlib_ndarray_free( arrays[ 0 ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssum/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssum/src/addon.c
@@ -45,8 +45,12 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 		assert( status == napi_ok );
 		return NULL;
 	}
+	// Create a const-qualified view of the argument pointer list:
+	const struct ndarray *arr[ 1 ] = {
+		arrays[ 0 ]
+	};
 	// Perform computation:
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_blas_ext_ssum( arrays ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_blas_ext_ssum( arr ), v );
 
 	// Free allocated memory:
 	stdlib_ndarray_free( arrays[ 0 ] );

--- a/lib/node_modules/@stdlib/stats/strided/dnanmskmin/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/dnanmskmin/benchmark/c/benchmark.length.c
@@ -95,13 +95,15 @@ static double rand_double( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_double() < 0.2 ) {
 			mask[ i ] = 1; // missing
@@ -124,6 +126,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 
@@ -135,13 +139,15 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_double() < 0.2 ) {
 			mask[ i ] = 1; // missing
@@ -164,6 +170,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/dnanmskrange/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/dnanmskrange/benchmark/c/benchmark.length.c
@@ -95,13 +95,15 @@ static double rand_double( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_double() < 0.2 ) {
 			mask[ i ] = 1; // missing
@@ -124,6 +126,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 
@@ -135,13 +139,15 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_double() < 0.2 ) {
 			mask[ i ] = 1; // missing
@@ -164,6 +170,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/scumax/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/scumax/benchmark/c/benchmark.length.c
@@ -96,11 +96,13 @@ static float rand_float( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float() * 20000.0f ) - 10000.0f;
 		y[ i ] = 0.0f;
@@ -118,6 +120,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 
@@ -130,11 +134,13 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float() * 20000.0f ) - 10000.0f;
 		y[ i ] = 0.0f;
@@ -152,6 +158,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/scumaxabs/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/scumaxabs/benchmark/c/benchmark.length.c
@@ -96,11 +96,13 @@ static float rand_float( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float() * 20000.0f ) - 10000.0f;
 		y[ i ] = 0.0f;
@@ -118,6 +120,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 
@@ -130,11 +134,13 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float() * 20000.0f ) - 10000.0f;
 		y[ i ] = 0.0f;
@@ -152,6 +158,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/scumin/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/scumin/benchmark/c/benchmark.length.c
@@ -96,11 +96,13 @@ static float rand_float( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float() * 20000.0f ) - 10000.0f;
 		y[ i ] = 0.0f;
@@ -118,6 +120,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 
@@ -130,11 +134,13 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float() * 20000.0f ) - 10000.0f;
 		y[ i ] = 0.0f;
@@ -152,6 +158,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/scuminabs/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/scuminabs/benchmark/c/benchmark.length.c
@@ -96,11 +96,13 @@ static float rand_float( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float() * 20000.0f ) - 10000.0f;
 		y[ i ] = 0.0f;
@@ -118,6 +120,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 
@@ -130,11 +134,13 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float() * 20000.0f ) - 10000.0f;
 		y[ i ] = 0.0f;
@@ -152,6 +158,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( y[ len-1 ] != y[ len-1 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/smskmax/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/smskmax/benchmark/c/benchmark.length.c
@@ -95,13 +95,15 @@ static float rand_float( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -124,6 +126,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 
@@ -135,13 +139,15 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -164,6 +170,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/smskmin/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/smskmin/benchmark/c/benchmark.length.c
@@ -95,13 +95,15 @@ static float rand_float( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -124,6 +126,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 
@@ -135,13 +139,15 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -164,6 +170,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/smskrange/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/smskrange/benchmark/c/benchmark.length.c
@@ -95,13 +95,15 @@ static float rand_float( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -124,6 +126,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 
@@ -135,13 +139,15 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -164,6 +170,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/snanmskmax/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/snanmskmax/benchmark/c/benchmark.length.c
@@ -95,13 +95,15 @@ static float rand_float( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -124,6 +126,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 
@@ -135,13 +139,15 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -164,6 +170,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/snanmskmin/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/snanmskmin/benchmark/c/benchmark.length.c
@@ -95,13 +95,15 @@ static float rand_float( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -124,6 +126,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 
@@ -135,13 +139,15 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -164,6 +170,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/snanmskrange/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/snanmskrange/benchmark/c/benchmark.length.c
@@ -95,13 +95,15 @@ static float rand_float( void ) {
 * @return             elapsed time in seconds
 */
 static double benchmark1( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -124,6 +126,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 
@@ -135,13 +139,15 @@ static double benchmark1( int iterations, int len ) {
 * @return             elapsed time in seconds
 */
 static double benchmark2( int iterations, int len ) {
-	unsigned char mask[ len ];
+	unsigned char *mask;
 	double elapsed;
-	float x[ len ];
+	float *x;
 	float v;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
+	mask = (unsigned char *)malloc( len * sizeof( unsigned char ) );
 	for ( i = 0; i < len; i++ ) {
 		if ( rand_float() < 0.2f ) {
 			mask[ i ] = 1; // missing
@@ -164,6 +170,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( mask );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/sztest/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/sztest/benchmark/c/benchmark.length.c
@@ -100,7 +100,7 @@ static float random_uniform( const float min, const float max ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
+	float *x;
 	double t;
 	int i;
 
@@ -115,6 +115,7 @@ static double benchmark1( int iterations, int len ) {
 		.sd = 0.0f
 	};
 
+	x = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = random_uniform( -5.0f, 5.0f );
 	}
@@ -131,6 +132,7 @@ static double benchmark1( int iterations, int len ) {
 	if ( results.statistic != results.statistic ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
@@ -143,7 +145,7 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
+	float *x;
 	double t;
 	int i;
 
@@ -158,6 +160,7 @@ static double benchmark2( int iterations, int len ) {
 		.sd = 0.0f
 	};
 
+	x = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = random_uniform( -5.0f, 5.0f );
 	}
@@ -174,6 +177,7 @@ static double benchmark2( int iterations, int len ) {
 	if ( results.statistic != results.statistic ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/strided/sztest2/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/strided/sztest2/benchmark/c/benchmark.length.c
@@ -100,8 +100,8 @@ static float random_uniform( const float min, const float max ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
@@ -117,6 +117,8 @@ static double benchmark1( int iterations, int len ) {
 		.ymean = 0.0f
 	};
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = random_uniform( -5.0f, 5.0f );
 		y[ i ] = random_uniform( -5.0f, 5.0f );
@@ -134,6 +136,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( results.statistic != results.statistic ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 
@@ -146,8 +150,8 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
-	float y[ len ];
+	float *x;
+	float *y;
 	double t;
 	int i;
 
@@ -163,6 +167,8 @@ static double benchmark2( int iterations, int len ) {
 		.ymean = 0.0f
 	};
 
+	x = (float *)malloc( len * sizeof( float ) );
+	y = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = random_uniform( -5.0f, 5.0f );
 		y[ i ] = random_uniform( -5.0f, 5.0f );
@@ -180,6 +186,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( results.statistic != results.statistic ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/strided/base/cmap/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/strided/base/cmap/benchmark/c/benchmark.length.c
@@ -106,12 +106,14 @@ static float complex identity( const float complex x ) {
 * @return             elapsed time in seconds
 */
 static double benchmark( int iterations, int len ) {
-	float complex x[ len ];
-	float complex y[ len ];
+	float complex *x;
+	float complex *y;
 	double elapsed;
 	double t;
 	int i;
 
+	x = (float complex *)malloc( len * sizeof( float complex ) );
+	y = (float complex *)malloc( len * sizeof( float complex ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( ( rand_float()*200.0f ) - 100.0f ) + ( ( rand_float()*200.0f ) - 100.0f )*I;
 		y[ i ] = 0.0f + 0.0f*I;
@@ -129,6 +131,8 @@ static double benchmark( int iterations, int len ) {
 	if ( y[ i%len ] != y[ i%len ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-08-07T13:11Z and 2026-08-08T13:11Z to sibling packages with the same underlying defects.

### Propagated fix: const-qualified `arrays` view

Commit ebbf2de9f fixed the `arrays` pointer mismatch in `src/addon.c`: passing a non-const `struct ndarray *arrays[]` into APIs declared to take `const struct ndarray *arrays[]`. Same defect existed unfixed in four more packages; this PR applies the identical remedy — construct a const-qualified view of the argument pointer list and pass that view to the API call, leaving `arrays` itself non-const since `stdlib_ndarray_napi_addon_arguments` and `stdlib_ndarray_free` require the mutable pointer.

-   `@stdlib/blas/ext/base/ndarray/ssum`
-   `@stdlib/blas/ext/base/ndarray/dsum`
-   `@stdlib/blas/ext/base/ndarray/snansum`
-   `@stdlib/blas/ext/base/ndarray/dnansum`

### Propagated fix: heap allocation for benchmark VLAs

-   `f19d370e0` converted stack-allocated variable-length arrays to `malloc`/`free` in `benchmark.length.c`. `len` runs up to 10^6; a VLA of that size overflows the stack.
-   Same conversion applied here to the 15 remaining benchmark files still declaring VLAs: `@stdlib/strided/base/cmap` and `@stdlib/stats/strided/{scumin,scumax,scuminabs,scumaxabs,smskmin,smskmax,smskrange,snanmskmin,snanmskmax,snanmskrange,dnanmskmin,dnanmskrange,sztest,sztest2}`. Every array per benchmark function — data, output, mask — moves to the heap, matching the already-converted sibling files.
-   `@stdlib/stats/strided/dnanmskmax` excluded: data array is already heap-allocated, mask array is still a VLA. Left for human review.
-   `@stdlib/blas/base/zdscal` excluded: cppcheck reports `uninitdata` false positives for malloc'd `stdlib_complex128_t` elements assigned via function call (see the reverting commit), and no `uninitdata` suppression precedent exists in the repository. Left for human review.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8643

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed per site: exact-signature search over the affected namespaces (`rg` on the addon call shape and on `[ len ];` VLA declarations in benchmark C files); two independent validation passes reading each target file and the callee headers in full; a per-site adaptation pass tailoring patches to dtype, array count, and declaration layout (mirroring converted siblings `dcumin`, `dnanmskminabs`, `dztest`/`dztest2`, `zmap`); and a style-consistency pass against the source commits' conventions. All benchmark files compile cleanly with `gcc -fsyntax-only -Wall` and pass `cppcheck` with the repository's benchmark suppressions and full include paths. Deliberately excluded: `dnanmskmax` (half-converted, needs human review); `zdscal` (cppcheck `uninitdata` false positive, see above); sites requiring cross-package changes; c8.mk `FAIL_FAST`/`FAST_FAIL` doc rename (doc/code disagreement); repl.txt trailing-newline and README include removals (no unambiguous canonical form).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a scheduled fix-propagation routine: it identified generalizable fixes merged to `develop` in the last 24 hours, located sibling packages with the same defects, and applied the equivalent patches after multi-agent validation.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX6uDwjW9prE4N4VY8qwSu