### PR TITLE
test: migrate `math/base/special/asecf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/asecf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asecf/test/test.js
@@ -22,8 +22,7 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var asecf = require( './../lib' );
 
@@ -50,8 +49,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-3.0,-1.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -63,21 +60,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-3.0,-1.
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 2.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[1.0,3.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -89,21 +78,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[1.0,3.0]
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 68.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 97 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[3.0,100.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -115,21 +96,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[3.0,100.
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-100.0,-3.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -141,21 +114,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-100.0,-
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[100.0,1000.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -167,21 +132,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[100.0,10
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-1000.0,-100.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -193,21 +150,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-1000.0,
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-1e20,-1e28]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -219,21 +168,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-1e20,-1
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[1e30,1e38]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -245,13 +186,7 @@ tape( 'the function computes the inverse (arc) secant on the interval `[1e30,1e3
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asecf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asecf/test/test.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -59,8 +58,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-3.0,-1.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -72,21 +69,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-3.0,-1.
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 2.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[1.0,3.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -98,21 +87,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[1.0,3.0]
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 68.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 97 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[3.0,100.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -124,21 +105,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[3.0,100.
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-100.0,-3.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -150,21 +123,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-100.0,-
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[100.0,1000.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -176,21 +141,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[100.0,10
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-1000.0,-100.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -202,21 +159,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-1000.0,
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[-1e20,-1e28]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -228,21 +177,13 @@ tape( 'the function computes the inverse (arc) secant on the interval `[-1e20,-1
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse (arc) secant on the interval `[1e30,1e38]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -254,13 +195,7 @@ tape( 'the function computes the inverse (arc) secant on the interval `[1e30,1e3
 	for ( i = 0; i < x.length; i++ ) {
 		y = asecf( x[i] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[i]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 1.0 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/asecf` from computed relative tolerance (`EPS`-scaled `delta <= tol`) checks to ULP-based assertions;
-   replaces the `@stdlib/constants/float32/eps` and `@stdlib/math/base/special/abs` requires with `@stdlib/number/float32/base/assert/is-almost-same-value`.
-   both `test/test.js` and `test/test.native.js` are modified to use the new ULP assertions.

**ULP bounds** (one per fixture set, each tightened to the measured minimum):

| fixture set | previous tolerance | ULP bound |
| ----------- | ------------------ | --------- |
| `medium_negative` | `2.0 * EPS` | `3` |
| `medium_positive` | `68.0 * EPS` | `97` |
| `large_positive` | `1.0 * EPS` | `1` |
| `large_negative` | `1.0 * EPS` | `1` |
| `larger_positive` | `1.0 * EPS` | `0` |
| `larger_negative` | `1.0 * EPS` | `1` |
| `huge_negative` | `1.0 * EPS` | `0` |
| `huge_positive` | `1.0 * EPS` | `0` |

Each bound is the smallest non-negative integer for which every fixture in the corresponding set passes. Starting from a high bound and lowering, the suite passes at the values above (4013/4013 assertions), and decrementing each of the five non-zero bounds by one produces exactly five failures - one per set ; confirming that no bound can be tightened further. The `larger_positive`, `huge_negative`, and `huge_positive` sets match the reference values exactly, hence a bound of `0`.

The suite was run twice at the final bounds with identical results, so the bounds are not sensitive to FMA/contraction differences on this machine.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
