### PR TITLE
test: migrate `stats/base/dists/negative-binomial/logpmf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/logpmf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/logpmf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -175,8 +174,6 @@ tape( 'if provided a `r` which is not a positive number, the created function al
 tape( 'the created function evaluates the logpmf for `x` given large `r` and `p`', function test( t ) {
 	var expected;
 	var logpmf;
-	var delta;
-	var tol;
 	var x;
 	var r;
 	var p;
@@ -190,13 +187,7 @@ tape( 'the created function evaluates the logpmf for `x` given large `r` and `p`
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( r[i], p[i] );
 		y = logpmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 109 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -204,8 +195,6 @@ tape( 'the created function evaluates the logpmf for `x` given large `r` and `p`
 tape( 'the created function evaluates the logpmf for `x` given a large parameter `r` and small `p`', function test( t ) {
 	var expected;
 	var logpmf;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -219,13 +208,7 @@ tape( 'the created function evaluates the logpmf for `x` given a large parameter
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( r[i], p[i] );
 		y = logpmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 9 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -233,8 +216,6 @@ tape( 'the created function evaluates the logpmf for `x` given a large parameter
 tape( 'the created function evaluates the logpmf for `x` given small `r` and large parameter `p`', function test( t ) {
 	var expected;
 	var logpmf;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -248,13 +229,7 @@ tape( 'the created function evaluates the logpmf for `x` given small `r` and lar
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( r[i], p[i] );
 		y = logpmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 40.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 57 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -262,8 +237,6 @@ tape( 'the created function evaluates the logpmf for `x` given small `r` and lar
 tape( 'the created function evaluates the logpmf for `x` given small `r` and `p`', function test( t ) {
 	var expected;
 	var logpmf;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -277,13 +250,7 @@ tape( 'the created function evaluates the logpmf for `x` given small `r` and `p`
 	for ( i = 0; i < x.length; i++ ) {
 		logpmf = factory( r[i], p[i] );
 		y = logpmf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/logpmf/test/test.logpmf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/logpmf/test/test.logpmf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logpmf = require( './../lib' );
 
 
@@ -122,8 +121,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function evaluates the logpmf for `x` given large `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -136,21 +133,13 @@ tape( 'the function evaluates the logpmf for `x` given large `r` and `p`', funct
 	p = highHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 109 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpmf for `x` given large parameter `r` and small `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -163,21 +152,13 @@ tape( 'the function evaluates the logpmf for `x` given large parameter `r` and s
 	p = highSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 9 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpmf for `x` given small `r` and large `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -190,21 +171,13 @@ tape( 'the function evaluates the logpmf for `x` given small `r` and large `p`',
 	p = smallHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 40.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 57 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logpmf for `x` given small `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -217,13 +190,7 @@ tape( 'the function evaluates the logpmf for `x` given small `r` and `p`', funct
 	p = smallSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpmf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 6 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/negative-binomial/logpmf` from relative tolerance testing to ULP difference testing, replacing the computed `delta`/`tol` comparisons with `@stdlib/assert/is-almost-same-value`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires and the associated `delta`/`tol` local variables.
-   applies the same changes to both `test/test.factory.js` and `test/test.logpmf.js` (`test/test.js` only asserts exports and required no changes).

The ULP bounds were tightened to the **minimum** value which still passes over the full fixture sets (each fixture set contains 1000 values, and the `factory` and main entry points require identical bounds):

| Fixture set | Assertion | Previous tolerance | Final ULP | Measured minimum |
| ----------- | --------- | ------------------ | --------- | ---------------- |
| `small_small.json` | small `r` and `p` | `10.0 * EPS * abs( expected )` | `6` | `6` (fails at `5`; worst case `x = 13`, `r = 9`, `p = 0.135318550619653`) |
| `small_high.json` | small `r`, large `p` | `40.0 * EPS * abs( expected )` | `57` | `57` (fails at `56`; worst case `x = 0`, `r = 8`, `p = 0.9868792801820985`) |
| `high_small.json` | large `r`, small `p` | `10.0 * EPS * abs( expected )` | `9` | `9` (fails at `8`; worst case `x = 39`, `r = 14`, `p = 0.12604764008592798`) |
| `high_high.json` | large `r` and `p` | `80.0 * EPS * abs( expected )` | `109` | `109` (fails at `108`; worst case `x = 1`, `r = 93`, `p = 0.8327586644536866`) |

The larger bounds correspond to fixtures whose expected values are log-probabilities close to zero, where the relative tolerance expressed in ULPs is necessarily looser.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification notes:

-   `make test TESTS_FILTER=".*/stats/base/dists/negative-binomial/logpmf/.*"` passes: 4026 assertions in `test/test.factory.js`, 4020 in `test/test.logpmf.js`, and 3 in `test/test.js`, with no failures. The suite was run twice at the final ULP values with identical results, in order to rule out FMA/architecture-dependent flakiness.
-   Tightness was confirmed by re-evaluating every fixture set at `N-1` ULP; each set fails at `N-1`, so none of the four bounds can be lowered further.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/negative-binomial/logpmf/.*"` is clean.
-   The package has no native implementation, so there is no `test/test.native.js` to update.
-   Only the two test files are changed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, running as an unattended scheduled task. The conversion mirrors the idiom established in previously merged migration commits, and the ULP bounds were determined empirically rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqbmGdvGjziBtU3pQnBwDi)_