### PR TITLE
test: migrate `math/base/special/asinf` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/asinf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asinf/test/test.js
@@ -24,7 +24,7 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
@@ -48,8 +48,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the arcsine', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -61,21 +59,13 @@ tape( 'the function computes the arcsine', function test( t ) {
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinf( ( ( x[ i ] ) ) );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 3.3 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsine (small negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -87,21 +77,13 @@ tape( 'the function computes the arcsine (small negative values)', function test
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinf( ( x[ i ] ) );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsine (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -113,13 +95,7 @@ tape( 'the function computes the arcsine (small positive values)', function test
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asinf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asinf/test/test.native.js
@@ -25,7 +25,7 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
@@ -57,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the arcsine', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -70,21 +68,13 @@ tape( 'the function computes the arcsine', opts, function test( t ) {
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinf( ( ( x[ i ] ) ) );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = 3.3 * EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 5 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsine (small negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -96,21 +86,13 @@ tape( 'the function computes the arcsine (small negative values)', opts, functio
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinf( ( x[ i ] ) );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the arcsine (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -122,13 +104,7 @@ tape( 'the function computes the arcsine (small positive values)', opts, functio
 	for ( i = 0; i < x.length; i++ ) {
 		y = asinf( x[ i ] );
 		e = float64ToFloat32( expected[ i ] );
-		if ( y === e ) {
-			t.strictEqual( y, e, 'x: '+x[ i ]+'. E: '+e );
-		} else {
-			delta = abs( y - e );
-			tol = EPS * abs( e );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. y: '+y+'. E: '+e+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, e, 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/asinf` from computed relative tolerance (`EPS`-scaled `delta <= tol`) checks to ULP-based assertions;
-   replaces the `@stdlib/math/base/special/abs` require with `@stdlib/number/float32/base/assert/is-almost-same-value`. (The `EPS` constant is retained as it is utilized for boundary generation tests).
-   both `test/test.js` and `test/test.native.js` are modified to use the new ULP assertions.

**ULP bounds** (one per fixture set, each tightened to the measured minimum):

| fixture set | previous tolerance | ULP bound |
| ----------- | ------------------ | --------- |
| `data` | `3.3 * EPS` | `5` |
| `small_negative` | `1.0 * EPS` | `0` |
| `small_positive` | `1.0 * EPS` | `0` |

Each bound is the smallest non-negative integer for which every fixture in the corresponding set passes. Starting from a high bound and lowering, the suite passes at the values above (8014/8014 assertions), and decrementing each bound by one produces exactly one failure per set, confirming that no bound can be tightened further. 

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
