### PR TITLE
test: migrate `stats/base/dists/lognormal/variance` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
 
@@ -76,9 +75,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function 
 
 tape( 'the function returns the variance of a lognormal distribution', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -89,13 +86,7 @@ tape( 'the function returns the variance of a lognormal distribution', function 
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/variance/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -88,9 +87,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', opts, fun
 
 tape( 'the function returns the variance of a lognormal distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var y;
 	var i;
@@ -101,13 +98,7 @@ tape( 'the function returns the variance of a lognormal distribution', opts, fun
 	for ( i = 0; i < mu.length; i++ ) {
 		y = variance( mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/lognormal/variance` from computed relative tolerance testing (`delta = abs( y - expected[i] )`, `tol = 1.0 * EPS * abs( expected[i] )`, `t.ok( delta <= tol, ... )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates both `test/test.js` and `test/test.native.js`, which mirror one another.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from both test files (neither is used elsewhere in these files).

**ULP bounds** (tightened to the measured minimum over the full fixture set):

| Fixture file | Test case | ULP bound | Measured maximum ULP difference |
| --- | --- | --- | --- |
| `fixtures/julia/data.json` | the function returns the variance of a lognormal distribution | `0` | 0 (JS and native) |

Notes on how the bound was determined:

-   The bound is the minimum non-negative integer for which every fixture value passes. All 100 fixture values are bit-for-bit exact against the Julia reference values, for both the JavaScript and the C implementations, so `0` is both the measured maximum and the tightest possible bound.
-   The measurement was performed by computing, for each fixture value, the smallest `N` for which `isAlmostSameValue( y, expected[i], N )` is `true`, and taking the maximum over the fixture set. Starting from a bound of `64` and lowering, the suite passes all the way down to `0`.
-   This is consistent with the implementation: the variance of a lognormal distribution is `( exp( s2 ) - 1 ) * exp( ( 2*mu ) + s2 )` with `s2 = sigma^2`, and the JavaScript and C implementations evaluate exactly the same expression using the same underlying `exp` kernel, leaving no room for the two to diverge on these inputs.
-   Because the results are exact, the old `y === expected[i]` fast path was taken for every fixture value and the tolerance branch was never exercised.
-   The JavaScript and C implementations agree exactly, so `test.js` and `test.native.js` use identical bounds.
-   The native add-on was compiled locally (`node-gyp rebuild`), so `test/test.native.js` was exercised against the actual C implementation rather than skipped. Both test files were run twice at the final bound with identical results (110 assertions for `test.js`, 111 for `test.native.js`, all passing, per run), so the bound is not sensitive to FMA/contraction differences on this machine.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

Two minor points:

-   The existing `if ( expected[i] !== null )` guard was retained in both loops in order to keep the diff limited to the tolerance math. The current fixture data contains no `null` entries, so the guard is presently inert and could be dropped if reviewers prefer.
-   Given that every fixture value is bit-for-bit exact, a bound of `0` is equivalent to a strict equality check. `isAlmostSameValue( ..., 0 )` was chosen for consistency with the other converted packages, matching the approach taken in `stats/base/dists/erlang/skewness` (#14022).

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.
-   Verified with `make test TESTS_FILTER=".*/stats/base/dists/lognormal/variance/.*"` and by running both test files directly against the compiled add-on. Linting is clean via ESLint using `etc/eslint/.eslintrc.tests.js`.
-   The `editorconfig` pre-commit hook could not run in this environment, as it downloads its binary from a host this session cannot reach. The two files were instead checked against `.editorconfig` (LF endings, tab indentation, final newline, UTF-8); the diff introduces no new violations.
-   The idiom follows previously merged conversions, in particular `stats/base/dists/erlang/skewness` (#14022), which uses an inline integer ULP argument per fixture loop and the `'returns expected value'` assertion message.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. The test migration follows the idiom established by previously merged conversions, and the ULP bound was measured empirically against both the JavaScript and compiled C implementations rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_012UX8BbHrhK7dzxTe4AqUpP)_