### PR TITLE
docs: fix description and add missing spaces

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/eps/include/stdlib/constants/float32/eps.h
+++ b/lib/node_modules/@stdlib/constants/float32/eps/include/stdlib/constants/float32/eps.h
@@ -20,7 +20,7 @@
 #define STDLIB_CONSTANTS_FLOAT32_EPS_H
 
 /**
-* Macro for the difference between one and the smallest value greater than one that can be represented as a single-precision floating-point number..
+* Macro for the difference between one and the smallest value greater than one that can be represented as a single-precision floating-point number.
 */
 #define STDLIB_CONSTANT_FLOAT32_EPS 1.1920928955078125e-7f
 

--- a/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/broadcast-scalar-like/docs/types/index.d.ts
@@ -223,7 +223,7 @@ declare function broadcastScalarLike( x: float64ndarray, value: number, options?
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 * // returns <ndarray>
 */
@@ -241,7 +241,7 @@ declare function broadcastScalarLike( x: ndarray, value: number, options: Float6
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'float32'
+*     'dtype': 'float32'
 * });
 * // returns <ndarray>
 *
@@ -265,7 +265,7 @@ declare function broadcastScalarLike( x: float32ndarray, value: number, options?
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'float32'
+*     'dtype': 'float32'
 * });
 * // returns <ndarray>
 */
@@ -283,7 +283,7 @@ declare function broadcastScalarLike( x: ndarray, value: number, options: Float3
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'complex128'
+*     'dtype': 'complex128'
 * });
 * // returns <ndarray>
 *
@@ -307,7 +307,7 @@ declare function broadcastScalarLike( x: complex128ndarray, value: number | Comp
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'complex128'
+*     'dtype': 'complex128'
 * });
 * // returns <ndarray>
 */
@@ -325,7 +325,7 @@ declare function broadcastScalarLike( x: ndarray, value: number | ComplexLike, o
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'complex64'
+*     'dtype': 'complex64'
 * });
 * // returns <ndarray>
 *
@@ -349,7 +349,7 @@ declare function broadcastScalarLike( x: complex64ndarray, value: number | Compl
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'complex64'
+*     'dtype': 'complex64'
 * });
 * // returns <ndarray>
 */
@@ -367,7 +367,7 @@ declare function broadcastScalarLike( x: ndarray, value: number | ComplexLike, o
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'bool'
+*     'dtype': 'bool'
 * });
 * // returns <ndarray>
 *
@@ -391,7 +391,7 @@ declare function broadcastScalarLike( x: boolndarray, value: boolean, options?: 
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, true, {
-*    'dtype': 'bool'
+*     'dtype': 'bool'
 * });
 * // returns <ndarray>
 */
@@ -409,7 +409,7 @@ declare function broadcastScalarLike( x: ndarray, value: boolean, options: BoolO
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'int32'
+*     'dtype': 'int32'
 * });
 * // returns <ndarray>
 *
@@ -433,7 +433,7 @@ declare function broadcastScalarLike( x: int32ndarray, value: number, options?: 
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'int32'
+*     'dtype': 'int32'
 * });
 * // returns <ndarray>
 */
@@ -451,7 +451,7 @@ declare function broadcastScalarLike( x: ndarray, value: number, options: Int32O
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'int16'
+*     'dtype': 'int16'
 * });
 * // returns <ndarray>
 *
@@ -475,7 +475,7 @@ declare function broadcastScalarLike( x: int16ndarray, value: number, options?: 
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'int16'
+*     'dtype': 'int16'
 * });
 * // returns <ndarray>
 */
@@ -493,7 +493,7 @@ declare function broadcastScalarLike( x: ndarray, value: number, options: Int16O
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'int8'
+*     'dtype': 'int8'
 * });
 * // returns <ndarray>
 *
@@ -517,7 +517,7 @@ declare function broadcastScalarLike( x: int8ndarray, value: number, options?: B
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'int8'
+*     'dtype': 'int8'
 * });
 * // returns <ndarray>
 */
@@ -535,7 +535,7 @@ declare function broadcastScalarLike( x: ndarray, value: number, options: Int8Op
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'uint32'
+*     'dtype': 'uint32'
 * });
 * // returns <ndarray>
 *
