### PR TITLE
test: migrate `stats/base/dists/pareto-type1/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -161,10 +160,8 @@ tape( 'if provided a nonpositive `alpha`, the created function always returns `N
 tape( 'the created function evaluates the quantile for `p` given large `alpha` and `beta`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -176,13 +173,7 @@ tape( 'the created function evaluates the quantile for `p` given large `alpha` a
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( alpha[i], beta[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -190,10 +181,8 @@ tape( 'the created function evaluates the quantile for `p` given large `alpha` a
 tape( 'the created function evaluates the quantile for `p` given large parameter `alpha`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -205,13 +194,7 @@ tape( 'the created function evaluates the quantile for `p` given large parameter
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( alpha[i], beta[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -219,10 +202,8 @@ tape( 'the created function evaluates the quantile for `p` given large parameter
 tape( 'the created function evaluates the quantile for `p` given large parameter `beta`', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -234,13 +215,7 @@ tape( 'the created function evaluates the quantile for `p` given large parameter
 	for ( i = 0; i < p.length; i++ ) {
 		quantile = factory( alpha[i], beta[i] );
 		y = quantile( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -127,10 +126,8 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', opts, func
 
 tape( 'the function evaluates the quantile for `x` given large parameters `alpha` and `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -141,23 +138,15 @@ tape( 'the function evaluates the quantile for `x` given large parameters `alpha
 	beta = bothLarge.beta;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `x` given large parameter `alpha`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -168,23 +157,15 @@ tape( 'the function evaluates the quantile for `x` given large parameter `alpha`
 	beta = largeAlpha.beta;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `x` given large parameter `beta`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -195,13 +176,7 @@ tape( 'the function evaluates the quantile for `x` given large parameter `beta`'
 	beta = largeBeta.beta;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/test/test.quantile.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -118,10 +117,8 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 
 tape( 'the function evaluates the quantile for `x` given large parameters `alpha` and `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -132,23 +129,15 @@ tape( 'the function evaluates the quantile for `x` given large parameters `alpha
 	beta = bothLarge.beta;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `x` given large parameter `alpha`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -159,23 +148,15 @@ tape( 'the function evaluates the quantile for `x` given large parameter `alpha`
 	beta = largeAlpha.beta;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the quantile for `x` given large parameter `beta`', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -186,13 +167,7 @@ tape( 'the function evaluates the quantile for `x` given large parameter `beta`'
 	beta = largeBeta.beta;
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `@stdlib/stats/base/dists/pareto-type1/quantile` tests from relative tolerance (`EPS`/`delta`/`tol`) comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.

Converted files:

-   `test/test.quantile.js`
-   `test/test.factory.js`
-   `test/test.native.js`

`test/test.js` only performs exact export checks and was left unchanged.

### ULP bounds

All three fixture loops (`both_large.json`, `large_alpha.json`, `large_beta.json`) use:

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
```

| File | Previous tolerance | ULP constant | Measured minimum |
| ---- | ------------------ | ------------ | ---------------- |
| `test.quantile.js` | `1.0 * EPS * abs( expected[i] )` | `0` | `0` |
| `test.factory.js` | `1.0 * EPS * abs( expected[i] )` | `0` | `0` |
| `test.native.js` | `1.0 * EPS * abs( expected[i] )` | `0` | `0` |

The bound was determined empirically: the minimum ULP distance was computed for every fixture value in all three fixture files, and the maximum observed distance was `0` — i.e., every returned value is bit-identical to the Julia reference value, so `0` is the tightest possible bound. The suite was run twice at the final value to confirm determinism.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The native add-on was not compiled in the environment used to measure the bound, so `test/test.native.js` was skipped locally and its `0` ULP bound is inferred rather than directly measured. The inference is that `src/main.c` computes `beta / stdlib_base_pow( 1.0-p, 1.0/alpha )` using stdlib's own `pow` port — the same expression and same algorithm as `lib/main.js` — so results are expected to be bit-identical. Please confirm against a build with add-ons enabled; if native results diverge, the native bound will need to be raised.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only test files are modified; no source, docs, or benchmark changes.
-   Linting was verified with `etc/eslint/.eslintrc.tests.js` (clean). The `editorconfig-checker` pre-commit step could not download its binary in this environment; EditorConfig compliance (LF, tab indentation, no trailing whitespace, final newline) was verified manually instead.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was written primarily by Claude Code, which studied the prior ULP migrations in this family (e.g. `stats/base/dists/chi/quantile`, `stats/base/dists/pareto-type1/kurtosis`), applied the same idiom, and measured the minimum ULP bound over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_019vL4WsqC1a6DU6VewVmvx5)_