### PR TITLE
docs: fix note

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/clogspace/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/clogspace/README.md
@@ -128,7 +128,7 @@ The function has the following parameters:
     // returns <Complex64>[ ~3.162, 0.0 ]
     ```
 
-    where `arr[1]` is only guaranteed to be approximately equal to the square root of `10`.
+    where `v` is only guaranteed to be approximately equal to the square root of `10`.
 
 -   When `N = 1` and `endpoint` is `false`, only the `base^start` value is written to a provided input ndarray. When `N = 1` and `endpoint` is `true`, only the `base^stop` value is written to a provided input ndarray.
 

--- a/lib/node_modules/@stdlib/fft/base/fftpack/rfftf/README.md
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/rfftf/README.md
@@ -94,7 +94,7 @@ The function accepts the following arguments:
 
 -   If `N` equals `1`, the function returns early without modifying the input, as a single data point is its own Fourier transform.
 
--   This transform is unnormalized as a call to this function followed by a call performing a backward transform will multiply the input array by `N`.
+-   This transform is unnormalized as a call to this function followed by a call performing a [backward transform][@stdlib/fft/base/fftpack/rfftb] will multiply the input array by `N`.
 
 </section>
 
@@ -152,6 +152,8 @@ console.log( r );
 <section class="links">
 
 [@stdlib/fft/base/fftpack/rffti]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/rffti
+
+[@stdlib/fft/base/fftpack/rfftb]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/rfftb
 
 </section>
 

--- a/lib/node_modules/@stdlib/fft/base/fftpack/rfftf/README.md
+++ b/lib/node_modules/@stdlib/fft/base/fftpack/rfftf/README.md
@@ -94,7 +94,7 @@ The function accepts the following arguments:
 
 -   If `N` equals `1`, the function returns early without modifying the input, as a single data point is its own Fourier transform.
 
--   This transform is unnormalized as a call to this function followed by a call performing a [backward transform][@stdlib/fft/base/fftpack/rfftb] will multiply the input array by `N`.
+-   This transform is unnormalized as a call to this function followed by a call performing a backward transform will multiply the input array by `N`.
 
 </section>
 
@@ -152,8 +152,6 @@ console.log( r );
 <section class="links">
 
 [@stdlib/fft/base/fftpack/rffti]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/rffti
-
-[@stdlib/fft/base/fftpack/rfftb]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fft/base/fftpack/rfftb
 
 </section>
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request contains follow-up fixes for commits merged to `develop` between 2026-08-14T13:55:13-07:00 (`75cbfe86`) and 2026-08-15T04:48:58-07:00 (`086aa4d2`). All 31 commits in the window were reviewed for typos, bugs, and style-guide violations; two documentation fixes resulted.

This pull request:

-   **`fft/base/fftpack/rfftf`**: Fix dangling link in `lib/node_modules/@stdlib/fft/base/fftpack/rfftf/README.md` (086aa4d2): `rfftb` doesn't exist as a package, so drop the `[backward transform][@stdlib/fft/base/fftpack/rfftb]` markup and the orphaned link definition, keep the plain-text reference.
-   **`blas/ext/base/ndarray/clogspace`**: Fixed leftover `dlogspace` template text in `lib/node_modules/@stdlib/blas/ext/base/ndarray/clogspace/README.md` (3d734756): Notes section referenced `arr[1]`, but the example only defines `v`. Changed to `v` to match `zlogspace`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Review window**: 31 commits merged to `develop` in the 24 hours preceding 2026-08-15, spanning new `fft/base/fftpack` packages (`rfftf`, `ndarray/rffti`), five new `stats/base/ndarray/dvariance*` kernels, native C backing for `dnanmidrange`/`dnanmeanwd`, new single-precision `math/base/special` functions (`expm1f`, `exp2f`, `cfloornf`), BLAS additions (`ssymv`, `clogspace`, `zlogspace`), nine ULP-based test migrations, and CI/docs housekeeping.

**Validation performed**:

-   Style-guide compliance audit (two independent passes) against `docs/style-guides` and established sibling packages of comparable complexity.
-   Bug scan (two independent passes) over the union diff and per-commit diffs, including execution of new kernels against reference implementations (`rfftf` vs. brute-force DFT and shipped C fixtures; `exp2f`/`expm1f` vs. FreeBSD msun references and Julia fixtures; JS vs. C parity checks). No runtime defects found.

**Deliberately excluded**: subjective suggestions, style preferences not explicitly required by the style guides, and anything requiring interpretation. Notably, `fft/base/fftpack/ndarray/rffti` describing its workspace argument as "a one-dimensional input ndarray" was flagged and dropped: pre-existing siblings (`blas/ext/base/ndarray/dlogspace`, `glogspace`) use identical wording for mutated destination ndarrays, so this is established convention. Runtime namespace registrations without matching `docs/types/index.d.ts` entries (`098f2aa`, `bc5638e`) were likewise not flagged, as batched TypeScript declaration updates are the normal workflow.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated review of commits recently merged to `develop`. Claude Code identified the documentation errors, applied the fixes, and drafted this PR for human audit and promotion.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017G9gqSojAEsvA2t1ZViA7z)_