@@ -559,7 +559,7 @@ declare function broadcastScalarLike( x: uint32ndarray, value: number, options?:
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'uint32'
+*     'dtype': 'uint32'
 * });
 * // returns <ndarray>
 */
@@ -577,7 +577,7 @@ declare function broadcastScalarLike( x: ndarray, value: number, options: Uint32
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'uint16'
+*     'dtype': 'uint16'
 * });
 * // returns <ndarray>
 *
@@ -601,7 +601,7 @@ declare function broadcastScalarLike( x: uint16ndarray, value: number, options?:
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'uint16'
+*     'dtype': 'uint16'
 * });
 * // returns <ndarray>
 */
@@ -619,7 +619,7 @@ declare function broadcastScalarLike( x: ndarray, value: number, options: Uint16
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'uint8'
+*     'dtype': 'uint8'
 * });
 * // returns <ndarray>
 *
@@ -643,7 +643,7 @@ declare function broadcastScalarLike( x: uint8ndarray, value: number, options?: 
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'uint8'
+*     'dtype': 'uint8'
 * });
 * // returns <ndarray>
 */
@@ -661,7 +661,7 @@ declare function broadcastScalarLike( x: ndarray, value: number, options: Uint8O
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'uint8c'
+*     'dtype': 'uint8c'
 * });
 * // returns <ndarray>
 *
@@ -685,7 +685,7 @@ declare function broadcastScalarLike( x: uint8cndarray, value: number, options?:
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'uint8c'
+*     'dtype': 'uint8c'
 * });
 * // returns <ndarray>
 */
@@ -703,7 +703,7 @@ declare function broadcastScalarLike( x: ndarray, value: number, options: Uint8c
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 * // returns <ndarray>
 *
@@ -727,7 +727,7 @@ declare function broadcastScalarLike<T = unknown>( x: genericndarray<any>, value
 * // returns <ndarray>
 *
 * var out = broadcastScalarLike( x, 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 * // returns <ndarray>
 */
@@ -745,7 +745,7 @@ declare function broadcastScalarLike<T = unknown>( x: ndarray, value: T, options
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2, 2 ], {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 * // returns <ndarray>
 *

--- a/lib/node_modules/@stdlib/ndarray/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/docs/types/index.d.ts
@@ -554,7 +554,7 @@ interface Namespace {
 	* var empty = require( '@stdlib/ndarray/empty' );
 	*
 	* var x = empty( [ 2, 2 ], {
-	*    'dtype': 'generic'
+	*     'dtype': 'generic'
 	* });
 	* // returns <ndarray>
 	*

--- a/lib/node_modules/@stdlib/ndarray/find-last/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/find-last/docs/types/index.d.ts
@@ -173,7 +173,7 @@ interface FindLast {
 	* var x = new ndarray( 'float64', xbuf, sh, sx, ox, 'row-major' );
 	*
 	* var opts = {
-	*    'dims': [ 0 ]
+	*     'dims': [ 0 ]
 	* };
 	*
 	* // Perform the operation:

--- a/lib/node_modules/@stdlib/ndarray/find/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/find/docs/types/index.d.ts
@@ -176,7 +176,7 @@ interface Find {
 	* var x = new ndarray( 'float64', xbuf, sh, sx, ox, 'row-major' );
 	*
 	* var opts = {
-	*    'dims': [ 0 ]
+	*     'dims': [ 0 ]
 	* };
 	*
 	* // Perform the operation:

--- a/lib/node_modules/@stdlib/ndarray/from-scalar-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/from-scalar-like/docs/types/index.d.ts
@@ -222,7 +222,7 @@ declare function scalar2ndarrayLike( x: float64ndarray, value: number, options?:
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 * // returns <ndarray>[ 1.0 ]
 *
@@ -248,7 +248,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number, options: Float64
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'float32'
+*     'dtype': 'float32'
 * });
 * // returns <ndarray>
 *
@@ -280,7 +280,7 @@ declare function scalar2ndarrayLike( x: float32ndarray, value: number, options?:
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'float32'
+*     'dtype': 'float32'
 * });
 * // returns <ndarray>[ 1.0 ]
 *
@@ -306,7 +306,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number, options: Float32
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'complex128'
+*     'dtype': 'complex128'
 * });
 * // returns <ndarray>
 *
@@ -338,7 +338,7 @@ declare function scalar2ndarrayLike( x: complex128ndarray, value: number | Compl
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'complex128'
+*     'dtype': 'complex128'
 * });
 * // returns <ndarray>[ <Complex128>[ 1.0, 0.0 ] ]
 *
@@ -364,7 +364,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number | ComplexLike, op
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'complex64'
+*     'dtype': 'complex64'
 * });
 * // returns <ndarray>
 *
