### PR TITLE
test: migrate `stats/base/dists/laplace/logcdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -141,8 +140,6 @@ tape( 'if provided a nonpositive `b`, the created function always returns `NaN`'
 tape( 'the created function evaluates the logcdf for `x` given positive `mu`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -156,13 +153,7 @@ tape( 'the created function evaluates the logcdf for `x` given positive `mu`', f
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( mu[i], b[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -170,8 +161,6 @@ tape( 'the created function evaluates the logcdf for `x` given positive `mu`', f
 tape( 'the created function evaluates the logcdf for `x` given negative `mu`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -185,13 +174,7 @@ tape( 'the created function evaluates the logcdf for `x` given negative `mu`', f
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( mu[i], b[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -199,8 +182,6 @@ tape( 'the created function evaluates the logcdf for `x` given negative `mu`', f
 tape( 'the created function evaluates the logcdf for `x` given large variance ( = large `b`)', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var i;
@@ -214,13 +195,7 @@ tape( 'the created function evaluates the logcdf for `x` given large variance ( 
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( mu[i], b[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/test/test.logcdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
 
@@ -92,8 +91,6 @@ tape( 'if provided a negative `b`, the function returns `NaN`', function test( t
 
 tape( 'the function evaluates the logcdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -106,21 +103,13 @@ tape( 'the function evaluates the logcdf for `x` given positive `mu`', function 
 	b = positiveMean.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -133,21 +122,13 @@ tape( 'the function evaluates the logcdf for `x` given negative `mu`', function 
 	b = negativeMean.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large variance ( = large `b` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -160,13 +141,7 @@ tape( 'the function evaluates the logcdf for `x` given large variance ( = large 
 	b = largeVariance.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/logcdf/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -101,8 +100,6 @@ tape( 'if provided a negative `b`, the function returns `NaN`', opts, function t
 
 tape( 'the function evaluates the logcdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -115,21 +112,13 @@ tape( 'the function evaluates the logcdf for `x` given positive `mu`', opts, fun
 	b = positiveMean.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -142,21 +131,13 @@ tape( 'the function evaluates the logcdf for `x` given negative `mu`', opts, fun
 	b = negativeMean.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large variance ( = large `b` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var b;
@@ -169,13 +150,7 @@ tape( 'the function evaluates the logcdf for `x` given large variance ( = large 
 	b = largeVariance.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], mu[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/laplace/logcdf` from relative tolerance testing to ULP difference testing, replacing the `delta`/`tol` comparisons in `test/test.logcdf.js`, `test/test.factory.js`, and `test/test.native.js` with `isAlmostSameValue`.
-   adds the `@stdlib/assert/is-almost-same-value` import and removes the now unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` imports.

Final ULP constant: **`0`** for every fixture group, in all three test files.

The ULP bound was measured rather than guessed: for every fixture value, the minimum ULP difference which admits the computed result was computed directly (searching upward from `0`), and the maximum over the full fixture set was taken. Both the JavaScript and C implementations reproduce every Julia fixture value exactly, so the measured minimum is `0` ULP — the tightest bound expressible — for all of:

| Fixture | Values | Previous tolerance | Measured max ULP diff | ULP constant |
| --- | --- | --- | --- | --- |
| `positive_mean` | 1000 | `1.0*EPS` | 0 | 0 |
| `negative_mean` | 1000 | `1.0*EPS` | 0 | 0 |
| `large_variance` | 1000 | `1.0*EPS` | 0 | 0 |

`test/test.native.js` was verified against a locally compiled add-on (`make install-node-addons NODE_ADDONS_PATTERN='laplace/logcdf'`) so that it did **not** skip; the `0` ULP bound is therefore measured for the C implementation as well, not merely inherited from the JavaScript results. Each suite was run twice at the final bound to confirm determinism (no FMA/architecture variation); all assertions pass on every run (`test.logcdf.js`: 3013, `test.factory.js`: 3018, `test.native.js`: 3013, `test.js`: 3).

Only the three test files are changed; the implementation and fixtures are untouched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft pending maintainer review of the `0` ULP bound. A bound of `0` requires bit-for-bit agreement with the fixtures; there is existing precedent in the repo (`stats/base/dists/weibull/logcdf`, `stats/base/dists/uniform/entropy`, `math/base/special/covercos`, and `math/base/special/asec` all use `0` for fixture groups which match exactly), and the results here are deterministic IEEE-754 in both the JavaScript and C implementations. If maintainers would prefer a `1` ULP margin in `test/test.native.js` as a hedge against compiler/architecture variation in the C build, that is a one-character change.

Two environment notes, neither affecting the diff:

-   The `editorconfig-checker` stage of the local pre-commit hook could not run, because it downloads its binary from a GitHub release which was not reachable from this environment. EditorConfig conformance was instead verified manually for the changed files (LF line endings, UTF-8, tab indentation, no trailing whitespace introduced, final newline present), and `make eslint-tests TESTS_FILTER=".*/stats/base/dists/laplace/logcdf/.*"` passes cleanly.
-   `make install-node-modules` fails in this environment because two transitive dependencies request registry versions which are not resolvable here (`es-object-atoms@^1.1.2`, `hasown@^2.0.4`; the registry as seen from this environment publishes at most `1.1.1` and `2.0.2` respectively). Installing with temporary local `overrides` pinning those two shims produced a working toolchain; the override was reverted before committing and is not part of this pull request. Flagging it in case CI hits the same resolution failure.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task: it selected the package, studied prior conversions in the repo to match the established idiom, applied the test migration, measured the minimum ULP bound empirically, and verified tests and linting locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_011B4fs8EPgjzfB41xou4sDQ)_