### PR TITLE
docs: fix parameter description in `blas/ext/base/ndarray/gtril`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtril/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtril/docs/types/index.d.ts
@@ -31,7 +31,7 @@ import { typedndarray } from '@stdlib/types/ndarray';
 *
 *     -   a two-dimensional input ndarray corresponding to `A`.
 *     -   a two-dimensional output ndarray corresponding to `B`.
-*     -   a zero-dimensional ndarray specifying the diagonal below which to ignore.
+*     -   a zero-dimensional ndarray specifying the diagonal above which to ignore.
 *
 * @param arrays - array-like object containing ndarrays
 * @returns output ndarray

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtril/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtril/lib/main.js
@@ -39,7 +39,7 @@ var strided = require( '@stdlib/blas/ext/base/gtril' ).ndarray;
 *
 *     -   a two-dimensional input ndarray corresponding to `A`.
 *     -   a two-dimensional output ndarray corresponding to `B`.
-*     -   a zero-dimensional ndarray specifying the diagonal below which to ignore.
+*     -   a zero-dimensional ndarray specifying the diagonal above which to ignore.
 *
 * @param {ArrayLikeObject<Object>} arrays - array-like object containing ndarrays
 * @returns {Object} output ndarray


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-08-12 15:56 (-0700, 83e21db9) and 2026-08-13 01:39 (-0700, fa128942).

This pull request:

-   Fixes a docstring copy-paste error from `gtriu` in `gtril` (0c4c031e): `main.js:42` and `docs/types/index.d.ts:34` said "diagonal below which to ignore"; `gtril` masks the upper triangle, so it's "above which to ignore" — matches README.md, docs/repl.txt, and dtril/stril/ctril/ztril.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This PR is the output of an automated review of the 25 commits merged to `develop` in the last 24 hours (83e21db9..fa128942).

**Validation performed:**

-   Style-guide compliance audit of the seven new `blas/ext/base/ndarray` packages (`dtril`, `stril`, `ctril`, `ztril`, `gtril`, `dlogspace`, `slast-index-of-falsy`) against established sibling packages (dtype wording, `@module` paths, requires, keywords, REPL docs, `// returns` annotations).
-   Style-guide compliance audit of the ULP test migrations, namespace rollups, and docs/style micro-fixes against prior migrations and `docs/style-guides`.
-   Two independent bug scans over the union and per-commit diffs (logic, loop bounds, dtype mismatches, copy-paste errors, doc/impl contradictions).

**Deliberately excluded** (anything requiring interpretation or scope expansion beyond the window's diff):

-   The `nullary-strided1d` (1394f07f) error message still saying "must have the same number of loop dimensions" after the guard was relaxed to `< K` — the identical guard+message pairing is the established convention across `unary-strided1d` and the `*-reduce-strided1d` family, so a one-package change would break family consistency.
-   Remaining unspaced `x[i]`/`a[i]`/`b[i]` accesses adjacent to the lines fixed in 6f563d5f — those lines are outside the window's diff.
-   The `ccis` native test (1811a325) collapsing the previously documented `1.05 * EPS` native-divergence allowance to 0 ULP — tightening was applied uniformly and deliberately across the file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by a scheduled Claude Code review of the last 24 hours of commits merged to `develop`; the fix and PR body were authored by Claude Code and are pending human audit (draft).

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013APPGrUwWpZD7STaS93dEk)_