### PR TITLE
test: migrate `math/base/special/boxcox1p` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/boxcox1p/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox1p/test/test.js
@@ -23,9 +23,9 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var boxcox1p = require( './../lib' );
 
 
@@ -92,8 +92,6 @@ tape( 'the function returns `NaN` if `x` is less than negative one', function te
 
 tape( 'the function computes a one-parameter Box-Cox transformation for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -104,21 +102,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for positive
 	y = mediumPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 17.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 27 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for positive small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -129,21 +119,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for positive
 	y = smallPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 4.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for very small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -154,21 +136,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for very sma
 	y = verySmall.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -179,21 +153,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny num
 	y = tiny.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny numbers and large lambda', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -204,21 +170,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny num
 	y = tinyLargeLambda.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny lambda', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -229,13 +187,7 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny lam
 	y = tinyLambda.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/boxcox1p/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox1p/test/test.native.js
@@ -24,9 +24,9 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -101,8 +101,6 @@ tape( 'the function returns `NaN` if `x` is less than negative one', opts, funct
 
 tape( 'the function computes a one-parameter Box-Cox transformation for positive medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -113,21 +111,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for positive
 	y = mediumPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 17.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 27 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for positive small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -138,21 +128,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for positive
 	y = smallPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 4.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for very small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -163,21 +145,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for very sma
 	y = verySmall.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -188,21 +162,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny num
 	y = tiny.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny numbers and large lambda', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -213,21 +179,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny num
 	y = tinyLargeLambda.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 3.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny lambda', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -238,13 +196,7 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny lam
 	y = tinyLambda.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox1p( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/boxcox1p` from relative tolerance testing (`delta <= tol`, where `tol = N * EPS * abs( expected )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value], as proposed in #11352.

Changes are limited to `test/test.js` and `test/test.native.js`. In each fixture loop, the `if ( b === expected[ i ] ) { ... } else { ... }` tolerance branch is replaced by a single assertion of the form

```javascript
t.strictEqual( isAlmostSameValue( b, expected[ i ], N ), true, 'returns expected value' );
```

the now-unused `delta`/`tol` locals and the `@stdlib/math/base/special/abs` import are removed, and the `@stdlib/assert/is-almost-same-value` import is added. The `@stdlib/constants/float64/eps` import is retained, as `EPS` is still used when generating random inputs less than negative one. No test cases, fixtures, or assertion counts were added or removed.

### ULP bounds

Each bound is the **measured minimum** for its fixture, determined by computing the ULP difference for every fixture value and taking the maximum. Both test files use the same bounds, mirroring the existing convention for JavaScript/C test pairs.

| Fixture | Previous tolerance | ULP bound |
| ------- | ------------------ | --------- |
| `medium_positive` | `17.0 * EPS` | `27` |
| `small_positive` | `4.0 * EPS` | `4` |
| `very_small` | `1.0 * EPS` | `0` |
| `tiny` | `1.0 * EPS` | `0` |
| `tiny_and_large_lambda` | `3.0 * EPS` | `2` |
| `tiny_lambda` | `1.0 * EPS` | `1` |

Each bound was confirmed tight by lowering it by one and re-running the suite; every reduction produces failures (`27`→`26`: 1 failure, `4`→`3`: 7, `2`→`1`: 24, `1`→`0`: 187). The `very_small` and `tiny` fixtures match exactly, so `0` is the minimum by construction. The full suite (11089 assertions) passes, and was run twice at the final bounds to confirm the results are deterministic.

Note: the native add-on could not be compiled in the environment used to author this change, so `test/test.native.js` was verified to load and skip cleanly, but its bounds were not exercised locally and rely on CI. The C implementation is a direct port of the JavaScript implementation and calls stdlib's own `log1p`/`expm1`, so the same bounds are expected to hold.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, which performed the mechanical test migration and empirically measured the minimum ULP bounds.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZjUjUFz1Y8zc4pZDnhsff)_