### PR TITLE
fix: address off-by-one bug

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/blocked/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/blocked/lib/main.js
@@ -44,7 +44,7 @@ var KERNELS = [
 	kernel9d,
 	kernel10d // 8
 ];
-var MAX_DIMS = KERNELS.length + 2;
+var MAX_DIMS = KERNELS.length + 1;
 
 
 // MAIN //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-08-16 15:33 (-0700) (`7d941afae`) and 2026-08-17 04:59 (-0700) (`0f459b6e5`).

This pull request:

-   **`ndarray/base/kernels/generic/unary-strided1d/blocked`**: Fix `resolveKernel()`'s off-by-one range guard: `MAX_DIMS` was `KERNELS.length + 2` (11) against a `KERNELS[ndims-2]` lookup covering ndims 2–10, so `resolveKernel(11)` fell through to `undefined` instead of the `null` documented in the README, repl.txt, and `@returns` annotation. Changed to `KERNELS.length + 1` (10) in `lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/blocked/lib/main.js:47` (commit 0f459b6e5); re-verified resolveKernel(1)/(11)/(12) → `null` and (2)…(10) → function.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Review scope**: automated review of the 33 commits merged to `develop` in the 24 hours ending 2026-08-17 04:59 (-0700) (236 files, ~21k insertions): new `blas/base/ndarray` triangular/packed wrappers (`dtrmv`/`strmv`/`dtrsv`/`strsv`/`dspmv`), new `blas/ext/base/ndarray/{s,c,z}index-of-falsy` packages, new `ndarray/base` kernel infrastructure (`offsets`, `set-descriptor-offsets`, `kernels/utils/increment-offsets`, `kernels/generic/unary-strided1d/blocked`), `math/base/special/{log2f,sincospif}`, ULP-based test-assertion migrations, equation/docs regeneration, and namespace/TypeScript declaration catch-ups.

**Validation performed**: style-guide compliance audit against `docs/style-guides` and established sibling reference packages; two independent bug scans of the full union diff, including runtime execution of the new blocked kernels (2d–10d boundary/coverage probes), BLAS wrapper example verification, and FreeBSD-reference checks of the `log2f`/`sincospif` constants and special cases. The fix above was independently identified by both bug scans and verified by execution before and after the change.

**Deliberately excluded**: anything requiring interpretation or judgment (no subjective style preferences), and anything whose fix would touch code outside the reviewed diff window — e.g. namespace registration of the new `*index-of-falsy` packages was left to the usual dedicated `feat: add X to namespace` follow-up commits, and the `blocked` package's TypeScript declarations were not authored here since the sibling `ndarray/base/unary-strided1d` package shares the same current state.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was produced by a scheduled Claude Code review of the last 24 hours of commits merged to `develop`: multiple independent AI review passes flagged candidate issues, each surviving issue was verified by direct code reading and runtime execution, and the one-line fix was authored and validated by Claude Code. A maintainer will audit before promoting from draft.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwN7AEABin3f7C1NSfUPWB)_