### PR TITLE
bench: fix description and update variable names in `blas/base/ndarray`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/cgemv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/cgemv/benchmark/benchmark.js
@@ -48,10 +48,10 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var trans;
 	var alpha;
 	var beta;
@@ -62,17 +62,17 @@ function createBenchmark( len ) {
 	var x;
 	var y;
 
-	Abuf = uniform( len*len*2, -100.0, 100.0, {
+	Abuf = uniform( N*N*2, -100.0, 100.0, {
 		'dtype': 'float32'
 	});
-	A = new Complex64Matrix( Abuf.buffer, 0, [ len, len ] );
+	A = new Complex64Matrix( Abuf.buffer, 0, [ N, N ] );
 
-	xbuf = uniform( len*2, -100.0, 100.0, {
+	xbuf = uniform( N*2, -100.0, 100.0, {
 		'dtype': 'float32'
 	});
 	x = new Complex64Vector( xbuf.buffer );
 
-	ybuf = uniform( len*2, -100.0, 100.0, {
+	ybuf = uniform( N*2, -100.0, 100.0, {
 		'dtype': 'float32'
 	});
 	y = new Complex64Vector( ybuf.buffer );
@@ -103,7 +103,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnanf( realf( z.get( i%len ) ) ) ) {
+		if ( isnanf( realf( z.get( i%N ) ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -120,9 +120,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -130,9 +130,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dgemm/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dgemm/benchmark/benchmark.js
@@ -44,10 +44,10 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var transA;
 	var transB;
 	var alpha;
@@ -56,9 +56,9 @@ function createBenchmark( len ) {
 	var B;
 	var C;
 
-	A = uniform( [ len, len ], -100.0, 100.0, options );
-	B = uniform( [ len, len ], -100.0, 100.0, options );
-	C = uniform( [ len, len ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
+	B = uniform( [ N, N ], -100.0, 100.0, options );
+	C = uniform( [ N, N ], -100.0, 100.0, options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	beta = scalar2ndarray( 1.0, options );
@@ -89,7 +89,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( i%len, i%len ) ) ) {
+		if ( isnan( z.get( i%N, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -106,9 +106,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -116,9 +116,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dgemv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dgemv/benchmark/benchmark.js
@@ -44,10 +44,10 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var trans;
 	var alpha;
 	var beta;
@@ -55,9 +55,9 @@ function createBenchmark( len ) {
 	var x;
 	var y;
 
-	A = uniform( [ len, len ], -100.0, 100.0, options );
-	x = uniform( [ len ], -100.0, 100.0, options );
-	y = uniform( [ len ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	y = uniform( [ N ], -100.0, 100.0, options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	beta = scalar2ndarray( 1.0, options );
@@ -85,7 +85,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( i%len ) ) ) {
+		if ( isnan( z.get( i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -102,9 +102,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -112,9 +112,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dger/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dger/benchmark/benchmark.js
@@ -43,18 +43,18 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var x;
 	var y;
 	var A;
 
-	x = uniform( [ len ], -100.0, 100.0, options );
-	y = uniform( [ len ], -100.0, 100.0, options );
-	A = uniform( [ len, len ], -100.0, 100.0, options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	y = uniform( [ N ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
 
 	alpha = scalar2ndarray( 1.0, options );
 
@@ -78,7 +78,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( 0, i%len ) ) ) {
+		if ( isnan( z.get( 0, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -95,9 +95,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -105,9 +105,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dspr/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dspr/benchmark/benchmark.js
@@ -44,17 +44,17 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var uplo;
 	var AP;
 	var x;
 
-	AP = uniform( [ ( len * ( len+1 ) ) / 2 ], -100.0, 100.0, options );
-	x = uniform( [ len ], -100.0, 100.0, options );
+	AP = uniform( [ ( N * ( N+1 ) ) / 2 ], -100.0, 100.0, options );
+	x = uniform( [ N ], -100.0, 100.0, options );
 
 	uplo = scalar2ndarray( resolveEnum( 'upper' ), {
 		'dtype': 'int8'
@@ -81,7 +81,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( i%len ) ) ) {
+		if ( isnan( z.get( i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -98,9 +98,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -108,9 +108,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, ( N * ( N+1 ) ) / 2 ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dsyr/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dsyr/benchmark/benchmark.js
@@ -45,17 +45,17 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var uplo;
 	var x;
 	var A;
 
-	x = uniform( [ len ], -100.0, 100.0, options );
-	A = zeros( [ len, len ], options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	A = zeros( [ N, N ], options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	uplo = scalar2ndarray( resolveEnum( 'upper' ), {
@@ -82,7 +82,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( 0, i%len ) ) ) {
+		if ( isnan( z.get( 0, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -99,9 +99,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -109,9 +109,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/dsyr2/benchmark/benchmark.js
@@ -45,19 +45,19 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var uplo;
 	var x;
 	var y;
 	var A;
 
-	x = uniform( [ len ], -100.0, 100.0, options );
-	y = uniform( [ len ], -100.0, 100.0, options );
-	A = zeros( [ len, len ], options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	y = uniform( [ N ], -100.0, 100.0, options );
+	A = zeros( [ N, N ], options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	uplo = scalar2ndarray( resolveEnum( 'upper' ), {
@@ -84,7 +84,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( 0, i%len ) ) ) {
+		if ( isnan( z.get( 0, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -101,9 +101,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -111,9 +111,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ggemm/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ggemm/benchmark/benchmark.js
@@ -44,10 +44,10 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var transA;
 	var transB;
 	var alpha;
@@ -56,9 +56,9 @@ function createBenchmark( len ) {
 	var B;
 	var C;
 
-	A = uniform( [ len, len ], -100.0, 100.0, options );
-	B = uniform( [ len, len ], -100.0, 100.0, options );
-	C = uniform( [ len, len ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
+	B = uniform( [ N, N ], -100.0, 100.0, options );
+	C = uniform( [ N, N ], -100.0, 100.0, options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	beta = scalar2ndarray( 1.0, options );
@@ -89,7 +89,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( i%len, i%len ) ) ) {
+		if ( isnan( z.get( i%N, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -106,9 +106,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -116,9 +116,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ggemv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ggemv/benchmark/benchmark.js
@@ -44,10 +44,10 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var trans;
 	var alpha;
 	var beta;
@@ -55,9 +55,9 @@ function createBenchmark( len ) {
 	var x;
 	var y;
 
-	A = uniform( [ len, len ], -100.0, 100.0, options );
-	x = uniform( [ len ], -100.0, 100.0, options );
-	y = uniform( [ len ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	y = uniform( [ N ], -100.0, 100.0, options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	beta = scalar2ndarray( 1.0, options );
@@ -85,7 +85,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( i%len ) ) ) {
+		if ( isnan( z.get( i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -102,9 +102,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -112,9 +112,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/gger/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/gger/benchmark/benchmark.js
@@ -43,18 +43,18 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var x;
 	var y;
 	var A;
 
-	x = uniform( [ len ], -100.0, 100.0, options );
-	y = uniform( [ len ], -100.0, 100.0, options );
-	A = uniform( [ len, len ], -100.0, 100.0, options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	y = uniform( [ N ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
 
 	alpha = scalar2ndarray( 1.0, options );
 
@@ -78,7 +78,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( 0, i%len ) ) ) {
+		if ( isnan( z.get( 0, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -95,9 +95,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -105,9 +105,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/gsyr/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/gsyr/benchmark/benchmark.js
@@ -45,17 +45,17 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var uplo;
 	var x;
 	var A;
 
-	x = uniform( [ len ], -100.0, 100.0, options );
-	A = zeros( [ len, len ], options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	A = zeros( [ N, N ], options );
 
 	uplo = scalar2ndarray( resolveEnum( 'upper' ), {
 		'dtype': 'int32'
@@ -82,7 +82,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnan( z.get( 0, i%len ) ) ) {
+		if ( isnan( z.get( 0, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -99,9 +99,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -109,9 +109,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/sgemm/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/sgemm/benchmark/benchmark.js
@@ -44,10 +44,10 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var transA;
 	var transB;
 	var alpha;
@@ -56,9 +56,9 @@ function createBenchmark( len ) {
 	var B;
 	var C;
 
-	A = uniform( [ len, len ], -100.0, 100.0, options );
-	B = uniform( [ len, len ], -100.0, 100.0, options );
-	C = uniform( [ len, len ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
+	B = uniform( [ N, N ], -100.0, 100.0, options );
+	C = uniform( [ N, N ], -100.0, 100.0, options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	beta = scalar2ndarray( 1.0, options );
@@ -89,7 +89,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnanf( z.get( i%len, i%len ) ) ) {
+		if ( isnanf( z.get( i%N, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -106,9 +106,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -116,9 +116,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/sgemv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/sgemv/benchmark/benchmark.js
@@ -44,10 +44,10 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var trans;
 	var alpha;
 	var beta;
@@ -55,9 +55,9 @@ function createBenchmark( len ) {
 	var x;
 	var y;
 
-	A = uniform( [ len, len ], -100.0, 100.0, options );
-	x = uniform( [ len ], -100.0, 100.0, options );
-	y = uniform( [ len ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	y = uniform( [ N ], -100.0, 100.0, options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	beta = scalar2ndarray( 1.0, options );
@@ -85,7 +85,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnanf( z.get( i%len ) ) ) {
+		if ( isnanf( z.get( i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -102,9 +102,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -112,9 +112,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/sger/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/sger/benchmark/benchmark.js
@@ -43,18 +43,18 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var x;
 	var y;
 	var A;
 
-	x = uniform( [ len ], -100.0, 100.0, options );
-	y = uniform( [ len ], -100.0, 100.0, options );
-	A = uniform( [ len, len ], -100.0, 100.0, options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	y = uniform( [ N ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
 
 	alpha = scalar2ndarray( 1.0, options );
 
@@ -78,7 +78,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnanf( z.get( 0, i%len ) ) ) {
+		if ( isnanf( z.get( 0, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -95,9 +95,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -105,9 +105,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/sspr/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/sspr/benchmark/benchmark.js
@@ -44,17 +44,17 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var uplo;
 	var AP;
 	var x;
 
-	AP = uniform( [ ( len * ( len+1 ) ) / 2 ], -100.0, 100.0, options );
-	x = uniform( [ len ], -100.0, 100.0, options );
+	AP = uniform( [ ( N * ( N+1 ) ) / 2 ], -100.0, 100.0, options );
+	x = uniform( [ N ], -100.0, 100.0, options );
 
 	uplo = scalar2ndarray( resolveEnum( 'upper' ), {
 		'dtype': 'int8'
@@ -81,7 +81,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnanf( z.get( i%len ) ) ) {
+		if ( isnanf( z.get( i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -98,9 +98,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -108,9 +108,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, ( N * ( N+1 ) ) / 2 ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ssyr/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ssyr/benchmark/benchmark.js
@@ -45,17 +45,17 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var uplo;
 	var x;
 	var A;
 
-	x = uniform( [ len ], -100.0, 100.0, options );
-	A = zeros( [ len, len ], options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	A = zeros( [ N, N ], options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	uplo = scalar2ndarray( resolveEnum( 'upper' ), {
@@ -82,7 +82,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnanf( z.get( 0, i%len ) ) ) {
+		if ( isnanf( z.get( 0, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -99,9 +99,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -109,9 +109,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/blas/base/ndarray/ssyr2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ssyr2/benchmark/benchmark.js
@@ -45,19 +45,19 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var uplo;
 	var x;
 	var y;
 	var A;
 
-	x = uniform( [ len ], -100.0, 100.0, options );
-	y = uniform( [ len ], -100.0, 100.0, options );
-	A = zeros( [ len, len ], options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	y = uniform( [ N ], -100.0, 100.0, options );
+	A = zeros( [ N, N ], options );
 
 	alpha = scalar2ndarray( 1.0, options );
 	uplo = scalar2ndarray( resolveEnum( 'upper' ), {
@@ -84,7 +84,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnanf( z.get( 0, i%len ) ) ) {
+		if ( isnanf( z.get( 0, i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -101,9 +101,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -111,9 +111,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-08-13 and 2026-08-14 to sibling packages.

Same defect propagates through the level-2/level-3 `blas/base/ndarray` matrix benchmarks (cgemv, dgemm, dgemv, dger, dspr, dsyr, dsyr2, ggemm, ggemv, gger, gsyr, sgemm, sgemv, sger, sspr, ssyr, ssyr2): benchmark factories document `len` as array length when it is the matrix dimension, and labels report `len=%d` rather than `size=%d` per `docs/contributing/benchmark_names.md`. Rename `len` to `N` in each `benchmark/benchmark.js`, correct the JSDoc to "number of elements along each dimension", and switch labels to `size=%d` using `N*N` for dense routines or `( N * ( N+1 ) ) / 2` for packed routines (dspr, sspr), bringing these ndarray variants in line with their already-migrated `blas/base/*` counterparts.

Source commit: d0d285717b (`bench: fix description and update variable names`). Target packages:

-   `@stdlib/blas/base/ndarray/cgemv`
-   `@stdlib/blas/base/ndarray/dgemm`
-   `@stdlib/blas/base/ndarray/dgemv`
-   `@stdlib/blas/base/ndarray/dger`
-   `@stdlib/blas/base/ndarray/dspr`
-   `@stdlib/blas/base/ndarray/dsyr`
-   `@stdlib/blas/base/ndarray/dsyr2`
-   `@stdlib/blas/base/ndarray/ggemm`
-   `@stdlib/blas/base/ndarray/ggemv`
-   `@stdlib/blas/base/ndarray/gger`
-   `@stdlib/blas/base/ndarray/gsyr`
-   `@stdlib/blas/base/ndarray/sgemm`
-   `@stdlib/blas/base/ndarray/sgemv`
-   `@stdlib/blas/base/ndarray/sger`
-   `@stdlib/blas/base/ndarray/sspr`
-   `@stdlib/blas/base/ndarray/ssyr`
-   `@stdlib/blas/base/ndarray/ssyr2`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation: candidate sites were enumerated by searching all benchmark files for `len=%d` labels co-occurring with N×N matrix construction; two independent validation passes confirmed the defect at each site by reading each original file in full, an adaptation pass verified the per-site size expressions (dense vs. packed storage, complex interleaved buffers), and a style pass checked declaration ordering, label naming per `docs/contributing/benchmark_names.md`, and JSDoc wording against the source commit and already-migrated `blas/base/*` counterparts. Deliberately excluded: `benchmark.length.js` files for cartesian-product-style packages (label semantics differ), level-1 vector routines (where `len=%d` is correct), and BLAS-level `blas/base/*gemm`/`*ger` files (already migrated to `size=%d`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of an automated fix-propagation routine: it applies the fix from commit d0d285717b to sibling packages, with each target site validated by independent review passes before inclusion.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z4Xtpa7cD9BHHLV96uPcg)_