### PR TITLE
test: migrate `math/base/special/rising-factorial` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rising-factorial/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rising-factorial/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var risingFactorial = require( './../lib' );
 
 
@@ -82,8 +81,6 @@ tape( 'the function returns evaluates the rising factorial if provided `x = 0` a
 
 tape( 'the function evaluates the rising factorial', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var x;
@@ -94,13 +91,7 @@ tape( 'the function evaluates the rising factorial', function test( t ) {
 	n = data.n;
 	for ( i = 0; i < x.length; i++ ) {
 		y = risingFactorial( x[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. n: '+n[i]+', y: '+y+'. expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 70.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 72 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/rising-factorial/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rising-factorial/test/test.native.js
@@ -22,9 +22,8 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -88,8 +87,6 @@ tape( 'the function returns evaluates the rising factorial if provided `x = 0` a
 
 tape( 'the function evaluates the rising factorial', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var n;
 	var x;
@@ -100,13 +97,7 @@ tape( 'the function evaluates the rising factorial', opts, function test( t ) {
 	n = data.n;
 	for ( i = 0; i < x.length; i++ ) {
 		y = risingFactorial( x[i], n[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. n: '+n[i]+', y: '+y+'. expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 70.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. n: '+n[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 72 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/rising-factorial` from relative tolerance (`EPS`-scaled `delta <= tol`) comparisons to ULP difference testing via `@stdlib/assert/is-almost-same-value`.
-   updates both `test/test.js` and `test/test.native.js`, replacing the previous `70.0 * EPS` relative tolerance (and its exact-equality fast path) with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 72 ), true, 'returns expected value' );`.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**Measured ULP bound:** `72` for both the JavaScript and native implementations. This is the minimum integer bound which passes over the full 1000-value fixture set (`test/fixtures/cpp/output.json`); at `71` both files fail on the worst-case entry (`x = -18.13813813813814`, `n = -34`). Of the 1000 fixture values, 305 match exactly and 948 are within 32 ULP. The native add-on was built locally so that `test/test.native.js` was exercised rather than skipped, and the same worst-case entry and bound were measured for both implementations. The full suite was run twice at the final bound with identical results.

Only the two test files are modified.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated conversion task. The test migration and the ULP bound search (starting high and tightening to the minimum passing integer) were performed by Claude Code, mirroring the idiom established in previously merged conversions.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01XunV1tDBZ3ZR8WfyAqms4g)_