### PR TITLE
style: resolve lint errors

### DIFF
--- a/lib/node_modules/@stdlib/types/index.d.ts
+++ b/lib/node_modules/@stdlib/types/index.d.ts
@@ -1789,10 +1789,9 @@ declare module '@stdlib/types/blas' {
 * };
 */
 declare module '@stdlib/types/ndarray' {
-	import { ArrayLike, AccessorArrayLike, BooleanArray, BooleanTypedArray, Collection, Complex128Array, Complex64Array, Complex32Array, Int64Array, Uint64Array, RealOrComplexTypedArray, FloatOrComplexTypedArray, RealTypedArray, ComplexTypedArray, IntegerTypedArray, FloatTypedArray, SignedIntegerTypedArray, UnsignedIntegerTypedArray } from '@stdlib/types/array';
-	import { Float16Array } from '@stdlib/types/array'; // FIXME: remove me once `Float16Array` is recognized as a built-in type
+	import { ArrayLike, AccessorArrayLike, BooleanArray, BooleanTypedArray, Collection, Complex128Array, Complex64Array, Complex32Array, Int64Array, Uint64Array, RealOrComplexTypedArray, FloatOrComplexTypedArray, RealTypedArray, ComplexTypedArray, IntegerTypedArray, FloatTypedArray, SignedIntegerTypedArray, UnsignedIntegerTypedArray, Float16Array } from '@stdlib/types/array'; // FIXME: remove `Float16Array` once recognized as a built-in type
 	import { ComplexLike, Complex128, Complex64, Complex32 } from '@stdlib/types/complex'; // eslint-disable-line no-duplicate-imports
-	import { Int64, Uint64 } from '@stdlib/types/number';
+	import { Int64, Uint64 } from '@stdlib/types/number'; // eslint-disable-line no-duplicate-imports
 	import { Layout } from '@stdlib/types/blas';
 	import { Remap } from '@stdlib/types/utilities'; // eslint-disable-line no-duplicate-imports
 


### PR DESCRIPTION
Resolves #{{TODO: add issue number}}.

## Description

> What is the purpose of this pull request?

This pull request:

-   Resolves two ESLint `no-duplicate-imports` errors in `types/index.d.ts` that were failing the `Lint TypeScript declarations files` job on `develop`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{{TODO: add related issue number}}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/31675037905 (`lint_changed_files` / `Lint TypeScript declarations files`).

**Symptom:** ESLint `no-duplicate-imports` at `types/index.d.ts:1793` (`@stdlib/types/array`) and `:1795` (`@stdlib/types/number`).

**Root cause:** line 1793 was a genuine same-scope duplicate — two separate `import` statements from `@stdlib/types/array` inside the same `declare module '@stdlib/types/ndarray'` block. Line 1795 duplicates, at the flat-file scope ESLint uses for this rule, an unrelated import inside an earlier, different `declare module '@stdlib/types/array'` block; every other cross-module-block duplicate in this file already carries a `// eslint-disable-line no-duplicate-imports` comment, but this one was missing it.

**Fix:** merged the duplicate `@stdlib/types/array` import into the existing import list (no symbols dropped, `FIXME` comment preserved), and added the missing `eslint-disable-line` comment to the `@stdlib/types/number` import, matching this file's own established pattern (see lines 6179, 6260, 6311 for the same treatment of other cross-block duplicates).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code (Anthropic) as part of an automated CI-failure investigation and fix routine; the change was validated by re-deriving the ESLint duplicate-import rule's scoping behavior against the file and independently reviewed by three automated reviewer passes before submission.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_019XRBYMXjkLXiotemoLiK4V)_