### PR TITLE
test: migrate `math/base/special/atan2d` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/atan2d/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/atan2d/test/test.js
@@ -24,8 +24,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/number/float64/base/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var atan2d = require( './../lib' );
@@ -186,8 +185,6 @@ tape( 'the function returns `-90.0` if provided a negative `y` and `x=-0`', func
 tape( 'the function evaluates the `atan2d` function (when x and y are positive)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -197,9 +194,7 @@ tape( 'the function evaluates the `atan2d` function (when x and y are positive)'
 	expected = positivePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2d( y[i], x[i] );
-		delta = abs( actual - expected[i] );
-		tol = 1.2 * EPS * abs( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -207,8 +202,6 @@ tape( 'the function evaluates the `atan2d` function (when x and y are positive)'
 tape( 'the function evaluates the `atan2d` function (when x is negative and y is positive)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -218,9 +211,7 @@ tape( 'the function evaluates the `atan2d` function (when x is negative and y is
 	expected = negativePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2d( y[i], x[i] );
-		delta = abs( actual - expected[i] );
-		tol = 2.3 * EPS * abs( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -228,8 +219,6 @@ tape( 'the function evaluates the `atan2d` function (when x is negative and y is
 tape( 'the function evaluates the `atan2d` function (when x and y are negative)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -239,9 +228,7 @@ tape( 'the function evaluates the `atan2d` function (when x and y are negative)'
 	expected = negativeNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2d( y[i], x[i] );
-		delta = abs( actual - expected[i] );
-		tol = 2.0 * EPS * abs( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/atan2d/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/atan2d/test/test.native.js
@@ -25,9 +25,8 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/number/float64/base/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 
@@ -195,8 +194,6 @@ tape( 'the function returns `-90.0` if provided a negative `y` and `x=-0`', opts
 tape( 'the function evaluates the `atan2d` function (when x and y are positive)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -206,9 +203,7 @@ tape( 'the function evaluates the `atan2d` function (when x and y are positive)'
 	expected = positivePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2d( y[i], x[i] );
-		delta = abs( actual - expected[i] );
-		tol = 1.2 * EPS * abs( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -216,8 +211,6 @@ tape( 'the function evaluates the `atan2d` function (when x and y are positive)'
 tape( 'the function evaluates the `atan2d` function (when x is negative and y is positive)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -227,9 +220,7 @@ tape( 'the function evaluates the `atan2d` function (when x is negative and y is
 	expected = negativePositive.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2d( y[i], x[i] );
-		delta = abs( actual - expected[i] );
-		tol = 2.3 * EPS * abs( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -237,8 +228,6 @@ tape( 'the function evaluates the `atan2d` function (when x is negative and y is
 tape( 'the function evaluates the `atan2d` function (when x and y are negative)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -248,9 +237,7 @@ tape( 'the function evaluates the `atan2d` function (when x and y are negative)'
 	expected = negativeNegative.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2d( y[i], x[i] );
-		delta = abs( actual - expected[i] );
-		tol = 2.0 * EPS * abs( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/atan2d` from computed relative tolerance (`EPS`-scaled `delta <= tol`) checks to ULP-based assertions;
-   replaces the `@stdlib/math/base/special/abs` require with `@stdlib/number/float64/base/assert/is-almost-same-value`. (The `EPS` constant is removed as it is no longer required).
-   both `test/test.js` and `test/test.native.js` are modified to use the new ULP assertions.

**ULP bounds** (one per fixture set, each tightened to the measured minimum):

| fixture set | previous tolerance | ULP bound |
| ----------- | ------------------ | --------- |
| `positive_positive` | `1.2 * EPS` | `2` |
| `negative_positive` | `2.3 * EPS` | `4` |
| `negative_negative` | `2.0 * EPS` | `2` |

Each bound is the smallest non-negative integer for which every fixture in the corresponding set passes. Starting from a high bound and lowering, the suite passes at the values above, and decrementing each bound by one produces exactly one failure per set, confirming that no bound can be tightened further. 

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
