### PR TITLE
test: migrate `math/base/special/cphasef` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cphasef/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphasef/test/test.js
@@ -23,9 +23,8 @@
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var PI = require( '@stdlib/constants/float32/pi' );
@@ -162,8 +161,6 @@ tape( 'the function returns `-PI/2` if provided a negative `im` and `re=0`', fun
 tape( 'the function computes the argument of a complex number (when `re` and `im` are positive)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -174,9 +171,7 @@ tape( 'the function computes the argument of a complex number (when `re` and `im
 	for ( i = 0; i < re.length; i++ ) {
 		actual = cphasef( new Complex64( re[i], im[i] ) );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = 1.3 * EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. re: '+re[i]+'. im: '+im[i]+'. Actual: '+actual+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -184,8 +179,6 @@ tape( 'the function computes the argument of a complex number (when `re` and `im
 tape( 'the function computes the argument of a complex number (when `re` is negative and `im` is positive)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -196,9 +189,7 @@ tape( 'the function computes the argument of a complex number (when `re` is nega
 	for ( i = 0; i < re.length; i++ ) {
 		actual = cphasef( new Complex64( re[i], im[i] ) );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. re: '+re[i]+'. im: '+im[i]+'. Actual: '+actual+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -206,8 +197,6 @@ tape( 'the function computes the argument of a complex number (when `re` is nega
 tape( 'the function computes the argument of a complex number (when `re` and `im` are negative)', function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -218,9 +207,7 @@ tape( 'the function computes the argument of a complex number (when `re` and `im
 	for ( i = 0; i < re.length; i++ ) {
 		actual = cphasef( new Complex64( re[i], im[i] ) );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. re: '+re[i]+'. im: '+im[i]+'. Actual: '+actual+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cphasef/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphasef/test/test.native.js
@@ -24,9 +24,8 @@ var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var PI = require( '@stdlib/constants/float32/pi' );
@@ -171,8 +170,6 @@ tape( 'the function returns `-PI/2` if provided a negative `im` and `re=0`', opt
 tape( 'the function computes the argument of a complex number (when `re` and `im` are positive)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -183,9 +180,7 @@ tape( 'the function computes the argument of a complex number (when `re` and `im
 	for ( i = 0; i < re.length; i++ ) {
 		actual = cphasef( new Complex64( re[i], im[i] ) );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = 1.3 * EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. re: '+re[i]+'. im: '+im[i]+'. Actual: '+actual+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 2 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -193,8 +188,6 @@ tape( 'the function computes the argument of a complex number (when `re` and `im
 tape( 'the function computes the argument of a complex number (when `re` is negative and `im` is positive)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -205,9 +198,7 @@ tape( 'the function computes the argument of a complex number (when `re` is nega
 	for ( i = 0; i < re.length; i++ ) {
 		actual = cphasef( new Complex64( re[i], im[i] ) );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. re: '+re[i]+'. im: '+im[i]+'. Actual: '+actual+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -215,8 +206,6 @@ tape( 'the function computes the argument of a complex number (when `re` is nega
 tape( 'the function computes the argument of a complex number (when `re` and `im` are negative)', opts, function test( t ) {
 	var expected;
 	var actual;
-	var delta;
-	var tol;
 	var re;
 	var im;
 	var i;
@@ -227,9 +216,7 @@ tape( 'the function computes the argument of a complex number (when `re` and `im
 	for ( i = 0; i < re.length; i++ ) {
 		actual = cphasef( new Complex64( re[i], im[i] ) );
 		expected[ i ] = f32( expected[ i ] );
-		delta = absf( actual - expected[i] );
-		tol = EPS * absf( expected[i] );
-		t.strictEqual( delta <= tol, true, 'within tolerance. re: '+re[i]+'. im: '+im[i]+'. Actual: '+actual+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		t.strictEqual( isAlmostSameValue( actual, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/cphasef` from relative tolerance testing to ULP difference testing, per #11352.
-   replaces the `delta`/`tol` computations in the fixture loops of `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( actual, expected[ i ], N ), true, 'returns expected value' );`.
-   adds the `@stdlib/number/float32/base/assert/is-almost-same-value` require (the single-precision variant, matching the idiom already used for other `*f` packages, e.g. `math/base/special/atan2f` and `math/base/special/rad2degf`) and removes the now-unused `@stdlib/math/base/special/absf` and `@stdlib/constants/float32/eps` requires.

Only the two test files are modified; no fixtures, implementations, or other packages are touched.

### ULP bounds

The following bounds are the **measured minimum** for each fixture set. Each was found by computing the exact ULP distance between the returned and expected value for every fixture point, and then confirmed by re-running the suite at `N - 1` (which fails):

| Fixture | Points | ULP | `N - 1` result |
| ------- | -----: | --: | -------------- |
| `positive_positive.json` | 5001 | `2` | 56 failing assertions at `N = 1` |
| `negative_positive.json` | 1001 | `1` | failing assertions at `N = 0` |
| `negative_negative.json` | 1001 | `1` | failing assertions at `N = 0` |

The same three bounds hold for both the JavaScript and the native (C) implementation, so `test.js` and `test.native.js` use identical values. The two implementations do return differing values for a small number of fixture points (27 / 2 / 2 respectively), but in every such case both results remain within the bounds above, so no separate C-specific tolerances are required.

The previous relative tolerances were `1.3 * EPS` for `positive_positive` and `EPS` for the other two fixture sets, which is consistent with the `2 / 1 / 1` ULP bounds above.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/math/base/special/cphasef/.*"` passes: 7052 assertions in `test/test.js` and 7052 in `test/test.native.js`, 0 failing. The native add-on was built locally, so `test.native.js` was actually executed rather than skipped.
-   The suite was run repeatedly at the final ULP values with identical results, to rule out FMA/architecture-dependent flakiness.
-   ESLint is clean for both files using `etc/eslint/.eslintrc.tests.js`.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. The agent studied the already-merged conversions for `math/base/special/cphase`, `math/base/special/atan2f`, and `math/base/special/rad2degf` in order to mirror the established idiom, applied the equivalent edits here, measured the minimum ULP bounds empirically over the full fixture set, and verified the result by building the native add-on and running both test files under `make test`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_019F2ePawZ7B5jD6HiutB7rS)_