### PR TITLE
build: increase `random_benchmarks` step timeout

### DIFF
--- a/.github/workflows/random_benchmarks.yml
+++ b/.github/workflows/random_benchmarks.yml
@@ -86,7 +86,7 @@ jobs:
       - name: 'Run JavaScript and native add-on benchmarks'
         run: |
           make benchmark-random-javascript RANDOM_SELECTION_SIZE=50 BUILD_ADDONS=1
-        timeout-minutes: 60
+        timeout-minutes: 90
 
       # Install Cephes dependencies (required by C benchmarks which compare against the Cephes math library; accounting for possible network failures when downloading):
       - name: 'Install Cephes dependencies'


### PR DESCRIPTION
## Description

This pull request:

-   increases `timeout-minutes` from `60` to `90` on the "Run JavaScript and native add-on benchmarks" step in `.github/workflows/random_benchmarks.yml`.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/31916609719

**Symptom:** `The action 'Run random benchmarks' has timed out after 60 minutes.` — chronic, hitting the majority of recent nightly `random_benchmarks` runs on unrelated develop SHAs, not a one-off.

**Root cause:** with `BUILD_ADDONS=1`, each of the 50 randomly sampled packages triggers a native add-on clean+rebuild cycle (`install-node-addons`/`clean-node-addons`), and both targets pattern-match against the full package tree. That per-package overhead grows with total repository size even though `RANDOM_SELECTION_SIZE` itself stays fixed, so the aggregate step time creeps past the 60-minute budget over time.

Every observed failure hit the 60-minute wall exactly (the data is right-censored), so this is a pragmatic interim margin rather than a precisely sized fix — noted directly in the commit message. If 90 minutes also proves insufficient, the underlying per-package addon clean/rebuild + glob overhead should be addressed directly (e.g. caching or parallelizing add-on builds).

## Related Issues

This pull request has the following related issues:

-   None.

## Questions

No.

## Other

Reviewer notes: one reviewer noted the observed failure count in the commit message ("22 of the last 30 runs") likely includes 1-2 runs that time out on the separate "Run C benchmarks" step rather than the JS step this PR targets; the qualitative conclusion (chronic, non-flaky, majority of runs) holds either way. Validated via three independent automated reviewers (correctness, regression scope, style/conventions) across two review cycles; round 1 caught a factual error in the root-cause citation (a reference to PR #12513 as "already applied" when it is actually still open/draft), which was corrected before this PR was opened. All three reviewers approved on round 2.

## Checklist

Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was proposed by Claude Code as part of an automated CI-failure investigation routine. The failure enumeration/clustering, root-cause analysis, the fix, and three-reviewer validation (two rounds, correctness/regression-scope/style) were produced by Claude Code. Final review and merge decision rest with the maintainers.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017ShLTyikAc8BvHK2bDBHN8)_