### PR TITLE
test: migrate `stats/base/dists/rayleigh/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -128,10 +127,8 @@ tape( 'if `sigma` equals `0`, the created function evaluates a degenerate distri
 
 tape( 'the created function evaluates the pdf for `x` given small scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var pdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -143,13 +140,7 @@ tape( 'the created function evaluates the pdf for `x` given small scale paramete
 		pdf = factory( sigma[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -157,10 +148,8 @@ tape( 'the created function evaluates the pdf for `x` given small scale paramete
 
 tape( 'the created function evaluates the pdf for `x` given medium scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var pdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -172,13 +161,7 @@ tape( 'the created function evaluates the pdf for `x` given medium scale paramet
 		pdf = factory( sigma[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -186,10 +169,8 @@ tape( 'the created function evaluates the pdf for `x` given medium scale paramet
 
 tape( 'the created function evaluates the pdf for `x` given large scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var pdf;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -201,13 +182,7 @@ tape( 'the created function evaluates the pdf for `x` given large scale paramete
 		pdf = factory( sigma[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -111,9 +110,7 @@ tape( 'if provided `sigma` equal to `0`, the function evaluates a degenerate dis
 
 tape( 'the function evaluates the pdf for `x` given small scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -124,13 +121,7 @@ tape( 'the function evaluates the pdf for `x` given small scale parameter `sigma
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -138,9 +129,7 @@ tape( 'the function evaluates the pdf for `x` given small scale parameter `sigma
 
 tape( 'the function evaluates the pdf for `x` given medium scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -151,13 +140,7 @@ tape( 'the function evaluates the pdf for `x` given medium scale parameter `sigm
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -165,9 +148,7 @@ tape( 'the function evaluates the pdf for `x` given medium scale parameter `sigm
 
 tape( 'the function evaluates the pdf for `x` given large scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -178,13 +159,7 @@ tape( 'the function evaluates the pdf for `x` given large scale parameter `sigma
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -102,9 +101,7 @@ tape( 'if provided `sigma` equal to `0`, the function evaluates a degenerate dis
 
 tape( 'the function evaluates the pdf for `x` given small scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -115,13 +112,7 @@ tape( 'the function evaluates the pdf for `x` given small scale parameter `sigma
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -129,9 +120,7 @@ tape( 'the function evaluates the pdf for `x` given small scale parameter `sigma
 
 tape( 'the function evaluates the pdf for `x` given medium scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -142,13 +131,7 @@ tape( 'the function evaluates the pdf for `x` given medium scale parameter `sigm
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -156,9 +139,7 @@ tape( 'the function evaluates the pdf for `x` given medium scale parameter `sigm
 
 tape( 'the function evaluates the pdf for `x` given large scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -169,13 +150,7 @@ tape( 'the function evaluates the pdf for `x` given large scale parameter `sigma
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/rayleigh/pdf` from relative tolerance testing (`delta <= tol`, where `tol = 3.0 * EPS * abs( expected[ i ] )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js`. The `expected[i] !== null` fixture guards are left in place, and no fixtures, implementations, or other test cases were modified.
-   uses a ULP bound of `2` for every fixture loop (`small_scale`, `medium_scale`, `large_scale`) in all three test files. This is the measured minimum: the maximum observed ULP difference over the full fixture set (1000 values per fixture file, 3000 per test file) is exactly `2` for the JavaScript implementation, the factory-created function, and the C implementation alike. Tests fail at a bound of `1` (58 failing assertions) and pass at `2`, and the full suite was run twice at the final bound to confirm determinism.

Test results for the package (per test file):

-   `test/test.pdf.js`: 3014 passing, 0 failing
-   `test/test.factory.js`: 3014 passing, 0 failing
-   `test/test.native.js`: 3014 passing, 0 failing (native add-on built locally, so these did not skip)
-   `test/test.js`: 3 passing, 0 failing

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The JavaScript and C implementations agree on the measured maximum ULP difference (`2`), so a single bound is used across `test.pdf.js`, `test.factory.js`, and `test.native.js`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. It studied previously merged ULP migrations in the same family (e.g. `stats/base/dists/gamma/pdf`, `stats/base/dists/laplace/pdf`, `stats/base/dists/uniform/logpdf`) to mirror the established idiom, measured the minimum ULP bound empirically via `@stdlib/number/float64/base/ulp-difference` over the full fixture set, and verified the result by running the package test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value


---
_Generated by [Claude Code](https://claude.ai/code/session_011WxgQeo8ZNdRy5X9gvUWhG)_