### PR TITLE
test: migrate `stats/base/dists/pareto-type1/median` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/median/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the median of a Pareto (Type I) distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the median of a Pareto (Type I) distribution', funct
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = median( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `@stdlib/stats/base/dists/pareto-type1/median` tests from relative tolerance (`EPS`/`delta`/`tol`) comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.

Converted files:

-   `test/test.js`

The package has no `test/test.native.js` (no C implementation is currently present in `develop`), so `test/test.js` is the only test file in the package.

### ULP bounds

The single fixture loop (`fixtures/julia/data.json`, 1000 cases) uses:

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
```

| File | Previous tolerance | ULP constant | Measured minimum |
| ---- | ------------------ | ------------ | ---------------- |
| `test.js` | `1.0 * EPS * abs( expected[i] )` | `0` | `0` |

The bound was determined empirically. Starting from `64`, the constant was lowered until the suite no longer passed; it passed at every step down to and including `0`. Independently, the ULP distance was computed via `@stdlib/number/float64/base/ulp-difference` for all 1000 fixture cases, and the maximum observed distance was `0` — i.e., every returned value is bit-identical to the Julia reference value, so `0` is the tightest possible bound. The suite was run twice at the final value to confirm determinism (1014/1014 assertions passing on both runs).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

Resolves a part of #11352.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only test files are modified; no source, docs, or benchmark changes.
-   Linting was verified with `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/pareto-type1/median/.*"` (clean).
-   The `editorconfig-checker` pre-commit step could not download its binary in this environment; EditorConfig compliance (LF line endings, tab indentation, no trailing whitespace, final newline) was verified manually instead.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was written primarily by Claude Code, which studied the prior ULP migrations in this family (e.g. `stats/base/dists/pareto-type1/quantile`, `stats/base/dists/pareto-type1/kurtosis`, `stats/base/dists/signrank/quantile`), applied the same idiom, and measured the minimum ULP bound over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01XyseKi76BWSB497twpHsGa)_