### PR TITLE
test: migrate `math/base/special/covercos` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/covercos/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/covercos/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var covercos = require( './../lib' );
 
 
@@ -49,8 +48,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the coversed cosine (for -256*pi < x < 0)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -60,21 +57,13 @@ tape( 'the function computes the coversed cosine (for -256*pi < x < 0)', functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for 0 < x < 256*pi)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -84,21 +73,13 @@ tape( 'the function computes the coversed cosine (for 0 < x < 256*pi)', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for -2**60 (pi/2) < x < -2**20 (pi/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -108,21 +89,13 @@ tape( 'the function computes the coversed cosine (for -2**60 (pi/2) < x < -2**20
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for 2**20 (pi/2) < x < 2**60 (pi/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -132,21 +105,13 @@ tape( 'the function computes the coversed cosine (for 2**20 (pi/2) < x < 2**60 (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for x <= -2**60 (PI/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -156,21 +121,13 @@ tape( 'the function computes the coversed cosine (for x <= -2**60 (PI/2))', func
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for x >= 2**60 (PI/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -180,13 +137,7 @@ tape( 'the function computes the coversed cosine (for x >= 2**60 (PI/2))', funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/covercos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/covercos/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the coversed cosine (for -256*pi < x < 0)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -69,21 +66,13 @@ tape( 'the function computes the coversed cosine (for -256*pi < x < 0)', opts, f
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 4.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for 0 < x < 256*pi)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -93,21 +82,13 @@ tape( 'the function computes the coversed cosine (for 0 < x < 256*pi)', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 4.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for -2**60 (pi/2) < x < -2**20 (pi/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -117,21 +98,13 @@ tape( 'the function computes the coversed cosine (for -2**60 (pi/2) < x < -2**20
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 4.6 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for 2**20 (pi/2) < x < 2**60 (pi/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -141,21 +114,13 @@ tape( 'the function computes the coversed cosine (for 2**20 (pi/2) < x < 2**60 (
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 5.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for x <= -2**60 (PI/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -165,21 +130,13 @@ tape( 'the function computes the coversed cosine (for x <= -2**60 (PI/2))', opts
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 4.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversed cosine (for x >= 2**60 (PI/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -189,13 +146,7 @@ tape( 'the function computes the coversed cosine (for x >= 2**60 (PI/2))', opts,
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = covercos( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 3.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/covercos` from relative tolerance testing to ULP difference testing, replacing the `delta`/`tol` comparisons in `test/test.js` and `test/test.native.js` with `isAlmostSameValue`.
-   adds the `@stdlib/assert/is-almost-same-value` import and removes the now unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` imports.

Final ULP constant: **`0`** for every fixture group, in both `test/test.js` and `test/test.native.js`.

The ULP bound was tightened by measuring the maximum ULP difference over the full fixture set (6 fixture groups × 4000 values = 24000 values per test file) rather than by guessing: starting from a high bound and bisecting down to the minimum integer which still passes. Both the JavaScript and C implementations reproduce every Julia fixture value exactly, so the measured minimum is `0` ULP for all of:

| Fixture | Values | Previous tolerance (`test.js` / `test.native.js`) | Measured max ULP diff | ULP constant |
| --- | --- | --- | --- | --- |
| `medium_negative` | 4000 | `EPS` / `4.0*EPS` | 0 | 0 |
| `medium_positive` | 4000 | `EPS` / `4.0*EPS` | 0 | 0 |
| `large_negative` | 4000 | `EPS` / `4.6*EPS` | 0 | 0 |
| `large_positive` | 4000 | `EPS` / `5.0*EPS` | 0 | 0 |
| `huge_negative` | 4000 | `EPS` / `4.0*EPS` | 0 | 0 |
| `huge_positive` | 4000 | `EPS` / `3.0*EPS` | 0 | 0 |

`test/test.native.js` was verified against a locally compiled add-on (not skipped), so the `0` ULP bound is measured for the C implementation as well, not merely inherited from the JavaScript results. Each suite was run twice at the final bound to confirm determinism; all 24005 assertions pass in each file on every run.

Only the two test files are changed; the implementation and fixtures are untouched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft pending maintainer review of the `0` ULP bound. A bound of `0` requires bit-for-bit agreement with the fixtures; there is existing precedent for this in the repo (e.g. `math/base/special/ahavercos`, `math/base/special/asec`, `math/base/special/polygamma` all use `0` for fixture groups which match exactly), and the JavaScript results are deterministic IEEE-754. If maintainers would prefer a `1` ULP margin in `test/test.native.js` as a hedge against compiler/architecture variation in the C build, that is a one-character change.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task: it selected the package, studied prior conversions in the repo to match the established idiom, applied the test migration, measured the minimum ULP bound empirically, and verified tests and linting locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01K7L86MUHJiJfXuRUZzE1tD)_