### PR TITLE
test: migrate `stats/base/dists/arcsine/logcdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -133,8 +132,6 @@ tape( 'if provided a `a >= b`, the created function always returns `NaN`', funct
 tape( 'the created function evaluates the logcdf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -148,13 +145,7 @@ tape( 'the created function evaluates the logcdf for `x` given a small range `b 
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( a[i], b[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 18 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -162,8 +153,6 @@ tape( 'the created function evaluates the logcdf for `x` given a small range `b 
 tape( 'the created function evaluates the logcdf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -177,13 +166,7 @@ tape( 'the created function evaluates the logcdf for `x` given a medium range `b
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( a[i], b[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 19 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -191,8 +174,6 @@ tape( 'the created function evaluates the logcdf for `x` given a medium range `b
 tape( 'the created function evaluates the logcdf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -206,13 +187,7 @@ tape( 'the created function evaluates the logcdf for `x` given a large range `b 
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( a[i], b[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 30.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 33 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/test/test.logcdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
 
@@ -86,8 +85,6 @@ tape( 'if provided `a >= b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function evaluates the logcdf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -100,21 +97,13 @@ tape( 'the function evaluates the logcdf for `x` given a small range `b - a`', f
 	b = smallRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 18 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -127,21 +116,13 @@ tape( 'the function evaluates the logcdf for `x` given a medium range `b - a`', 
 	b = mediumRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 20.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 19 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -154,13 +135,7 @@ tape( 'the function evaluates the logcdf for `x` given a large range `b - a`', f
 	b = largeRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 30.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 33 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/arcsine/logcdf` from relative tolerance (`EPS`-scaled) comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.

Affected files: `test/test.logcdf.js` and `test/test.factory.js`. The package has no `test/test.native.js`, and `test/test.js` contains only exact export assertions and is left unchanged.

Each fixture loop of the form

```js
if ( y === expected[i] ) {
    t.strictEqual( y, expected[i], ... );
} else {
    delta = abs( y - expected[ i ] );
    tol = 20.0 * EPS * abs( expected[ i ] );
    t.ok( delta <= tol, ... );
}
```

is replaced by

```js
t.strictEqual( isAlmostSameValue( y, expected[i], <ulps> ), true, 'returns expected value' );
```

and the now-unused `abs`/`EPS` requires and `delta`/`tol` locals are removed.

**ULP bounds.** Mirroring the surrounding `stats/base/dists` conversions, each fixture group uses its own bound, tightened to the measured minimum that passes over the full fixture set (1000 values per fixture, identical for the main and factory code paths):

| Fixture | Previous tolerance | ULP bound |
| --- | --- | --- |
| `small_range.json` | `20.0 * EPS * abs( expected[i] )` | `18` |
| `medium_range.json` | `20.0 * EPS * abs( expected[i] )` | `19` |
| `large_range.json` | `30.0 * EPS * abs( expected[i] )` | `33` |

These are minimal: decrementing any of the three bounds to `17` / `18` / `32` fails exactly one assertion in each corresponding group, in both `test.logcdf.js` and `test.factory.js`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally on `linux/x64`, Node.js v22:

-   `test/test.logcdf.js` (3011 assertions), `test/test.factory.js` (3016 assertions), and `test/test.js` (3 assertions) all pass. The suite was run twice at the final bounds with identical results, to rule out FMA/arch-dependent flakiness.
-   `make eslint-tests TESTS_FILTER=".*/stats/base/dists/arcsine/logcdf/.*"` is clean.
-   Only the two test files are modified; no source, fixture, or documentation changes.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was written by Claude Code, which performed the test migration, measured the minimum ULP bounds against the fixtures, and ran the test and lint checks.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3AYP1piEzo99Hn2hKhfPa)_