### PR TITLE
test: migrate `math/base/special/fresnelc` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fresnelc/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnelc/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var fresnelc = require( './../lib' );
 
@@ -47,8 +46,6 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function computes the Fresnel integral C(x) (small positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var x;
 	var y;
@@ -59,20 +56,12 @@ tape( 'the function computes the Fresnel integral C(x) (small positive values)',
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnelc( x[i] );
-		if ( y === C[ i ] ) {
-			t.strictEqual( y, C[ i ], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y - C[i] );
-			tol = 4.0 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, C[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the Fresnel integral C(x) (medium positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var x;
 	var y;
@@ -83,20 +72,12 @@ tape( 'the function computes the Fresnel integral C(x) (medium positive values)'
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnelc( x[i] );
-		if ( y === C[ i ] ) {
-			t.strictEqual( y, C[ i ], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, C[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the Fresnel integral C(x) (large positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var x;
 	var y;
@@ -107,20 +88,12 @@ tape( 'the function computes the Fresnel integral C(x) (large positive values)',
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnelc( x[i] );
-		if ( y === C[ i ] ) {
-			t.strictEqual( y, C[ i ], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, C[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the Fresnel integral C(x) (very large positive values)', function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var x;
 	var y;
@@ -131,13 +104,7 @@ tape( 'the function computes the Fresnel integral C(x) (very large positive valu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnelc( x[i] );
-		if ( y === C[ i ] ) {
-			t.strictEqual( y, C[ i ], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, C[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/fresnelc/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnelc/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
@@ -56,8 +55,6 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function computes the Fresnel integral C(x) (small positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var x;
 	var y;
@@ -68,20 +65,12 @@ tape( 'the function computes the Fresnel integral C(x) (small positive values)',
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnelc( x[i] );
-		if ( y === C[ i ] ) {
-			t.strictEqual( y, C[ i ], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y - C[i] );
-			tol = 4.0 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, C[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the Fresnel integral C(x) (medium positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var x;
 	var y;
@@ -92,20 +81,12 @@ tape( 'the function computes the Fresnel integral C(x) (medium positive values)'
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnelc( x[i] );
-		if ( y === C[ i ] ) {
-			t.strictEqual( y, C[ i ], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, C[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the Fresnel integral C(x) (large positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var x;
 	var y;
@@ -116,20 +97,12 @@ tape( 'the function computes the Fresnel integral C(x) (large positive values)',
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnelc( x[i] );
-		if ( y === C[ i ] ) {
-			t.strictEqual( y, C[ i ], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, C[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the Fresnel integral C(x) (very large positive values)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var C;
 	var x;
 	var y;
@@ -140,13 +113,7 @@ tape( 'the function computes the Fresnel integral C(x) (very large positive valu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = fresnelc( x[i] );
-		if ( y === C[ i ] ) {
-			t.strictEqual( y, C[ i ], 'x: '+x[i]+'. Expected: '+C[i] );
-		} else {
-			delta = abs( y - C[i] );
-			tol = 1.5 * EPS * abs( C[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. Value: '+y+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, C[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suite for `math/base/special/fresnelc` from relative-tolerance-based assertions to ULP (units in the last place) difference-based assertions, per the RFC in #11352.
-   replaces the manual `delta`/`tol` tolerance computation (`EPS * abs( expected )`) in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( actual, expected[ i ], N ), true, 'returns expected value' )`, using `@stdlib/assert/is-almost-same-value`.
-   uses the minimum ULP bound that still passes across the full fixture set for each test case:
    -   small positive values: `3` ULPs (measured maximum observed diff; `2` ULPs fails on 8/1000 fixture values)
    -   medium positive values: `0` ULPs (exact match)
    -   large positive values: `0` ULPs (exact match)
    -   very large positive values: `0` ULPs (exact match)
-   the same bounds hold for both the pure JavaScript implementation (`test.js`) and the native C implementation (`test.native.js`); I built the native addon locally and confirmed the measured maximum ULP diff is identical for both.
-   verified determinism by running the full test suite twice at the final ULP bounds (4505/4505 passing both times, for both `test.js` and `test.native.js`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, run as an unattended scheduled task on my account. It discovered the candidate package, studied prior-art conversions in this repo (e.g. `math/base/special/fresnel`, `math/base/special/hyp2f1`), computed the exact ULP differences using `@stdlib/number/float64/base/ulp-difference` to determine the minimum passing bounds, and verified the result by running the test suite twice.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_015VRyxfvYqUfcL6hv19t8ws)_