### PR TITLE
test: migrate `math/base/special/cscd` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cscd/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var cscd = require( './../lib' );
 
 
@@ -83,8 +82,6 @@ tape( 'the function returns `+0` if provided `+infinity`', function test( t ) {
 
 tape( 'the function computes the cosecant in degrees (negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -98,21 +95,13 @@ tape( 'the function computes the cosecant in degrees (negative values)', functio
 			t.strictEqual( y, NINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant in degrees (positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -126,13 +115,7 @@ tape( 'the function computes the cosecant in degrees (positive values)', functio
 			t.strictEqual( y, PINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cscd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -92,8 +91,6 @@ tape( 'the function returns `+0` if provided `+infinity`', opts, function test( 
 
 tape( 'the function computes the cosecant in degrees (negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -107,21 +104,13 @@ tape( 'the function computes the cosecant in degrees (negative values)', opts, f
 			t.strictEqual( y, NINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the cosecant in degrees (positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -135,13 +124,7 @@ tape( 'the function computes the cosecant in degrees (positive values)', opts, f
 			t.strictEqual( y, PINF, 'x: '+x[i]+'. E: '+expected[i] );
 			continue;
 		}
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.4 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/cscd` from relative tolerance testing (`delta <= tol`, where `tol = 1.4 * EPS * abs( expected[ i ] )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

Both `test/test.js` and `test/test.native.js` are updated. In each file, the two fixture loops (negative and positive values) now assert

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
```

The now-unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` requires are removed, and the `@stdlib/assert/is-almost-same-value` require is added. The pre-existing `expected[ i ] === null` branches (which assert exact `-Infinity`/`+Infinity` returns at multiples of `180`) are left unchanged, as those are exact comparisons rather than tolerance-based ones.

### ULP constant

The measured **minimum** ULP value is **2**, used in all four converted fixture loops:

| File | Test | ULP |
| --- | --- | --- |
| `test/test.js` | negative values | 2 |
| `test/test.js` | positive values | 2 |
| `test/test.native.js` | negative values | 2 |
| `test/test.native.js` | positive values | 2 |

The bound was tightened by measuring the exact worst-case ULP difference over the full Julia fixture sets (999 non-null cases per set): the maximum observed difference is exactly 2 ULP in both the negative and positive sets, and the suite fails at 1 ULP. The test suite was run twice at the final value to confirm determinism (2009 passing assertions, no failures, both runs).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

`test/test.native.js` uses the same 2 ULP bound as `test/test.js`. The native addon was not built in the environment used to author this change, so those tests were skipped locally and the C implementation's ULP behavior was not measured directly. The bound mirrors the JavaScript measurement on the grounds that both implementations are the same expression (`1.0 / sind( x )` in `lib/main.js` and `stdlib_base_cscd` in `src/main.c`). Happy to adjust if reviewers would prefer a separately measured value for the native tests.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The conversion mirrors the idiom already used by the sibling package `math/base/special/cotd`, which has the same fixture structure, including the `null` special-case branches.

Verification performed:

-   `make test TESTS_FILTER=".*/math/base/special/cscd/.*"` — passing (run twice)
-   `make eslint-tests TESTS_FILTER=".*/math/base/special/cscd/.*"` — clean
-   only the two test files are modified

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. The tolerance-to-ULP conversion, the ULP bound search, and the local verification runs were all performed by the agent.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value


---
_Generated by [Claude Code](https://claude.ai/code/session_016Hd7g7r7EjwhA7WTUh11WN)_