### PR TITLE
feat: add `fft/base/fftpack/ndarray/scosqi`

### DIFF
--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/README.md
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/README.md
@@ -1,0 +1,136 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2026 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# scosqi
+
+> Initialize a workspace array for performing a quarter-wave cosine transform on a one-dimensional single-precision floating-point ndarray.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var scosqi = require( '@stdlib/fft/base/fftpack/ndarray/scosqi' );
+```
+
+#### scosqi( arrays )
+
+Initializes a workspace array for performing a quarter-wave cosine transform on a one-dimensional single-precision floating-point ndarray.
+
+```javascript
+var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var Slice = require( '@stdlib/slice/ctor' );
+var slice = require( '@stdlib/ndarray/slice' );
+
+var N = 8;
+var len = scalar2ndarray( N, {
+    'dtype': 'int32'
+});
+
+var w = new Float32Vector( ( 3*N ) + 34 );
+
+var out = scosqi( [ w, len ] );
+// returns <ndarray>
+
+var bool = ( out === w );
+// returns true
+
+var cosineTable = slice( w, new Slice( 0, N ) );
+// returns <ndarray>[ ~0.98, ~0.92, ~0.83, ~0.7, ~0.56, ~0.38, ~0.2, ~0.0 ]
+
+var twiddleFactors = slice( w, new Slice( 2*N, 3*N ) );
+// returns <ndarray>[ ~0.707, ~0.707, 0, 0, 0, 0, 0, 0 ]
+
+var factors = slice( w, new Slice( 3*N, ( 3*N ) + 4 ) );
+// returns <ndarray>[ 8, 2, 2, 4 ]
+```
+
+The function has the following parameters:
+
+-   **arrays**: array-like object containing the following ndarrays:
+
+    -   a one-dimensional input ndarray.
+    -   a zero-dimensional ndarray containing the length of the sequence to transform.
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If provided an empty one-dimensional input ndarray, the function returns the output ndarray unchanged.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var scosqi = require( '@stdlib/fft/base/fftpack/ndarray/scosqi' );
+
+var N = 8;
+
+var w = new Float32Vector( ( 3*N ) + 34 );
+console.log( ndarray2array( w ) );
+
+var len = scalar2ndarray( N, {
+    'dtype': 'int32'
+});
+
+var out = scosqi( [ w, len ] );
+console.log( ndarray2array( out ) );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/benchmark/benchmark.js
@@ -1,0 +1,106 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var format = require( '@stdlib/string/format' );
+var pkg = require( './../package.json' ).name;
+var scosqi = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} N - sequence length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( N ) {
+	var len = scalar2ndarray( N, {
+		'dtype': 'int32'
+	});
+	var w = new Float32Vector( ( 3*N ) + 34 );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = scosqi( [ w, len ] );
+			if ( typeof v !== 'object' ) {
+				b.fail( 'should return an ndarray' );
+			}
+		}
+		b.toc();
+		if ( isnanf( v.get( 2*N ) ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var lengths;
+	var N;
+	var f;
+	var i;
+
+	lengths = [
+		8,
+		16,
+		32,
+		64,
+		128,
+		256,
+		512,
+		1024
+	];
+
+	for ( i = 0; i < lengths.length; i++ ) {
+		N = lengths[ i ];
+		f = createBenchmark( N );
+		bench( format( '%s:N=%d', pkg, N ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/benchmark/benchmark.js
@@ -39,10 +39,14 @@ var scosqi = require( './../lib' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( N ) {
-	var len = scalar2ndarray( N, {
+	var len;
+	var w;
+
+	len = scalar2ndarray( N, {
 		'dtype': 'int32'
 	});
-	var w = new Float32Vector( ( 3*N ) + 34 );
+	w = new Float32Vector( ( 3*N ) + 34 );
+
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/docs/repl.txt
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/docs/repl.txt
@@ -1,0 +1,44 @@
+
+{{alias}}( arrays )
+    Initializes a workspace array for performing a quarter-wave cosine
+    transform on a one-dimensional single-precision floating-point ndarray.
+
+    If provided an empty input ndarray, the function returns the output ndarray
+    unchanged.
+
+    Parameters
+    ----------
+    arrays: ArrayLikeObject<ndarray>
+        Array-like object containing the following ndarrays:
+
+        - a one-dimensional input ndarray.
+        - a zero-dimensional ndarray containing the length of the sequence to
+        transform.
+
+    Returns
+    -------
+    out: ndarray
+        Output ndarray.
+
+    Examples
+    --------
+    > var N = 8;
+    > var w = new {{alias:@stdlib/ndarray/vector/float32}}( ( 3*N ) + 34 );
+    > var len = {{alias:@stdlib/ndarray/from-scalar}}( N, { 'dtype': 'int32' });
+    > var out = {{alias}}( [ w, len ] )
+    <ndarray>
+    > var bool = ( out === w )
+    true
+    > var s = new {{alias:@stdlib/slice/ctor}}( 0, N );
+    > var cosineTable = {{alias:@stdlib/ndarray/slice}}( w, s )
+    <ndarray>[ ~0.98, ~0.92, ~0.83, ~0.7, ~0.56, ~0.38, ~0.2, ~0.0 ]
+    > s = new {{alias:@stdlib/slice/ctor}}( 2*N, 3*N );
+    > var twiddleFactors = {{alias:@stdlib/ndarray/slice}}( w, s )
+    <ndarray>[ ~0.707, ~0.707, 0, 0, 0, 0, 0, 0 ]
+    > s = new {{alias:@stdlib/slice/ctor}}( 3*N, ( 3*N ) + 4 );
+    > var factors = {{alias:@stdlib/ndarray/slice}}( w, s )
+    <ndarray>[ 8, 2, 2, 4 ]
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/docs/types/index.d.ts
@@ -1,0 +1,71 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { typedndarray, float32ndarray } from '@stdlib/types/ndarray';
+
+/**
+* Initializes a workspace array for performing a quarter-wave cosine transform on a one-dimensional single-precision floating-point ndarray.
+*
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the length of the sequence to transform.
+*
+* @param arrays - array-like object containing ndarrays
+* @returns output ndarray
+*
+* @example
+* var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+* var Slice = require( '@stdlib/slice/ctor' );
+* var slice = require( '@stdlib/ndarray/slice' );
+*
+* var N = 8;
+* var len = scalar2ndarray( N, {
+*     'dtype': 'int32'
+* });
+*
+* var w = new Float32Vector( ( 3*N ) + 34 );
+*
+* var out = scosqi( [ w, len ] );
+* // returns <ndarray>
+*
+* var bool = ( out === w );
+* // returns true
+*
+* var cosineTable = slice( w, new Slice( 0, N ) );
+* // returns <ndarray>[ ~0.98, ~0.92, ~0.83, ~0.7, ~0.56, ~0.38, ~0.2, ~0.0 ]
+*
+* var twiddleFactors = slice( w, new Slice( 2*N, 3*N ) );
+* // returns <ndarray>[ ~0.707, ~0.707, 0, 0, 0, 0, 0, 0 ]
+*
+* var factors = slice( w, new Slice( 3*N, ( 3*N ) + 4 ) );
+* // returns <ndarray>[ 8, 2, 2, 4 ]
+*/
+declare function scosqi( arrays: [ float32ndarray, typedndarray<number> ] ): float32ndarray;
+
+
+// EXPORTS //
+
+export = scosqi;

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/docs/types/test.ts
@@ -1,0 +1,63 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable space-in-parens */
+
+import zeros = require( '@stdlib/ndarray/zeros' );
+import scosqi = require( './index' );
+
+
+// TESTS //
+
+// The function returns an ndarray...
+{
+	const w = zeros( [ 10 ], {
+		'dtype': 'float32'
+	});
+	const N = zeros( [], {
+		'dtype': 'int32'
+	});
+
+	scosqi( [ w, N ] ); // $ExpectType float32ndarray
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
+{
+	scosqi( '10' ); // $ExpectError
+	scosqi( 10 ); // $ExpectError
+	scosqi( true ); // $ExpectError
+	scosqi( false ); // $ExpectError
+	scosqi( null ); // $ExpectError
+	scosqi( undefined ); // $ExpectError
+	scosqi( [] ); // $ExpectError
+	scosqi( {} ); // $ExpectError
+	scosqi( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const w = zeros( [ 10 ], {
+		'dtype': 'float32'
+	});
+	const N = zeros( [], {
+		'dtype': 'int32'
+	});
+
+	scosqi(); // $ExpectError
+	scosqi( [ w, N ], {} ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/examples/index.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var scosqi = require( './../lib' );
+
+var N = 8;
+
+var w = new Float32Vector( ( 3*N ) + 34 );
+console.log( ndarray2array( w ) );
+
+var len = scalar2ndarray( N, {
+	'dtype': 'int32'
+});
+
+var out = scosqi( [ w, len ] );
+console.log( ndarray2array( out ) );

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/lib/index.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/lib/index.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Initialize a workspace array for performing a quarter-wave cosine transform on a one-dimensional single-precision floating-point ndarray.
+*
+* @module @stdlib/fft/base/fftpack/ndarray/scosqi
+*
+* @example
+* var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+* var Slice = require( '@stdlib/slice/ctor' );
+* var slice = require( '@stdlib/ndarray/slice' );
+* var scosqi = require( '@stdlib/fft/base/fftpack/ndarray/scosqi' );
+*
+* var N = 8;
+* var len = scalar2ndarray( N, {
+*     'dtype': 'int32'
+* });
+*
+* var w = new Float32Vector( ( 3*N ) + 34 );
+*
+* var out = scosqi( [ w, len ] );
+* // returns <ndarray>
+*
+* var bool = ( out === w );
+* // returns true
+*
+* var cosineTable = slice( w, new Slice( 0, N ) );
+* // returns <ndarray>[ ~0.98, ~0.92, ~0.83, ~0.7, ~0.56, ~0.38, ~0.2, ~0.0 ]
+*
+* var twiddleFactors = slice( w, new Slice( 2*N, 3*N ) );
+* // returns <ndarray>[ ~0.707, ~0.707, 0, 0, 0, 0, 0, 0 ]
+*
+* var factors = slice( w, new Slice( 3*N, ( 3*N ) + 4 ) );
+* // returns <ndarray>[ 8, 2, 2, 4 ]
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/lib/main.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/lib/main.js
@@ -1,0 +1,86 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var getStride = require( '@stdlib/ndarray/base/stride' );
+var getOffset = require( '@stdlib/ndarray/base/offset' );
+var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var strided = require( '@stdlib/fft/base/fftpack/cosqi' );
+var ndarraylike2scalar = require( '@stdlib/ndarray/base/ndarraylike2scalar' );
+
+
+// MAIN //
+
+/**
+* Initializes a workspace array for performing a quarter-wave cosine transform on a one-dimensional single-precision floating-point ndarray.
+*
+* ## Notes
+*
+* -   The function expects the following ndarrays:
+*
+*     -   a one-dimensional input ndarray.
+*     -   a zero-dimensional ndarray containing the length of the sequence to transform.
+*
+* @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
+* @returns {ndarrayLike} output ndarray
+*
+* @example
+* var Float32Vector = require( '@stdlib/ndarray/vector/float32' );
+* var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+* var Slice = require( '@stdlib/slice/ctor' );
+* var slice = require( '@stdlib/ndarray/slice' );
+*
+* var N = 8;
+* var len = scalar2ndarray( N, {
+*     'dtype': 'int32'
+* });
+*
+* var w = new Float32Vector( ( 3*N ) + 34 );
+*
+* var out = scosqi( [ w, len ] );
+* // returns <ndarray>
+*
+* var bool = ( out === w );
+* // returns true
+*
+* var cosineTable = slice( w, new Slice( 0, N ) );
+* // returns <ndarray>[ ~0.98, ~0.92, ~0.83, ~0.7, ~0.56, ~0.38, ~0.2, ~0.0 ]
+*
+* var twiddleFactors = slice( w, new Slice( 2*N, 3*N ) );
+* // returns <ndarray>[ ~0.707, ~0.707, 0, 0, 0, 0, 0, 0 ]
+*
+* var factors = slice( w, new Slice( 3*N, ( 3*N ) + 4 ) );
+* // returns <ndarray>[ 8, 2, 2, 4 ]
+*/
+function scosqi( arrays ) {
+	var w;
+	var N;
+
+	w = arrays[ 0 ];
+	N = ndarraylike2scalar( arrays[ 1 ] );
+	strided( N, getData( w ), getStride( w, 0 ), getOffset( w ) );
+	return w;
+}
+
+
+// EXPORTS //
+
+module.exports = scosqi;

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/package.json
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@stdlib/fft/base/fftpack/ndarray/scosqi",
+  "version": "0.0.0",
+  "description": "Initialize a workspace array for performing a quarter-wave cosine transform on a one-dimensional single-precision floating-point ndarray.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "fft",
+    "fftpack",
+    "scosqi",
+    "fourier",
+    "transform",
+    "twiddle",
+    "cosine",
+    "workspace",
+    "initialization",
+    "real",
+    "ndarray"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/test/test.js
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/ndarray/scosqi/test/test.js
@@ -1,0 +1,315 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable max-len */
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isSameFloat32Array = require( '@stdlib/assert/is-same-float32array' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
+var Float32Array = require( '@stdlib/array/float32' );
+var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var getData = require( '@stdlib/ndarray/data-buffer' );
+var scosqi = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns a one-dimensional ndarray.
+*
+* @private
+* @param {Float32Array} buffer - underlying data buffer
+* @param {NonNegativeInteger} length - number of indexed elements
+* @param {integer} stride - stride length
+* @param {NonNegativeInteger} offset - index offset
+* @returns {ndarray} one-dimensional ndarray
+*/
+function vector( buffer, length, stride, offset ) {
+	return new ndarray( 'float32', buffer, [ length ], [ stride ], offset, 'row-major' );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof scosqi, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 1', function test( t ) {
+	t.strictEqual( scosqi.length, 1, 'has expected arity' );
+	t.end();
+});
+
+tape( 'the function correctly initializes cosine, twiddle and integer factors in a one-dimensional ndarray `w`', function test( t ) {
+	var expectedTwiddles;
+	var expectedFactors;
+	var expectedCosines;
+	var wBuf;
+	var ulps;
+	var len;
+	var N;
+	var w;
+	var v;
+	var i;
+	var y;
+	var e;
+
+	N = 8;
+	len = scalar2ndarray( N, {
+		'dtype': 'int32'
+	});
+	wBuf = new Float32Array( ( 3*N ) + 34 );
+	w = vector( wBuf, ( 3*N ) + 34, 1, 0 );
+	v = scosqi( [ w, len ] );
+	t.strictEqual( v, w, 'returns expected workspace reference' );
+
+	expectedCosines = new Float32Array( [ 0.9807852506637573, 0.9238795042037964, 0.8314695954322815, 0.7071067690849304, 0.5555702447891235, 0.3826834261417389, 0.19509032368659973, 6.123234262925839e-17 ] );
+	expectedTwiddles = new Float32Array( [ 0.7071067690849304, 0.7071067690849304, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expectedFactors = new Float32Array( [ 8, 2, 2, 4 ] );
+
+	ulps = 1;
+	for ( i = 0; i < expectedCosines.length; i++ ) {
+		y = wBuf[ i ];
+		e = expectedCosines[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < expectedTwiddles.length; i++ ) {
+		y = wBuf[ ( 2*N ) + i ];
+		e = expectedTwiddles[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < expectedFactors.length; i++ ) {
+		y = wBuf[ ( 3*N ) + i ];
+		e = expectedFactors[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = N; i < 2*N; i++ ) {
+		y = wBuf[ i ];
+		e = 0.0;
+		t.strictEqual( y, e, 'returns expected value' );
+	}
+
+	t.end();
+});
+
+tape( 'if provided an empty ndarray, the function returns the output ndarray unchanged', function test( t ) {
+	var expected;
+	var wBuf;
+	var len;
+	var w;
+	var N;
+	var v;
+
+	N = 4;
+	wBuf = new Float32Array( [] );
+	w = vector( wBuf, 0, 1, 0 );
+	len = scalar2ndarray( N, {
+		'dtype': 'int32'
+	});
+
+	v = scosqi( [ w, len ] );
+
+	expected = new Float32Array( [] );
+	t.strictEqual( v, w, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( getData( v ), expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a one-dimensional ndarray having a non-unit stride', function test( t ) {
+	var expectedTwiddles;
+	var expectedFactors;
+	var expectedCosines;
+	var wBuf;
+	var ulps;
+	var len;
+	var w;
+	var y;
+	var e;
+	var i;
+	var N;
+	var v;
+
+	N = 8;
+	wBuf = new Float32Array( ( 6*N ) + 68 );
+	w = vector( wBuf, ( 3*N ) + 34, 2, 0 );
+	len = scalar2ndarray( N, {
+		'dtype': 'int32'
+	});
+
+	v = scosqi( [ w, len ] );
+
+	expectedCosines = new Float32Array( [ 0.9807852506637573, 0.9238795042037964, 0.8314695954322815, 0.7071067690849304, 0.5555702447891235, 0.3826834261417389, 0.19509032368659973, 6.123234262925839e-17 ] );
+	expectedTwiddles = new Float32Array( [ 0.7071067690849304, 0.7071067690849304, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expectedFactors = new Float32Array( [ 8, 2, 2, 4 ] );
+
+	t.strictEqual( v, w, 'returns expected value' );
+
+	ulps = 1;
+	for ( i = 0; i < expectedCosines.length; i++ ) {
+		y = wBuf[ 2*i ];
+		e = expectedCosines[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < expectedTwiddles.length; i++ ) {
+		y = wBuf[ ( 4*N ) + ( 2*i ) ];
+		e = expectedTwiddles[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < expectedFactors.length; i++ ) {
+		y = wBuf[ ( 6*N ) + ( 2*i ) ];
+		e = expectedFactors[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < N; i++ ) {
+		y = wBuf[ ( 2*N ) + ( 2*i ) ];
+		e = 0.0;
+		t.strictEqual( y, e, 'returns expected value' );
+
+		y = wBuf[ ( 4*N ) + ( 2*i ) + 1 ];
+		t.strictEqual( y, e, 'returns expected value' );
+	}
+
+	t.end();
+});
+
+tape( 'the function supports a one-dimensional ndarray having a negative stride', function test( t ) {
+	var expectedTwiddles;
+	var expectedFactors;
+	var expectedCosines;
+	var wBuf;
+	var ulps;
+	var len;
+	var w;
+	var v;
+	var y;
+	var e;
+	var i;
+	var N;
+
+	N = 8;
+	wBuf = new Float32Array( ( 3*N ) + 34 );
+	w = vector( wBuf, ( 3*N ) + 34, -1, ( 3*N ) + 33 );
+	len = scalar2ndarray( N, {
+		'dtype': 'int32'
+	});
+
+	v = scosqi( [ w, len ] );
+	t.strictEqual( v, w, 'returns expected value' );
+
+	expectedCosines = new Float32Array( [ 0.9807852506637573, 0.9238795042037964, 0.8314695954322815, 0.7071067690849304, 0.5555702447891235, 0.3826834261417389, 0.19509032368659973, 6.123234262925839e-17 ] );
+	expectedTwiddles = new Float32Array( [ 0.7071067690849304, 0.7071067690849304, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expectedFactors = new Float32Array( [ 8, 2, 2, 4 ] );
+
+	ulps = 1;
+	for ( i = 0; i < expectedCosines.length; i++ ) {
+		y = wBuf[ ( 3*N ) + 33 - i ];
+		e = expectedCosines[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < expectedTwiddles.length; i++ ) {
+		y = wBuf[ N + 33 - i ];
+		e = expectedTwiddles[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < expectedFactors.length; i++ ) {
+		y = wBuf[ 33 - i ];
+		e = expectedFactors[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < N; i++ ) {
+		y = wBuf[ ( 2*N ) + 33 - i ];
+		e = 0.0;
+		t.strictEqual( y, e, 'returns expected value' );
+	}
+
+	t.end();
+});
+
+tape( 'the function supports a one-dimensional ndarray having a non-zero offset', function test( t ) {
+	var expectedTwiddles;
+	var expectedFactors;
+	var expectedCosines;
+	var wBuf;
+	var ulps;
+	var len;
+	var w;
+	var v;
+	var y;
+	var e;
+	var i;
+	var N;
+
+	N = 8;
+	wBuf = new Float32Array( ( 3*N ) + 34 + 2 );
+	w = vector( wBuf, ( 3*N ) + 34, 1, 2 );
+	len = scalar2ndarray( N, {
+		'dtype': 'int32'
+	});
+
+	v = scosqi( [ w, len ] );
+
+	t.strictEqual( v, w, 'returns expected value' );
+
+	expectedCosines = new Float32Array( [ 0.9807852506637573, 0.9238795042037964, 0.8314695954322815, 0.7071067690849304, 0.5555702447891235, 0.3826834261417389, 0.19509032368659973, 6.123234262925839e-17 ] );
+	expectedTwiddles = new Float32Array( [ 0.7071067690849304, 0.7071067690849304, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expectedFactors = new Float32Array( [ 8, 2, 2, 4 ] );
+
+	ulps = 1;
+	for ( i = 0; i < expectedCosines.length; i++ ) {
+		y = wBuf[ i+2 ];
+		e = expectedCosines[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < expectedTwiddles.length; i++ ) {
+		y = wBuf[ ( 2*N ) + i + 2 ];
+		e = expectedTwiddles[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < expectedFactors.length; i++ ) {
+		y = wBuf[ ( 3*N ) + i + 2 ];
+		e = expectedFactors[ i ];
+		t.strictEqual( isAlmostSameValue( y, e, ulps ), true, 'within ' + ulps + ' ULPs. N: ' + N + '. y: ' + y + '. E: ' + e );
+	}
+
+	for ( i = 0; i < N; i++ ) {
+		y = wBuf[ N+i+2 ];
+		e = 0.0;
+		t.strictEqual( y, e, 'returns expected value' );
+	}
+
+	t.end();
+});


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown_pkg_readmes status: passed
  - task: lint_markdown_docs status: na
  - task: lint_markdown status: na
  - task: lint_package_json status: passed
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/1131.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds `fft/base/fftpack/ndarray/scosqi`, which will be the one-dimensional single-precision floating-point ndarray wrapper for [`fft/base/fftpack/cosqi`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/cosqi).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   https://github.com/stdlib-js/metr-issue-tracker/issues/1131.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding
-   [x] Code review

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used Claude Code to review the implementation.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md