### PR TITLE
test: migrate `stats/base/dists/discrete-uniform/median` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function returns the median of a discrete uniform distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -88,13 +85,7 @@ tape( 'the function returns the median of a discrete uniform distribution', func
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = median( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/test/test.native.js
@@ -22,9 +22,8 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -60,8 +59,6 @@ tape( 'if provided `a > b`, the function returns `NaN`', opts, function test( t 
 
 tape( 'the function returns the median of a discrete uniform distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var a;
 	var b;
 	var i;
@@ -72,13 +69,7 @@ tape( 'the function returns the median of a discrete uniform distribution', opts
 	b = data.b;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = median( a[i], b[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/discrete-uniform/median` from relative tolerance assertions to ULP-based assertions.

Specifically, in `test/test.js` and `test/test.native.js`, the `if ( y === expected[i] ) { ... } else { delta/tol ... }` branch is replaced by

```javascript
t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
```

along with the corresponding require of `@stdlib/assert/is-almost-same-value` and the removal of the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

**ULP bound: `0` in both `test/test.js` and `test/test.native.js`.**

The bound was determined empirically by computing, for every entry in the Julia fixture set (1000 cases), the minimum ULP difference required for the assertion to hold. The maximum required over the full fixture set is `0`, i.e., every returned value is bit-identical to the expected value, so `0` is the minimum admissible bound. The test suite was run twice at the final bound to confirm determinism (1008 assertions passing on each run).

This result is consistent with the implementations: the JS implementation returns `( a/2 ) + ( b/2 )` and the C implementation returns `( a + b ) / 2.0`, both of which are exact for integer-valued `a` and `b` in the tested range, and both of which agree bit-for-bit with the fixture values. Note that the native tests are skipped when the native add-on has not been built, so the native bound was additionally checked by evaluating the C expression over the same fixture set.

Only the two test files are modified; no source, fixture, or documentation files are touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The conversion mirrors the idiom used in the previously merged sibling package `stats/base/dists/discrete-uniform/stdev` (#14337).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task: it selected the package, studied previously merged ULP migrations for the idiom, applied the test changes, and determined the minimum ULP bound empirically over the fixture set.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_019hrk86NWAm29g4zkctUY4b)_