### PR TITLE
test: migrate `math/base/special/fast/asinh` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fast/asinh/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/asinh/test/test.js
@@ -21,13 +21,13 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var asinh = require( './../lib' );
 
 
@@ -61,8 +61,6 @@ tape( 'the function underflows if provided a number which is negligible compared
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-0.8,0.8]` (tests whether `asinh` behaves as an odd function)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -72,21 +70,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-0.8,0.8]`
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 50.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 79 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-1.0,-0.8]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -96,21 +86,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-1.0,-0.8]
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[0.8,1.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -120,21 +102,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[0.8,1.0]`'
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-3.0,-1.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -144,21 +118,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-3.0,-1.0]
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[1.0,3.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -168,21 +134,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[1.0,3.0]`'
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[3.0,28.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -192,21 +150,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[3.0,28.0]`
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-28.0,-3.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -216,21 +166,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-28.0,-3.0
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[28.0,100.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -240,21 +182,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[28.0,100.0
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-100.0,-28.0]`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -264,13 +198,7 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-100.0,-28
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/fast/asinh/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/asinh/test/test.native.js
@@ -22,13 +22,13 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -70,8 +70,6 @@ tape( 'the function underflows if provided a number which is negligible compared
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-0.8,0.8]` (tests whether `asinh` behaves as an odd function)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -81,21 +79,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-0.8,0.8]`
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 50.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 79 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-1.0,-0.8]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -105,21 +95,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-1.0,-0.8]
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[0.8,1.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -129,21 +111,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[0.8,1.0]`'
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-3.0,-1.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -153,21 +127,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-3.0,-1.0]
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[1.0,3.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -177,21 +143,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[1.0,3.0]`'
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[3.0,28.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -201,21 +159,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[3.0,28.0]`
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-28.0,-3.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -225,21 +175,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-28.0,-3.0
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[28.0,100.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -249,21 +191,13 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[28.0,100.0
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the hyperbolic arcsine on the interval `[-100.0,-28.0]`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -273,13 +207,7 @@ tape( 'the function computes the hyperbolic arcsine on the interval `[-100.0,-28
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinh( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tolerance: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/fast/asinh` from computed relative tolerance comparisons (`delta = abs( y - expected[i] ); tol = N * EPS * abs( expected[i] ); t.ok( delta <= tol, ... )`) to ULP difference assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   applies the change to both `test/test.js` and `test/test.native.js`.

Only the two test files are modified; no implementation or fixture changes.

### ULP bounds

Bounds were tightened agentically: starting from `64` and lowering to the minimum integer which still passes over the **full** fixture set. The measured maximum ULP difference per fixture set is:

| Fixture set | Test | Previous tolerance | Final ULP bound | Measured max ULP |
| ----------- | ---- | ------------------ | --------------- | ---------------- |
| `smaller` (n=503) | `[-0.8,0.8]` (odd function) | `50.0 * EPS` | `79` | 79 |
| `small_negative` (n=503) | `[-1.0,-0.8]` | `1.5 * EPS` | `2` | 2 |
| `small_positive` (n=503) | `[0.8,1.0]` | `1.5 * EPS` | `2` | 2 |
| `medium_negative` (n=503) | `[-3.0,-1.0]` | `2.0 * EPS` | `2` | 2 |
| `medium_positive` (n=503) | `[1.0,3.0]` | `2.0 * EPS` | `2` | 2 |
| `large_positive` (n=503) | `[3.0,28.0]` | `1.0 * EPS` | `1` | 1 |
| `large_negative` (n=503) | `[-28.0,-3.0]` | `1.0 * EPS` | `1` | 1 |
| `larger_positive` (n=503) | `[28.0,100.0]` | `1.0 * EPS` | `1` | 1 |
| `larger_negative` (n=503) | `[-100.0,-28.0]` | `1.0 * EPS` | `1` | 1 |

The bounds are minimal: decrementing every bound by one (`79 → 78`, `2 → 1`, `1 → 0`) yields 192 failing assertions, with at least one failure in each of the nine fixture loops.

The larger bound on the `smaller` fixture set is expected for this package: `fast/asinh` evaluates `ln( x + sqrt( x*x + 1 ) )` directly, so for small `|x|` the argument to `ln` is close to `1` and cancellation dominates the error. The worst case is at the smallest magnitude in that set (`x = -0.006374501992031873`). This mirrors the previous `50.0 * EPS` relative tolerance, which was already loosened for that interval relative to the others.

The JavaScript and native implementations were measured independently and produce **identical** maximum ULP differences (79 / 2 / 2 / 2 / 2 / 1 / 1 / 1 / 1), so `test.js` and `test.native.js` use the same bounds.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `test/test.js`: 4536 assertions passing; run twice at the final bounds with identical results (no FMA/arch nondeterminism observed).
-   `test/test.native.js`: the native addon was built locally via `node-gyp rebuild`, so these tests ran for real rather than being skipped — 4536 assertions passing, also run twice.
-   ESLint clean against `etc/eslint/.eslintrc.tests.js` (the config the `eslint-tests` target uses for test files).
-   `git diff --check` clean; tab indentation and trailing-newline conventions preserved.
-   The now-unused `@stdlib/math/base/special/abs` require was removed from both files; `@stdlib/constants/float64/eps` is retained because `EPS` is still used by the underflow test.

Environment note: the editorconfig pre-commit hook could not run in this environment because downloading the `editorconfig-checker` binary is blocked, so the relevant checks (indentation style, trailing whitespace, final newline, line endings) were verified manually instead.

Opened as a draft pending CI.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied prior converted packages (including the already-migrated sibling `math/base/special/fast/acosh`, #14004) to match the established idiom, applied the conversion, and empirically searched for the minimum passing ULP bound for each fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3zHCEMhwS9mRnbZ9MvaxJ)_