### PR TITLE
test: migrate `stats/base/dists/invgamma/mean` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
 
@@ -96,25 +95,18 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 
 tape( 'the function returns the mean of an inverse gamma distribution', function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
 	expected = data.expected;
 	alpha = data.alpha;
 	beta = data.beta;
+
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mean( alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -105,25 +104,18 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 
 tape( 'the function returns the mean of an inverse gamma distribution', opts, function test( t ) {
 	var expected;
-	var delta;
 	var alpha;
 	var beta;
-	var tol;
 	var i;
 	var y;
 
 	expected = data.expected;
 	alpha = data.alpha;
 	beta = data.beta;
+
 	for ( i = 0; i < expected.length; i++ ) {
 		y = mean( alpha[ i ], beta[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'alpha: '+alpha[ i ]+', beta: '+beta[ i ]+', y: '+y+', expected: '+expected[ i ] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[ i ]+'. beta: '+beta[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/invgamma/mean` from EPS-scaled relative tolerance assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   updates both `test/test.js` and `test/test.native.js`, replacing the `delta`/`tol` branch in the Julia fixture loop with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' )`.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**ULP constant: `0` (both `test/test.js` and `test/test.native.js`).**

The bound was tightened empirically. Starting from a high value and lowering it, every one of the 200 Julia fixture cases matches the expected value bit-for-bit, so the measured minimum is `0` ULP — no slack is needed. The suite was run twice at the final bound to confirm determinism (214 assertions passing, 0 failing, on both runs). `test/test.native.js` uses the same constant as `test/test.js`, matching the convention used by previously converted packages; its assertions are skipped locally because the native add-on is not built in this environment.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched. Linting is clean under `etc/eslint/.eslintrc.tests.js`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, which studied previously merged conversions in the same package family to mirror the established idiom, applied the test edits, and measured the minimum ULP bound by running the suite against the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01595u84QGBUkozTsndu8BsY)_