### PR TITLE
test: migrate `stats/strided/dsem` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/dsem/test/test.dsem.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsem/test/test.dsem.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var dsem = require( './../lib/dsem.js' );
 
 
@@ -44,8 +43,6 @@ tape( 'the function has an arity of 4', function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -53,9 +50,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsem( x.length, 0, x, 1 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsem( x.length, 0, x, 1 );
@@ -70,8 +65,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -79,9 +72,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsem( x.length, 1, x, 1 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsem( x.length, 1, x, 1 );

--- a/lib/node_modules/@stdlib/stats/strided/dsem/test/test.dsem.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsem/test/test.dsem.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -53,8 +52,6 @@ tape( 'the function has an arity of 4', opts, function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -62,9 +59,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsem( x.length, 0, x, 1 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsem( x.length, 0, x, 1 );
@@ -79,8 +74,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -88,9 +81,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsem( x.length, 1, x, 1 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsem( x.length, 1, x, 1 );

--- a/lib/node_modules/@stdlib/stats/strided/dsem/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsem/test/test.ndarray.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var dsem = require( './../lib/ndarray.js' );
 
 
@@ -44,8 +43,6 @@ tape( 'the function has an arity of 5', function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -53,9 +50,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsem( x.length, 0, x, 1, 0 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsem( x.length, 0, x, 1, 0 );
@@ -70,8 +65,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -79,9 +72,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsem( x.length, 1, x, 1, 0 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsem( x.length, 1, x, 1, 0 );

--- a/lib/node_modules/@stdlib/stats/strided/dsem/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/dsem/test/test.ndarray.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -53,8 +52,6 @@ tape( 'the function has an arity of 5', opts, function test( t ) {
 
 tape( 'the function calculates the standard error of the mean for a strided array (population)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -62,9 +59,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsem( x.length, 0, x, 1, 0 );
 	expected = sqrt( 53.5/x.length ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsem( x.length, 0, x, 1, 0 );
@@ -79,8 +74,6 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 
 tape( 'the function calculates the standard error of the mean for a strided array (sample)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -88,9 +81,7 @@ tape( 'the function calculates the standard error of the mean for a strided arra
 	v = dsem( x.length, 1, x, 1, 0 );
 	expected = sqrt( 53.5/(x.length-1) ) / sqrt( x.length );
 
-	delta = abs( v - expected );
-	tol = 1.0 * EPS * abs( expected );
-	t.strictEqual( delta <= tol, true, 'within tolerance. Actual: '+v+'. E: '+expected+'. tol: '+tol+'. Δ: '+delta+'.' );
+	t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' );
 
 	x = new Float64Array( [ -4.0, -4.0 ] );
 	v = dsem( x.length, 1, x, 1, 0 );


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/strided/dsem` from relative-tolerance-based floating-point comparisons to ULP-based comparisons using `@stdlib/assert/is-almost-same-value`, per the migration described in #11352.
-   replaces the `delta`/`tol` tolerance computation (`delta = abs( v - expected ); tol = 1.0 * EPS * abs( expected ); t.strictEqual( delta <= tol, true, ... )`) in `test/test.dsem.js`, `test/test.dsem.native.js`, `test/test.ndarray.js`, and `test/test.ndarray.native.js` with `t.strictEqual( isAlmostSameValue( v, expected, 1 ), true, 'returns expected value' )`.
-   the minimum ULP tolerance required for all assertions to pass was determined empirically to be **1 ULP** (0 ULP fails for both the population and sample standard-error-of-the-mean assertions). The full test suite was run twice at this value to confirm deterministic results.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, run as an automated scheduled task against issue #11352: it searched the codebase for a qualifying package with relative-tolerance tests, converted the four test files to use `isAlmostSameValue`, and determined the minimum passing ULP value (1) empirically by running the test suite at decreasing values.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMo74eYNb67HC5AWJQQNWj)_