### PR TITLE
test: migrate `math/base/special/factorial` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/factorial/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorial/test/test.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factorial = require( './../lib' );
 
 
@@ -103,8 +102,6 @@ tape( 'if `x < -171.56749...`, the function returns zero', function test( t ) {
 
 tape( 'the function evaluates the factorial function (positive integers < 171)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -113,13 +110,7 @@ tape( 'the function evaluates the factorial function (positive integers < 171)',
 	expected = integers.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		v = factorial( x[ i ] );
-		if ( v === expected[ i ] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided '+x[i] );
-		} else {
-			delta = abs( v - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Tolerance: ' + tol + '. Delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -136,8 +127,6 @@ tape( 'if provided positive integers greater than `170`, the function returns po
 
 tape( 'the function evaluates the factorial function (decimal values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -146,9 +135,7 @@ tape( 'the function evaluates the factorial function (decimal values)', function
 	expected = decimals.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		v = factorial( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.5 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Tolerance: ' + tol + '. Delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/factorial/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorial/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -112,8 +111,6 @@ tape( 'if `x < -171.56749...`, the function returns zero', opts, function test( 
 
 tape( 'the function evaluates the factorial function (positive integers < 171)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -122,13 +119,7 @@ tape( 'the function evaluates the factorial function (positive integers < 171)',
 	expected = integers.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		v = factorial( x[ i ] );
-		if ( v === expected[ i ] ) {
-			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided '+x[i] );
-		} else {
-			delta = abs( v - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Tolerance: ' + tol + '. Delta: ' + delta + '.' );
-		}
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -145,8 +136,6 @@ tape( 'if provided positive integers greater than `170`, the function returns po
 
 tape( 'the function evaluates the factorial function (decimal values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -155,9 +144,7 @@ tape( 'the function evaluates the factorial function (decimal values)', opts, fu
 	expected = decimals.expected;
 	for ( i = 0; i < x.length; i++ ) {
 		v = factorial( x[ i ] );
-		delta = abs( v - expected[ i ] );
-		tol = 3.5 * EPS * abs( expected[ i ] );
-		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + v + '. Expected: ' + expected[ i ] + '. Tolerance: ' + tol + '. Delta: ' + delta + '.' );
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/factorial` from relative tolerance testing to ULP difference testing, replacing the computed `delta`/`tol` comparisons with `@stdlib/assert/is-almost-same-value`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires and the associated `delta`/`tol` local variables.
-   applies the same changes to both `test/test.js` and `test/test.native.js`.

The ULP bounds were tightened to the **minimum** value which still passes over the full fixture sets:

| Fixture set | Assertion | Final ULP | Measured minimum |
| ----------- | --------- | --------- | ---------------- |
| `integers.json` (171 values) | positive integers < 171 | `1` | `1` (fails at `0`, worst case `x = 33`) |
| `decimals.json` (1003 values) | decimal values | `6` | `6` (fails at `5`, worst case `x = -26.71996007984032`) |

Note that the previous tolerances were `EPS * abs( expected )` and `3.5 * EPS * abs( expected )`, respectively, so the new bounds are of comparable tightness while being expressed in the natural floating-point accuracy unit.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification notes:

-   `test/test.js` passes (2671 assertions). The suite was run twice at the final ULP values with identical results, in order to rule out FMA/architecture-dependent flakiness.
-   Tightness was confirmed by re-running the fixture sets at `N-1`: the integer fixtures fail at `0` ULP (13 cases) and the decimal fixtures fail at `5` ULP (1 case).
-   `test/test.native.js` reports no assertions in this environment because the native add-on was not built. To avoid assuming that the C implementation matches the JavaScript implementation, the C implementation (`src/main.c` plus its transitive C dependencies) was compiled standalone and evaluated against the same fixtures. It requires **identical** bounds (`1` and `6`) with the same worst-case inputs, so the same ULP values are used in both test files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, running as an unattended scheduled task. The conversion mirrors the idiom established in previously merged migration commits, and the ULP bounds were determined empirically rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01LG6eNsViEh6xK1Ms4x2tGr)_