### PR TITLE
test: migrate `stats/incr/nanskewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanskewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanskewness/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var incrnanskewness = require( './../lib' );
 
 
@@ -42,10 +41,8 @@ tape( 'the function returns an accumulator function', function test( t ) {
 tape( 'the accumulator function incrementally computes a corrected sample skewness', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var i;
 
 	data = [ 3.0, 2.0, 7.0, NaN, -1.0, NaN, 9.0 ];
@@ -67,9 +64,7 @@ tape( 'the accumulator function incrementally computes a corrected sample skewne
 		if ( expected[ i ] === null ) {
 			t.strictEqual( actual, expected[i], 'returns expected value' );
 		} else {
-			delta = abs( actual - expected[ i ] );
-			tol = 1.5 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual+'. E: '+expected[i]+' Δ: '+delta+'. tol: '+tol );
+			t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -78,10 +73,8 @@ tape( 'the accumulator function incrementally computes a corrected sample skewne
 tape( 'if not provided an input value, the accumulator function returns the current corrected sample skewness', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
 	var data;
 	var acc;
-	var tol;
 	var i;
 
 	data = [ 1.0, 4.0, 1.0, NaN, 0.0, 2.0, 12.0 ];
@@ -91,9 +84,7 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 	}
 	expected = 1.986829609590966;
 	actual = acc();
-	delta = abs( actual - expected );
-	tol = EPS * abs( expected );
-	t.ok( delta <= tol, 'within tolerance. actual: '+actual+'. E: '+expected+' Δ: '+delta+'. tol: '+tol );
+	t.strictEqual( isAlmostSameValue( actual, expected, 1 ), true, 'returns expected value' );
 	t.end();
 });
 


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `stats/incr/nanskewness` from relative-tolerance testing to ULP (units in the last place) difference testing, per the tracking issue.
-   Replaces both `delta`/`tol` (EPS-based) comparisons in `test/test.js` with `@stdlib/assert/is-almost-same-value`. The package has no `test/test.native.js`, so `test/test.js` is the only changed file.
-   The minimum required ULP bound was determined by computing the actual ULP difference between observed and expected values for every non-`null` expected value in both test cases. The maximum observed difference was **1 ULP**, so both assertions use `isAlmostSameValue( actual, expected, 1 )`.
-   Minimality was verified by re-running the suite at `0` ULPs, which fails 6 assertions; `1` is therefore the tightest bound which passes.
-   The test suite was run twice at this bound to confirm deterministic results (no FMA/architecture-related flakiness).
-   The existing `expected[ i ] === null` branch in the accumulator loop is retained as-is, since it asserts the accumulator's `null` return prior to three data points and is not part of the tolerance idiom being migrated.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

`make lint-javascript-tests` is clean for the changed file. The `editorconfig-checker` step could not be executed in the authoring environment, as the package downloads its binary from a GitHub release which was unreachable; the file was instead checked manually against `.editorconfig` (tab indentation, LF line endings, UTF-8, no trailing whitespace, final newline).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, following the conventions established in already-merged ULP migration PRs (e.g. #14255, #14252, #14163). The minimum ULP bound was determined empirically by computing actual ULP differences, not guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFBgQFAtEnsnHWC53ERcZ3)_