### PR TITLE
docs: add missing space and fix punctuation

### DIFF
--- a/lib/node_modules/@stdlib/_tools/browserify/string/lib/validate.js
+++ b/lib/node_modules/@stdlib/_tools/browserify/string/lib/validate.js
@@ -60,7 +60,7 @@ var SPECIAL_KEYS = {
 * @example
 * var opts = {};
 * var options = {
-*    'standalone': 'foo'
+*     'standalone': 'foo'
 * };
 * var err = validate( opts, options );
 * if ( err ) {

--- a/lib/node_modules/@stdlib/array/base/flatten3d-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/flatten3d-by/docs/types/index.d.ts
@@ -72,7 +72,7 @@ type Callback<T, U, V> = Nullary<U, V> | Unary<T, U, V> | Binary<T, U, V> | Tern
 */
 interface Flatten3dBy {
 	/**
-	* Flattens a three-dimensional nested array according to a callback function..
+	* Flattens a three-dimensional nested array according to a callback function.
 	*
 	* ## Notes
 	*

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ctril/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ctril/lib/index.js
@@ -32,7 +32,7 @@
 * var B = new Complex64Matrix( [ [ 0.0, 0.0, 0.0, 0.0 ], [ 0.0, 0.0, 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = ctril( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ctriu/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ctriu/lib/index.js
@@ -32,7 +32,7 @@
 * var B = new Complex64Matrix( [ [ 0.0, 0.0, 0.0, 0.0 ], [ 0.0, 0.0, 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = ctriu( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcircshift/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcircshift/lib/index.js
@@ -31,7 +31,7 @@
 * var x = new Float64Vector( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
 *
 * var k = scalar2ndarray( 2, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dcircshift( [ x, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcircshift/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dcircshift/lib/main.js
@@ -50,7 +50,7 @@ var strided = require( '@stdlib/blas/ext/base/dcircshift' ).ndarray;
 * var x = new Float64Vector( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
 *
 * var k = scalar2ndarray( 2, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dcircshift( [ x, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlinspace/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlinspace/lib/index.js
@@ -31,11 +31,11 @@
 * var x = new Float64Vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 *
 * var start = scalar2ndarray( 0.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var stop = scalar2ndarray( 100.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var endpoint = scalar2ndarray( true, {

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlinspace/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlinspace/lib/main.js
@@ -52,11 +52,11 @@ var strided = require( '@stdlib/blas/ext/base/dlinspace' ).ndarray;
 * var x = new Float64Vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 *
 * var start = scalar2ndarray( 0.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var stop = scalar2ndarray( 100.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var endpoint = scalar2ndarray( true, {

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlogspace/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlogspace/lib/index.js
@@ -31,15 +31,15 @@
 * var x = new Float64Vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 *
 * var base = scalar2ndarray( 10.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var strt = scalar2ndarray( 0.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var stp = scalar2ndarray( 5.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var endpoint = scalar2ndarray( true, {

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlogspace/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dlogspace/lib/main.js
@@ -53,15 +53,15 @@ var strided = require( '@stdlib/blas/ext/base/dlogspace' ).ndarray;
 * var x = new Float64Vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 *
 * var base = scalar2ndarray( 10.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var strt = scalar2ndarray( 0.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var stp = scalar2ndarray( 5.0, {
-*    'dtype': 'float64'
+*     'dtype': 'float64'
 * });
 *
 * var endpoint = scalar2ndarray( true, {

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsort/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsort/lib/main.js
@@ -50,7 +50,7 @@ var strided = require( '@stdlib/blas/ext/base/dsort' ).ndarray;
 * var x = new Float64Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var order = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dsort( [ x, order ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/lib/index.js
@@ -31,7 +31,7 @@
 * var x = new Float64Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dsorthp( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsorthp/lib/main.js
@@ -50,7 +50,7 @@ var strided = require( '@stdlib/blas/ext/base/dsorthp' ).ndarray;
 * var x = new Float64Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dsorthp( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsortins/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsortins/lib/index.js
@@ -31,7 +31,7 @@
 * var x = new Float64Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dsortins( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsortins/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsortins/lib/main.js
@@ -50,7 +50,7 @@ var strided = require( '@stdlib/blas/ext/base/dsortins' ).ndarray;
 * var x = new Float64Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dsortins( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsortsh/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsortsh/lib/index.js
@@ -31,7 +31,7 @@
 * var x = new Float64Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dsortsh( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsortsh/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dsortsh/lib/main.js
@@ -50,7 +50,7 @@ var strided = require( '@stdlib/blas/ext/base/dsortsh' ).ndarray;
 * var x = new Float64Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dsortsh( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dtril/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dtril/lib/index.js
@@ -32,7 +32,7 @@
 * var B = new Float64Matrix( [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dtril( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/dtriu/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/dtriu/lib/index.js
@@ -32,7 +32,7 @@
 * var B = new Float64Matrix( [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = dtriu( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcircshift/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcircshift/lib/index.js
@@ -31,7 +31,7 @@
 * var x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0 ], 'generic' );
 *
 * var k = scalar2ndarray( 2, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = gcircshift( [ x, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcircshift/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gcircshift/lib/main.js
@@ -50,7 +50,7 @@ var strided = require( '@stdlib/blas/ext/base/gcircshift' ).ndarray;
 * var x = vector( [ 1.0, 2.0, 3.0, 4.0, 5.0 ], 'generic' );
 *
 * var k = scalar2ndarray( 2, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = gcircshift( [ x, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glinspace/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glinspace/lib/index.js
@@ -31,11 +31,11 @@
 * var x = vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ], 'generic' );
 *
 * var start = scalar2ndarray( 0.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var stop = scalar2ndarray( 100.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var endpoint = scalar2ndarray( true, {

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/glinspace/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/glinspace/lib/main.js
@@ -52,11 +52,11 @@ var strided = require( '@stdlib/blas/ext/base/glinspace' ).ndarray;
 * var x = vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ], 'generic' );
 *
 * var start = scalar2ndarray( 0.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var stop = scalar2ndarray( 100.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var endpoint = scalar2ndarray( true, {

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsort/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsort/lib/index.js
@@ -31,7 +31,7 @@
 * var x = vector( [ 1.0, -2.0, 3.0, -4.0 ], 'generic' );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = gsort( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsort/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsort/lib/main.js
@@ -52,7 +52,7 @@ var strided = require( '@stdlib/blas/ext/base/gsort' ).ndarray;
 * var x = vector( [ 1.0, -2.0, 3.0, -4.0 ], 'generic' );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = gsort( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsorthp/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsorthp/lib/index.js
@@ -31,7 +31,7 @@
 * var x = vector( [ 1.0, -2.0, 3.0, -4.0 ], 'generic' );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = gsorthp( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsorthp/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gsorthp/lib/main.js
@@ -52,7 +52,7 @@ var strided = require( '@stdlib/blas/ext/base/gsorthp' ).ndarray;
 * var x = vector( [ 1.0, -2.0, 3.0, -4.0 ], 'generic' );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = gsorthp( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtril/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtril/lib/index.js
@@ -32,7 +32,7 @@
 * var B = matrix( [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ], 'generic' );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = gtril( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtriu/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/gtriu/lib/index.js
@@ -32,7 +32,7 @@
 * var B = matrix( [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ], 'generic' );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = gtriu( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/scircshift/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/scircshift/lib/index.js
@@ -31,7 +31,7 @@
 * var x = new Float32Vector( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
 *
 * var k = scalar2ndarray( 2, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = scircshift( [ x, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/scircshift/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/scircshift/lib/main.js
@@ -50,7 +50,7 @@ var strided = require( '@stdlib/blas/ext/base/scircshift' ).ndarray;
 * var x = new Float32Vector( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
 *
 * var k = scalar2ndarray( 2, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = scircshift( [ x, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/slinspace/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/slinspace/lib/index.js
@@ -31,11 +31,11 @@
 * var x = new Float32Vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 *
 * var start = scalar2ndarray( 0.0, {
-*    'dtype': 'float32'
+*     'dtype': 'float32'
 * });
 *
 * var stop = scalar2ndarray( 100.0, {
-*    'dtype': 'float32'
+*     'dtype': 'float32'
 * });
 *
 * var endpoint = scalar2ndarray( true, {

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/slinspace/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/slinspace/lib/main.js
@@ -52,11 +52,11 @@ var strided = require( '@stdlib/blas/ext/base/slinspace' ).ndarray;
 * var x = new Float32Vector( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 *
 * var start = scalar2ndarray( 0.0, {
-*    'dtype': 'float32'
+*     'dtype': 'float32'
 * });
 *
 * var stop = scalar2ndarray( 100.0, {
-*    'dtype': 'float32'
+*     'dtype': 'float32'
 * });
 *
 * var endpoint = scalar2ndarray( true, {

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssort/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssort/lib/main.js
@@ -52,7 +52,7 @@ var strided = require( '@stdlib/blas/ext/base/ssort' ).ndarray;
 * var x = new Float32Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var order = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = ssort( [ x, order ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssorthp/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssorthp/lib/index.js
@@ -31,7 +31,7 @@
 * var x = new Float32Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = ssorthp( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssorthp/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ssorthp/lib/main.js
@@ -52,7 +52,7 @@ var strided = require( '@stdlib/blas/ext/base/ssorthp' ).ndarray;
 * var x = new Float32Vector( [ 1.0, -2.0, 3.0, -4.0 ] );
 *
 * var ord = scalar2ndarray( 1.0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = ssorthp( [ x, ord ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/stril/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/stril/lib/index.js
@@ -32,7 +32,7 @@
 * var B = new Float32Matrix( [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = stril( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/striu/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/striu/lib/index.js
@@ -32,7 +32,7 @@
 * var B = new Float32Matrix( [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = striu( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ztril/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ztril/lib/index.js
@@ -32,7 +32,7 @@
 * var B = new Complex128Matrix( [ [ 0.0, 0.0, 0.0, 0.0 ], [ 0.0, 0.0, 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = ztril( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/ztriu/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/ztriu/lib/index.js
@@ -32,7 +32,7 @@
 * var B = new Complex128Matrix( [ [ 0.0, 0.0, 0.0, 0.0 ], [ 0.0, 0.0, 0.0, 0.0 ] ] );
 *
 * var k = scalar2ndarray( 0, {
-*    'dtype': 'generic'
+*     'dtype': 'generic'
 * });
 *
 * var out = ztriu( [ A, B, k ] );

--- a/lib/node_modules/@stdlib/object/none-own-by/lib/index.js
+++ b/lib/node_modules/@stdlib/object/none-own-by/lib/index.js
@@ -31,9 +31,9 @@
 * }
 *
 * var obj = {
-*    'a': 10,
-*    'b': 12,
-*    'c': 15
+*     'a': 10,
+*     'b': 12,
+*     'c': 15
 * };
 *
 * var bool = noneOwnBy( obj, isUnderage );

--- a/lib/node_modules/@stdlib/repl/server/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/repl/server/docs/types/test.ts
@@ -21,7 +21,7 @@
 import repl = require( './index' );
 
 /**
-* Callback invoked after creating a REPL environment..
+* Callback invoked after creating a REPL environment.
 *
 * @param error - error object or null
 * @param server - server object

--- a/lib/node_modules/@stdlib/utils/zip/lib/index.js
+++ b/lib/node_modules/@stdlib/utils/zip/lib/index.js
@@ -30,7 +30,7 @@
 * // returns [ [ 1, 'a' ], [ 2, 'b' ] ]
 *
 * var opts = {
-*    'trunc': false
+*     'trunc': false
 * };
 *
 * zipped = zip( [ 1, 2, 3 ], [ 'a', 'b' ], opts );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request propagates fixes merged to `develop` between 2026-08-12T15:56:50-07:00 and 2026-08-13T01:39:41-07:00 to sibling packages.

### JSDoc example object-key indentation (source: 6f563d5f6, a0ddbae6d)

Fixed indentation in JSDoc `@example` blocks: quoted object-literal member lines used a three-space code indent rather than the conventional four (`*    'dtype': 'generic'` → `*     'dtype': 'generic'`), per 6f563d5f6 and a0ddbae6d, merged to develop 2026-08-12. This PR applies the same fix to the 53 remaining occurrences across 41 files — the full set of `blas/ext/base/ndarray/*` packages (`gcircshift`, `dcircshift`, `scircshift`, `gsort`, `dsort`, `ssort`, `dsorthp`, `ssorthp`, `gsorthp`, `dsortsh`, `dsortins`, `glinspace`, `dlinspace`, `slinspace`, `dlogspace`, `gtril`, `dtril`, `stril`, `ctril`, `ztril`, `gtriu`, `dtriu`, `striu`, `ctriu`, `ztriu`), plus `object/none-own-by`, `utils/zip`, and `_tools/browserify/string`. In several `*tril`/`*triu` packages, `lib/main.js` already used the correct four-space indent while `lib/index.js` did not; this change removes that intra-package inconsistency.

### Doubled trailing periods in doc-comment descriptions (source: a0ddbae6d)

Commit a0ddbae6d fixed a doubled trailing period in the `constants/float32/eps` doc-comment description but missed two other instances of the same typo elsewhere in the tree. This PR applies the identical fix to `array/base/flatten3d-by` (`docs/types/index.d.ts`) and `repl/server` (`docs/types/test.ts`), removing the duplicate period in each description. No functional changes; docs-only.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation: candidate sites were enumerated by exact pattern signature over `lib/node_modules/@stdlib/` (quoted object-key lines at three-space code indent; doc-comment descriptions ending in `..`), and every site was independently confirmed by two validation passes reading the enclosing JSDoc blocks in full, plus a patch-adaptation pass and a style-consistency pass (repo-wide, 3348 files already use the four-space form; the 41 files changed here were the complete remainder). Deliberately excluded: other three-space-indented example lines not of the quoted object-key shape (the source commits left those untouched in the same files), a four-dot line-comment ellipsis in `repl/server/docs/types/test.ts` (out of pattern scope), and the `expected[i]` bracket-spacing shape from 6f563d5f6 (unbounded repo-wide; cannot be faithfully scoped without a mass style campaign). No changed file is auto-generated.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated fix-propagation routine: it identified fix patterns in commits recently merged to `develop`, searched for sibling occurrences, validated each site with independent review passes, and applied the mechanical fixes.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KD3a6S33LnMzJbqMjk4AkC)_