### PR TITLE
docs: fix comment and example

### DIFF
--- a/lib/node_modules/@stdlib/ml/base/sgd/learning-rates/lib/enum.js
+++ b/lib/node_modules/@stdlib/ml/base/sgd/learning-rates/lib/enum.js
@@ -35,7 +35,7 @@
 * // returns <Object>
 */
 function enumerated() {
-	// NOTE: the following should match the C `learning rates.h` enumeration!!!!
+	// NOTE: the following should match the C `learning_rates.h` enumeration!!!!
 	return {
 		// Basic learning rate function according to the formula `10/(10+t)` where `t` is the current iteration:
 		'basic': 0,

--- a/lib/node_modules/@stdlib/ml/base/sgd/loss-functions/README.md
+++ b/lib/node_modules/@stdlib/ml/base/sgd/loss-functions/README.md
@@ -83,9 +83,9 @@ The output array contains the following loss functions:
 
 ```javascript
 var contains = require( '@stdlib/array/base/assert/contains' ).factory;
-var lossFunction = require( '@stdlib/ml/base/sgd/loss-functions' );
+var lossFunctions = require( '@stdlib/ml/base/sgd/loss-functions' );
 
-var isLossFunction = contains( lossFunction() );
+var isLossFunction = contains( lossFunctions() );
 
 var bool = isLossFunction( 'hinge' );
 // returns true


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects two documentation drift items in the `@stdlib/ml/base/sgd` namespace, surfaced by a cross-package majority-vote comparison of its 15 sibling packages:

-   **`ml/base/sgd/learning-rates`** — the `lib/enum.js` `NOTE` comment referenced the C header as `` `learning rates.h` `` (with a space); the actual file is `learning_rates.h`. Corrected to the underscore form already used by the two sibling list packages (`` `loss_functions.h` ``, `` `penalties.h` ``) and by this package's own README. Comment only; the enumeration and its integer values are unchanged.
-   **`ml/base/sgd/loss-functions`** — the README `## Examples` block bound the module to a singular `lossFunction`, disagreeing with the plural export used in the reference block above it, in the package's own `examples/index.js`, and in the sibling `learning-rates` and `penalties` READMEs. Renamed to `lossFunctions`. Documentation only; no code path is affected.

Sibling conformance for both patterns: 100% (2/2 comparable list packages). Total diff: 3 lines across 2 files. No behavior, signature, or test change.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Scope was deliberately limited to mechanical, zero-behavior documentation drift. One further inconsistency was found and intentionally left out of scope: `ml/base/sgd/penalty-resolve-enum` and `ml/base/sgd/penalty-resolve-str` omit the `'none'` penalty from their `test/test.js` and `benchmark/benchmark.js` value arrays, whereas the parallel resolve siblings enumerate their complete enum set. Correcting that would modify test/benchmark expectations, so it is left for a maintainer.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running an automated cross-package drift-detection routine. The routine compared all 15 packages in the `ml/base/sgd` namespace across structural and semantic features, identified the majority convention per feature, and flagged the two deviations corrected here. Two independent AI review agents confirmed the findings; a human maintainer should verify before merging.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01FB9mpw1QMSTXrWXqfFMH3n)_