### PR TITLE
test: migrate `math/base/special/truncb` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/truncb/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/test/test.js
@@ -24,15 +24,14 @@ var tape = require( 'tape' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var trunc = require( '@stdlib/math/base/special/trunc' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var truncb = require( './../lib' );
 
 
@@ -222,8 +221,6 @@ tape( 'if `b^n` is too large and `x > 0`, the function returns `+0`', function t
 
 tape( 'the function supports rounding very small numbers (including subnormals)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;
@@ -257,13 +254,7 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = truncb( x, n[i], 10 );
-		if ( v === expected[i] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
-		} else {
-			delta = abs( v - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/truncb/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/test/test.native.js
@@ -25,15 +25,14 @@ var tape = require( 'tape' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var trunc = require( '@stdlib/math/base/special/trunc' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -188,8 +187,6 @@ tape( 'if `b^n` is too large and `x > 0`, the function returns `+0`', opts, func
 
 tape( 'the function supports rounding very small numbers (including subnormals)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var n;
 	var v;
@@ -223,13 +220,7 @@ tape( 'the function supports rounding very small numbers (including subnormals)'
 
 	for ( i = 0; i < n.length; i++ ) {
 		v = truncb( x, n[i], 10 );
-		if ( v === expected[i] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
-		} else {
-			delta = abs( v - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/truncb` from relative tolerance testing to ULP difference testing, as proposed in #11352.
-   replaces the `delta`/`tol` computation in the "very small numbers (including subnormals)" test with `isAlmostSameValue( v, expected[ i ], 1 )`, in both `test/test.js` and `test/test.native.js`.
-   adds the `@stdlib/assert/is-almost-same-value` require and removes the now unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` requires.

The ULP bound was tightened to the **measured minimum of `1` ULP** for both the JavaScript and native test files. Over the 17 subnormal fixtures, 11 cases match exactly (0 ULP) and 6 cases require exactly 1 ULP (e.g. `n = -308` returns `2.9999999999999997e-308` versus an expected `3e-308`); no case requires more than 1, so `0` would fail and `1` is the tightest passing bound. The full test file was run twice at the final bound with identical results (766 passing assertions, no failures).

This matches the bound and idiom already used by the sibling packages `math/base/special/floorb`, `math/base/special/ceilb`, and `math/base/special/truncn`, which share the identical fixture set. Note that for `b = 10` — the case exercised by this test — `truncb` delegates to `truncn` in both the JavaScript and C implementations, so the native path is expected to agree with the already-merged `truncn` native test at 1 ULP.

No implementation files were modified; the only changes are to the two test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The native tests (`test/test.native.js`) were skipped locally, as the native add-on was not built in the environment used to author this change; `npm install` could not complete because the available registry mirror had no `es-object-atoms@^1.1.2`. The JavaScript tests were run directly and pass. Please confirm the native tests in CI.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled task. The conversion mirrors the already-merged `floorb`/`ceilb`/`truncn` migrations, and the 1 ULP bound was determined empirically by measuring the minimum passing ULP difference for every fixture rather than assumed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01JrLXUTeSNAoV2Qxr1BMRsL)_