@@ -396,7 +396,7 @@ declare function scalar2ndarrayLike( x: complex64ndarray, value: number | Comple
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'complex64'
+*     'dtype': 'complex64'
 * });
 * // returns <ndarray>[ <Complex64>[ 1.0, 0.0 ] ]
 *
@@ -422,7 +422,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number | ComplexLike, op
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'bool'
+*     'dtype': 'bool'
 * });
 * // returns <ndarray>
 *
@@ -454,7 +454,7 @@ declare function scalar2ndarrayLike( x: boolndarray, value: boolean, options?: B
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, true, {
-*    'dtype': 'bool'
+*     'dtype': 'bool'
 * });
 * // returns <ndarray>[ true ]
 *
@@ -480,7 +480,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: boolean, options: BoolOp
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'int32'
+*     'dtype': 'int32'
 * });
 * // returns <ndarray>
 *
@@ -512,7 +512,7 @@ declare function scalar2ndarrayLike( x: int32ndarray, value: number, options?: B
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'int32'
+*     'dtype': 'int32'
 * });
 * // returns <ndarray>[ 1 ]
 *
@@ -538,7 +538,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number, options: Int32Op
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'int16'
+*     'dtype': 'int16'
 * });
 * // returns <ndarray>
 *
@@ -570,7 +570,7 @@ declare function scalar2ndarrayLike( x: int16ndarray, value: number, options?: B
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'int16'
+*     'dtype': 'int16'
 * });
 * // returns <ndarray>[ 1 ]
 *
@@ -596,7 +596,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number, options: Int16Op
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'int8'
+*     'dtype': 'int8'
 * });
 * // returns <ndarray>
 *
@@ -628,7 +628,7 @@ declare function scalar2ndarrayLike( x: int8ndarray, value: number, options?: Ba
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'int8'
+*     'dtype': 'int8'
 * });
 * // returns <ndarray>[ 1 ]
 *
@@ -654,7 +654,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number, options: Int8Opt
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'uint32'
+*     'dtype': 'uint32'
 * });
 * // returns <ndarray>
 *
@@ -686,7 +686,7 @@ declare function scalar2ndarrayLike( x: uint32ndarray, value: number, options?: 
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'uint32'
+*     'dtype': 'uint32'
 * });
 * // returns <ndarray>[ 1 ]
 *
@@ -712,7 +712,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number, options: Uint32O
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'uint16'
+*     'dtype': 'uint16'
 * });
 * // returns <ndarray>
 *
@@ -744,7 +744,7 @@ declare function scalar2ndarrayLike( x: uint16ndarray, value: number, options?: 
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'uint16'
+*     'dtype': 'uint16'
 * });
 * // returns <ndarray>[ 1 ]
 *
@@ -770,7 +770,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number, options: Uint16O
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'uint8'
+*     'dtype': 'uint8'
 * });
 * // returns <ndarray>
 *
@@ -802,7 +802,7 @@ declare function scalar2ndarrayLike( x: uint8ndarray, value: number, options?: B
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'uint8'
+*     'dtype': 'uint8'
 * });
 * // returns <ndarray>[ 1 ]
 *
@@ -828,7 +828,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number, options: Uint8Op
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'uint8c'
+*     'dtype': 'uint8c'
 * });
 * // returns <ndarray>
 *
