### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ccopy-within/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ccopy-within/README.md
@@ -205,7 +205,7 @@ Performs an in-place copy of elements within a single-precision complex floating
 ```c
 #include "stdlib/complex/float32/ctor.h"
 
-float x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+float x[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
 float w[ 8 ];
 
 stdlib_strided_ccopy_within( 4, 2, 0, 2, (stdlib_complex64_t *)x, 1, (stdlib_complex64_t *)w, 1 );
@@ -237,7 +237,7 @@ Performs an in-place copy of elements within a single-precision complex floating
 ```c
 #include "stdlib/complex/float32/ctor.h"
 
-float x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+float x[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
 float w[ 8 ];
 
 stdlib_strided_ccopy_within_ndarray( 3, 2, 0, 2, (stdlib_complex64_t *)x, 1, 1, (stdlib_complex64_t *)w, 1, 0 );
@@ -285,7 +285,7 @@ void stdlib_strided_ccopy_within_ndarray( const CBLAS_INT N, const CBLAS_INT tar
 
 int main( void ) {
     // Create a strided array:
-    float x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+    float x[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
 
     // Create a workspace array:
     float w[ 8 ];

--- a/lib/node_modules/@stdlib/blas/ext/base/ccopy-within/examples/c/example.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ccopy-within/examples/c/example.c
@@ -22,7 +22,7 @@
 
 int main( void ) {
 	// Create a strided array:
-	float x[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+	float x[] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
 
 	// Create a workspace array:
 	float w[ 8 ];

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ctriu/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ctriu/benchmark/benchmark.js
@@ -85,7 +85,7 @@ function createBenchmark( len ) {
 		}
 		b.toc();
 		if ( isnanf( realf( out.get( i%len, i%len ) ) ) ) {
-			b.fail( 'should return an ndarray' );
+			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
 		b.end();

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ctriu/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ctriu/docs/types/index.d.ts
@@ -44,7 +44,7 @@ import { complex64ndarray, typedndarray } from '@stdlib/types/ndarray';
 * var B = new Complex64Matrix( [ [ 0.0, 0.0, 0.0, 0.0 ], [ 0.0, 0.0, 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = ctriu( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtriu/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtriu/docs/types/index.d.ts
@@ -44,7 +44,7 @@ import { typedndarray } from '@stdlib/types/ndarray';
 * var B = matrix( [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ], 'generic' );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = gtriu( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/striu/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/striu/docs/types/index.d.ts
@@ -44,7 +44,7 @@ import { float32ndarray, typedndarray } from '@stdlib/types/ndarray';
 * var B = new Float32Matrix( [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = striu( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ztriu/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ztriu/docs/types/index.d.ts
@@ -44,7 +44,7 @@ import { complex128ndarray, typedndarray } from '@stdlib/types/ndarray';
 * var B = new Complex128Matrix( [ [ 0.0, 0.0, 0.0, 0.0 ], [ 0.0, 0.0, 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = ztriu( [ A, B, k ] );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request contains follow-up fixes for commits merged to `develop` between `b3d9447` (2026-08-09 06:03 PT) and `af0c6b6` (2026-08-10 05:41 PT).

This pull request:

-   **`blas/ext/base/ccopy-within`**: fixes float literal suffixes for `x[]` in ccopy-within (f24cab5): the README.md examples (three blocks) and examples/c/example.c initialize a `float x[]` with unsuffixed `1.0`/`2.0` doubles instead of `1.0f`/`2.0f`, inconsistent with scopy-within/caxpy and every other single-precision sibling.
-   **`blas/ext/base/ndarray/ctriu`**: fixes a copy-paste error message in the `ctriu` benchmark's NaN guard, introduced in 375701a: `lib/node_modules/@stdlib/blas/ext/base/ndarray/ctriu/benchmark/benchmark.js:88` says `'should return an ndarray'` but should say `'should not return NaN'`, matching the identical guard in `gtriu`/`ztriu`/`striu` from the same batch.
-   **`blas/ext/base/ndarray/{gtriu,ctriu,ztriu,striu}`**: fixes a docstring indentation issue in `docs/types/index.d.ts` (line 47) across all four packages: the `'dtype': 'generic'` line under `@example` used four spaces after the `*` instead of five, out of step with each package's `lib/main.js` and every other `blas/ext/base/ndarray` declaration file. Introduced in 9f9dfc5, 375701a, a6dc0eb, and 5bab5d6 respectively; the fix adds the missing space in all four files.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 36 commits merged to `develop` in the 24-hour window were reviewed for bugs and for compliance with the guidelines in `docs/style-guides`, with new packages compared against established sibling packages of similar functionality (e.g., `scopy-within`, `gfill-equal`, `dtriu`, `secf`, `round10`). Each finding above was independently re-verified against the diff and the current `develop` checkout before a fix was committed. Deliberately excluded: subjective concerns, style preferences not required by the style guides, and anything requiring interpretation or changes outside the reviewed diff (one candidate finding — operator spacing in `math/base/special/acschf` — was rejected as a false positive, as `space-infix-ops` is disabled in the project ESLint configuration and established siblings such as `acothf` use the same spacing).

**Note:** this is a draft PR intended for maintainer audit before promotion.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of a scheduled automated review of commits merged to `develop` in the preceding 24 hours. Findings were generated and cross-checked by multiple independent review passes, re-verified against sibling packages, and the fixes were applied and committed by Claude Code.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4YTBZCxEQMGhhRSuZ4pbw)_