### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/ndarray/ssymv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/ndarray/ssymv/benchmark/benchmark.js
@@ -45,10 +45,10 @@ var options = {
 * Creates a benchmark function.
 *
 * @private
-* @param {PositiveInteger} len - array length
+* @param {PositiveInteger} N - number of elements along each dimension
 * @returns {Function} benchmark function
 */
-function createBenchmark( len ) {
+function createBenchmark( N ) {
 	var alpha;
 	var uplo;
 	var beta;
@@ -57,14 +57,14 @@ function createBenchmark( len ) {
 	var x;
 	var y;
 
-	A = uniform( [ len, len ], -100.0, 100.0, options );
+	A = uniform( [ N, N ], -100.0, 100.0, options );
 	k = scalar2ndarray( 1, {
 		'dtype': 'generic'
 	});
 	striu2tril( [ A, A, k ] );
 
-	x = uniform( [ len ], -100.0, 100.0, options );
-	y = uniform( [ len ], -100.0, 100.0, options );
+	x = uniform( [ N ], -100.0, 100.0, options );
+	y = uniform( [ N ], -100.0, 100.0, options );
 
 	uplo = scalar2ndarray( resolveEnum( 'upper' ), {
 		'dtype': 'int32'
@@ -92,7 +92,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( isnanf( z.get( i%len ) ) ) {
+		if ( isnanf( z.get( i%N ) ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
@@ -109,9 +109,9 @@ function createBenchmark( len ) {
 * @private
 */
 function main() {
-	var len;
 	var min;
 	var max;
+	var N;
 	var f;
 	var i;
 
@@ -119,9 +119,9 @@ function main() {
 	max = 3; // 10^max
 
 	for ( i = min; i <= max; i++ ) {
-		len = pow( 10, i );
-		f = createBenchmark( len );
-		bench( format( '%s:len=%d', pkg, len ), f );
+		N = pow( 10, i );
+		f = createBenchmark( N );
+		bench( format( '%s:size=%d', pkg, N*N ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/variance/README.md
@@ -156,7 +156,7 @@ double out = stdlib_base_dists_geometric_variance( 0.5 );
 
 The function accepts the following arguments:
 
--   **p**: `[in] double` success probablity.
+-   **p**: `[in] double` success probability.
 
 ```c
 double stdlib_base_dists_geometric_variance( const double p );


### PR DESCRIPTION
## Description

&gt; What is the purpose of this pull request?

This pull request:

-   propagates fixes merged to `develop` between 2026-08-14 and 2026-08-15 to sibling packages.

Source commit a99a888df (`docs: fix typo`) corrected `probablity` to `probability` in `stats/base/dists/geometric/variance/src/main.c` but left the identical string in the package README, which documents the same C API parameter. That README line was the last occurrence of `probablity` anywhere in the repository; fixing it brings the file in line with all eight sibling `stats/base/dists/geometric/*` READMEs, which already read "success probability". Target package:

-   `@stdlib/stats/base/dists/geometric/variance`

`blas/base/ndarray/ssymv` (added in 26e6545e5 after PR #14261's `len` → `N` cleanup was authored) shipped with the same stale template: `len` documented as "array length" for a parameter that is actually the dense `N`-by-`N` symmetric matrix dimension, plus a `len=%d` benchmark label reporting the wrong problem size. This commit applies the identical fix from source commit 75cbfe861 (`bench: fix description and update variable names in blas/base/ndarray`) — rename `len` to `N`, correct the JSDoc to "number of elements along each dimension", and switch the label to `%s:size=%d` reporting `N*N` — bringing `ssymv` in line with `ssyr`, `sgemv`, and the rest of the `blas/base/ndarray` matrix-op benchmarks. With this change, every matrix-op benchmark in `blas/base/ndarray` follows the `docs/contributing/benchmark_names.md` convention. Target package:

-   `@stdlib/blas/base/ndarray/ssymv`

## Related Issues

&gt; Does this pull request have any related issues?

No.

## Questions

&gt; Any questions for reviewers of this pull request?

No.

## Other

&gt; Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Validation: candidate sites were enumerated per source pattern (repo-wide `probablity` search with a single remaining hit; `%s:len=%d` labels co-occurring with two-dimensional allocations across `blas/base/ndarray/*/benchmark/`, where the 40 remaining `len=%d` files are level-1 vector routines for which `len` is correct terminology). Two independent validation passes confirmed each defect by reading each target file in full, an adaptation pass verified the dense (`N*N`) versus packed (`( N * ( N+1 ) ) / 2`) size expression and the declaration ordering against the fixed siblings, and a style pass checked wording against the eight sibling `geometric/*` READMEs and the fixed `ssyr`/`sgemv` benchmarks. Deliberately excluded: three additional source patterns from the window (stale README variable note from 8d4d1355, missing `ComplexLike` JSDoc types from ee85255c, missing Cephes install step from 7f74364d) after exhaustive searches found no remaining sibling defects.

## Checklist

&gt; Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

&gt; When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

&gt; If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code as part of an automated fix-propagation routine: it applies fixes from commits a99a888df and 75cbfe861 to sibling packages, with each target site validated by independent review passes before inclusion.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDPteKXsG9t8kxHKjbrAif)_