### PR TITLE
test: migrate `stats/base/dists/rayleigh/logcdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logcdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -127,9 +126,7 @@ tape( 'if `sigma` equals `0`, the created function evaluates a degenerate distri
 tape( 'the created function evaluates the logcdf for `x` given small scale parameter `sigma`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -140,13 +137,7 @@ tape( 'the created function evaluates the logcdf for `x` given small scale param
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( sigma[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -154,9 +145,7 @@ tape( 'the created function evaluates the logcdf for `x` given small scale param
 tape( 'the created function evaluates the logcdf for `x` given medium scale parameter `sigma`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -167,13 +156,7 @@ tape( 'the created function evaluates the logcdf for `x` given medium scale para
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( sigma[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -181,9 +164,7 @@ tape( 'the created function evaluates the logcdf for `x` given medium scale para
 tape( 'the created function evaluates the logcdf for `x` given large scale parameter `sigma`', function test( t ) {
 	var expected;
 	var logcdf;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -194,13 +175,7 @@ tape( 'the created function evaluates the logcdf for `x` given large scale param
 	for ( i = 0; i < x.length; i++ ) {
 		logcdf = factory( sigma[i] );
 		y = logcdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logcdf/test/test.logcdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
 
@@ -93,9 +92,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the logcdf for `x` given small scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -105,22 +102,14 @@ tape( 'the function evaluates the logcdf for `x` given small scale parameter `si
 	sigma = smallScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given medium scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -130,22 +119,14 @@ tape( 'the function evaluates the logcdf for `x` given medium scale parameter `s
 	sigma = mediumScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large scale parameter `sigma`', function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -155,13 +136,7 @@ tape( 'the function evaluates the logcdf for `x` given large scale parameter `si
 	sigma = largeScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logcdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/logcdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -102,9 +101,7 @@ tape( 'if provided `sigma` equals `0`, the function evaluates a degenerate distr
 
 tape( 'the function evaluates the logcdf for `x` given small scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -114,22 +111,14 @@ tape( 'the function evaluates the logcdf for `x` given small scale parameter `si
 	sigma = smallScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given medium scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -139,22 +128,14 @@ tape( 'the function evaluates the logcdf for `x` given medium scale parameter `s
 	sigma = mediumScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the logcdf for `x` given large scale parameter `sigma`', opts, function test( t ) {
 	var expected;
-	var delta;
 	var sigma;
-	var tol;
 	var i;
 	var x;
 	var y;
@@ -164,13 +145,7 @@ tape( 'the function evaluates the logcdf for `x` given large scale parameter `si
 	sigma = largeScale.sigma;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logcdf( x[i], sigma[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/rayleigh/logcdf` from EPS-scaled relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.

Changes are limited to test files:

-   `test/test.logcdf.js`
-   `test/test.factory.js`
-   `test/test.native.js`

In each fixture loop, the `if ( y === expected[i] ) { ... } else { delta/tol ... }` branch was replaced with

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
```

and the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires (along with the `delta` and `tol` locals) were removed.

**Final ULP constant: `0`** (all fixture loops, in both the JavaScript and native test files).

The bound was tightened agentically: starting from a high value and lowering it to the minimum integer that still passes. The measured minimum is `0` for every fixture file — the JavaScript implementation, the factory-generated function, and the native implementation each reproduce the Julia reference values bit-exactly across all 3000 fixture values (1000 each in `small_scale.json`, `medium_scale.json`, and `large_scale.json`).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The measured minimum is `0` ULP, which is what is committed here. If reviewers would prefer a small amount of headroom (e.g., `1`) to guard against platform-specific differences on architectures not exercised locally, that is an easy change.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally on `linux/x64`, Node.js v22:

-   `test/test.js` — 3 passing
-   `test/test.logcdf.js` — 3011 passing
-   `test/test.factory.js` — 3013 passing
-   `test/test.native.js` — 3011 passing (the native add-on was compiled locally via `node-gyp rebuild`, so these assertions actually executed rather than being skipped)

The full suite was run twice at the final ULP value with identical results, confirming no FMA/arch-dependent flakiness locally. `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/rayleigh/logcdf/.*"` passes cleanly, and the only files changed are the three test files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written primarily by Claude Code, which mirrored the conversion idiom from already-migrated packages (e.g., `stats/base/dists/rayleigh/pdf` and `stats/base/dists/arcsine/logcdf`) and empirically determined the minimum ULP bound over the full fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01E1SM9ZH1ZA2Gamaz998sP9)_