### PR TITLE
test: migrate `math/base/special/kernel-betaincinv` to ULP-based testing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/kernel-betaincinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-betaincinv/test/test.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var kernelBetaincinv = require( './../lib' );
 
 
@@ -41,8 +40,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function evaluates the inverse of the lower regularized incomplete beta function', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var y;
 	var i;
 	var a;
@@ -55,13 +52,7 @@ tape( 'the function evaluates the inverse of the lower regularized incomplete be
 	expected = data.y;
 	for ( i = 0; i < p.length; i++ ) {
 		y = kernelBetaincinv( a[i], b[i], p[i], 1.0-p[i] )[ 0 ];
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'a: '+a[i]+'. b: '+b[i]+'. p: '+p[i]+', y: '+y+'. expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 15.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. p: '+p[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 20 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352 .

## Description

> What is the purpose of this pull request?

This pull request:

-  Migrates tests in `math/base/special/kernel-betaincinv` from relative tolerance testing to ULP difference testing.
-  All fixtures pass when the ULP bound is 10 except for index 1818, which requires a ULP bound of 20; this fixture case also had the tightest margin under the previous `15.0 * EPS` tolerance.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I consulted AI to understand the codebase, specifically the purpose and migration approach of the issue and this package, but the proposed changes were authored by myself.

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
