### PR TITLE
test: migrate `math/base/special/boxcoxinv` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/boxcoxinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/boxcoxinv/test/test.js
@@ -23,8 +23,7 @@
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var boxcoxinv = require( './../lib' );
 
 
@@ -93,8 +92,6 @@ tape( 'the function returns `NaN` if `x` is positive and `lambda` is less than n
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for positive medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -105,21 +102,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = mediumPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for negative medium numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -130,21 +119,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = mediumNegative.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for positive small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -155,21 +136,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = smallPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for negative small numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -180,21 +153,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = smallNegative.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for tiny numbers', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -205,21 +170,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = tiny.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation when `lambda` is zero', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -230,13 +187,7 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = lambdaZero.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/boxcoxinv/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/boxcoxinv/test/test.native.js
@@ -24,8 +24,7 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -102,8 +101,6 @@ tape( 'the function returns `NaN` if `x` is positive and `lambda` is less than n
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for positive medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -114,21 +111,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = mediumPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for negative medium numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -139,21 +128,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = mediumNegative.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for positive small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -164,21 +145,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = smallPositive.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for negative small numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -189,21 +162,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = smallNegative.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation for tiny numbers', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -214,21 +179,13 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = tiny.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the inverse of a one-parameter Box-Cox transformation when `lambda` is zero', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var b;
@@ -239,13 +196,7 @@ tape( 'the function computes the inverse of a one-parameter Box-Cox transformati
 	y = lambdaZero.y;
 	for ( i = 0; i < expected.length; i++ ) {
 		b = boxcoxinv( x[ i ], y[ i ] );
-		if ( b === expected[ i ] ) {
-			t.strictEqual( b, expected[ i ], 'returns '+b+' when provided '+x[i]+' and '+y[i]+'.' );
-		} else {
-			delta = abs( expected[ i ] - b );
-			tol = 2.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. returns '+b+' when provided '+x[i]+' and '+y[i]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: ' +tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( b, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/boxcoxinv` from computed relative tolerance (`EPS`-scaled `delta <= tol`) checks to ULP-based assertions;
-   replaces the `@stdlib/math/base/special/abs` require with `@stdlib/assert/is-almost-same-value` and removes the `EPS` constant as it is no longer required;
-   both `test/test.js` and `test/test.native.js` are modified to use the new ULP assertions.

**ULP bounds** (one per fixture set, each tightened to the measured minimum):

| fixture set | previous tolerance | ULP bound |
| ----------- | ------------------ | --------- |
| `mediumPositive` | `2.5 * EPS` | `4` |
| `mediumNegative` | `2.0 * EPS` | `2` |
| `smallPositive` | `3.5 * EPS` | `2` |
| `smallNegative` | `1.5 * EPS` | `2` |
| `tiny` | `1.0 * EPS` | `0` |
| `lambdaZero` | `1.0 * EPS` | `1` |

Each bound is the smallest non-negative integer for which the fixtures in the corresponding set pass (with `0` being an exact match for the `tiny` fixture).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
