### PR TITLE
test: migrate `stats/base/dists/weibull/logcdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -181,8 +180,6 @@ tape( 'the created function evaluates the logcdf for `x` given large `lambda` an
 	var expected;
 	var lambda;
 	var logcdf;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -195,13 +192,7 @@ tape( 'the created function evaluates the logcdf for `x` given large `lambda` an
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( k[i], lambda[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -210,8 +201,6 @@ tape( 'the created function evaluates the logcdf for `x` given large shape param
 	var expected;
 	var lambda;
 	var logcdf;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -224,13 +213,7 @@ tape( 'the created function evaluates the logcdf for `x` given large shape param
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( k[i], lambda[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -239,8 +222,6 @@ tape( 'the created function evaluates the logcdf for `x` given large scale param
 	var expected;
 	var logcdf;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -253,13 +234,7 @@ tape( 'the created function evaluates the logcdf for `x` given large scale param
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( k[i], lambda[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/test/test.logcdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
 
@@ -123,8 +122,6 @@ tape( 'if provided a nonpositive `k`, the function returns `NaN`', function test
 tape( 'the function evaluates the logcdf for `x` given large `lambda` and `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -136,13 +133,7 @@ tape( 'the function evaluates the logcdf for `x` given large `lambda` and `k`', 
 	k = bothLarge.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -150,8 +141,6 @@ tape( 'the function evaluates the logcdf for `x` given large `lambda` and `k`', 
 tape( 'the function evaluates the logcdf for `x` given large shape parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -163,13 +152,7 @@ tape( 'the function evaluates the logcdf for `x` given large shape parameter `la
 	k = largeShape.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -177,8 +160,6 @@ tape( 'the function evaluates the logcdf for `x` given large shape parameter `la
 tape( 'the function evaluates the logcdf for `x` given large scale parameter `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -190,13 +171,7 @@ tape( 'the function evaluates the logcdf for `x` given large scale parameter `k`
 	k = largeScale.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -132,8 +131,6 @@ tape( 'if provided a nonpositive `k`, the function returns `NaN`', opts, functio
 tape( 'the function evaluates the logcdf for `x` given large `lambda` and `k`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -145,13 +142,7 @@ tape( 'the function evaluates the logcdf for `x` given large `lambda` and `k`', 
 	k = bothLarge.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -159,8 +150,6 @@ tape( 'the function evaluates the logcdf for `x` given large `lambda` and `k`', 
 tape( 'the function evaluates the logcdf for `x` given large shape parameter `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -172,13 +161,7 @@ tape( 'the function evaluates the logcdf for `x` given large shape parameter `la
 	k = largeShape.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -186,8 +169,6 @@ tape( 'the function evaluates the logcdf for `x` given large shape parameter `la
 tape( 'the function evaluates the logcdf for `x` given large scale parameter `k`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -199,13 +180,7 @@ tape( 'the function evaluates the logcdf for `x` given large scale parameter `k`
 	k = largeScale.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/weibull/logcdf` from relative tolerance testing to ULP difference testing, replacing the `delta`/`tol` comparisons in `test/test.logcdf.js`, `test/test.factory.js`, and `test/test.native.js` with `isAlmostSameValue`.
-   adds the `@stdlib/assert/is-almost-same-value` import and removes the now unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` imports.

Final ULP constant: **`0`** for every fixture group, in all three test files.

The ULP bound was tightened by measuring the maximum ULP difference over the full fixture set (3 fixture groups × 1000 values per test file) rather than by guessing: starting from a high bound and bisecting down to the minimum integer which still passes. Both the JavaScript and C implementations reproduce every Julia fixture value exactly, so the measured minimum is `0` ULP for all of:

| Fixture | Values | Previous tolerance | Measured max ULP diff | ULP constant |
| --- | --- | --- | --- | --- |
| `both_large` | 1000 | `1.0*EPS` | 0 | 0 |
| `large_shape` | 1000 | `1.0*EPS` | 0 | 0 |
| `large_scale` | 1000 | `1.0*EPS` | 0 | 0 |

`test/test.native.js` was verified against a locally compiled add-on (not skipped), so the `0` ULP bound is measured for the C implementation as well, not merely inherited from the JavaScript results. Each suite was run twice at the final bound to confirm determinism; all assertions pass on every run (`test.logcdf.js`: 3021, `test.factory.js`: 3026, `test.native.js`: 3021, `test.js`: 3).

Only the three test files are changed; the implementation and fixtures are untouched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft pending maintainer review of the `0` ULP bound. A bound of `0` requires bit-for-bit agreement with the fixtures; there is existing precedent for this in the repo (e.g. `stats/base/dists/uniform/entropy`, `math/base/special/covercos`, `math/base/special/asec` all use `0` for fixture groups which match exactly), and the JavaScript results are deterministic IEEE-754. If maintainers would prefer a `1` ULP margin in `test/test.native.js` as a hedge against compiler/architecture variation in the C build, that is a one-character change.

Note: the `editorconfig-checker` stage of the local pre-commit hook could not run in this environment because it downloads its binary from GitHub releases, which was blocked. EditorConfig conformance was instead verified manually for the changed files (LF line endings, UTF-8, tab indentation, no trailing whitespace, final newline present), and `make lint-javascript-tests` passes cleanly for the package.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task: it selected the package, studied prior conversions in the repo to match the established idiom, applied the test migration, measured the minimum ULP bound empirically, and verified tests and linting locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_016NiaAxgddCqSgfcmwYtzNo)_