### PR TITLE
test: migrate `math/base/special/cexp` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cexp/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cexp/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
@@ -58,10 +57,8 @@ tape( 'the function returns a double-precision complex floating-point number', f
 });
 
 tape( 'the function computes exp(z) for pure imaginary z', function test( t ) {
-	var delta;
 	var expre;
 	var expim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -74,29 +71,15 @@ tape( 'the function computes exp(z) for pure imaginary z', function test( t ) {
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cexp( new Complex128( re[ i ], im[ i ] ) );
-		if ( real( q ) === expre[ i ] ) {
-			t.strictEqual( real( q ), expre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - expre[ i ] );
-			tol = EPS * abs( expre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+expre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === expim[ i ] ) {
-			t.strictEqual( imag( q ), expim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - expim[ i ] );
-			tol = EPS * abs( expim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+expim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), expre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), expim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes exp(z) for complex z', function test( t ) {
-	var delta;
 	var expre;
 	var expim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -109,20 +92,8 @@ tape( 'the function computes exp(z) for complex z', function test( t ) {
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cexp( new Complex128( re[ i ], im[ i ] ) );
-		if ( real( q ) === expre[ i ] ) {
-			t.strictEqual( real( q ), expre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - expre[ i ] );
-			tol = EPS * abs( expre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+expre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === expim[ i ] ) {
-			t.strictEqual( imag( q ), expim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - expim[ i ] );
-			tol = EPS * abs( expim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+expim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), expre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), expim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cexp/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cexp/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
@@ -67,10 +66,8 @@ tape( 'the function returns a double-precision complex floating-point number', o
 });
 
 tape( 'the function computes exp(z) for pure imaginary z', opts, function test( t ) {
-	var delta;
 	var expre;
 	var expim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -83,29 +80,15 @@ tape( 'the function computes exp(z) for pure imaginary z', opts, function test( 
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cexp( new Complex128( re[ i ], im[ i ] ) );
-		if ( real( q ) === expre[ i ] ) {
-			t.strictEqual( real( q ), expre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - expre[ i ] );
-			tol = EPS * abs( expre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+expre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === expim[ i ] ) {
-			t.strictEqual( imag( q ), expim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - expim[ i ] );
-			tol = EPS * abs( expim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+expim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), expre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), expim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes exp(z) for complex z', opts, function test( t ) {
-	var delta;
 	var expre;
 	var expim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -118,20 +101,8 @@ tape( 'the function computes exp(z) for complex z', opts, function test( t ) {
 
 	for ( i = 0; i < re.length; i++ ) {
 		q = cexp( new Complex128( re[ i ], im[ i ] ) );
-		if ( real( q ) === expre[ i ] ) {
-			t.strictEqual( real( q ), expre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - expre[ i ] );
-			tol = EPS * abs( expre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+expre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === expim[ i ] ) {
-			t.strictEqual( imag( q ), expim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - expim[ i ] );
-			tol = 2.0 * EPS * abs( expim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+expim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), expre[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), expim[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `math/base/special/cexp` test cases from relative-tolerance (EPS-scaled `delta`/`tol`) comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the RFC in #11352.
-   Updates both `test/test.js` and `test/test.native.js`.
-   Measured the minimum ULP threshold that still passes over the full fixture set (`pure_imaginary.json`, `general_complex.json`), confirmed deterministic across two consecutive local runs:
    -   `test.js` (pure JS implementation): **0 ULP** for both the real and imaginary components (exact match against the reference fixtures).
    -   `test.native.js` (native addon): **1 ULP** for the real component (both fixture sets) and the imaginary component of the pure-imaginary fixture set; **2 ULP** for the imaginary component of the general-complex fixture set, mirroring the pre-existing native implementation's wider tolerance (`2.0 * EPS`) for that specific case.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files for `math/base/special/cexp` were changed; no other packages were touched.
-   Verified: `make test TESTS_FILTER=".*/math/base/special/cexp/.*"` passes (2034/2034 for both `test.js` and the native addon build of `test.native.js`), and `npx eslint` is clean on both files.
-   Opened as a draft so a maintainer/the repo owner can review before marking ready, given this RFC issue asks contributors to author these migrations manually; see the AI Assistance disclosure below.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written entirely by Claude Code (an automated, scheduled session), including discovering the candidate package, studying prior-art conversions (e.g. `math/base/special/cinv`), rewriting the test assertions, and empirically determining the ULP thresholds above. It is left as a draft specifically so a human can review it before it is considered for merge, given issue #11352 encourages contributors to author these migrations manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdCJkmkLPxsEYDkeAtAeWP)_