### PR TITLE
test: migrate `stats/base/dists/normal/mgf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -113,10 +112,8 @@ tape( 'if provided a nonpositive `sigma`, the created function always returns `N
 
 tape( 'the created function evaluates the MGF for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var mgf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -130,13 +127,7 @@ tape( 'the created function evaluates the MGF for `x` given positive `mu`', func
 		mgf = factory( mu[i], sigma[i] );
 		y = mgf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1200.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1867 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -144,10 +135,8 @@ tape( 'the created function evaluates the MGF for `x` given positive `mu`', func
 
 tape( 'the created function evaluates the MGF for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var mgf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -161,13 +150,7 @@ tape( 'the created function evaluates the MGF for `x` given negative `mu`', func
 		mgf = factory( mu[i], sigma[i] );
 		y = mgf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1050.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2039 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -175,10 +158,8 @@ tape( 'the created function evaluates the MGF for `x` given negative `mu`', func
 
 tape( 'the created function evaluates the MGF for `x` given large variance ( = large `sigma`)', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
 	var mgf;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -192,13 +173,7 @@ tape( 'the created function evaluates the MGF for `x` given large variance ( = l
 		mgf = factory( mu[i], sigma[i] );
 		y = mgf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 700.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 969 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/test/test.mgf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/test/test.mgf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var mgf = require( './../lib' );
 
 
@@ -83,9 +82,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function 
 
 tape( 'the function evaluates the MGF for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -98,13 +95,7 @@ tape( 'the function evaluates the MGF for `x` given positive `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1200.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1867 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -112,9 +103,7 @@ tape( 'the function evaluates the MGF for `x` given positive `mu`', function tes
 
 tape( 'the function evaluates the MGF for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -127,13 +116,7 @@ tape( 'the function evaluates the MGF for `x` given negative `mu`', function tes
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1050.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2039 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -141,9 +124,7 @@ tape( 'the function evaluates the MGF for `x` given negative `mu`', function tes
 
 tape( 'the function evaluates the MGF for `x` given large variance ( = large `sigma` )', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -156,13 +137,7 @@ tape( 'the function evaluates the MGF for `x` given large variance ( = large `si
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 700.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 969 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -92,9 +91,7 @@ tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', opts, fun
 
 tape( 'the function evaluates the MGF for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -107,13 +104,7 @@ tape( 'the function evaluates the MGF for `x` given positive `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1200.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 1867 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -121,9 +112,7 @@ tape( 'the function evaluates the MGF for `x` given positive `mu`', opts, functi
 
 tape( 'the function evaluates the MGF for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -136,13 +125,7 @@ tape( 'the function evaluates the MGF for `x` given negative `mu`', opts, functi
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 1050.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 2039 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -150,9 +133,7 @@ tape( 'the function evaluates the MGF for `x` given negative `mu`', opts, functi
 
 tape( 'the function evaluates the MGF for `x` given large variance ( = large `sigma` )', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var mu;
 	var x;
 	var y;
@@ -165,13 +146,7 @@ tape( 'the function evaluates the MGF for `x` given large variance ( = large `si
 	for ( i = 0; i < x.length; i++ ) {
 		y = mgf( x[i], mu[i], sigma[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 700.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 969 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/normal/mgf` from relative tolerance testing to ULP difference testing, as described in #11352.

Changes are confined to `test/test.mgf.js`, `test/test.factory.js`, and `test/test.native.js`. In each fixture loop, `var delta`/`var tol` and the `abs( y - expected[i] ) <= EPS * abs( expected[i] )` comparison are replaced with `t.strictEqual( isAlmostSameValue( y, expected[ i ], N ), true, 'returns expected value' )`, and the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires are removed in favor of `@stdlib/assert/is-almost-same-value`. The existing `expected[i] !== null` guards are left in place.

The ULP bounds were measured against the full fixture set (1000 cases per fixture) and tightened to the minimum passing integer:

| Fixture | Previous tolerance | ULP bound |
| ------- | ------------------ | --------- |
| `positive_location.json` | `1200.0 * EPS` | `1867` |
| `negative_location.json` | `1050.0 * EPS` | `2039` |
| `large_variance.json` | `700.0 * EPS` | `969` |

Each bound is the measured maximum ULP difference over its fixture, and is minimal: lowering any of them by one causes that fixture to fail (verified by running the suite at `N-1`, which yields exactly one failure per fixture loop). The same bounds apply to all three test files, since `factory` and the main export return identical values for every fixture case, and the C implementation mirrors the JavaScript implementation directly (`exp( ( mu*t ) + ( 0.5 * pow( sigma*t, 2.0 ) ) )`), so no JS vs. C divergence needed to be accounted for.

The package test suite passes, and was run twice at the final ULP values to confirm the results are deterministic. ESLint (via `etc/eslint/.eslintrc.tests.js`) is clean for the package.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

`test/test.native.js` was skipped locally, as the native add-on was not built in the environment used to author this change; the bounds applied there are the ones measured against the JavaScript implementation. Please confirm CI exercises the native tests.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, following the migration pattern established in previously merged conversions (e.g. #14274, #14272, #14267). The ULP bounds were determined empirically by measuring ULP differences across the full fixture set and verifying minimality, rather than guessed.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYbMUHCscinCpwPMnzDvH4)_