### PR TITLE
test: migrate `stats/base/dists/cosine/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 
 tape( 'the function returns the standard deviation of a raised cosine distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var y;
@@ -89,13 +86,7 @@ tape( 'the function returns the standard deviation of a raised cosine distributi
 	for ( i = 0; i < mu.length; i++ ) {
 		y = stdev( mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -88,8 +87,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 
 tape( 'the function returns the standard deviation of a raised cosine distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var y;
@@ -101,13 +98,7 @@ tape( 'the function returns the standard deviation of a raised cosine distributi
 	for ( i = 0; i < mu.length; i++ ) {
 		y = stdev( mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/cosine/stdev` from relative tolerance (`EPS`-based) comparisons to ULP-based assertions, per #11352.

Specifically, in both `test/test.js` and `test/test.native.js`, the fixture loop's `delta`/`tol` computation is replaced with

```js
t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
```

adding a `@stdlib/assert/is-almost-same-value` require and dropping the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Final ULP constant: `1`** (both `test.js` and `test.native.js`).

The bound was tightened empirically rather than assumed. Starting from `64`, the minimum passing integer over the full fixture set (100 non-`null` cases) is `1`:

-   at `N = 0`: 36 of 110 assertions fail;
-   at `N = 1`: 110/110 pass.

The maximum observed ULP difference across the fixtures is exactly 1 ULP.

`test.js` was run twice at the final `N` with identical results. The native test is skipped locally (the addon is not built in this environment), but the same bound is safe by construction: `src/main.c` and `lib/main.js` both compute `s * 0.36151205519132795` using the identical constant. A single IEEE-754 double multiplication is correctly rounded and admits no FMA contraction, so the native result is bit-identical to the JavaScript result and the measured 1 ULP bound carries over.

Only the two test files are modified; no implementation, fixture, or documentation changes.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The full project toolchain could not be installed in the authoring environment: `make install-node-modules` fails with `ETARGET: No matching version found for es-object-atoms@^1.1.2` (the registry reachable from that environment publishes only up to `1.1.1`), so `make init` and the project `eslint` configuration could not be run. As a workaround, `tape` was installed in an isolated scratch directory to execute the package's test suite, and the changed files were linted against core rules (`no-unused-vars`, `no-undef`, `no-trailing-spaces`, `no-mixed-spaces-and-tabs`, `one-var`, `vars-on-top`, `semi`, `eqeqeq`, `no-irregular-whitespace`), which report clean. The diff otherwise mirrors the idiom of previously merged conversions (e.g. #14163, #14155) verbatim. Leaving this as a draft so CI can confirm the full lint and native builds.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It surveyed prior merged conversions to match the established idiom, applied the test changes, and determined the minimum ULP bound empirically by bisecting the constant against the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM8TrUPLiKK9AWMBWRbsXu)_