### PR TITLE
test: migrate `stats/base/dists/logistic/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 
 tape( 'the function returns the differential entropy of a logistic distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var y;
@@ -89,13 +86,7 @@ tape( 'the function returns the differential entropy of a logistic distribution'
 	for ( i = 0; i < mu.length; i++ ) {
 		y = entropy( mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/entropy/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -88,8 +87,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 
 tape( 'the function returns the differential entropy of a logistic distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var s;
 	var y;
@@ -101,13 +98,7 @@ tape( 'the function returns the differential entropy of a logistic distribution'
 	for ( i = 0; i < mu.length; i++ ) {
 		y = entropy( mu[i], s[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', s: '+s[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. s: '+s[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/logistic/entropy` from relative tolerance (`EPS`-based) comparisons to ULP-based assertions, per #11352.

Specifically, in both `test/test.js` and `test/test.native.js`, the fixture loop's `delta`/`tol` computation is replaced with

```js
t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
```

adding a `@stdlib/assert/is-almost-same-value` require and dropping the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Final ULP constant: `0`** (both `test.js` and `test.native.js`).

The bound was tightened empirically rather than assumed. Starting from `64` and lowering, the minimum passing integer over the full fixture set (100 non-`null` cases) is `0`:

-   at `N = 0`: 110/110 assertions pass.

The maximum observed ULP difference across the fixtures is `0`; every fixture value is returned exactly, so the previous `2.0 * EPS` relative tolerance was never actually exercised. `test.js` was run twice at the final `N` with identical results.

The native test is skipped locally (the addon is not built in this environment), but the same bound is safe by construction, and this was checked rather than assumed. Both `lib/main.js` and `src/main.c` compute `ln( s ) + 2.0` using stdlib's own `ln`, so the C implementation was compiled directly (`stdlib_base_ln` plus its dependency closure, via `gcc`) and evaluated over the 100 fixture `s` values: the results are bit-identical to the JavaScript implementation and match the Julia fixtures to `0` ULP. The single addition admits no FMA contraction, so the measured bound carries over to the native path.

Only the two test files are modified; no implementation, fixture, or documentation changes.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

`make install-node-modules` initially failed in the authoring environment with `ETARGET: No matching version found for es-object-atoms@^1.1.2` (the reachable registry publishes only up to `1.1.1`). This was worked around by installing the dev dependencies into an isolated scratch tree with an npm `overrides` entry pinning `es-object-atoms` to `1.1.1`, so the project toolchain could be exercised for real:

-   `make test TESTS_FILTER=".*/stats/base/dists/logistic/entropy/.*"` — green (110 passing; native suite skipped, addon not built);
-   `eslint` with `etc/eslint/.eslintrc.tests.js` on both changed files — clean;
-   the `pre-commit` hook's filename, `package.json`, REPL-help, and JavaScript test lint steps — clean.

The one check that could not be run is `lint-editorconfig-files`, which downloads the `editorconfig-checker` binary from GitHub and is blocked by this environment's network policy. The changed files were verified manually against `.editorconfig` instead: LF line endings, UTF-8, tab indentation, no trailing whitespace, final newline present.

Leaving this as a draft so CI can confirm the full lint and the native builds.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. It surveyed prior merged conversions (e.g. #14211, #14213) to match the established idiom, applied the test changes, and determined the minimum ULP bound empirically against the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01G3SrW8juEFjGc5kVqJDtR1)_