### PR TITLE
test: migrate `stats/base/dists/chi/pdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chi/pdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/pdf/test/test.factory.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -145,9 +145,7 @@ tape( 'the returned function returns `0` for all `x < 0`', function test( t ) {
 
 tape( 'the created function evaluates the pdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
-	var delta;
 	var pdf;
-	var tol;
 	var k;
 	var x;
 	var y;
@@ -159,13 +157,7 @@ tape( 'the created function evaluates the pdf for `x` given degrees of freedom `
 	for ( i = 0; i < x.length; i++ ) {
 		pdf = factory( k[i] );
 		y = pdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 140.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 230 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/pdf/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -94,8 +93,6 @@ tape( 'if provided `-infinity` for `x` and a valid `k`, the function returns `0`
 
 tape( 'the function evaluates the pdf for `x` given degrees of freedom `k`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -106,13 +103,7 @@ tape( 'the function evaluates the pdf for `x` given degrees of freedom `k`', opt
 	k = data.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 140.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 230 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/pdf/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/pdf/test/test.pdf.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
@@ -117,8 +117,6 @@ tape( 'the function returns `0` for all `x < 0`', function test( t ) {
 
 tape( 'the function evaluates the pdf for `x` given degrees of freedom `k`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var k;
 	var y;
@@ -129,13 +127,7 @@ tape( 'the function evaluates the pdf for `x` given degrees of freedom `k`', fun
 	k = decimalDecimal.k;
 	for ( i = 0; i < x.length; i++ ) {
 		y = pdf( x[i], k[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+'. k:'+k[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 140.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. k: '+k[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 230 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/chi/pdf` from relative tolerance testing (`delta <= tol`, where `tol = 140.0 * EPS * abs( expected[ i ] )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].

Changes are limited to test files:

-   `test/test.pdf.js`
-   `test/test.factory.js`
-   `test/test.native.js`

In each of the three fixture loops, the `if ( y === expected[i] ) { ... } else { delta/tol ... }` branch was replaced with

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 230 ), true, 'returns expected value' );
```

The `@stdlib/assert/is-almost-same-value` require was added, and the now-unused `@stdlib/math/base/special/abs` require (along with the `delta` and `tol` locals) was removed. The `@stdlib/constants/float64/eps` require is retained in `test/test.pdf.js` and `test/test.factory.js`, where `EPS` is still used to generate negative input values, and removed from `test/test.native.js`, where it is no longer referenced.

### ULP constant

The measured **minimum** ULP value is **230**, used in all three converted fixture loops:

| File | ULP |
| --- | --- |
| `test/test.pdf.js` | 230 |
| `test/test.factory.js` | 230 |
| `test/test.native.js` | 230 |

The bound was tightened by measuring the exact worst-case ULP difference over the full Julia fixture set (`decimal_decimal.json`, 5000 values). The maximum observed difference is exactly 230 ULP, and the suite fails at 229 (a single failing case), so 230 is the minimum admissible integer bound.

Notably, the JavaScript implementation, the factory-generated function, and the native implementation return **bit-identical** results for all 5000 fixture values, so the same bound is the measured minimum for all three files. The observed ULP differences form a smooth, monotonically decaying distribution (373 cases at 1 ULP, tapering to a single case at 230 ULP), rather than a tight cluster with one outlier. For reference, the previous `140.0 * EPS` relative tolerance corresponds to roughly 140–280 ULP, so the new bound is consistent with the tolerance it replaces.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed locally on `linux/x64`, Node.js v22:

-   `make test TESTS_FILTER=".*/stats/base/dists/chi/pdf/.*"` — 15242 assertions passing, 0 failing (`test.pdf.js` 5115, `test.factory.js` 5115, `test.js` 3, `test.native.js` 5009). The native add-on was compiled locally via `node-gyp rebuild`, so the `test.native.js` assertions actually executed rather than being skipped.
-   The full suite was run twice at the final ULP value with identical results, confirming no FMA/architecture-dependent flakiness locally.
-   `make lint-javascript-tests TESTS_FILTER=".*/stats/base/dists/chi/pdf/.*"` — clean.
-   The only files changed are the three test files.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was written by Claude Code running as an unattended scheduled task. The tolerance-to-ULP conversion mirrors the idiom of already-migrated packages in the same family (e.g., `stats/base/dists/rayleigh/pdf` and `stats/base/dists/lognormal/pdf`); the ULP bound search and the local verification runs were performed by the agent.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwPLobovTtdadCUZKEmb7K)_