### PR TITLE
test: migrate `stats/base/dists/discrete-uniform/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the standard deviation of a discrete uniform distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -88,13 +85,7 @@ tape( 'the function returns the standard deviation of a discrete uniform distrib
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/test/test.native.js
@@ -22,9 +22,8 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -60,8 +59,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', opts, function test( t 
 
 tape( 'the function returns the standard deviation of a discrete uniform distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -72,13 +69,7 @@ tape( 'the function returns the standard deviation of a discrete uniform distrib
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/discrete-uniform/stdev` from relative tolerance testing to ULP difference testing, per #11352.

Changes are confined to the package's test files (`test/test.js`, `test/test.native.js`):

-   adds the `@stdlib/assert/is-almost-same-value` require and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.
-   removes the `delta`/`tol` declarations and the `if ( y === expected[i] ) { ... } else { ... }` tolerance branch.
-   replaces the fixture-loop assertion with `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );`.

No implementation, fixture, or documentation files are touched, and no test cases were added, removed, or otherwise altered.

### ULP bound

**The converted assertion loop uses an ULP value of `1`**, which is the measured minimum.

The bound was measured rather than guessed: computing the exact ULP difference (via `@stdlib/number/float64/base/ulp-difference`) between the computed value and the expected fixture value for all 1000 fixtures (`test/fixtures/julia/data.json`) yields a **maximum observed ULP difference of `1`**.

Verification:

-   `test/test.js` — 1008 assertions (1000 fixture comparisons + 8 edge-case assertions), all passing at ULP bound `1`.
-   The full suite was run twice at the final ULP value with identical results, to confirm the bound is not sensitive to FMA/architecture-dependent rounding.
-   `test/test.native.js` was updated identically for consistency with the JS implementation's idiom; the native add-on was not compiled in this environment, so those assertions are skipped (as they were prior to this change, since `lib/native.js` is not built by default).
-   ESLint reports no problems for the two changed files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Opened as a draft.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code running as an unattended scheduled task. It studied the issue and previously merged ULP migrations in the same package family (notably the sibling package `stats/base/dists/discrete-uniform/cdf`, #14311) to match the established idiom, applied the mechanical test conversion, and empirically measured the minimum ULP bound before verifying the test suite.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qk8s9UoHREKnUuewTYSMZy)_