### PR TITLE
style: add missing spaces

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ccopy-within/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ccopy-within/docs/types/index.d.ts
@@ -45,17 +45,17 @@ import { typedndarray, complex64ndarray } from '@stdlib/types/ndarray';
 *
 * var x = new Complex64Vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 * var target = scalar2ndarray( 1, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 * var start = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 * var end = scalar2ndarray( 2, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var w = zeros( [ 3 ], {
-*    'dtype': 'complex64'
+*     'dtype': 'complex64'
 * });
 *
 * var out = ccopyWithin( [ x, target, start, end, w ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/zcopy-within/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/zcopy-within/docs/types/index.d.ts
@@ -45,17 +45,17 @@ import { typedndarray, complex128ndarray } from '@stdlib/types/ndarray';
 *
 * var x = new Complex128Vector( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 * var target = scalar2ndarray( 1, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 * var start = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 * var end = scalar2ndarray( 2, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var w = zeros( [ 3 ], {
-*    'dtype': 'complex128'
+*     'dtype': 'complex128'
 * });
 *
 * var out = zcopyWithin( [ x, target, start, end, w ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/test/test.factory.js
@@ -145,7 +145,7 @@ tape( 'the created function evaluates the logcdf for `x` given a small range `b 
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( a[i], b[i] );
 		y = logcdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 18 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 18 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -166,7 +166,7 @@ tape( 'the created function evaluates the logcdf for `x` given a medium range `b
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( a[i], b[i] );
 		y = logcdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 19 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 19 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -187,7 +187,7 @@ tape( 'the created function evaluates the logcdf for `x` given a large range `b 
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( a[i], b[i] );
 		y = logcdf( x[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 33 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 33 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/test/test.logcdf.js
@@ -97,7 +97,7 @@ tape( 'the function evaluates the logcdf for `x` given a small range `b - a`', f
 	b = smallRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 18 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 18 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -116,7 +116,7 @@ tape( 'the function evaluates the logcdf for `x` given a medium range `b - a`', 
 	b = mediumRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 19 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 19 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -135,7 +135,7 @@ tape( 'the function evaluates the logcdf for `x` given a large range `b - a`', f
 	b = largeRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], a[i], b[i] );
-		t.strictEqual( isAlmostSameValue( y, expected[i], 33 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 33 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-08-11 16:39 PT (`99b2dea`) and 2026-08-12 01:35 PT (`6e66cf0`).

This pull request:

-   `blas/ext/base/ndarray/ccopy-within`: fix indentation in `blas/ext/base/ndarray/ccopy-within`'s `.d.ts` `@example` blocks: the `'dtype'` lines are 4-space indented, one space short of the repo convention — same issue already fixed at the namespace level in 7026843, just missed here (from ba1e337). Re-indents the 4 lines to 5 spaces to match `scopy-within` and sibling packages.
-   `blas/ext/base/ndarray/zcopy-within`: fix `zcopy-within` types example indentation to 5 spaces; `blas/ext/base/ndarray/zcopy-within/docs/types/index.d.ts` (`'dtype'` lines) missed the 5-space convention applied to the namespace declarations in 7026843 (from 6dbb82e). Re-indents all four occurrences to match `scopy-within` and the rest of the tree.
-   `stats/base/dists/arcsine/logcdf`: fix `expected[i]` → `expected[ i ]` in the six lines added by 99b2dea for the arcsine `logcdf` ULP migration, in `test/test.factory.js` and `test/test.logcdf.js` (3 lines each); leaves the untouched unspaced lines alone, matching every other ULP migration in this window.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation performed on the 40-commit window:

-   Style guide compliance audit (two independent passes) of all hand-written changes against `docs/style-guides` and established sibling packages (new `blas/ext/base/ndarray` packages compared against `scopy-within`, `dfill-equal`, `sfirst-index-equal`, `dindex-of-falsy`, etc.).
-   Bug scan (two independent passes) over the introduced code: loop bounds, stride/offset arithmetic, boundary normalization, dtype copy-paste slips, doc example outputs, and test assertions. No bugs found.
-   Deliberately excluded: subjective concerns, style preferences not required by the style guide, anything requiring interpretation, and anything whose validation or fix would require touching code outside the window's diff (e.g. pre-existing unspaced array indices on lines not modified in the window).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of a scheduled automated review of commits recently merged to `develop`; all fixes were machine-proposed, cross-verified against the style guide and sibling packages, and are pending human audit (hence the draft state).

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013h4HJcwR26t7SJGpuzB7rt

---
_Generated by [Claude Code](https://claude.ai/code/session_013h4HJcwR26t7SJGpuzB7rt)_