### PR TITLE
test: migrate `stats/base/dists/weibull/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -123,8 +122,6 @@ tape( 'if provided a nonpositive `k`, the function returns `NaN`', function test
 tape( 'the function evaluates the cdf for `x` given large `lambda` and `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -136,13 +133,7 @@ tape( 'the function evaluates the cdf for `x` given large `lambda` and `k`', fun
 	k = bothLarge.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -150,8 +141,6 @@ tape( 'the function evaluates the cdf for `x` given large `lambda` and `k`', fun
 tape( 'the function evaluates the cdf for `x` given large shape parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -163,13 +152,7 @@ tape( 'the function evaluates the cdf for `x` given large shape parameter `lambd
 	k = largeShape.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -177,8 +160,6 @@ tape( 'the function evaluates the cdf for `x` given large shape parameter `lambd
 tape( 'the function evaluates the cdf for `x` given large scale parameter `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -190,13 +171,7 @@ tape( 'the function evaluates the cdf for `x` given large scale parameter `k`', 
 	k = largeScale.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -180,9 +179,7 @@ tape( 'if provided a nonpositive `lambda`, the created function always returns `
 tape( 'the created function evaluates the cdf for `x` given large `k` and `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var cdf;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -195,13 +192,7 @@ tape( 'the created function evaluates the cdf for `x` given large `k` and `lambd
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( k[i], lambda[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -209,9 +200,7 @@ tape( 'the created function evaluates the cdf for `x` given large `k` and `lambd
 tape( 'the created function evaluates the cdf for `x` given large shape parameter `lambda`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var cdf;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -224,13 +213,7 @@ tape( 'the created function evaluates the cdf for `x` given large shape paramete
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( k[i], lambda[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -238,9 +221,7 @@ tape( 'the created function evaluates the cdf for `x` given large shape paramete
 tape( 'the created function evaluates the cdf for `x` given large scale parameter `k`', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
 	var cdf;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -253,13 +234,7 @@ tape( 'the created function evaluates the cdf for `x` given large scale paramete
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( k[i], lambda[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', lambda: '+lambda[i]+', k: '+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -132,8 +131,6 @@ tape( 'if provided a nonpositive `k`, the function returns `NaN`', opts, functio
 tape( 'the function evaluates the cdf for `x` given large `lambda` and `k`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -145,13 +142,7 @@ tape( 'the function evaluates the cdf for `x` given large `lambda` and `k`', opt
 	k = bothLarge.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -159,8 +150,6 @@ tape( 'the function evaluates the cdf for `x` given large `lambda` and `k`', opt
 tape( 'the function evaluates the cdf for `x` given large shape parameter `lambda`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -172,13 +161,7 @@ tape( 'the function evaluates the cdf for `x` given large shape parameter `lambd
 	k = largeShape.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -186,8 +169,6 @@ tape( 'the function evaluates the cdf for `x` given large shape parameter `lambd
 tape( 'the function evaluates the cdf for `x` given large scale parameter `k`', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var k;
 	var x;
@@ -199,13 +180,7 @@ tape( 'the function evaluates the cdf for `x` given large scale parameter `k`', 
 	k = largeScale.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], k[i], lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. Expected: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/weibull/cdf` from relative tolerance testing to ULP difference testing, per #11352.

Changes are confined to the package's test files (`test/test.cdf.js`, `test/test.factory.js`, `test/test.native.js`):

-   adds the `@stdlib/assert/is-almost-same-value` require and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.
-   removes the `delta`/`tol` declarations and the `if ( y === expected[i] ) { ... } else { ... }` tolerance branch.
-   replaces each fixture-loop assertion with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );`.

No implementation, fixture, or documentation files are touched, and no test cases were added, removed, or otherwise altered.

### ULP bound

**All nine converted assertion loops use an ULP value of `0`**, which is the tightest bound possible.

The bound was measured rather than guessed: computing `@stdlib/number/float64/base/ulp-difference` between each computed value and its expected fixture value across the full fixture set (`both_large.json`, `large_shape.json`, `large_scale.json`; 1000 values each, 3000 total) yields a **maximum observed ULP difference of `0`** for the main export, for the function returned by `factory`, and for the native C implementation. In other words, every fixture value is reproduced exactly.

Verification:

-   `test/test.cdf.js` — 3021 assertions, all passing.
-   `test/test.factory.js` — 3026 assertions, all passing.
-   `test/test.native.js` — 3021 assertions, all passing. The native add-on was built locally so that these tests actually executed rather than being skipped.
-   The full suite was run twice at the final ULP value with identical results, to confirm the bound is not sensitive to FMA/architecture-dependent rounding.
-   ESLint (`etc/eslint/.eslintrc.tests.js`) reports no problems for the three changed files.

This mirrors the bound used by the already-merged sibling package `stats/base/dists/weibull/logcdf` (#14109), which likewise settled on `0`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled task. It studied the previously merged ULP migrations (in particular the sibling package `stats/base/dists/weibull/logcdf`) to match the established idiom, applied the mechanical test conversion, and empirically measured the minimum ULP bound and ran the test suite to verify it.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7sCoXnQ32e7WyEnjVg2Rh)_