### PR TITLE
test: migrate `math/base/special/polygamma` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/polygamma/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/polygamma/test/test.js
@@ -21,14 +21,13 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var factorial = require( '@stdlib/math/base/special/factorial' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var isnan = require( '@stdlib/assert/is-nan' );
 var ldexp = require( '@stdlib/math/base/special/ldexp' );
 var zeta = require( '@stdlib/math/base/special/riemann-zeta' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var polygamma = require( './../lib' );
 
 
@@ -82,8 +81,6 @@ tape( 'if provided an odd negative integer for `x`, the function returns positiv
 
 tape( 'the function evaluates the polygamma function for small positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var x;
 	var y;
@@ -94,21 +91,13 @@ tape( 'the function evaluates the polygamma function for small positive numbers'
 	expected = smallPositive.y;
 	for ( i = 0; i < x.length; i++ ) {
 		y = polygamma(n[i], x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'n: '+n[i]+'. x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 20.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. n: '+n[i]+'. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the polygamma function for positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var x;
 	var y;
@@ -119,21 +108,13 @@ tape( 'the function evaluates the polygamma function for positive numbers', func
 	expected = positive.y;
 	for ( i = 0; i < x.length; i++ ) {
 		y = polygamma(n[i], x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'n: '+n[i]+'. x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 20.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. n: '+n[i]+'. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the polygamma function for negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var x;
 	var y;
@@ -144,21 +125,13 @@ tape( 'the function evaluates the polygamma function for negative numbers', func
 	expected = negative.y;
 	for ( i = 0; i < x.length; i++ ) {
 		y = polygamma( n[i], x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'n: '+n[i]+'. x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2300.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. n: '+n[i]+'. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2858 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the polygamma function for large positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var x;
 	var y;
@@ -169,21 +142,13 @@ tape( 'the function evaluates the polygamma function for large positive numbers'
 	expected = largePositive.y;
 	for ( i = 0; i < x.length; i++ ) {
 		y = polygamma(n[i], x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'n: '+n[i]+'. x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 20.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. n: '+n[i]+'. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 18 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the polygamma function for large negative numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var x;
 	var y;
@@ -194,23 +159,15 @@ tape( 'the function evaluates the polygamma function for large negative numbers'
 	expected = largeNegative.y;
 	for ( i = 0; i < x.length; i++ ) {
 		y = polygamma( n[i], x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'n: '+n[i]+'. x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
 
-			// The large discrepancies for a few input values seem to be mostly due to a slight difference in the calculation of `cospi`, which is used in `polycotpi.js`. For example, for `x = 128.69279279279279`, our `cospi` function returns `-0.5693183042040957`, whereas Boost returns `-0.56931830420405894`. These differences are then magnified as the result is used as the value at which polynomials are evaluated.
-			tol = 2200.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. n: '+n[i]+'. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		// The large discrepancies for a few input values seem to be mostly due to a slight difference in the calculation of `cospi`, which is used in `polycotpi.js`. For example, for `x = 128.69279279279279`, our `cospi` function returns `-0.5693183042040957`, whereas Boost returns `-0.56931830420405894`. These differences are then magnified as the result is used as the value at which polynomials are evaluated.
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2773 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the polygamma function for huge positive numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var x;
 	var y;
@@ -221,13 +178,7 @@ tape( 'the function evaluates the polygamma function for huge positive numbers',
 	expected = hugePositive.y;
 	for ( i = 0; i < x.length; i++ ) {
 		y = polygamma(n[i], x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'n: '+n[i]+'. x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. n: '+n[i]+'. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/polygamma` from computed relative tolerance (`EPS`-scaled `delta <= tol`) checks to ULP-based assertions, per the RFC in #11352.
-   replaces the `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` requires with `@stdlib/assert/is-almost-same-value`.
-   only `test/test.js` is modified. The package has no `test/test.native.js`, and `test/test.atinfinityplus.js` contains only exact comparisons and is left untouched.

**ULP bounds** (one per fixture set, each tightened to the measured minimum):

| fixture set | previous tolerance | ULP bound |
| ----------- | ------------------ | --------- |
| `small_positive` | `20.0 * EPS` | `3` |
| `positive` | `20.0 * EPS` | `15` |
| `negative` | `2300.0 * EPS` | `2858` |
| `large_positive` | `20.0 * EPS` | `18` |
| `large_negative` | `2200.0 * EPS` | `2773` |
| `huge_positive` | `1.0 * EPS` | `0` |

Each bound is the smallest non-negative integer for which every fixture in the corresponding set passes. Starting from a high bound and lowering, the suite passes at the values above (6305/6305 assertions, 6000 fixture comparisons across the six sets), and decrementing each of the five non-zero bounds by one produces exactly five failures — one per set — confirming that no bound can be tightened further. The `huge_positive` set matches the reference values exactly, hence a bound of `0`.

The suite was run twice at the final bounds with identical results, so the bounds are not sensitive to FMA/contraction differences on this machine.

The explanatory comment in the "large negative numbers" test regarding `cospi` discrepancies against Boost has been retained, as it continues to explain why that set requires a comparatively loose bound.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The idiom follows previously merged conversions in this family, in particular `math/base/special/acsch` (#14037) and `math/base/special/fresnel` (#14035), which use an inline integer ULP argument per fixture loop and the `'returns expected value'` assertion message.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which performed the test migration and empirically determined the minimum ULP bounds by running the test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01CgRqQ4n28AKhV1XHRR2a2s)_