### PR TITLE
test: migrate `stats/base/dists/hypergeometric/pmf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -202,9 +201,7 @@ tape( 'if provided an `n` which is not a nonnegative integer, the created functi
 
 tape( 'the created function evaluates the pmf for `x`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var N;
 	var K;
@@ -220,13 +217,7 @@ tape( 'the created function evaluates the pmf for `x`', function test( t ) {
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( N[i], K[i], n[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', N: '+N[i]+', K: '+K[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1040.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. N: '+N[i]+'. K: '+K[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1967 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/test/test.native.js
@@ -23,9 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -113,8 +112,6 @@ tape( 'if provided an `n` which is not a nonnegative integer, the function retur
 
 tape( 'the function evaluates the pmf for `x`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var N;
 	var K;
@@ -129,13 +126,7 @@ tape( 'the function evaluates the pmf for `x`', opts, function test( t ) {
 	n = data.n;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], N[i], K[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', N: '+N[i]+', K: '+K[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1040.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. N: '+N[i]+'. K: '+K[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1967 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/test/test.pmf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/test/test.pmf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pmf = require( './../lib' );
 
 
@@ -145,8 +144,6 @@ tape( 'if provided an `n` which is not a nonnegative integer, the function retur
 
 tape( 'the function evaluates the pmf for `x`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var N;
 	var K;
@@ -161,13 +158,7 @@ tape( 'the function evaluates the pmf for `x`', function test( t ) {
 	n = data.n;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], N[i], K[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', N: '+N[i]+', K: '+K[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1040.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. N: '+N[i]+'. K: '+K[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1967 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/hypergeometric/pmf` from computed relative tolerance testing (`delta = abs( y - expected[i] )`, `tol = 1040.0 * EPS * abs( expected[i] )`, `t.ok( delta <= tol, ... )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates `test/test.pmf.js`, `test/test.factory.js`, and `test/test.native.js`, each of which contains one fixture loop over `test/fixtures/julia/data.json`. `test/test.js` contains no tolerance math and is unchanged.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from all three files (neither is used elsewhere in these files).

**ULP bounds** (tightened to the measured minimum over the full fixture set):

| Fixture file | Test case | ULP bound | Measured maximum ULP difference |
| --- | --- | --- | --- |
| `fixtures/julia/data.json` | the function evaluates the pmf for `x` (`test.pmf.js`) | `1967` | 1967 |
| `fixtures/julia/data.json` | the created function evaluates the pmf for `x` (`test.factory.js`) | `1967` | 1967 |
| `fixtures/julia/data.json` | the function evaluates the pmf for `x` (`test.native.js`) | `1967` | 1967 |

Notes on how the bound was determined:

-   The bound is the minimum non-negative integer for which every fixture value passes. It was measured by computing, for each of the 1000 fixture values, the smallest `N` for which `isAlmostSameValue( y, expected[i], N )` is `true`, and taking the maximum over the fixture set. Starting from a bound of `64` and adjusting, the suite passes at `1967` and fails at `1966` (a single failing assertion, at `x: 81, N: 100, K: 87, n: 86`), confirming that `1967` is tight rather than merely sufficient.
-   The worst case is `pmf( 81, 100, 87, 86 )`, which returns `1.4708214585445427e-5` against a Julia reference value of `1.4708214585448759e-5`.
-   The measured maximum is identical for the main export, the factory-created function, and the C implementation, so all three files use the same bound.
-   This is consistent with the previous tolerance: the old bound of `1040.0 * EPS` corresponds to a relative tolerance of ~`2.31e-13`, while the observed worst-case relative error is ~`2.27e-13`. The prior tolerance was therefore already close to the observed error, and the ULP bound is of a comparable magnitude. The relatively large bound reflects the implementation, which evaluates the pmf via a sum of log-factorial terms (`gammaln`-based binomial coefficients) followed by exponentiation, so the argument reduction amplifies the error of the underlying kernels for large `N` and `K`.
-   The native add-on was compiled locally (`node-gyp rebuild`), so `test/test.native.js` was exercised against the actual C implementation rather than skipped. The JavaScript and C implementations agree exactly on every fixture value.
-   The full suite was run twice at the final bound with identical results (1027 assertions for `test.pmf.js`, 1031 for `test.factory.js`, 3 for `test.js`, and 1013 for `test.native.js`, all passing, per run), so the bound is not sensitive to FMA/contraction differences on this machine.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

One point:

-   `1967` is a much larger bound than most converted packages have needed. It is the measured minimum over the existing fixture set and is consistent with the relative tolerance it replaces, but reviewers may wish to consider whether the underlying accuracy of the implementation is itself worth a follow-up, since the ULP bound now makes the error magnitude explicit rather than hiding it behind an `EPS` multiplier.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the three test files are modified; no source, documentation, benchmark, or fixture files are touched.
-   Verified with `make test TESTS_FILTER=".*/stats/base/dists/hypergeometric/pmf/.*"`. Linting is clean via `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/hypergeometric/pmf/.*"`, which uses `etc/eslint/.eslintrc.tests.js`.
-   The `editorconfig` pre-commit hook could not run in this environment, as it downloads its binary from a host this session cannot reach. The three files were instead checked against `.editorconfig` (LF endings, tab indentation, final newline, UTF-8, no trailing whitespace); the diff introduces no new violations.
-   The idiom follows previously merged conversions, in particular `stats/base/dists/chi/quantile` (#14086) and `stats/base/dists/lognormal/variance` (#14069), which use an inline integer ULP argument per fixture loop and the `'returns expected value'` assertion message.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. The test migration follows the idiom established by previously merged conversions, and the ULP bound was measured empirically against both the JavaScript and compiled C implementations rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_015izr9YSaKGfPBoCKcKwFbA)_