### PR TITLE
test: migrate `stats/base/dists/beta/median` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/median/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
 
@@ -96,10 +95,8 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the median of a beta distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
@@ -108,13 +105,7 @@ tape( 'the function returns the median of a beta distribution', function test( t
 	beta = data.beta;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = median( alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 15.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/beta/median` from relative tolerance testing to ULP difference testing, as proposed in #11352.
-   replaces the `delta`/`tol` computation (`tol = 15.0 * EPS * abs( expected[ i ] )`) in the fixture loop with `isAlmostSameValue( y, expected[ i ], 15 )`.
-   adds the `@stdlib/assert/is-almost-same-value` require and removes the now unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` requires.

The ULP bound was tightened to the **measured minimum of `15` ULP**. Over the full fixture set (1000 cases from `test/fixtures/julia/data.json`), the maximum observed ULP difference is exactly 15, attained at `alpha = 17.553104872605317`, `beta = 17.707711393619853`, where the implementation returns `0.4977657564823537` versus an expected `0.4977657564823529`. A bound of `14` fails that one case, so `15` is the tightest passing integer bound. The bound was found by starting at `64` and stepping down (`64` → `32` → `16` → `15` pass; `14` fails, 1 assertion). The test file was run twice at the final bound with identical results (1014 passing assertions, no failures), so the result is deterministic in this environment.

This package has no `test/test.native.js` and no native implementation, so only `test/test.js` is affected. No implementation files were modified; the only change is to the single test file.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

`make install-node-modules` could not complete in the environment used to author this change: the available registry mirror has no `es-object-atoms@^1.1.2`, which a transitive dependency requires. The package tests were therefore run with a standalone `tape` installation and `NODE_PATH` pointed at `lib/node_modules`, and the repository linter could not be run (its ESLint plugin/config chain depends on the full dev dependency tree). The changed file was checked with a reduced ESLint ruleset (unused variables, undefined references, indentation, quotes, semicolons) and is clean; the diff mirrors the idiom of the already-merged conversions in this family (e.g. `stats/base/dists/f/mode`, `stats/base/dists/lognormal/variance`, `stats/base/dists/pareto-type1/kurtosis`). Please confirm lint in CI.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled task. The conversion mirrors already-merged migrations in the same family, and the 15 ULP bound was determined empirically by measuring the minimum passing ULP difference over every fixture rather than assumed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT1k4EJXMZQLG6FfPXP8kR)_