### PR TITLE
docs: fix example and description

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmean/README.md
@@ -167,7 +167,7 @@ double v = stdlib_stats_dnanmean( arrays );
 // returns 2.5
 
 // Free allocated memory:
-stdlib_ndarray_free( arr );
+stdlib_ndarray_free( x );
 ```
 
 The function accepts the following arguments:

--- a/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanpn/include/stdlib/stats/base/ndarray/dnanmeanpn.h
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/dnanmeanpn/include/stdlib/stats/base/ndarray/dnanmeanpn.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
-* Computes the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using a two-pass error correction algorithm..
+* Computes the arithmetic mean of a one-dimensional double-precision floating-point ndarray, ignoring `NaN` values and using a two-pass error correction algorithm.
 */
 double stdlib_stats_dnanmeanpn( const struct ndarray *arrays[] );
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   contains follow-up fixes for commits merged to `develop` between 2026-08-10 05:41:15 -0700 (`735a9411e`) and 2026-08-10 18:02:46 -0700 (`e45106f37`).
-   `stats/base/ndarray/dnanmean`: Fixed a copy-paste bug from e45106f: the `dnanmean` README's C API usage snippet (README.md:170) freed an undeclared `arr` instead of `x`, which wouldn't compile — brought it in line with `dnanmeanpn`/`dnanmeanors` and the package's own Examples section.
-   `stats/base/ndarray/dnanmeanpn`: Fixed a doubled period in the `stdlib_stats_dnanmeanpn` doxygen comment (`algorithm..` → `algorithm.`) introduced in 473d131c; brings `include/stdlib/stats/base/ndarray/dnanmeanpn.h:32` in line with the README, `lib/index.js`, `lib/native.js`, and `src/main.c`, which all use a single period.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed on the 30-commit window:

-   Style-guide compliance: two independent review passes comparing the changed code against `docs/style-guides` and established reference packages (`stats/base/ndarray/dmean*` for the new C addons, `blas/ext/base/ndarray/dfill-nan` for the new JS packages, sibling `array/*` packages for the float16 doc updates).
-   Bug scan: two independent passes over the union diff, including executing the new `array/min-dtype` float16 boundary logic against its test vectors, cross-diffing the three near-identical `dnanmean*` addon packages, and checking the `zaxpy` C benchmark `malloc`/`free` change for leaks. No runtime bugs found beyond the doc fixes above.
-   Deliberately excluded: anything subjective or requiring interpretation. One candidate finding (the `$ExpectType Float16Array` annotation in `array/ones-like/docs/types/test.ts`) was dropped after verifying the annotation matches actual compiler output — `onesLike`'s generic overload (`T extends TypedArray | ComplexTypedArray`, returning `T`) preserves the input class type, unlike `nansLike`'s explicit overloads typed via `@stdlib/types/array`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was produced by Claude Code running a scheduled automated review of commits merged to `develop` in the last 24 hours. The review, the fixes, and this PR text were authored by Claude Code; a human maintainer will audit before promoting from draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md