### PR TITLE
test: migrate `math/base/special/ccis` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ccis/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/test/test.js
@@ -21,12 +21,11 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var ccis = require( './../lib' );
@@ -60,10 +59,8 @@ tape( 'the function evaluates the cis function for a double-precision complex fl
 });
 
 tape( 'the function computes cis(z) for pure real z', function test( t ) {
-	var delta;
 	var cisre;
 	var cisim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -79,29 +76,15 @@ tape( 'the function computes cis(z) for pure real z', function test( t ) {
 		z = new Complex128( re[ i ], im[ i ] );
 		q = ccis( z );
 
-		if ( real( q ) === cisre[ i ] ) {
-			t.strictEqual( real( q ), cisre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - cisre[ i ] );
-			tol = EPS * abs( cisre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+cisre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === cisim[ i ] ) {
-			t.strictEqual( imag( q ), cisim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - cisim[ i ] );
-			tol = EPS * abs( cisim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+cisim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), cisre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), cisim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes cis(z) for complex z', function test( t ) {
-	var delta;
 	var cisre;
 	var cisim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -117,20 +100,8 @@ tape( 'the function computes cis(z) for complex z', function test( t ) {
 		z = new Complex128( re[ i ], im[ i ] );
 		q = ccis( z );
 
-		if ( real( q ) === cisre[ i ] ) {
-			t.strictEqual( real( q ), cisre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - cisre[ i ] );
-			tol = EPS * abs( cisre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+cisre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === cisim[ i ] ) {
-			t.strictEqual( imag( q ), cisim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - cisim[ i ] );
-			tol = EPS * abs( cisim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+cisim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), cisre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), cisim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/ccis/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -69,10 +68,8 @@ tape( 'the function evaluates the cis function for a double-precision complex fl
 });
 
 tape( 'the function computes cis(z) for pure real z', opts, function test( t ) {
-	var delta;
 	var cisre;
 	var cisim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -88,29 +85,15 @@ tape( 'the function computes cis(z) for pure real z', opts, function test( t ) {
 		z = new Complex128( re[ i ], im[ i ] );
 		q = ccis( z );
 
-		if ( real( q ) === cisre[ i ] ) {
-			t.strictEqual( real( q ), cisre[ i ], 'returns expected real component' );
-		} else {
-			delta = abs( real( q ) - cisre[ i ] );
-			tol = EPS * abs( cisre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+cisre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === cisim[ i ] ) {
-			t.strictEqual( imag( q ), cisim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - cisim[ i ] );
-			tol = EPS * abs( cisim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+cisim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), cisre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), cisim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes cis(z) for complex z', opts, function test( t ) {
-	var delta;
 	var cisre;
 	var cisim;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -126,21 +109,8 @@ tape( 'the function computes cis(z) for complex z', opts, function test( t ) {
 		z = new Complex128( re[ i ], im[ i ] );
 		q = ccis( z );
 
-		if ( real( q ) === cisre[ i ] ) {
-			t.strictEqual( real( q ), cisre[ i ], 'returns expected real component' );
-		} else {
-			// NOTE: the results may differ slightly from the reference and JavaScript implementations due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
-			delta = abs( real( q ) - cisre[ i ] );
-			tol = 1.05 * EPS * abs( cisre[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. real: '+real( q )+'. expected: '+cisre[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-		if ( imag( q ) === cisim[ i ] ) {
-			t.strictEqual( imag( q ), cisim[ i ], 'returns expected imaginary component' );
-		} else {
-			delta = abs( imag( q ) - cisim[ i ] );
-			tol = EPS * abs( cisim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. z: '+re[i]+'+ '+im[i]+'i. imag: '+imag( q )+'. expected: '+cisim[i]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( q ), cisre[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( q ), cisim[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates `math/base/special/ccis` test cases from relative-tolerance (EPS-scaled `delta`/`tol`) comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the RFC in #11352.
-   Updates both `test/test.js` and `test/test.native.js`.
-   Measured the minimum ULP threshold that still passes over the full fixture set (`pure_real.json`, `general_complex.json`), confirmed deterministic across three consecutive local runs (including a build of the native addon via `node-gyp`):
    -   `test.js` (pure JS implementation): **0 ULP** for both the real and imaginary components, across both fixture sets (exact bit-for-bit match against the reference fixtures).
    -   `test.native.js` (native addon): **0 ULP** for both the real and imaginary components, across both fixture sets (also an exact match).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files for `math/base/special/ccis` were changed; no other packages were touched.
-   Verified: `make test TESTS_FILTER=".*/math/base/special/ccis/.*"` passes (2018/2018 for both `test.js` and the native addon build of `test.native.js`), run three times to confirm determinism, and `make eslint-tests TESTS_FILTER=".*/math/base/special/ccis/.*"` (the repo's test-specific ESLint config) is clean on both files.
-   Studied prior-art conversions of similar complex-valued packages (e.g. `math/base/special/cexp`, and the reference commit 121f2c0 linked from the RFC) to mirror the exact idiom, including using literal per-assertion ULP values (rather than a single named constant) since that matches the convention used across all merged conversions in this codebase to date.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written entirely by Claude Code (an automated, unattended session), including discovering the candidate package, checking for collisions with existing/prior ULP-migration PRs, studying prior-art conversions (e.g. `math/base/special/cexp`), rewriting the test assertions, building the native addon locally to measure the native-implementation ULP threshold empirically, and verifying determinism across repeated runs. It is left as a draft specifically so a human can review it before it is considered for merge, given issue #11352 encourages contributors to author these migrations manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbM6Q1gTrvGXht6CDLCTrg)_