### PR TITLE
test: migrate `math/base/special/csignumf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
@@ -48,10 +47,8 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function evaluates the signum function', function test( t ) {
-	var delta;
 	var ere;
 	var eim;
-	var tol;
 	var re;
 	var im;
 	var y;
@@ -64,18 +61,8 @@ tape( 'the function evaluates the signum function', function test( t ) {
 
 	for ( i = 0; i < re.length; i++ ) {
 		y = csignumf( new Complex64( re[ i ], im[ i ] ) );
-		if ( real( y ) === ere[ i ] && imag( y ) === eim[ i ] ) {
-			t.strictEqual( real( y ), ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
-			t.strictEqual( imag( y ), eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
-		} else {
-			delta = absf( real( y ) - ere[ i ] );
-			tol = EPS * absf( ere[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual re: '+real( y )+'. Expected re: '+ere[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-
-			delta = absf( imag( y ) - eim[ i ] );
-			tol = EPS * absf( eim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual im: '+imag( y )+'. Expected im: '+eim[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( y ), ere[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( y ), eim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.native.js
@@ -22,11 +22,10 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
@@ -57,10 +56,8 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function evaluates the signum function', opts, function test( t ) {
-	var delta;
 	var ere;
 	var eim;
-	var tol;
 	var re;
 	var im;
 	var y;
@@ -73,18 +70,8 @@ tape( 'the function evaluates the signum function', opts, function test( t ) {
 
 	for ( i = 0; i < re.length; i++ ) {
 		y = csignumf( new Complex64( re[ i ], im[ i ] ) );
-		if ( real( y ) === ere[ i ] && imag( y ) === eim[ i ] ) {
-			t.strictEqual( real( y ), ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
-			t.strictEqual( imag( y ), eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
-		} else {
-			delta = absf( real( y ) - ere[ i ] );
-			tol = EPS * absf( ere[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual re: '+real( y )+'. Expected re: '+ere[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-
-			delta = absf( imag( y ) - eim[ i ] );
-			tol = EPS * absf( eim[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: '+re[ i ]+'. im: '+im[ i ]+'. Actual im: '+imag( y )+'. Expected im: '+eim[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( real( y ), ere[ i ], 1 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( imag( y ), eim[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/csignumf` from relative tolerance testing to ULP difference testing.
-   replaces the `EPS`-scaled tolerance comparisons in `test/test.js` and `test/test.native.js` with `isAlmostSameValue` assertions from [`@stdlib/number/float32/base/assert/is-almost-same-value`][is-almost-same-value] (the single-precision variant, as `csignumf` returns a `Complex64`).
-   removes the now unused `@stdlib/constants/float32/eps` and `@stdlib/math/base/special/absf` requires, along with the associated `delta` and `tol` variables and the exact-versus-tolerance `if...else` branch.

The final ULP bound is **1 ULP**, applied to both the real and imaginary component assertions in `test/test.js` and `test/test.native.js`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Notes on how the bound was determined:

-   The Julia fixtures (`test/fixtures/julia/data.json`) contain 2003 test cases, yielding 4006 component assertions.
-   Measuring the single-precision ULP difference (via `@stdlib/number/float32/base/ulp-difference`) between the JavaScript implementation and the fixture values over the full fixture set gives a **maximum of 1 ULP** for both the real and imaginary components (376 of the 2003 cases differ by exactly 1 ULP; the remainder are exact). Hence, `1` is the minimum required ULP value, and the tests fail at `0`.
-   The C implementation was measured independently by compiling `src/main.c` against its manifest dependency closure and running it over the same fixture inputs. It produces an identical error profile (maximum 1 ULP, the same 376 non-exact cases), which is expected given that the JavaScript and C implementations use the same algorithm (`z / cabsf( z )`). Accordingly, the same bound of `1` is used in `test/test.native.js`.
-   The package test suite was run twice at the final ULP value to confirm determinism; all 4018 assertions pass on both runs.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, following the idiom established in previously merged conversions (e.g. #14080 for the double-precision `csignum` counterpart, #14327, and the `atan2f` conversion for the single-precision assertion variant). The ULP bound was measured empirically over the full fixture set rather than guessed, for both the JavaScript and C implementations.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/float32/base/assert/is-almost-same-value


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pzw21sMzvqG5GKJGoM8eHb)_