### PR TITLE
test: migrate `math/base/special/atan2f` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/atan2f/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/atan2f/test/test.js
@@ -24,9 +24,8 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var PI = require( '@stdlib/constants/float32/pi' );
@@ -188,8 +187,6 @@ tape( 'the function returns `-PI/2` if provided a negative `y` and `x=-0`', func
 tape( 'the function evaluates the `atan2f` function (when x and y are positive)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -200,9 +197,7 @@ tape( 'the function evaluates the `atan2f` function (when x and y are positive)'
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2f( y[i], x[i] );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = 1.3 * EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -210,8 +205,6 @@ tape( 'the function evaluates the `atan2f` function (when x and y are positive)'
 tape( 'the function evaluates the `atan2f` function (when x is negative and y is positive)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -222,9 +215,7 @@ tape( 'the function evaluates the `atan2f` function (when x is negative and y is
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2f( y[i], x[i] );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -232,8 +223,6 @@ tape( 'the function evaluates the `atan2f` function (when x is negative and y is
 tape( 'the function evaluates the `atan2f` function (when x and y are negative)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -244,9 +233,7 @@ tape( 'the function evaluates the `atan2f` function (when x and y are negative)'
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2f( y[i], x[i] );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/atan2f/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/atan2f/test/test.native.js
@@ -25,9 +25,8 @@ var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var PI = require( '@stdlib/constants/float32/pi' );
@@ -197,8 +196,6 @@ tape( 'the function returns `-PI/2` if provided a negative `y` and `x=-0`', opts
 tape( 'the function evaluates the `atan2f` function (when x and y are positive)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -209,9 +206,7 @@ tape( 'the function evaluates the `atan2f` function (when x and y are positive)'
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2f( y[i], x[i] );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = 1.3 * EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -219,8 +214,6 @@ tape( 'the function evaluates the `atan2f` function (when x and y are positive)'
 tape( 'the function evaluates the `atan2f` function (when x is negative and y is positive)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -231,9 +224,7 @@ tape( 'the function evaluates the `atan2f` function (when x is negative and y is
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2f( y[i], x[i] );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -241,8 +232,6 @@ tape( 'the function evaluates the `atan2f` function (when x is negative and y is
 tape( 'the function evaluates the `atan2f` function (when x and y are negative)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -253,9 +242,7 @@ tape( 'the function evaluates the `atan2f` function (when x and y are negative)'
 	for ( i = 0; i < x.length; i++ ) {
 		actual = atan2f( y[i], x[i] );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. y: '+y[i]+'. x: '+x[i]+'. Actual: '+actual+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `math/base/special/atan2f` test cases from relative-tolerance testing to ULP (units in the last place) difference testing, per the guidance in #11352.
-   Replaces the `delta`/`tol` relative-tolerance checks in the three fixture-driven test cases (`x` and `y` both positive; `x` negative, `y` positive; `x` and `y` both negative) in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( actual, expected[ i ], N ), true, 'returns expected value' )`, using `@stdlib/number/float32/base/assert/is-almost-same-value` (matching the convention used by sibling `float32` functions such as `atanf` and `hypotf`).
-   Determines the minimum required ULP tolerance for each fixture group by computing the exact ULP difference between actual and expected values across the full fixture set: `positivePositive` → 2 ULPs (5001 cases), `negativePositive` → 1 ULP (1001 cases), `negativeNegative` → 1 ULP (1001 cases). Both `test.js` and `test.native.js` use the same bounds, mirroring the recently converted `math/base/special/atan2d` (same underlying algorithm, JS vs. native).
-   Removes the now-unused `absf`/`EPS` imports.

Verified: `node test/test.js` passes 7062/7062 assertions at the tightened bounds, run twice back-to-back with identical results (no flakiness). `npx eslint` is clean on both changed files. The native addon is not built in this environment, so `test.native.js` ULPs were set to match the JS bounds (same as the `atan2d` precedent) rather than independently measured; `test.native.js` assertions are skipped (not failed) when the addon is absent.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Test/benchmark generation

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was authored end-to-end by Claude Code, run as a scheduled/unattended task on my account. It found the candidate package, studied prior art (issue #11352 and the `atan2d` conversion), applied the ULP migration, computed the tightest ULP bounds directly from the fixtures, and verified tests/lint pass. Opened as a draft so I can review before it goes further.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxDGtL3RkuPzo2Wp3V97rB)_