### PR TITLE
test: migrate `math/base/special/coversin` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/coversin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/coversin/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var coversin = require( './../lib' );
 
 
@@ -49,8 +48,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the coversine (for -256*pi < x < 0)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -60,21 +57,13 @@ tape( 'the function computes the coversine (for -256*pi < x < 0)', function test
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for 0 < x < 256*pi)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -84,21 +73,13 @@ tape( 'the function computes the coversine (for 0 < x < 256*pi)', function test(
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for -2**60 (pi/2) < x < -2**20 (pi/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -108,21 +89,13 @@ tape( 'the function computes the coversine (for -2**60 (pi/2) < x < -2**20 (pi/2
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for 2**20 (pi/2) < x < 2**60 (pi/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -132,21 +105,13 @@ tape( 'the function computes the coversine (for 2**20 (pi/2) < x < 2**60 (pi/2))
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for x <= -2**60 (PI/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -156,21 +121,13 @@ tape( 'the function computes the coversine (for x <= -2**60 (PI/2))', function t
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for x >= 2**60 (PI/2))', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -180,13 +137,7 @@ tape( 'the function computes the coversine (for x >= 2**60 (PI/2))', function te
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/coversin/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/coversin/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -58,8 +57,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the coversine (for -256*pi < x < 0)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -69,21 +66,13 @@ tape( 'the function computes the coversine (for -256*pi < x < 0)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for 0 < x < 256*pi)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -93,21 +82,13 @@ tape( 'the function computes the coversine (for 0 < x < 256*pi)', opts, function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 4.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for -2**60 (pi/2) < x < -2**20 (pi/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -117,21 +98,13 @@ tape( 'the function computes the coversine (for -2**60 (pi/2) < x < -2**20 (pi/2
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 4.6 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for 2**20 (pi/2) < x < 2**60 (pi/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -141,21 +114,13 @@ tape( 'the function computes the coversine (for 2**20 (pi/2) < x < 2**60 (pi/2))
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.7 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for x <= -2**60 (PI/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -165,21 +130,13 @@ tape( 'the function computes the coversine (for x <= -2**60 (PI/2))', opts, func
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 2.3 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the coversine (for x >= 2**60 (PI/2))', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -189,13 +146,7 @@ tape( 'the function computes the coversine (for x >= 2**60 (PI/2))', opts, funct
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = coversin( x[i] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 3.6 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test cases for `math/base/special/coversin` from relative tolerance testing to ULP difference testing, replacing the `delta`/`tol` comparisons with `isAlmostSameValue( y, expected[ i ], 0 )` and adding the `@stdlib/assert/is-almost-same-value` import.

**Final ULP constant: `0` in both `test/test.js` and `test/test.native.js`** (all 12 fixture loops).

The bound was tightened empirically rather than assumed. Starting from a high value and lowering it, the minimum required ULP value over the full fixture set is **0** — i.e., both the JavaScript and the C implementations reproduce the Julia fixtures *exactly*, with no representable gap between actual and expected for any input. Measured per fixture file (4000 values each, 24000 total per implementation):

| Fixture | JS min ULP | C min ULP |
| --- | --- | --- |
| `medium_negative` | 0 | 0 |
| `medium_positive` | 0 | 0 |
| `large_negative` | 0 | 0 |
| `large_positive` | 0 | 0 |
| `huge_negative` | 0 | 0 |
| `huge_positive` | 0 | 0 |

Since `0` is the tightest bound expressible, no lower value exists.

Note that the previous relative tolerances in `test.native.js` varied per fixture (`2.0`, `4.0`, `4.6`, `1.7`, `2.3`, and `3.6` times `EPS`). Those multipliers were looser than the observed error: with the native add-on built locally, the C implementation matches the fixtures exactly at 0 ULP. This mirrors the sibling package `math/base/special/covercos` (#14103), whose native tolerances were likewise `3.0`–`5.0` times `EPS` before being migrated to `0`.

Verification:

-   `make test TESTS_FILTER=".*/math/base/special/coversin/.*"` — 24005 passing, 0 failing in each of `test.js` and `test.native.js` (48010 assertions total).
-   The native add-on was built locally so that `test.native.js` actually executes rather than being skipped.
-   The suite was run twice at the final ULP value with identical results, to rule out FMA/architecture-dependent flakiness.
-   ESLint is clean against `etc/eslint/.eslintrc.tests.js`.
-   The only files changed are the two test files; no source, fixture, or documentation changes.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The converted files are structurally identical to the already-merged sibling `math/base/special/covercos` (#14103), which was used as the reference for the project's ULP idiom.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was written by Claude Code running as an unattended scheduled task. It performed the mechanical test migration, measured the minimum ULP bound against the fixtures, and verified the result by running the test suite and linter locally. The changes should be reviewed accordingly.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_014wMuenVCso7e5Sw1pvi4Aj)_