### PR TITLE
build: fix line reporting for `no-empty-lines-between-requires` lint rule

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-empty-lines-between-requires/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-empty-lines-between-requires/lib/main.js
@@ -165,21 +165,9 @@ function main( context ) {
 	* @param {ASTNode} currNode - current require node
 	*/
 	function report( prevNode, currNode ) {
-		var loc = {
-			'start': {
-				'line': prevNode.loc.end.line + 1,
-				'column': 0
-			},
-			'end': {
-				'line': currNode.loc.start.line,
-				'column': 0
-			}
-		};
-
 		context.report({
-			'node': null,
+			'node': currNode,
 			'message': 'Unexpected empty line between require statements.',
-			'loc': loc,
 			'fix': fix
 		});
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-empty-lines-between-requires/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-empty-lines-between-requires/test/fixtures/invalid.js
@@ -34,7 +34,8 @@ var test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 7
 		}
 	],
 	'output': [
@@ -63,7 +64,8 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 8
 		}
 	],
 	'output': [
@@ -92,7 +94,8 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 8
 		}
 	],
 	'output': [
@@ -121,7 +124,8 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 7
 		}
 	],
 	'output': [
@@ -151,11 +155,13 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 7
 		},
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 9
 		}
 	],
 	'output': [
@@ -185,7 +191,8 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 8
 		}
 	],
 	'output': [
@@ -214,7 +221,8 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 7
 		}
 	],
 	'output': [
@@ -241,7 +249,8 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 6
 		}
 	],
 	'output': [
@@ -268,7 +277,8 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 7
 		}
 	],
 	'output': [
@@ -298,7 +308,8 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 7
 		}
 	],
 	'output': [
@@ -330,7 +341,8 @@ test = {
 	'errors': [
 		{
 			'message': 'Unexpected empty line between require statements.',
-			'type': null
+			'type': 'VariableDeclaration',
+			'line': 9
 		}
 	],
 	'output': [

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-empty-lines-between-requires/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-empty-lines-between-requires/test/fixtures/valid.js
@@ -172,6 +172,20 @@ test = {
 };
 valid.push( test );
 
+// Inline disable comment suppresses the rule for a specific require:
+test = {
+	'code': [
+		'\'use strict\';',
+		'',
+		'// MODULES //',
+		'',
+		'var tape = require( \'tape\' );',
+		'',
+		'var isnan = require( \'@stdlib/math/base/assert/is-nan\' ); // eslint-disable-line no-empty-lines-between-requires'
+	].join( '\n' )
+};
+valid.push( test );
+
 
 // EXPORTS //
 


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/153.

## Description

> What is the purpose of this pull request?

This pull request:

-   changes the `no-empty-lines-between-requires` ESLint rule to report errors on the first require statement after the empty lines, rather than on the empty lines themselves
-   enables targeted suppression via `// eslint-disable-line stdlib/no-empty-lines-between-requires`
-   adds a test case verifying that inline disable comments work

Previously, the rule reported errors with `node: null` and a synthetic `loc` pointing at the blank lines between require statements. Since blank lines contain no code, `// eslint-disable-line` comments could not be placed there, making per-line suppression impossible. The only workaround was disabling the rule for the entire file.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   https://github.com/stdlib-js/metr-issue-tracker/issues/153
-   https://github.com/stdlib-js/stdlib/pull/9530#discussion_r2660119242

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The key change in `context.report()`:

```diff
- context.report({
-     'node': null,
-     'message': 'Unexpected empty line between require statements.',
-     'loc': loc,
-     'fix': fix
- });
+ context.report({
+     'node': currNode,
+     'message': 'Unexpected empty line between require statements.',
+     'fix': fix
+ });
```

By reporting on `currNode` (the require statement after the gap), ESLint uses that node's location. Users can now append `// eslint-disable-line stdlib/no-empty-lines-between-requires` to suppress the rule on that specific line.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code under my direction.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md