### PR TITLE
test: migrate `stats/base/dists/signrank/quantile` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/signrank/quantile/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/signrank/quantile/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -107,8 +106,6 @@ tape( 'if provided a negative or non-integer `n`, the created function always re
 tape( 'the created function evaluates the quantile function at `p` given `n` observations', function test( t ) {
 	var expected;
 	var quantile;
-	var delta;
-	var tol;
 	var n;
 	var i;
 	var p;
@@ -121,13 +118,7 @@ tape( 'the created function evaluates the quantile function at `p` given `n` obs
 		quantile = factory( n[i] );
 		y = quantile( p[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/signrank/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/signrank/quantile/test/test.quantile.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
 
@@ -81,8 +80,6 @@ tape( 'if provided a negative or non-integer `n`, the function returns `NaN`', f
 
 tape( 'the function evaluates the quantile function at `p` given `n` observations', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var n;
 	var i;
 	var p;
@@ -94,13 +91,7 @@ tape( 'the function evaluates the quantile function at `p` given `n` observation
 	for ( i = 0; i < p.length; i++ ) {
 		y = quantile( p[i], n[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'p: '+p[i]+', n: '+n[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/signrank/quantile` from relative tolerance (`EPS`/`delta`/`tol`) assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   updates `test/test.factory.js` and `test/test.quantile.js` (the only test files in the package which used the tolerance idiom; `test/test.js` contains only exact assertions and is unchanged). The package has no `test.native.js`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires and the associated `delta`/`tol` locals, while preserving the existing `expected[ i ] !== null` fixture guard and overall test structure.

**ULP bound:** `0` in both files.

The bound was tightened agentically: assertions were run against the full R fixture set (150 cases per file) and pass at `0` ULP, i.e. bit-for-bit equality, which is the tightest bound possible. This is expected here, since the signrank quantile function returns integer-valued rank statistics which are exactly representable. The full package suite (326 assertions) was run twice at the final bound with identical results, confirming no FMA/arch-dependent flakiness.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only test files are changed; no source, docs, or fixtures were touched.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code. It mirrored the idiom established in previously merged conversions (e.g. #14129, #14141) and determined the minimum passing ULP bound empirically by running the package test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_013c335xppMBrVgyhHDbznao)_