### PR TITLE
test: migrate `stats/base/dists/pareto-type1/kurtosis` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/kurtosis/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/kurtosis/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var kurtosis = require( './../lib' );
 
 
@@ -105,10 +104,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the excess kurtosis of a Pareto (Type I) distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -117,13 +114,7 @@ tape( 'the function returns the excess kurtosis of a Pareto (Type I) distributio
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/kurtosis/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/kurtosis/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -114,10 +113,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the excess kurtosis of a Pareto (Type I) distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -126,13 +123,7 @@ tape( 'the function returns the excess kurtosis of a Pareto (Type I) distributio
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = kurtosis( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `stats/base/dists/pareto-type1/kurtosis` from relative-tolerance (`EPS`-scaled) test assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.

Changes are confined to `test/test.js` and `test/test.native.js`. In both files, the `abs`/`EPS` requires are replaced by `isAlmostSameValue`, the `delta`/`tol` locals are dropped, and the exact-vs-tolerance branch in the fixture loop collapses to a single assertion:

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
```

**Final ULP constants and measured minimum**

| File | Previous tolerance | ULP bound | Measured minimum |
| ---- | ------------------ | --------- | ---------------- |
| `test/test.js` | `1.0 * EPS * abs( expected )` | `0` | `0` |
| `test/test.native.js` | `2.0 * EPS * abs( expected )` | `0` | `0` |

Both bounds were tightened to the measured minimum of **0 ULP**. Starting from a high bound and lowering it, the per-fixture minimum ULP distance was measured across the full fixture set (1000 cases in `test/fixtures/julia/data.json`): both the JavaScript implementation and the C implementation reproduce the Julia reference values bit-exactly for every case, so no non-zero bound is required. `0` is the tightest representable bound, so no further lowering is possible.

The native addon was compiled locally so that `test.native.js` was actually exercised rather than skipped (1017 assertions passing, 0 skipped). Both suites were run repeatedly at the final bound and passed identically each time, indicating no FMA/architecture-dependent variation. The excess kurtosis is a closed-form rational expression in `alpha`, which is consistent with the observed bit-exactness.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The C implementation measured bit-exact against the fixtures on this machine (Linux x86-64, gcc), so both bounds are set to `0`. If the project would rather keep a small non-zero margin in `test.native.js` to absorb possible FMA contraction on other toolchains/architectures, I'm happy to raise that one bound.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Linting note: `make lint` could not be run in this environment because `make install-node-modules` fails during dependency resolution (`npm error notarget No matching version found for es-object-atoms@^1.1.2`), which is unrelated to this change. The two changed files were instead checked with a standalone ESLint pass for unused variables and related issues, and came back clean; the diff otherwise mirrors the shape of already-merged conversions such as `stats/base/dists/halfnormal/stdev` and `stats/base/dists/weibull/logcdf`. CI should be treated as the authoritative lint check here.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It studied previously merged ULP conversions to match the established idiom, applied the test changes, compiled the native addon, and measured the minimum passing ULP bound empirically over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRnhaYbnH5rDnzzpfGqT3o)_