### PR TITLE
fix: validate `k` shape when `dims` is omitted

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/circshift/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/circshift/lib/main.js
@@ -53,6 +53,7 @@ var DEFAULT_DTYPE = defaults.get( 'dtypes.integer' );
 * @throws {RangeError} dimension indices must not exceed input ndarray bounds
 * @throws {RangeError} number of dimension indices must not exceed the number of input ndarray dimensions
 * @throws {Error} must provide valid options
+* @throws {Error} second argument must be broadcast-compatible with the non-core dimensions of the first argument
 * @returns {ndarray} input ndarray
 *
 * @example
@@ -86,7 +87,7 @@ function circshift( x, k ) {
 		// Case: circshift( x, k_ndarray )
 		if ( isndarrayLike( k ) ) {
 			// As the operation is performed across all dimensions, `k` is assumed to be a zero-dimensional ndarray...
-			return base( x, k );
+			return base( x, maybeBroadcastArray( k, [] ) );
 		}
 		throw new TypeError( format( 'invalid argument. Second argument must be either an ndarray or an integer. Value: `%s`.', k ) );
 	}
@@ -108,7 +109,7 @@ function circshift( x, k ) {
 		if ( hasOwnProp( opts, 'dims' ) ) {
 			ka = maybeBroadcastArray( k, nonCoreShape( getShape( x ), opts.dims ) ); // eslint-disable-line max-len
 		} else {
-			ka = k;
+			ka = maybeBroadcastArray( k, [] );
 		}
 	} else {
 		throw new TypeError( format( 'invalid argument. Second argument must be either an ndarray or an integer. Value: `%s`.', k ) );


### PR DESCRIPTION
## Description

This pull request:

-   validates the shape of an ndarray-valued `k` argument against `maybeBroadcastArray( k, [] )` in the two `circshift` code paths that omit the `dims` option, matching the validation already applied in the `dims`-provided path.

**Failing run:** https://github.com/stdlib-js/stdlib/actions/runs/31938255523 (job `Node.js v16` on workflow `macos_test`; see raw logs)

**Symptom:** `circshift( x, k )` and `circshift( x, k, {} )` did not throw for a `k` shape that is not broadcast-compatible with the implied zero-dimensional target (e.g. `k` shape `[4]`, `[2,2,2]`, or `[0]` against `x` shape `[2,2]`), contrary to the documented contract.

**Root cause:** the no-`dims` branches for an ndarray `k` passed it straight through to `base()` unvalidated. In practice this was worse than a missing throw: an incompatible `k` silently no-op'd (returned `x` unmodified, ignoring `k` entirely) rather than either shifting correctly or raising an error.

## Related Issues

This pull request has the following related issues:

-   None.

## Questions

No.

## Other

Validated by three independent reviewers (correctness, regression scope, style/conventions); all approved. Reviewer B ran the package's full test suite directly (270/270 passing, including the two previously-failing blocks). No fan-out: `circshift` is a leaf package with no in-repo callers passing an ndarray `k`.

## Checklist

Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] Yes
-   [ ] No

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was proposed by Claude Code as part of an automated CI-failure investigation routine. The root-cause analysis, the fix, and three-reviewer validation (correctness, regression scope, style/conventions) were produced by Claude Code. Final review and merge decision rest with the maintainers.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_017ShLTyikAc8BvHK2bDBHN8)_