### PR TITLE
test: migrate `stats/base/dists/halfnormal/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/stdev/test/test.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -61,9 +60,7 @@ tape( 'if provided a non-positive number, the function returns `NaN`', function 
 
 tape( 'the function returns the standard deviation of a half-normal distribution', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var y;
 
@@ -71,13 +68,7 @@ tape( 'the function returns the standard deviation of a half-normal distribution
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], ', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/stdev/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -70,9 +69,7 @@ tape( 'if provided a non-positive number, the function returns `NaN`', opts, fun
 
 tape( 'the function returns the standard deviation of a half-normal distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var y;
 
@@ -80,13 +77,7 @@ tape( 'the function returns the standard deviation of a half-normal distribution
 	sigma = data.sigma;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], ', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/halfnormal/stdev` from EPS-scaled relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, as described in #11352.

Both `test/test.js` and `test/test.native.js` are converted. In each, the `if ( y === expected[i] ) { ... } else { delta/tol ... }` block in the fixture loop is replaced by a single

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
```

and the now-unused `abs`/`EPS` requires and `delta`/`tol` declarations are removed. This mirrors the idiom already used in this family (e.g., #14069 for `stats/base/dists/lognormal/variance`).

**ULP bound:** `1` in both `test/test.js` and `test/test.native.js`.

**Measured minimum:** `1`. Over the full 50-value Julia fixture set (`test/fixtures/julia/data.json`), the per-fixture minimum ULP requirement was computed by searching upward from `0`; the maximum requirement across all fixtures was `1` (worst case: `sigma = 2.577081059735365`, `y = 1.5534909422882428`, `expected = 1.553490942288243`). At `N = 0`, 6 of 50 fixtures fail, so `1` is tight and cannot be lowered further. `test/test.js` was run twice at the final bound with identical results (55/55 assertions passing both times).

The JavaScript implementation computes `sigma * sqrt( 1 - 2/pi )` and the C implementation computes `sigma * SQRT1M2PI` with `SQRT1M2PI = 0.6028102749890869`. Those two scale constants are bit-identical, and each implementation performs a single multiplication, so the same `1` ULP bound applies to both and there is no FMA-contraction exposure.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The native addon could not be compiled in the environment used to prepare this change, so `test/test.native.js` was skipped locally (0 assertions run). The `1` ULP bound for the native tests was established analytically, as described above, rather than by execution. Please confirm the native tests pass in CI.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

`make install-node-modules` failed in the environment used to prepare this change (the available npm registry snapshot has no `es-object-atoms@^1.1.2`, a transitive dependency), so the project's own lint tooling could not be run in full. Compensating checks that were run:

-   `test/test.js` executed with a locally installed `tape`: 55/55 assertions passing, twice.
-   ESLint run against the project's rule sets (`programmer_errors`, `best_practices`, `strict`, `variables`, `nodejs`, `style`, `es2015`) plus the `.eslintrc.tests.js` overrides: clean. The custom `stdlib/*` plugin rules could not be loaded (they pull in the remark toolchain), so `require-order`, `vars-order`, `require-spaces`, `uppercase-required-constants`, and `no-empty-lines-between-requires` were verified by inspection against the rule definitions in `etc/eslint/rules/stdlib.js`.
-   EditorConfig conformance (LF, UTF-8, tab indentation, no trailing whitespace, final newline) verified by inspection; `editorconfig-checker` downloads its binary at runtime and could not fetch it.

CI should be treated as the authoritative lint run. Only the two test files are changed; no source, docs, or `package.json` changes are included.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied previously merged conversions for the established idiom, applied the test changes, and measured the ULP bound empirically over the fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4ixBCT9ohYozkw8JZVWxV)_