### PR TITLE
test: migrate `math/base/special/boxcox` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/boxcox/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox/test/test.js
@@ -23,9 +23,8 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var boxcox = require( './../lib' );
 
 
@@ -94,8 +93,6 @@ tape( 'the function returns `NaN` if `x` is negative', function test( t ) {
 
 tape( 'the function computes a one-parameter Box-Cox transformation for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -106,21 +103,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for positive
 	y = mediumPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 16.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 22 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for positive small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -131,21 +120,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for positive
 	y = smallPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 16.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 29 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -156,21 +137,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny num
 	y = tiny.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 70.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 86 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny lambda', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -181,13 +154,7 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny lam
 	y = tinyLambda.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/boxcox/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/boxcox/test/test.native.js
@@ -24,9 +24,8 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -103,8 +102,6 @@ tape( 'the function returns `NaN` if `x` is negative', opts, function test( t ) 
 
 tape( 'the function computes a one-parameter Box-Cox transformation for positive medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -115,21 +112,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for positive
 	y = mediumPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 16.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 22 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for positive small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -140,21 +129,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for positive
 	y = smallPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 16.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 29 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -165,21 +146,13 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny num
 	y = tiny.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 70.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 86 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes a one-parameter Box-Cox transformation for tiny lambda', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -190,13 +163,7 @@ tape( 'the function computes a one-parameter Box-Cox transformation for tiny lam
 	y = tinyLambda.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcox( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/boxcox` from computed relative tolerance (`EPS`-scaled `delta <= tol`) checks to ULP-based assertions;
-   replaces the `@stdlib/math/base/special/abs` require with `@stdlib/assert/is-almost-same-value` and removes the `EPS` constant as it is no longer required;
-   both `test/test.js` and `test/test.native.js` are modified to use the new ULP assertions.

**ULP bounds** (one per fixture set, each tightened to the measured minimum):

| fixture set | previous tolerance | ULP bound |
| ----------- | ------------------ | --------- |
| `mediumPositive` | `16.0 * EPS` | `22` |
| `smallPositive` | `16.0 * EPS` | `29` |
| `tiny` | `70.0 * EPS` | `86` |
| `tinyLambda` | `1.0 * EPS` | `1` |

Each bound is the smallest non-negative integer for which every fixture in the corresponding set passes. Starting from a high bound and lowering, the suite passes at the values above, and decrementing each bound by one produces exactly one failure per set, confirming that no bound can be tightened further. 

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
