### PR TITLE
test: migrate `stats/base/dists/discrete-uniform/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -88,8 +87,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function evaluates the cdf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -102,21 +99,13 @@ tape( 'the function evaluates the cdf for `x` given a small range `b - a`', func
 	b = smallRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -129,21 +118,13 @@ tape( 'the function evaluates the cdf for `x` given a medium range `b - a`', fun
 	b = mediumRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -156,13 +137,7 @@ tape( 'the function evaluates the cdf for `x` given a large range `b - a`', func
 	b = largeRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -136,9 +135,7 @@ tape( 'if provided a `a > b`, the created function always returns `NaN`', functi
 
 tape( 'the created function evaluates the cdf for `x` given a small range `b - a`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -152,22 +149,14 @@ tape( 'the created function evaluates the cdf for `x` given a small range `b - a
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( a[i], b[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given a medium range `b - a`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -181,22 +170,14 @@ tape( 'the created function evaluates the cdf for `x` given a medium range `b - 
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( a[i], b[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given a large range `b - a`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -210,13 +191,7 @@ tape( 'the created function evaluates the cdf for `x` given a large range `b - a
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( a[i], b[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -79,8 +78,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', opts, function test( t 
 
 tape( 'the function evaluates the cdf for `x` given a small range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -93,21 +90,13 @@ tape( 'the function evaluates the cdf for `x` given a small range `b - a`', opts
 	b = smallRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a medium range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -120,21 +109,13 @@ tape( 'the function evaluates the cdf for `x` given a medium range `b - a`', opt
 	b = mediumRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given a large range `b - a`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var a;
 	var b;
@@ -147,13 +128,7 @@ tape( 'the function evaluates the cdf for `x` given a large range `b - a`', opts
 	b = largeRange.b;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/discrete-uniform/cdf` from relative tolerance testing to ULP difference testing, per #11352.

Changes are confined to the package's test files (`test/test.cdf.js`, `test/test.factory.js`, `test/test.native.js`):

-   adds the `@stdlib/assert/is-almost-same-value` require and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.
-   removes the `delta`/`tol` declarations and the `if ( y === expected[i] ) { ... } else { ... }` tolerance branch.
-   replaces each fixture-loop assertion with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );`.

No implementation, fixture, or documentation files are touched, and no test cases were added, removed, or otherwise altered. `test/test.js` contains no tolerance-based assertions and is left unchanged.

### ULP bound

**All nine converted assertion loops use an ULP value of `1`**, which is the measured minimum.

The bound was measured rather than guessed: computing the minimum ULP value for which `isAlmostSameValue` returns `true` for each computed value and its expected fixture value, across the full fixture set (`small_range.json`, `medium_range.json`, `large_range.json`; 1000 values each, 3000 total) yields a **maximum observed ULP difference of `1`** for the main export, for the function returned by `factory`, and for the native C implementation. Running the suite with the bound lowered to `0` fails (123 failing assertions), confirming `1` is the tightest value that passes.

Verification:

-   `test/test.cdf.js`, `test/test.factory.js`, `test/test.native.js` — 3006–3011 assertions each, 9037 in total, all passing.
-   The native add-on was built locally so that `test/test.native.js` actually executed rather than being skipped; the C implementation evaluates the same expression as the JavaScript implementation (`( floor( x ) - a + 1.0 ) / ( b - a + 1.0 )`), and measures the same 1 ULP maximum.
-   The full suite was run twice at the final ULP value with identical results, to confirm the bound is not sensitive to FMA/architecture-dependent rounding.
-   ESLint (`etc/eslint/.eslintrc.tests.js`) reports no problems for the three changed files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled task. It studied the previously merged ULP migrations (in particular the sibling package `stats/base/dists/weibull/cdf`, #14281, which has an identical test structure) to match the established idiom, applied the mechanical test conversion, and empirically measured the minimum ULP bound and ran the test suite to verify it.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACAqYrd3QLCADw4S7aHPrm)_