### PR TITLE
test: migrate `math/base/special/binomcoefln` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var binomcoefln = require( './../lib' );
 
@@ -65,20 +64,12 @@ tape( 'the function returns `NaN` if provided `NaN` for any parameter', function
 });
 
 tape( 'the function evaluates the binomial coefficient for integers `m` and `k`', function test( t ) {
-	var delta;
-	var tol;
 	var v;
 	var i;
 
 	for ( i = 0; i < expected.length; i++ ) {
 		v = binomcoefln( arg1[ i ], arg2[ i ] );
-		if ( v === expected[ i ] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided m: '+arg1[i]+' and k: '+arg2[i] );
-		} else {
-			delta = abs( v - expected[ i ] );
-			tol = 21.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. m: ' + arg1[ i ] + ' k: ' + arg2[ i ] + '. actual: ' + v + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/test/test.native.js
@@ -22,8 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -63,20 +62,12 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function evaluates the binomial coefficient for integers `m` and `k`', opts, function test( t ) {
-	var delta;
-	var tol;
 	var v;
 	var i;
 
 	for ( i = 0; i < expected.length; i++ ) {
 		v = binomcoefln( arg1[ i ], arg2[ i ] );
-		if ( v === expected[ i ] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided m: '+arg1[i]+' and k: '+arg2[i] );
-		} else {
-			delta = abs( v - expected[ i ] );
-			tol = 21.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. m: ' + arg1[ i ] + ' k: ' + arg2[ i ] + '. actual: ' + v + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/binomcoefln` from relative tolerance testing to ULP difference testing by replacing the computed `delta`/`tol` comparisons with `@stdlib/assert/is-almost-same-value`.
-   applies the migration to both `test/test.js` and `test/test.native.js`, removing the now unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` imports.
-   uses a ULP bound of `2`, which is the measured minimum bound which passes over the full R fixture set (1000 cases). The previous relative tolerance was `21.5 * EPS`.

Only test files are changed; no implementation, documentation, or fixture changes are included.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

How the bound was determined:

-   Starting from a high bound and tightening, the minimum integer ULP bound which passes over the entire fixture set is `2` for both implementations. `1` fails on `m = 24`, `k = 7` (`12.754494586910019` vs. `12.754494586910015`).
-   The maximum observed ULP difference over the fixture set is `2` for the JavaScript implementation and `2` for the native implementation (the native add-on was compiled locally in order to measure this, rather than relying on the tests being skipped).
-   The suite was run twice at the final bound with identical results (`test.js`: 1022 passing; `test.native.js`: 1004 passing).
-   `make eslint-tests TESTS_FILTER=".*/math/base/special/binomcoefln/.*"` is clean.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. The test migration and the ULP bound measurement were performed by the agent, mirroring the idiom established in previously merged migration PRs (e.g. #14103, #14036).

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_015Dyxkd4Qxixfeq1j9EM7Ta)_