### PR TITLE
test: migrate `stats/base/dists/negative-binomial/pmf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/pmf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/pmf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -174,9 +173,7 @@ tape( 'if provided a `r` which is not a positive number, the created function al
 
 tape( 'the created function evaluates the pmf for `x` given large `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var x;
 	var r;
 	var p;
@@ -190,22 +187,14 @@ tape( 'the created function evaluates the pmf for `x` given large `r` and `p`', 
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( r[i], p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 650.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 655 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pmf for `x` given a large parameter `r` and small `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -219,22 +208,14 @@ tape( 'the created function evaluates the pmf for `x` given a large parameter `r
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( r[i], p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 450.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 688 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pmf for `x` given small `r` and large parameter `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -248,22 +229,14 @@ tape( 'the created function evaluates the pmf for `x` given small `r` and large 
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( r[i], p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 143 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the pmf for `x` given small `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
 	var pmf;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -277,13 +250,7 @@ tape( 'the created function evaluates the pmf for `x` given small `r` and `p`', 
 	for ( i = 0; i < x.length; i++ ) {
 		pmf = factory( r[i], p[i] );
 		y = pmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 110 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/pmf/test/test.pmf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/pmf/test/test.pmf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pmf = require( './../lib' );
 
 
@@ -122,8 +121,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function evaluates the pmf for `x` given large `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -136,21 +133,13 @@ tape( 'the function evaluates the pmf for `x` given large `r` and `p`', function
 	p = highHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 650.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 655 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given large parameter `r` and small `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -163,21 +152,13 @@ tape( 'the function evaluates the pmf for `x` given large parameter `r` and smal
 	p = highSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 450.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 688 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given small `r` and large `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -190,21 +171,13 @@ tape( 'the function evaluates the pmf for `x` given small `r` and large `p`', fu
 	p = smallHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 143 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the pmf for `x` given small `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -217,13 +190,7 @@ tape( 'the function evaluates the pmf for `x` given small `r` and `p`', function
 	p = smallSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pmf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 110 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/negative-binomial/pmf` from computed relative tolerance testing (`delta = abs( y - expected[i] )`, `tol = k * EPS * abs( expected[i] )`, `t.strictEqual( delta <= tol, ... )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates `test/test.pmf.js` and `test/test.factory.js`, each of which contains four fixture loops (one per Julia fixture file). `test/test.js` contains no tolerance math and is unchanged. The package has no `test/test.native.js`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from both files (neither is used elsewhere in these files).

**ULP bounds** (tightened to the measured minimum over the full fixture set):

| Fixture file | Test case | ULP bound | Measured maximum ULP difference |
| --- | --- | --- | --- |
| `fixtures/julia/high_high.json` | large `r` and `p` | `655` | 655 |
| `fixtures/julia/high_small.json` | large `r`, small `p` | `688` | 688 |
| `fixtures/julia/small_high.json` | small `r`, large `p` | `143` | 143 |
| `fixtures/julia/small_small.json` | small `r` and `p` | `110` | 110 |

The main export and the factory-created function produce bit-identical results on every fixture value, so `test.pmf.js` and `test.factory.js` use the same bound per fixture set.

Notes on how the bounds were determined:

-   Each bound is the minimum non-negative integer for which every fixture value in that set passes. It was measured by computing, for each of the 1000 values in each of the four fixture sets, the ULP difference between the returned value and the Julia reference value, and taking the maximum over the set. Starting from a bound of `64` and adjusting, the suite passes at the tabulated bounds and fails at each bound minus one (exactly four failing assertions, one per fixture loop), confirming the bounds are tight rather than merely sufficient.
-   Worst cases per fixture set:
    -   `high_high`: `pmf( 1, 64, 0.7906898438417092 )` returns `3.975250904822743e-6` against a reference of `3.975250904823298e-6`.
    -   `high_small`: `pmf( 8, 88, 0.02637417550853125 )` returns `1.1366780042760316e-128` against a reference of `1.1366780042759434e-128`.
    -   `small_high`: `pmf( 14, 3, 0.9980475521581332 )` returns `1.3955555222417722e-36` against a reference of `1.3955555222417961e-36`.
    -   `small_small`: `pmf( 9, 13, 0.0038654584213952074 )` returns `1.2210093592394756e-26` against a reference of `1.2210093592394914e-26`.
-   The bounds are consistent with the tolerances they replace. The previous multipliers were `650.0 * EPS`, `450.0 * EPS`, `80.0 * EPS`, and `80.0 * EPS`; since a relative tolerance of `k * EPS` corresponds to roughly `2k` ULP, the measured bounds sit within the accuracy budget the tests already allowed. The `high_small` set is the one case where the measured error exceeds the naive `k`-to-ULP reading of the old multiplier, because the old comparison was relative to `abs( expected[i] )` rather than to the representable gap at that magnitude.
-   The magnitude of the bounds reflects the implementation, which evaluates the pmf via `binomcoefln`/`gammaln`-based log terms followed by exponentiation, so argument reduction amplifies the error of the underlying kernels for large `r` and for small `p`.
-   The full suite was run twice at the final bounds with identical results (4020 assertions for `test.pmf.js`, 4026 for `test.factory.js`, and 3 for `test.js`, all passing, per run), so the bounds are not sensitive to FMA/contraction differences on this machine.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

One point:

-   The four fixture sets need materially different bounds (`110` through `688`), so this PR keeps a per-fixture-loop bound rather than collapsing to a single package-wide maximum. That matches the per-loop tolerances the tests previously carried, but if reviewers would prefer one bound per file, `688` would cover all four sets at the cost of loosening the three tighter loops.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.
-   Verified with `make test TESTS_FILTER=".*/stats/base/dists/negative-binomial/pmf/.*"`. Linting is clean via `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/negative-binomial/pmf/.*"`, which uses `etc/eslint/.eslintrc.tests.js`.
-   The `editorconfig` pre-commit hook could not run in this environment, as it downloads its binary from a host this session cannot reach. The two files were instead checked against `.editorconfig` (LF endings, tab indentation, final newline, UTF-8, no trailing whitespace); the diff introduces no new violations.
-   The idiom follows previously merged conversions, in particular `stats/base/dists/hypergeometric/pmf` (#14091) and `stats/base/dists/halfnormal/stdev` (#14084), which use an inline integer ULP argument per fixture loop and the `'returns expected value'` assertion message.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. The test migration follows the idiom established by previously merged conversions, and the ULP bounds were measured empirically against the fixture data rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value