@@ -860,7 +860,7 @@ declare function scalar2ndarrayLike( x: uint8cndarray, value: number, options?: 
 * // returns <ndarray>
 *
 * var out = scalar2ndarrayLike( x, 1.0, {
-*    'dtype': 'uint8c'
+*     'dtype': 'uint8c'
 * });
 * // returns <ndarray>[ 1 ]
 *
@@ -886,7 +886,7 @@ declare function scalar2ndarrayLike( x: ndarray, value: number, options: Uint8cO
 * var empty = require( '@stdlib/ndarray/empty' );
 *
 * var x = empty( [ 2 ], {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 * // returns <ndarray>
 *

--- a/lib/node_modules/@stdlib/string/first/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/first/docs/types/index.d.ts
@@ -52,7 +52,7 @@ interface Options {
 *
 * @example
 * var out = first( '🐶🐮🐷🐰🐸', 2, {
-*    'mode': 'grapheme'
+*     'mode': 'grapheme'
 * });
 * // returns '🐶🐮'
 */
@@ -73,7 +73,7 @@ declare function first( str: string, n: number, options?: Options ): string;
 *
 * @example
 * var out = first( '🐶🐮🐷🐰🐸', {
-*    'mode': 'grapheme'
+*     'mode': 'grapheme'
 * });
 * // returns '🐶'
 */

--- a/lib/node_modules/@stdlib/string/last/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/last/docs/types/index.d.ts
@@ -52,7 +52,7 @@ interface Options {
 *
 * @example
 * var out = last( '🐶🐮🐷🐰🐸', 2, {
-*    'mode': 'grapheme'
+*     'mode': 'grapheme'
 * });
 * // returns '🐰🐸'
 */
@@ -73,7 +73,7 @@ declare function last( str: string, n: number, options?: Options ): string;
 *
 * @example
 * var out = last( '🐶🐮🐷🐰🐸', {
-*    'mode': 'grapheme'
+*     'mode': 'grapheme'
 * });
 * // returns '🐸'
 */


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-08-11 and 2026-08-12 to sibling packages with the same defects.

**Doubled period in C header doc comment** (source: 10f021cc6)

Removes a doubled sentence-ending period from the C header doc comment in `@stdlib/constants/float32/eps` (`include/stdlib/constants/float32/eps.h`, line 23), which read "...floating-point number.." — the float64 sibling header already uses a single period. Found via a repo-wide scan for the same defect fixed in 10f021cc6, which corrected an identical doubled period in the `@stdlib/stats/base/ndarray/dnanmeanpn` header. No functional change; doc comment only.

**JSDoc example indentation in TypeScript declaration files** (sources: cb9723af6, 7026843ac)

Fixes JSDoc example indentation in TypeScript declaration files, propagating the correction from cb9723af6 and 7026843ac (merged to develop 2026-08-11), which fixed object-literal option keys indented four spaces after the comment asterisk instead of the conventional five (e.g. `*    'dtype': 'generic'` → `*     'dtype': 'generic'`). A repo-wide scan turned up the same defect in seven remaining declaration files; this corrects all 57 lines. The `@stdlib/ndarray` namespace declaration is generated by `_tools/scripts/create_namespace_types.js` from sub-package declarations, and its one affected line derives from `ndarray/broadcast-scalar-like`, fixed in this same commit, so the manual edit matches what the next regeneration will emit. Two remaining instances, in `blas/ext/base/ndarray/ccopy-within` and `zcopy-within`, are intentionally excluded — already fixed by open PR #14201.

-   `@stdlib/ndarray` (namespace declarations, 1 line)
-   `@stdlib/ndarray/find` (1 line)
-   `@stdlib/ndarray/find-last` (1 line)
-   `@stdlib/ndarray/broadcast-scalar-like` (26 lines)
-   `@stdlib/ndarray/from-scalar-like` (24 lines)
-   `@stdlib/string/first` (2 lines)
-   `@stdlib/string/last` (2 lines)

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

Validation performed:

-   Pattern signatures were scanned repo-wide (`rg` over `*.h` for doubled periods; over `**/docs/types/index.d.ts` for four-space option-key indentation, where 761 files use the five-space form).
-   Each candidate site was independently verified by two full-file review passes, a verbatim-applicability pass, and a style-consistency pass against `docs/style-guides` and sibling packages fixed by the source commits.
-   Deliberately excluded: `blas/ext/base/ndarray/ccopy-within`/`zcopy-within` (covered by open PR #14201); four-space `@example` function-body lines in `ndarray/docs/types/index.d.ts` deriving from `ndarray/count-if` (different construct — fix belongs in `count-if` at source); `..`-terminated inline `//` comments in `.js` files (different context from doc comments).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated routine which propagates recently merged fixes to sibling packages. Candidate sites were located by pattern search and validated by independent review passes against the source commits and repository conventions.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpNMgm5XwGLrxHLQK1oVg)_