### PR TITLE
test: migrate `math/base/special/gammaln` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gammaln/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/gammaln/test/test.js
@@ -21,13 +21,12 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var gammaln = require( './../lib' );
 
 
@@ -88,8 +87,6 @@ tape( 'the function returns `-ln(x)` for very small x', function test( t ) {
 
 tape( 'the function evaluates the natural logarithm of the gamma function (positive integers)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -99,21 +96,13 @@ tape( 'the function evaluates the natural logarithm of the gamma function (posit
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = gammaln( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 21.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the natural logarithm of the gamma function (decimal values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -123,13 +112,7 @@ tape( 'the function evaluates the natural logarithm of the gamma function (decim
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = gammaln( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.1e4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/gammaln/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gammaln/test/test.native.js
@@ -22,13 +22,12 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -97,8 +96,6 @@ tape( 'the function returns `-ln(x)` for very small x', opts, function test( t )
 
 tape( 'the function evaluates the natural logarithm of the gamma function (positive integers)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -108,21 +105,13 @@ tape( 'the function evaluates the natural logarithm of the gamma function (posit
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = gammaln( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 21.2 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the natural logarithm of the gamma function (decimal values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -132,13 +121,7 @@ tape( 'the function evaluates the natural logarithm of the gamma function (decim
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = gammaln( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. Expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.1e4 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 15 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/gammaln` from relative-tolerance (`EPS`-scaled) assertions to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   applies the same change to both `test/test.js` and `test/test.native.js`.
-   removes the now-unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from both test files.

### ULP bounds

Each fixture group was measured against its expected values and the bound tightened to the minimum integer that still passes:

| Test | Fixtures | Previous tolerance | Final ULP bound | Measured max ULP |
| --- | --- | --- | --- | --- |
| positive integers | `data1` / `expected1` (171 values) | `21.2 * EPS * abs(expected)` | `2` | `2` |
| decimal values | `data2` / `expected2` (1000 values) | `1.1e4 * EPS * abs(expected)` | `15` | `15` |

The bounds are minimal: lowering them to `1` and `14` respectively produces 9 failing assertions (8 in the positive-integer set, 1 in the decimal set). At the final bounds the suite passes 1184/1184, and was run twice with identical results to rule out non-determinism.

The same bounds are used in `test.native.js`. To measure rather than assume this, the C implementation (`src/main.c` plus its transitive C dependencies) was compiled standalone and evaluated over both fixture sets: it is bit-for-bit identical to the JavaScript implementation across all 1171 fixture points (max ULP difference between the two implementations is `0`), so the native bounds are also exactly `2` and `15`.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The native test suite could not be executed in the authoring environment because the native add-on was not built there (`test.native.js` skips when the add-on is absent). The native ULP bounds were instead derived by compiling and evaluating the C implementation directly, as described above. Confirmation from CI, where the add-on is built, would be welcome.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Only the two test files are changed; the implementation and fixtures are untouched.

Note on verification environment: `make install-node-modules` could not complete in the authoring environment (the configured npm registry has no `es-object-atoms@^1.1.2`, which a transitive dependency requires), so the standard `make` lint/test targets were unavailable. As substitutes, `tape` was installed standalone to run the suite, ESLint was run against the repository's own rule set from `etc/eslint/rules` with the `etc/eslint/.eslintrc.tests.js` overrides applied (clean, and cross-checked against an already-merged converted package as a control), and the EditorConfig rules were validated directly. Full CI verification is still needed.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was written by Claude Code running as an unattended scheduled task. It selected the package, studied already-merged conversions to match the established idiom, applied the conversion, and measured and tightened the ULP bounds empirically.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_014Ae9H3xMMYKcipgJot7h18)_