### PR TITLE
test: migrate `stats/base/dists/normal/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -107,9 +106,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the cdf for `x` (given positive `mu`)', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var i;
 	var x;
@@ -121,22 +118,14 @@ tape( 'the function evaluates the cdf for `x` (given positive `mu`)', function t
 	sigma = positiveMean.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1600.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2207 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` (given large `sigma`)', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var i;
 	var x;
@@ -148,22 +137,14 @@ tape( 'the function evaluates the cdf for `x` (given large `sigma`)', function t
 	sigma = negativeMean.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1600.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2433 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` (given negative `mu`)', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var i;
 	var x;
@@ -175,13 +156,7 @@ tape( 'the function evaluates the cdf for `x` (given negative `mu`)', function t
 	sigma = largeVariance.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -150,10 +149,8 @@ tape( 'if `sigma` equals `0`, the created function evaluates a degenerate distri
 
 tape( 'the created function evaluates the cdf (given positive `mu`)', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var cdf;
-	var tol;
 	var mu;
 	var i;
 	var x;
@@ -166,23 +163,15 @@ tape( 'the created function evaluates the cdf (given positive `mu`)', function t
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], sigma[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1600.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2207 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf (given negative `mu`)', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var cdf;
-	var tol;
 	var mu;
 	var i;
 	var x;
@@ -195,23 +184,15 @@ tape( 'the created function evaluates the cdf (given negative `mu`)', function t
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], sigma[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1600.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2433 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf (given large `sigma`)', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var cdf;
-	var tol;
 	var mu;
 	var i;
 	var x;
@@ -224,13 +205,7 @@ tape( 'the created function evaluates the cdf (given large `sigma`)', function t
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( mu[i], sigma[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -116,9 +115,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the cdf for `x` (given positive `mu`)', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var i;
 	var x;
@@ -130,22 +127,14 @@ tape( 'the function evaluates the cdf for `x` (given positive `mu`)', opts, func
 	sigma = positiveMean.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1600.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2207 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` (given negative `mu`)', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var i;
 	var x;
@@ -157,22 +146,14 @@ tape( 'the function evaluates the cdf for `x` (given negative `mu`)', opts, func
 	sigma = negativeMean.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1600.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2433 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` (given large `sigma`)', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var i;
 	var x;
@@ -184,13 +165,7 @@ tape( 'the function evaluates the cdf for `x` (given large `sigma`)', opts, func
 	sigma = largeVariance.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], mu[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 250.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 4 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/normal/cdf` from relative tolerance testing to ULP difference testing, as described in #11352.

Changes are confined to `test/test.cdf.js`, `test/test.factory.js`, and `test/test.native.js`. In each fixture loop, `var delta`/`var tol` and the `abs( y - expected[i] ) <= EPS * abs( expected[i] )` comparison are replaced with `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' )`, and the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are removed in favor of `@stdlib/assert/is-almost-same-value`.

The ULP bounds were measured against the full fixture set (1000 cases per fixture) and tightened to the minimum passing integer:

| Fixture | Previous tolerance | ULP bound |
| ------- | ------------------ | --------- |
| `positive_mean.json` | `1600.0 * EPS` | `2207` |
| `negative_mean.json` | `1600.0 * EPS` | `2433` |
| `large_variance.json` | `250.0 * EPS` | `4` |

Each bound is the measured maximum ULP difference over its fixture, and is minimal: lowering any of them by one causes that fixture to fail. The same bounds apply to all three test files, as the C implementation returns bit-identical values to the JavaScript implementation for all 3000 fixture cases (verified locally with the native add-on built), so no JS vs. C divergence needed to be accounted for.

The full package test suite (`make test TESTS_FILTER=".*/stats/base/dists/normal/cdf/.*"`) passes, including `test.native.js` against a locally built add-on, and was run twice at the final ULP values to confirm the results are deterministic. `make eslint-tests` is clean for the package.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, following the migration pattern established in previously merged conversions (e.g. #14267, #14258, #14272). The ULP bounds were determined empirically by measuring ULP differences across the full fixture set and verifying minimality, rather than guessed.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

* * *

@stdlib-js/reviewers