### PR TITLE
test: migrate `stats/base/dists/laplace/mode` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mode = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', function test
 
 tape( 'the function returns the mode of a Laplace distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var y;
@@ -89,13 +86,7 @@ tape( 'the function returns the mode of a Laplace distribution', function test( 
 	for ( i = 0; i < mu.length; i++ ) {
 		y = mode( mu[i], b[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/laplace/mode/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -88,8 +87,6 @@ tape( 'if provided a nonpositive `b`, the function returns `NaN`', opts, functio
 
 tape( 'the function returns the mode of a Laplace distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var b;
 	var y;
@@ -101,13 +98,7 @@ tape( 'the function returns the mode of a Laplace distribution', opts, function 
 	for ( i = 0; i < mu.length; i++ ) {
 		y = mode( mu[i], b[i] );
 		if ( expected[i] !== null) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'mu:'+mu[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/laplace/mode` from relative tolerance testing (`delta = abs( y - expected[i] )`, `tol = 1.0 * EPS * abs( expected[i] )`, `t.ok( delta <= tol, ... )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates both `test/test.js` and `test/test.native.js`, which mirror one another.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports from both test files, as `abs` and `EPS` are not used anywhere else in these files.

The ULP bounds were tightened to the measured minimum which passes over the full fixture set, for both the JavaScript and the C implementations:

| Fixture file | Test case | ULP bound | Measured maximum ULP difference |
| --- | --- | --- | --- |
| `fixtures/julia/data.json` | the function returns the mode of a Laplace distribution | `0` | 0 (JS and native) |

Notes on how the bound was determined:

-   Each bound is the minimum non-negative integer for which every fixture value passes. All 100 fixture values are bit-for-bit exact against the Julia reference values, for both the JavaScript and the C implementations, so the measured maximum ULP difference is `0`. As `0` is the smallest admissible bound, it cannot be tightened further.
-   This is consistent with the implementation: the mode of a Laplace distribution is `mu`, which is returned unmodified, so no rounding is introduced and the returned value is exactly the reference value.
-   The JavaScript and C implementations agree exactly with one another, so `test.js` and `test.native.js` use identical bounds.
-   The native add-on was compiled locally (`make install-node-addons NODE_ADDONS_PATTERN="mode"`), so `test/test.native.js` was exercised against the actual C implementation rather than skipped. Both test files were run twice at the final bound, with identical results (110 assertions for `test.js`, 111 for `test.native.js`, all passing, per run).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.
-   Linting is clean via `make eslint-tests TESTS_FILTER=".*/stats/base/dists/laplace/mode/.*"` (ESLint with `etc/eslint/.eslintrc.tests.js`, including the `stdlib` plugin rules), and `make check-licenses-production` passed on push.
-   Environment notes, in case they are useful to others hitting the same issues:
    -   `make install-node-modules` initially failed with `ETARGET: No matching version found for es-object-atoms@^1.1.2`. This turned out to be a stale local npm metadata cache rather than a real registry state; `npm cache clean --force` followed by re-running `make install-node-modules` succeeded, and the full toolchain was then available.
    -   The `editorconfig-checker` npm package downloads its binary from GitHub releases at run time, which is blocked in this environment, so `lint-editorconfig-files` could not run and the commit was made with `SKIP_LINT_EDITORCONFIG=1` (all other pre-commit lints ran normally). Both files were instead checked by hand against `.editorconfig`: LF line endings, UTF-8, tab indentation, no trailing whitespace, and a final newline.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. The test migration follows the idiom established by previously merged conversions, and the ULP bound was measured empirically against both the JavaScript and compiled C implementations rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9BxU6hqgzFQiY2vHkAwGg)_