### PR TITLE
test: migrate `math/base/special/cospi` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cospi/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cospi/test/test.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var cospi = require( './../lib' );
@@ -134,8 +133,6 @@ tape( 'the function is even', function test( t ) {
 
 tape( 'the function computes `cos(πx)`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -144,13 +141,7 @@ tape( 'the function computes `cos(πx)`', function test( t ) {
 	expected = decimals.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cospi( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cospi/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cospi/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -143,8 +142,6 @@ tape( 'the function is even', opts, function test( t ) {
 
 tape( 'the function computes `cos(πx)`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -153,13 +150,7 @@ tape( 'the function computes `cos(πx)`', opts, function test( t ) {
 	expected = decimals.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cospi( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the `math/base/special/cospi` package tests from relative-tolerance (`delta`/`tol`/`EPS`) comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the tracking issue.
-   Updates both `test/test.js` and `test/test.native.js`, each of which had a single fixture-driven test block (`'the function computes cos(πx)'`) using the old idiom.
-   The minimum ULP tolerance was determined empirically: `1` passes reliably for both the JS and native implementations, while `0` (exact equality) fails (380 of 6214 cases). The test suite was run twice at ULP `1` for both files to confirm deterministic results.
-   No other test cases were touched; only the tolerance-based comparisons were converted.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, run as an unattended scheduled task. It searched the repository for a package still using the old relative-tolerance test idiom, cross-checked existing open/merged ULP-migration PRs to avoid duplicating work, studied prior-art commits (e.g. the `atan2d`, `powm1`, and `cceiln` conversions) to mirror the established idiom, converted the tolerance checks to `isAlmostSameValue`, and empirically determined the minimum passing ULP bound by testing both `1` and `0` and confirming determinism across repeated runs.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXRe7DKMnJDk6MHLbuqWgk)_