### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/zaxpy/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/zaxpy/benchmark/c/benchmark.length.c
@@ -97,13 +97,15 @@ static double rand_double( void ) {
 */
 static double benchmark1( int iterations, int N ) {
 	stdlib_complex128_t alpha;
-	double x[ N*2 ];
-	double y[ N*2 ];
 	double elapsed;
+	double *x;
+	double *y;
 	double t;
 	int i;
 
 	alpha = stdlib_complex128( 1.0, 0.0 );
+	x = (double *) malloc( N * 2 * sizeof( double ) );
+	y = (double *) malloc( N * 2 * sizeof( double ) );
 	for ( i = 0; i < N*2; i+=2 ) {
 		x[ i ] = ( rand_double()*20.0 ) - 10.0;
 		x[ i+1 ] = ( rand_double()*20.0 ) - 10.0;
@@ -122,6 +124,8 @@ static double benchmark1( int iterations, int N ) {
 	if ( y[ i%(N*2) ] != y[ i%(N*2) ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 
@@ -134,13 +138,15 @@ static double benchmark1( int iterations, int N ) {
 */
 static double benchmark2( int iterations, int N ) {
 	stdlib_complex128_t alpha;
-	double x[ N*2 ];
-	double y[ N*2 ];
 	double elapsed;
+	double *x;
+	double *y;
 	double t;
 	int i;
 
 	alpha = stdlib_complex128( 1.0, 0.0 );
+	x = (double *) malloc( N * 2 * sizeof( double ) );
+	y = (double *) malloc( N * 2 * sizeof( double ) );
 	for ( i = 0; i < N*2; i+=2 ) {
 		x[ i ] = ( rand_double()*20.0 ) - 10.0;
 		x[ i+1 ] = ( rand_double()*20.0 ) - 10.0;
@@ -159,6 +165,8 @@ static double benchmark2( int iterations, int N ) {
 	if ( y[ i%(N*2) ] != y[ i%(N*2) ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/README.md
@@ -184,8 +184,8 @@ double out = stdlib_base_dists_pareto_type1_skewness( 3.5, 1.0 );
 
 The function accepts the following arguments:
 
--   **alpha**: `[in] double` first shape parameter.
--   **beta**: `[in] double` second shape parameter.
+-   **alpha**: `[in] double` shape parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_pareto_type1_skewness( const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/src/main.c
@@ -23,8 +23,8 @@
 /**
 * Returns the skewness of a Pareto (Type I) distribution.
 *
-* @param alpha    first shape parameter
-* @param beta     second shape parameter
+* @param alpha    shape parameter
+* @param beta     scale parameter
 * @return         skewness
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/stdev/README.md
@@ -188,8 +188,8 @@ double out = stdlib_base_dists_pareto_type1_stdev( 2.5, 1.0 );
 
 The function accepts the following arguments:
 
--   **alpha**: `[in] double` first shape parameter.
--   **beta**: `[in] double` second shape parameter.
+-   **alpha**: `[in] double` shape parameter.
+-   **beta**: `[in] double` scale parameter.
 
 ```c
 double stdlib_base_dists_pareto_type1_stdev( const double alpha, const double beta );

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/stdev/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/stdev/src/main.c
@@ -23,8 +23,8 @@
 /**
 * Returns the standard deviation of a Pareto (Type I) distribution.
 *
-* @param alpha    first shape parameter
-* @param beta     second shape parameter
+* @param alpha    shape parameter
+* @param beta     scale parameter
 * @return         standard deviation
 *
 * @example


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-08-09 13:57 (-0700) and 2026-08-10 05:41 (-0700) to sibling packages with the same underlying defects.

### Copy-paste parameter mislabels in pareto-type1 C docs

af0c6b67a fixed doxygen `@param` copy-paste residue in `lognormal/kurtosis`; the same defect recurs in `pareto-type1/skewness` and `pareto-type1/stdev`, where `src/main.c` and the README C section call `alpha` a "first shape parameter" and `beta` a "second shape parameter", contradicting the JS docblocks and the other ten `pareto-type1` C implementations. `alpha` is the shape parameter, `beta` is the scale parameter — relabeled in both files, both packages.

### Stack-based VLAs in benchmark code

Commit 320832192 (`bench: refactor to use dynamic memory allocation`, #14099) converted stack-allocated variable-length arrays to heap allocation across 13 `blas/base`, `blas/ext/base`, and `lapack/base` benchmarks; `blas/base/zaxpy/benchmark/c/benchmark.length.c` was missed. This PR applies the same conversion there: `x`/`y` become pointers, `malloc` after the alpha assignment, `free` before return, timed region untouched. Pattern modeled on `zscal` from the source commit; no runtime-sized VLAs remain in the tree.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8643

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed before inclusion: candidate sites were enumerated by comparing C `@param` descriptions against each package's own JS docblocks across `stats/base/dists/*/*` and by scanning all `benchmark*.c` for runtime-sized stack arrays; each surviving site was independently confirmed by two validation passes, an adaptation pass producing the exact per-site patch, and a style-consistency pass against sibling packages.

Deliberately excluded: `lognormal/logcdf` (same defect class — `mu`/`sigma` documented as "mean"/"standard deviation" in `src/main.c`, README C section, and header — but the fix's scope over summary sentences is a maintainer call, since siblings split between "location parameter `mu`" and "location `mu`" phrasings); five misspelled-but-semantically-correct descriptions ("scale paramter" in `pareto-type1/{entropy,variance}` and `weibull/{entropy,variance}`, "success probablity" in `geometric/variance`), which are a separate spelling-defect class rather than analogs of af0c6b67a; and `negative-binomial/variance`, where the package's own docs disagree on whether `r` counts successes or failures.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a scheduled fix-propagation routine: it identified fix commits merged to `develop` in the last 24 hours, located sibling packages with the same defects, and applied the equivalent fixes after multi-pass validation.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RjECpzDmZvZKwosPjWkTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019RjECpzDmZvZKwosPjWkTJ)_