### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/ml/base/sgd/params/struct-factory/README.md
+++ b/lib/node_modules/@stdlib/ml/base/sgd/params/struct-factory/README.md
@@ -62,7 +62,7 @@ A returned [`struct`][@stdlib/dstructs/struct] constructor supports the followin
 
 -   **penaltyParams**: parameters specific to the regularization function being used. Must be an array having length `2`, with any unused elements set to zero. The expected array contents depend on `penalty`:
 
-    -   **l1**: : `[ lambda, 0.0 ]`
+    -   **l1**: `[ lambda, 0.0 ]`
     -   **l2**: `[ lambda, 0.0 ]`
     -   **elasticnet**: `[ lambda, l1Ratio ]`
     -   **none**: `[ 0.0, 0.0 ]` (unused)

--- a/lib/node_modules/@stdlib/number/int64/base/identity/README.md
+++ b/lib/node_modules/@stdlib/number/int64/base/identity/README.md
@@ -174,6 +174,7 @@ int64_t stdlib_base_int64_identity( const int64_t x );
 #include "stdlib/number/int64/base/identity.h"
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 int main( void ) {
     const int64_t x[] = { 3, 5, 10, 4294967296 };
@@ -182,7 +183,7 @@ int main( void ) {
     int i;
     for ( i = 0; i < 4; i++ ) {
         y = stdlib_base_int64_identity( x[ i ] );
-        printf( "f(%ld) = %ld\n", x[ i ], y );
+        printf( "f(%" PRId64 ") = %" PRId64 "\n", x[ i ], y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/number/int64/base/identity/examples/c/example.c
+++ b/lib/node_modules/@stdlib/number/int64/base/identity/examples/c/example.c
@@ -19,6 +19,7 @@
 #include "stdlib/number/int64/base/identity.h"
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 int main( void ) {
 	const int64_t x[] = { 3, 5, 10, 4294967296 };
@@ -27,6 +28,6 @@ int main( void ) {
 	int i;
 	for ( i = 0; i < 4; i++ ) {
 		y = stdlib_base_int64_identity( x[ i ] );
-		printf( "f(%ld) = %ld\n", x[ i ], y );
+		printf( "f(%" PRId64 ") = %" PRId64 "\n", x[ i ], y );
 	}
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between `ebbf2de9` (2026-08-08 06:00 PT) and `9bd464a4` (2026-08-09 05:04 PT).

This pull request:

-   **`number/int64/base/identity`**
    -   Fixes `%ld` → `PRId64` in `lib/node_modules/@stdlib/number/int64/base/identity/examples/c/example.c` (introduced in 5a6af334f): `int64_t` is `long long` on LLP64/32-bit, so the mismatched conversion specifier is UB and trips `-Wformat`. Brings it in line with every other C example that prints 64-bit ints.
    -   In commit 5a6af334f, the C "Examples" section in `lib/node_modules/@stdlib/number/int64/base/identity/README.md` prints `int64_t` values with `%ld`, mirroring the non-portable format specifier fixed in `examples/c/example.c`. Updates the README snippet to include `inttypes.h` and use `PRId64` so it doesn't hand LLP64/32-bit users undefined behavior when they copy it.
-   **`ml/base/sgd/params/struct-factory`**
    -   `lib/node_modules/@stdlib/ml/base/sgd/params/struct-factory/README.md#L65` has a stray extra colon in the `l1` bullet under `penaltyParams` (`**l1**: :`), introduced in 9bd464a46. Drops the duplicate so it matches every other bullet and the `l1` entry in `docs/types/index.d.ts`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 30 commits merged to `develop` in the window were reviewed for (1) stdlib style-guide compliance (compared against established sibling packages, e.g. `dtril`, `sfill-equal`, `ztril`, `dcopy-within`, `cexp`) and (2) objective bugs in the introduced code (loop/stride arithmetic, complex real/imag handling, int64 word handling, JS↔C implementation parity, README/repl.txt example outputs recomputed by hand, affected test suites executed). Only objective, independently re-verified issues are included; the fixed `printf` pattern was compile-checked with `-Wall -Wformat -Werror`.

**Deliberately excluded:** anything subjective or requiring interpretation, deliberate authorial choices (round-nearest-even change in `rempio2`/`rempio2f`, per-function ULP tolerances in migrated tests, VLA→`malloc` benchmark refactor), and one candidate finding (missing `__stdlib__` field in `blas/ext/base/gtril2triu/package.json`) dropped because 49 of 389 sibling packages — including the entire pre-existing `gtril`/`gtriu`/`gtriu2tril` family — omit the field, so the convention is not unambiguous.

**Note:** this is a draft PR; a maintainer will audit and promote it.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by a scheduled Claude Code review routine: Claude reviewed the last 24 hours of commits merged to `develop`, validated candidate findings against the repository, and authored the fixes and this PR description. All changes are pending human audit (hence draft status).

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md