### PR TITLE
test: migrate `stats/base/dists/lognormal/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -135,10 +134,8 @@ tape( 'if provided a nonpositive `sigma`, the created function always returns `N
 
 tape( 'the created function evaluates the pdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var pdf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -152,13 +149,7 @@ tape( 'the created function evaluates the pdf for `x` given positive `mu`', func
 		pdf = factory( mu[i], sigma[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 550.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 800 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -166,10 +157,8 @@ tape( 'the created function evaluates the pdf for `x` given positive `mu`', func
 
 tape( 'the created function evaluates the pdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var pdf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -183,13 +172,7 @@ tape( 'the created function evaluates the pdf for `x` given negative `mu`', func
 		pdf = factory( mu[i], sigma[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1050.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1489 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -197,10 +180,8 @@ tape( 'the created function evaluates the pdf for `x` given negative `mu`', func
 
 tape( 'the created function evaluates the pdf for `x` given large variance ( = large `sigma`)', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var pdf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -214,13 +195,7 @@ tape( 'the created function evaluates the pdf for `x` given large variance ( = l
 		pdf = factory( mu[i], sigma[i] );
 		y = pdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 300.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 305 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -104,9 +103,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', opts, fun
 
 tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -119,13 +116,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 550.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 800 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -133,9 +124,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', opts, functi
 
 tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -148,13 +137,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1050.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1489 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -162,9 +145,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', opts, functi
 
 tape( 'the function evaluates the pdf for `x` given large variance ( = large `sigma` )', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -177,13 +158,7 @@ tape( 'the function evaluates the pdf for `x` given large variance ( = large `si
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 300.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 305 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/test/test.pdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
 
@@ -95,9 +94,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function 
 
 tape( 'the function evaluates the pdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -110,13 +107,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 550.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 800 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -124,9 +115,7 @@ tape( 'the function evaluates the pdf for `x` given positive `mu`', function tes
 
 tape( 'the function evaluates the pdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -139,13 +128,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1050.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1489 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -153,9 +136,7 @@ tape( 'the function evaluates the pdf for `x` given negative `mu`', function tes
 
 tape( 'the function evaluates the pdf for `x` given large variance ( = large `sigma` )', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -168,13 +149,7 @@ tape( 'the function evaluates the pdf for `x` given large variance ( = large `si
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 300.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 305 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the tests for `stats/base/dists/lognormal/pdf` from relative-tolerance testing to ULP (units in the last place) difference testing, per the tracking issue.
-   Replaces the `delta`/`tol` (EPS-based) comparisons in `test/test.pdf.js`, `test/test.factory.js`, and `test/test.native.js` with `@stdlib/assert/is-almost-same-value`. `test/test.js` only performs exact assertions and is left unchanged.
-   The minimum required ULP bound was determined empirically by computing, for every non-`null` expected value in each fixture set (1000 values per set), the exact minimum ULP difference between the observed and expected values, and then taking the maximum over the set. The JavaScript and factory code paths yielded identical maxima. The measured minimums are:

    | Fixture set | Previous tolerance | ULP bound |
    | ----------- | ------------------ | --------- |
    | `positive_location` | `550.0 * EPS` | **800** |
    | `negative_location` | `1050.0 * EPS` | **1489** |
    | `large_variance` | `300.0 * EPS` | **305** |

-   Minimality was verified by re-running `test/test.pdf.js` with each bound decremented by one (`799`/`1488`/`304`), which fails exactly one assertion per fixture set; the values above are therefore the tightest bounds which pass.
-   The test suite was run twice at these bounds to confirm deterministic results (no FMA/architecture-related flakiness).
-   The existing `expected[ i ] !== null` guard in each fixture loop is retained as-is, since it is not part of the tolerance idiom being migrated.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The bounds for `test/test.native.js` mirror those measured for the JavaScript implementation. The native add-on was not built in the authoring environment, so those tests were skipped locally and the bounds are unverified against the C implementation; CI coverage for the native tests would confirm them.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

`test/test.js`, `test/test.pdf.js`, and `test/test.factory.js` are green (3, 3014, and 3017 assertions, respectively, all passing, across two consecutive runs). ESLint (`etc/eslint/.eslintrc.tests.js`), the EditorConfig check, the filename lint, and commitlint are all clean for the changed files; the same checks were run against an already-migrated package (`stats/base/dists/gamma/pdf`) as a control.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code, following the conventions established in already-merged ULP migration PRs (e.g. #14206, #14213). The ULP bounds were measured empirically, not guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01N6nGZrFRdZCmZGiBjMnGtZ)_