### PR TITLE
test: migrate `stats/base/dists/chi/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/quantile/test/test.factory.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -114,8 +113,6 @@ tape( 'if `k` equals `0`, the created function evaluates a degenerate distributi
 tape( 'the created function evaluates the quantile for `x` given parameter `k`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var p;
 	var k;
 	var y;
@@ -127,13 +124,7 @@ tape( 'the created function evaluates the quantile for `x` given parameter `k`',
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( k[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', k: '+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 195 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/quantile/test/test.quantile.js
@@ -21,10 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -92,8 +91,6 @@ tape( 'if `k` equals `0`, the function evaluates a degenerate distribution cente
 
 tape( 'the function evaluates the quantile for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var p;
 	var k;
 	var y;
@@ -104,13 +101,7 @@ tape( 'the function evaluates the quantile for `x` given degrees of freedom `k`'
 	k = decimalDecimal.k;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', k: '+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 195 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `stats/base/dists/chi/quantile` from relative tolerance testing to ULP (units in the last place) difference testing, per the guidance in #11352.
-   In `test/test.quantile.js` and `test/test.factory.js`, replaces the `delta`/`tol` (`EPS * abs( expected[ i ] )`) tolerance pattern with `@stdlib/assert/is-almost-same-value`.
-   The measured minimum ULP bound needed for both test files is **195** (the largest observed ULP difference between actual and expected values across the fixture set was 195, at `p = 0.2670201655788045`, `k = 0.019615079953134718`). A bound of 194 fails one test case, confirming 195 is the tight minimum. This is tighter than the previous relative tolerance of `250.0 * EPS`.
-   No other test files in this package (`test/test.js`) used the relative tolerance idiom and were left unchanged.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, which studied the RFC and the diffs of already-merged conversions in this repo (e.g. `stats/base/dists/halfnormal/stdev`, `stats/base/dists/lognormal/variance`) to mirror the established idiom, then measured the minimum required ULP bound empirically against the fixture data.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc6CJzHmjXDeDBtxYp2SgT)_