### PR TITLE
test(@stdlib/stats/incr/mpcorr): add absolute tolerance floor near zero

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/mpcorr/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/mpcorr/test/test.js
@@ -367,7 +367,7 @@ tape( 'the accumulator function computes a moving sample Pearson product-moment 
 				t.strictEqual( actual, expected, 'returns expected value. dataset: '+i+'. window: '+j+'.' );
 			} else {
 				delta = abs( actual - expected );
-				tol = 5.0e5 * EPS * abs( expected );
+				tol = ( 5.0e5 * EPS * abs( expected ) ) + ( 10.0 * EPS );
 				t.strictEqual( delta < tol, true, 'dataset: '+i+'. window: '+j+'. expected: '+expected+'. actual: '+actual+'. tol: '+tol+'. delta: '+delta+'.' );
 			}
 		}
@@ -415,7 +415,7 @@ tape( 'the accumulator function computes a moving sample Pearson product-moment 
 				t.strictEqual( actual, expected, 'returns expected value. dataset: '+i+'. window: '+j+'.' );
 			} else {
 				delta = abs( actual - expected );
-				tol = 5.0e5 * EPS * abs( expected );
+				tol = ( 5.0e5 * EPS * abs( expected ) ) + ( 10.0 * EPS );
 				t.strictEqual( delta < tol, true, 'dataset: '+i+'. window: '+j+'. expected: '+expected+'. actual: '+actual+'. tol: '+tol+'. delta: '+delta+'.' );
 			}
 		}


### PR DESCRIPTION
Resolves <!-- no tracked issue -->.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a flaky assertion in `lib/node_modules/@stdlib/stats/incr/mpcorr/test/test.js` that has failed the scheduled `linux_test` workflow (Node.js v12/v14/v16 jobs) on every run against `develop` for the past ~30 days (e.g. https://github.com/stdlib-js/stdlib/actions/runs/31582982055). The test "the accumulator function computes a moving sample Pearson product-moment correlation coefficient incrementally" fails intermittently, e.g. `dataset: 1. window: 77. expected: 0.00001111149059682119. actual: 0.00001111149059554248. tol: 1.2336232698496807e-15. delta: 1.2787097362952984e-15.`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Root cause: `tol = 5.0e5 * EPS * abs( expected );` is purely relative to `expected`. Over a window of W=10 independent random values, `expected` (a Pearson correlation coefficient) is frequently near zero. As `expected` approaches zero, the tolerance collapses toward zero and ordinary incremental-vs-batch floating-point noise (~1e-16 to 1e-15) exceeds it. This is not evidence of an unstable accumulator; no growing or unstable drift was found in the accumulator itself. Distinct from the bug fixed in the sibling `mpcorrdist` PR (#13152), where `r` itself lands slightly outside `[-1, 1]`; here `expected` is a small, valid, in-range value.

Fix: both occurrences of `tol = 5.0e5 * EPS * abs( expected );` (unknown-means and known-means test variants, ~lines 370 and 418) changed to `tol = ( 5.0e5 * EPS * abs( expected ) ) + ( 10.0 * EPS );`, adding a small absolute floor. The `10.0 * EPS` constant matches the existing absolute-floor constant already used for the analogous `expected === 0.0` case in `lib/node_modules/@stdlib/stats/incr/mpcorrdist/test/test.js` (line 384). No change to `lib/main.js`; accumulator runtime behavior is unchanged, this is test-only.

Validation: ran the package's full test suite (2422 assertions) 16 times locally against freshly-randomized data (test has no fixed seed); 100% pass. Three independent automated reviews (correctness, regression scope, style/conventions) returned approve with no blocking findings. One reviewer additionally ran an empirical simulation (2500 runs / 4.27M comparisons): old tolerance fails ~1% of runs, new tolerance fails 0/2500. A closed-form estimate puts residual per-run failure probability at ~1.2e-4, down from ~2.7e-2 (~230x reduction) — not full elimination, since the fix targets the near-zero regime without changing relative-noise magnitude at larger values.

Non-blocking notes for reviewers: (1) a larger absolute floor (30-50 * EPS) would be essentially free, since `r` is bounded to `[-1, 1]` and extra tolerance loses no meaningful test power, and would further shrink the residual failure probability; not applied here to keep the diff matching the existing reviewed constant exactly. (2) the same purely-relative-tolerance pattern (`tol = 5.0e5 * EPS * abs( expected )`) exists in sibling packages `mpcorr2`, `nanmpcorr`, `nanmpcorr2`, `mapcorr`, `nanmapcorr` — same latent flake risk, out of scope for this fix.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by an automated CI-failure triage routine running Claude Code, as part of a scheduled job that reviews GitHub Actions failures on `develop`. The routine identified the failure cluster from live job logs, investigated root cause via a dedicated sub-agent, applied the fix, validated it by running the full package test suite 16 times against freshly-randomized data, and required approval from three independent automated reviewers (correctness, regression scope, style/conventions) before committing.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Km7uZoCC6dHkwDCXuok372)_