### PR TITLE
test: migrate `stats/base/dists/f/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/f/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -108,8 +107,6 @@ tape( 'if provided `d2 <= 4`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the standard deviation of an F distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var i;
@@ -120,13 +117,7 @@ tape( 'the function returns the standard deviation of an F distribution', functi
 	d2 = data.d2;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( d1[i], d2[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'd1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/f/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -117,8 +116,6 @@ tape( 'if provided `d2 <= 4`, the function returns `NaN`', opts, function test( 
 
 tape( 'the function returns the standard deviation of an F distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var d1;
 	var d2;
 	var i;
@@ -129,13 +126,7 @@ tape( 'the function returns the standard deviation of an F distribution', opts, 
 	d2 = data.d2;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( d1[i], d2[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'd1: '+d1[i]+', d2: '+d2[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. d1: '+d1[i]+'. d2: '+d2[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `stats/base/dists/f/stdev` from relative-tolerance testing to ULP (units in the last place) difference testing, per the tracking issue.
-   Replaces the `delta`/`tol` (EPS-based) comparison in `test/test.js` and `test/test.native.js` with `@stdlib/assert/is-almost-same-value`.
-   The minimum required ULP bound was determined by computing the actual ULP difference between observed and expected values across the full fixture set (`test/fixtures/julia/data.json`, 100 cases). The maximum observed difference was **2 ULPs**, so both test files now assert `isAlmostSameValue( y, expected[ i ], 2 )`.
-   The test suite was run twice at this bound to confirm deterministic results (no FMA/architecture-related flakiness).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, following the conventions established in already-merged ULP migration PRs (e.g. #14227, #14206). The minimum ULP bound was determined empirically by computing actual ULP differences across the fixture set, not guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeM3pcbuNQiSxDDAo9LDyn)_