### PR TITLE
test: migrate `math/base/special/beta` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/beta/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/beta/test/test.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isInfinite = require( '@stdlib/math/base/assert/is-infinite' );
-var isnan = require( '@stdlib/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var beta = require( './../lib' );
 
 
@@ -99,27 +98,19 @@ tape( 'the function evaluates the beta function (tested against R)', function te
 		y2 = isnan( expected1[ i ] );
 		t.strictEqual( y1, y2, 'returned result is ' + ( (y1) ? '' : 'not' ) + ' NaN' );
 		if ( !y1 ) {
-			t.ok( abs( actual - expected1[ i ] ) < 8e-15, 'returned result is within tolerance. actual: ' + actual + '; expected: ' + expected1[ i ] + '.' );
+			t.strictEqual( isAlmostSameValue( actual, expected1[ i ], 1523 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the beta function (tested against Boost)', function test( t ) {
-	var delta;
-	var tol;
 	var i;
 	var y;
 
 	for ( i = 0; i < a2.length; i++ ) {
 		y = beta( a2[i], b2[i] );
-		if ( y === expected2[i] ) {
-			t.strictEqual( y, expected2[i], 'y: '+y+'. a: '+a2[i]+'. b: '+b2[i]+', expected: '+expected2[i] );
-		} else {
-			delta = abs( y - expected2[ i ] );
-			tol = 160.0 * EPS * abs( expected2[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a2[i]+'. b: '+b2[i]+'. y: '+y+'. E: '+expected2[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected2[ i ], 267 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/beta/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/beta/test/test.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isInfinite = require( '@stdlib/math/base/assert/is-infinite' );
-var isnan = require( '@stdlib/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -108,27 +107,19 @@ tape( 'the function evaluates the beta function (tested against R)', opts, funct
 		y2 = isnan( expected1[ i ] );
 		t.strictEqual( y1, y2, 'returned result is ' + ( (y1) ? '' : 'not' ) + ' NaN' );
 		if ( !y1 ) {
-			t.ok( abs( actual - expected1[ i ] ) < 8e-15, 'returned result is within tolerance. actual: ' + actual + '; expected: ' + expected1[ i ] + '.' );
+			t.strictEqual( isAlmostSameValue( actual, expected1[ i ], 1523 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the beta function (tested against Boost)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var i;
 	var y;
 
 	for ( i = 0; i < a2.length; i++ ) {
 		y = beta( a2[i], b2[i] );
-		if ( y === expected2[i] ) {
-			t.strictEqual( y, expected2[i], 'y: '+y+'. a: '+a2[i]+'. b: '+b2[i]+', expected: '+expected2[i] );
-		} else {
-			delta = abs( y - expected2[ i ] );
-			tol = 160.0 * EPS * abs( expected2[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a2[i]+'. b: '+b2[i]+'. y: '+y+'. E: '+expected2[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected2[ i ], 267 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/beta` from computed relative tolerance (`EPS`-scaled `delta <= tol`) and absolute tolerance checks to ULP-based assertions;
-   replaces the `@stdlib/math/base/special/abs` require with `@stdlib/assert/is-almost-same-value`, and corrects the invalid `@stdlib/assert/is-nan` require path to `@stdlib/math/base/assert/is-nan`. (The `EPS` constant is removed as it is no longer required);
-   both `test/test.js` and `test/test.native.js` are modified to use the new ULP assertions.

**ULP bounds** (one per fixture set, each tightened to the measured minimum):

| fixture set | previous tolerance | ULP bound |
| ----------- | ------------------ | --------- |
| `R` | `8e-15` (absolute) | `1523` |
| `Boost` | `160.0 * EPS` | `267` |

Each bound is the smallest non-negative integer for which every fixture in the corresponding set passes. Starting from a high bound and lowering, the suite passes at the values above, and decrementing each bound by one produces exactly one failure per set, confirming that no bound can be tightened further. 

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
