### PR TITLE
test: migrate `stats/base/dists/gamma/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -199,10 +198,8 @@ tape( 'if `alpha` equals `0`, the created function evaluates a degenerate distri
 tape( 'the created function evaluates the pdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -214,13 +211,7 @@ tape( 'the created function evaluates the pdf for `x` given large `alpha` and `b
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[i], beta[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 170.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 275 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -228,10 +219,8 @@ tape( 'the created function evaluates the pdf for `x` given large `alpha` and `b
 tape( 'the created function evaluates the pdf for `x` given a large shape parameter `alpha`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -243,13 +232,7 @@ tape( 'the created function evaluates the pdf for `x` given a large shape parame
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[i], beta[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 140.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 168 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -257,10 +240,8 @@ tape( 'the created function evaluates the pdf for `x` given a large shape parame
 tape( 'the created function evaluates the pdf for `x` given a large rate parameter `beta`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
 	var pdf;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -272,13 +253,7 @@ tape( 'the created function evaluates the pdf for `x` given a large rate paramet
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( alpha[i], beta[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 120.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 208 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -153,9 +152,7 @@ tape( 'if `alpha` equals `0`, the function evaluates a degenerate distribution c
 tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -166,13 +163,7 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', o
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 170.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 275 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -180,9 +171,7 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', o
 tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -193,13 +182,7 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 140.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 168 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -207,9 +190,7 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha
 tape( 'the function evaluates the pdf for `x` given large rate parameter `beta`', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -220,13 +201,7 @@ tape( 'the function evaluates the pdf for `x` given large rate parameter `beta`'
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 120.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 208 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -144,9 +143,7 @@ tape( 'if `alpha` equals `0`, the function evaluates a degenerate distribution c
 tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -157,13 +154,7 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', f
 	beta = bothLarge.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 170.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 275 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -171,9 +162,7 @@ tape( 'the function evaluates the pdf for `x` given large `alpha` and `beta`', f
 tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -184,13 +173,7 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha
 	beta = largeShape.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 140.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 168 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -198,9 +181,7 @@ tape( 'the function evaluates the pdf for `x` given large shape parameter `alpha
 tape( 'the function evaluates the pdf for `x` given large rate parameter `beta`', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
 	var beta;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -211,13 +192,7 @@ tape( 'the function evaluates the pdf for `x` given large rate parameter `beta`'
 	beta = largeRate.beta;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], alpha[i], beta[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', alpha: '+alpha[i]+', beta: '+beta[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 120.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. alpha: '+alpha[i]+'. beta: '+beta[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 208 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/gamma/pdf` from relative tolerance testing (`delta = abs( y - expected[i] )`, `tol = 170.0 * EPS * abs( expected[i] )`, `t.ok( delta <= tol, ... )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js`, which mirror one another. `test/test.js` only asserts the shape of the exported API and contains no tolerance comparisons, so it is left untouched.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports from the three updated test files, as `abs` and `EPS` are not used anywhere else in those files.

The ULP bounds were tightened to the measured minimum which passes over the full fixture set, for both the JavaScript and the C implementations:

| Fixture file | Test case | Previous tolerance | ULP bound | Measured maximum ULP difference |
| --- | --- | --- | --- | --- |
| `fixtures/julia/both_large.json` | evaluates the pdf for `x` given large `alpha` and `beta` | `170.0 * EPS` | `275` | 275 (JS and native) |
| `fixtures/julia/large_shape.json` | evaluates the pdf for `x` given large shape parameter `alpha` | `140.0 * EPS` | `168` | 168 (JS and native) |
| `fixtures/julia/large_rate.json` | evaluates the pdf for `x` given large rate parameter `beta` | `120.0 * EPS` | `208` | 208 (JS and native) |

Notes on how the bounds were determined:

-   Each bound is the minimum non-negative integer for which every fixture value passes, found by binary searching `isAlmostSameValue` per fixture value and taking the maximum over each 1000-value fixture set. In each set exactly one value attains the maximum, so none of the three bounds can be lowered.
-   Lowering each bound by one (`274`, `167`, `207`) was explicitly checked and fails with exactly three failing assertions, one per fixture set, confirming that the bounds are tight.
-   The JavaScript and C implementations agree exactly with one another on all 3000 fixture values, so `test.pdf.js`, `test.factory.js`, and `test.native.js` use identical bounds. The number of bit-for-bit exact values against the Julia reference is likewise identical for both implementations (10 of 1000 for `both_large`, 18 of 1000 for `large_shape`, 38 of 1000 for `large_rate`).
-   The bounds are larger than for many previously converted packages because the fixtures deliberately probe large shape and rate parameters, where the pdf is evaluated through `ln(gamma)`-style intermediates and the accumulated error relative to the Julia reference is correspondingly larger. The bounds are consistent in magnitude with the relative tolerances they replace (a `k * EPS` relative tolerance corresponds to roughly `k` to `2k` ULP, depending on where the value sits within its binade).
-   The native add-on was compiled locally, so `test/test.native.js` was exercised against the actual C implementation rather than skipped.
-   The full test suite was run twice at the final bounds, with identical results per run: 3 assertions for `test.js`, 3026 for `test.pdf.js`, 3030 for `test.factory.js`, and 3026 for `test.native.js`, all passing.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the three test files are modified; no source, documentation, benchmark, or fixture files are touched.
-   Linting is clean via `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/gamma/pdf/.*"`, which uses `etc/eslint/.eslintrc.tests.js`.
-   Environment note: the `pre-commit` hook's EditorConfig check could not run in this session, as it downloads the `editorconfig-checker` binary from GitHub releases and that request is blocked here. The commit was therefore made with `SKIP_LINT_EDITORCONFIG=1`; every other pre-commit check (JavaScript test linting, filename linting, license headers, commit message linting) ran and passed. The three modified files were instead checked manually against `.editorconfig`: LF line endings, UTF-8, tab indentation, no trailing whitespace, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. The test migration follows the idiom established by previously merged conversions, and the ULP bounds were measured empirically against both the JavaScript and compiled C implementations rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGwbG5ir9JJQ9XefVFP4rT)_