### PR TITLE
test: migrate `math/base/special/csignum` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/csignum/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignum/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
@@ -48,10 +47,8 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function evaluates the signum function', function test( t ) {
-	var delta;
 	var ere;
 	var eim;
-	var tol;
 	var re;
 	var im;
 	var y;
@@ -64,18 +61,8 @@ tape( 'the function evaluates the signum function', function test( t ) {
 
 	for ( i = 0; i < re.length; i++ ) {
 		y = csignum( new Complex128( re[ i ], im[ i ] ) );
-		if ( real( y ) === ere[ i ] && imag( y ) === eim[ i ] ) {
-			t.strictEqual( real( y ), ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
-			t.strictEqual( imag( y ), eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
-		} else {
-			delta = abs( real( y ) - ere[ i ] );
-			tol = EPS * abs( ere[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual re: '+real( y )+'. Expected re: '+ere[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-
-			delta = abs( imag( y ) - eim[ i ] );
-			tol = EPS * abs( eim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual im: '+imag( y )+'. Expected im: '+eim[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( y ), ere[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( y ), eim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/csignum/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignum/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
@@ -57,10 +56,8 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function evaluates the signum function', opts, function test( t ) {
-	var delta;
 	var ere;
 	var eim;
-	var tol;
 	var re;
 	var im;
 	var y;
@@ -73,18 +70,8 @@ tape( 'the function evaluates the signum function', opts, function test( t ) {
 
 	for ( i = 0; i < re.length; i++ ) {
 		y = csignum( new Complex128( re[ i ], im[ i ] ) );
-		if ( real( y ) === ere[ i ] && imag( y ) === eim[ i ] ) {
-			t.strictEqual( real( y ), ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
-			t.strictEqual( imag( y ), eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
-		} else {
-			delta = abs( real( y ) - ere[ i ] );
-			tol = EPS * abs( ere[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual re: '+real( y )+'. Expected re: '+ere[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-
-			delta = abs( imag( y ) - eim[ i ] );
-			tol = EPS * abs( eim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual im: '+imag( y )+'. Expected im: '+eim[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( y ), ere[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( y ), eim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Progresses #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suites for `math/base/special/csignum` from computed `EPS`-based relative tolerances to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the idiom described in #11352.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires, along with the `delta`/`tol` locals and the `if ( actual === expected ) { ... } else { ... }` branching, in both `test/test.js` and `test/test.native.js`.

### ULP constants

The single Julia fixture block (2003 values × 2 components = 4006 comparisons) was measured directly against `@stdlib/number/float64/base/ulp-difference`:

| File | Fixture block | ULP constant used | Measured minimum |
| ---- | ------------- | ----------------- | ---------------- |
| `test/test.js` | `data` | `0` | `0` |
| `test/test.native.js` | `data` | `0` | `0` |

**Measured minimum was `0` for both the JavaScript and the native implementation** — every fixture value matched bit-for-bit on this machine (linux/x86_64, gcc), including the `±0` entries, for which `isAlmostSameValue` falls back to SameValue semantics at `0` ULP. Both files therefore use the measured minimum of `0`.

One note for reviewers: the native path reaches `stdlib_base_hypot` (via `stdlib_base_cabs`), which evaluates `1.0 + ( b * b )` — an FMA-contraction candidate. That did not produce any divergence here, so `test/test.native.js` carries the measured minimum rather than headroom, but I'm happy to raise the native constant to `1` (with an explanatory `NOTE`, as in `math/base/special/cinv`) if reviewers would prefer insulation against architectures where the contraction fires.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

Yes — see the note above: should `test/test.native.js` keep the measured minimum of `0`, or carry `1` ULP of headroom for potential FMA contraction inside `hypot`?

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only `test/test.js` and `test/test.native.js` are modified; no fixtures, source, or documentation changed.
-   The native addon was built locally (`node-gyp rebuild`) so that `test/test.native.js` actually executed rather than being skipped; the run reports zero `SKIP` directives. Both suites pass (4018 assertions each), and both were run twice at the final constants with identical results. The locally built `build/` and `src/addon.node` artifacts were removed before committing.
-   `eslint --config etc/eslint/.eslintrc.tests.js` reports zero problems for both files.
-   `make lint-editorconfig-files` could not run in this environment (the `editorconfig-checker` binary download is blocked); formatting was instead verified manually against `.editorconfig` (LF endings, tab indentation, no trailing whitespace, final newline).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task on my account. It surveyed already-merged ULP migrations to match the established idiom, applied the mechanical test conversion, measured the ULP distances empirically, and drafted this description. Opened as a draft pending my own review.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCwbYG3pD5FBgGT3VjTJHZ)_