### PR TITLE
docs: fix C API parameter descriptions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/kurtosis/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/kurtosis/src/main.c
@@ -23,8 +23,8 @@
 /**
 * Returns the excess kurtosis for a lognormal distribution with location `mu` and scale `sigma`.
 *
-* @param mu       input value
-* @param sigma    minimum support
+* @param mu       location parameter
+* @param sigma    scale parameter
 * @return         excess kurtosis
 *
 * @example


### PR DESCRIPTION
_Surfaced by an automated cross-package documentation-consistency audit of the `stats/base/dists/lognormal` namespace. No associated issue._

## Description

> What is the purpose of this pull request?

This pull request corrects the C-source (`src/main.c`) parameter documentation for `stats/base/dists/lognormal/kurtosis`, which had drifted from the namespace convention:

-   The docblock described `mu` as `input value` and `sigma` as `minimum support` — copy-paste artifacts from a bounded distribution's parameterization. Both contradict the function's own summary line ("location `mu` and scale `sigma`"), the `kurtosis.h` header, and the `lib/main.js` JSDoc. They are corrected to `location parameter` and `scale parameter`, matching 11/13 (85%) of the addon-bearing sibling packages in the namespace. The change is comment-only: no behavior, signatures, or test expectations are affected.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

The `logcdf` C docblock, which documents `mu`/`sigma` as `mean`/`standard deviation`, was deliberately left untouched: those descriptions are mathematically accurate for the underlying normal and self-consistent between the header and source, so they are an authorial choice rather than drift.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored by Claude Code running an automated cross-package documentation-drift audit. The audit extracted structural and semantic features across all 14 packages in the namespace, identified the majority C-docblock `@param` pattern, flagged `kurtosis` as the sole outlier, and independently verified (with a second agent) that the deviation is an unintentional copy-paste rather than a genuine semantic difference before applying the correction. Please review before merge.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMTMF8BUDT6NqGgfY1E1o6)_