### PR TITLE
test: migrate `stats/base/dists/f/mode` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/f/mode/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/mode/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mode = require( './../lib' );
 
 
@@ -102,8 +101,6 @@ tape( 'if provided `d2 <= 0`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the mode of an F distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var i;
@@ -114,13 +111,7 @@ tape( 'the function returns the mode of an F distribution', function test( t ) {
 	d2 = data.d2;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mode( d1[i], d2[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'd1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/f/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/mode/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -111,8 +110,6 @@ tape( 'if provided `d2 <= 0`, the function returns `NaN`', opts, function test( 
 
 tape( 'the function returns the mode of an F distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var i;
@@ -123,13 +120,7 @@ tape( 'the function returns the mode of an F distribution', opts, function test(
 	d2 = data.d2;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mode( d1[i], d2[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'd1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/f/mode` from relative tolerance testing to ULP difference testing, replacing the `delta`/`tol` comparisons in `test/test.js` and `test/test.native.js` with `isAlmostSameValue`.
-   adds the `@stdlib/assert/is-almost-same-value` import and removes the now unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` imports.

Final ULP constant: **`0`**, in both test files.

The ULP bound was measured rather than guessed: for every fixture value, the minimum ULP difference which admits the computed result was determined directly (searching upward from `0`), and the maximum over the full fixture set was taken.

| Fixture | Values | Previous tolerance | Measured max ULP diff | ULP constant |
| --- | --- | --- | --- | --- |
| `data.json` | 100 | `1.0*EPS` | 0 | 0 |

Both the JavaScript and C implementations reproduce every Julia fixture value exactly, so the measured minimum is `0` ULP — the tightest bound expressible. This is expected here: both implementations evaluate the identical expression `( ( d1-2.0 ) / d1 ) * ( d2 / ( d2+2.0 ) )`, which is two divisions and a multiplication with no opportunity for FMA contraction.

`test/test.native.js` was verified against a locally compiled add-on (`make install-node-addons NODE_ADDONS_PATTERN='stats/base/dists/f/mode'`) so that it did **not** skip; the `0` ULP bound is therefore measured for the C implementation as well, not merely inherited from the JavaScript results. Each suite was run twice at the final bound to confirm determinism (no FMA/architecture variation); all assertions pass on every run (`test.js`: 116, `test.native.js`: 116).

Only the two test files are changed; the implementation and fixtures are untouched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft pending maintainer review of the `0` ULP bound. A bound of `0` requires bit-for-bit agreement with the fixtures; there is existing precedent in the repo (`stats/base/dists/pareto-type1/quantile`, `stats/base/dists/weibull/logcdf`, `stats/base/dists/uniform/entropy`, and `math/base/special/covercos` all use `0` for fixture groups which match exactly), and the results here are deterministic IEEE-754 in both implementations. If maintainers would prefer a `1` ULP margin in `test/test.native.js` as a hedge against compiler/architecture variation in the C build, that is a one-character change.

Two environment notes, neither affecting the diff:

-   The `editorconfig-checker` stage of the local pre-commit hook could not run, because it downloads its binary from a GitHub release which was not reachable from this environment. EditorConfig conformance was instead verified manually for the changed files (LF line endings, UTF-8, tab indentation, no trailing whitespace, final newline present). Linting passes cleanly with the repository's test configuration (`make lint-javascript-files ESLINT_CONF=./etc/eslint/.eslintrc.tests.js FILES=...`).
-   `make install-node-modules` initially failed in this environment because a transitive dependency requested a registry version which was not resolvable here (`es-object-atoms@^1.1.2`; the registry as seen from this environment publishes at most `1.1.1`). A subsequent install attempt resolved successfully and produced a working toolchain. Flagging it in case CI hits the same intermittent resolution failure.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task: it selected the package, studied prior conversions in the repo to match the established idiom, applied the test migration, measured the minimum ULP bound empirically, and verified tests and linting locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017bXA4hmb4tnGe18yLCcToS)_