### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/logpdf/lib/factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/logpdf/lib/factory.js
@@ -30,7 +30,7 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 // MAIN //
 
 /**
-* Returns a function for evaluating the logarithm of the probability density function (PDF) for a Fréchet distribution with shape `alpha`, scale `s`, and location `m`.
+* Returns a function for evaluating the natural logarithm of the probability density function (PDF) for a Fréchet distribution with shape `alpha`, scale `s`, and location `m`.
 *
 * @param {PositiveNumber} alpha - shape parameter
 * @param {PositiveNumber} s - scale parameter

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/pdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/pdf/package.json
@@ -63,6 +63,10 @@
     "density",
     "continuous",
     "frechet",
+    "weibull",
+    "inverse",
+    "extreme",
+    "value",
     "univariate"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/quantile/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/quantile/package.json
@@ -66,6 +66,7 @@
     "weibull",
     "inverse",
     "extreme",
+    "value",
     "univariate",
     "continuous"
   ]


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request normalizes three metadata/documentation inconsistencies in `@stdlib/stats/base/dists/frechet` where individual packages had drifted from the pattern shared by the rest of the namespace. No observable behavior, signatures, or test expectations change.

**Namespace summary.** `stats/base/dists/frechet` has 14 members (`cdf`, `ctor`, `entropy`, `kurtosis`, `logcdf`, `logpdf`, `mean`, `median`, `mode`, `pdf`, `quantile`, `skewness`, `stdev`, `variance`). Structural features (file tree, `package.json`/`manifest.json` shape, README section skeleton, test/benchmark/example naming) and semantic features (public signatures, return kind, validation prologue, error construction, JSDoc shape, dependencies) were extracted per package and compared at a 75% majority threshold (⌈14 × 0.75⌉ = 11). Features with a clear majority include the C-backed file layout, `package.json` structure, the distribution-level `keywords` cluster, and JSDoc shape within each of the two sub-templates. Features without a clear majority — the value-function vs. property-function split (`factory.js`, extra fixtures), `@returns` types, per-function dependencies, and per-function example counts — were excluded from drift analysis as semantically justified.

Three outliers cleared structural, semantic, and cross-reference validation:

### `pdf`

`pdf/package.json` carried only `frechet` from the distribution-level keyword cluster, dropping `weibull`, `inverse`, `extreme`, and `value`. Fréchet is the inverse Weibull / Type-II extreme value distribution, so these are distribution-level descriptors, not function-specific ones: `weibull`/`inverse`/`extreme` appear in 13/14 members and `value` in 12/14. Restored the canonical `frechet, weibull, inverse, extreme, value` run.

### `quantile`

`quantile/package.json` already carried `weibull`, `inverse`, and `extreme` but omitted `value`, splitting the "extreme value" descriptor that the sibling majority keeps intact (12/14). Added `value` after `extreme`.

### `logpdf`

The outer JSDoc description in `logpdf/lib/factory.js` read "logarithm of the probability density function (PDF)", dropping "natural". The package's own `lib/main.js` and the file's inner private-function JSDoc both say "natural logarithm", the implementation uses `ln`, and 4/5 value-function siblings carry "natural" in their factory descriptions. Restored "natural" to match.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request?

Corrections are grouped one commit per package for a per-package audit trail. **Validation:** each candidate passed a three-part review — a semantic review (intentional deviation vs. unintentional drift), a cross-reference review (no test, example, benchmark, or doctest pins the changed strings; `keywords` is never imported and the JSDoc text appears only in source/type/header files), and a structural review confirming the majority pattern is the one that should apply. **Deliberately excluded:** `ctor` (a pure-JS distribution class that legitimately lacks C infrastructure, `manifest.json`, and the `## C APIs` section — a different package kind, not drift); the value-function/property-function sub-template differences; and `mean/README.md`, whose linked, qualified prose (`[expected value][mean]`, `α > 0`) is used consistently throughout that README and is a stylistic choice rather than a mechanical one-line deviation.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was prepared with Claude Code: it extracted structural and semantic features across the `frechet` namespace, identified the majority pattern per feature, flagged the three deviating packages, and drafted the metadata/documentation corrections. Each correction was validated against the sibling majority and checked to ensure no tests or examples depend on the changed strings. A human should review before merge.

* * *

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

* * *

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6FX3YNHq4yikJPVcoQDra

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6FX3YNHq4yikJPVcoQDra)_