### PR TITLE
docs: fix descriptions

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/wasm/dswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dswap/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # dswap
 
-> Interchange two double-precision floating point vectors.
+> Interchange two double-precision floating-point vectors.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var dswap = require( '@stdlib/blas/base/wasm/dswap' );
 
 #### dswap.main( N, x, strideX, y, strideY )
 
-Interchanges two double-precision floating point vectors.
+Interchanges two double-precision floating-point vectors.
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -86,7 +86,7 @@ dswap.main( 3, x1, -2, y1, 1 );
 
 #### dswap.ndarray( N, x, strideX, offsetX, y, strideY, offsetY )
 
-Interchanges two double-precision floating point vectors using alternative indexing semantics.
+Interchanges two double-precision floating-point vectors using alternative indexing semantics.
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -146,7 +146,7 @@ mod.initializeSync();
 
 #### dswap.Module.prototype.main( N, xp, sx, yp, sy )
 
-Interchanges two double-precision floating point vectors.
+Interchanges two double-precision floating-point vectors.
 
 <!-- eslint-disable n/no-sync -->
 
@@ -210,7 +210,7 @@ The function has the following parameters:
 
 #### dswap.Module.prototype.ndarray( N, xp, sx, ox, yp, sy, oy )
 
-Interchanges two double-precision floating point vectors using alternative indexing semantics.
+Interchanges two double-precision floating-point vectors using alternative indexing semantics.
 
 <!-- eslint-disable n/no-sync -->
 

--- a/lib/node_modules/@stdlib/blas/base/wasm/scasum/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/wasm/scasum/lib/main.js
@@ -28,7 +28,7 @@ var Module = require( './module.js' );
 // MAIN //
 
 /**
-* WebAssembly module compute the sum of the absolute values of the real and imaginary components of a single-precision complex floating-point vector.
+* WebAssembly module to compute the sum of the absolute values of the real and imaginary components of a single-precision complex floating-point vector.
 *
 * @name scasum
 * @type {Routine}

--- a/lib/node_modules/@stdlib/blas/base/wasm/sswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sswap/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # sswap
 
-> Interchange two single-precision floating point vectors.
+> Interchange two single-precision floating-point vectors.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var sswap = require( '@stdlib/blas/base/wasm/sswap' );
 
 #### sswap.main( N, x, strideX, y, strideY )
 
-Interchanges two single-precision floating point vectors.
+Interchanges two single-precision floating-point vectors.
 
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );
@@ -86,7 +86,7 @@ sswap.main( 3, x1, -2, y1, 1 );
 
 #### sswap.ndarray( N, x, strideX, offsetX, y, strideY, offsetY )
 
-Interchanges two single-precision floating point vectors using alternative indexing semantics.
+Interchanges two single-precision floating-point vectors using alternative indexing semantics.
 
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );
@@ -146,7 +146,7 @@ mod.initializeSync();
 
 #### sswap.Module.prototype.main( N, xp, sx, yp, sy )
 
-Interchanges two single-precision floating point vectors.
+Interchanges two single-precision floating-point vectors.
 
 <!-- eslint-disable n/no-sync -->
 
@@ -210,7 +210,7 @@ The function has the following parameters:
 
 #### sswap.Module.prototype.ndarray( N, xp, sx, ox, yp, sy, oy )
 
-Interchanges two single-precision floating point vectors using alternative indexing semantics.
+Interchanges two single-precision floating-point vectors using alternative indexing semantics.
 
 <!-- eslint-disable n/no-sync -->
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request corrects three documentation-drift findings in the `blas/base/wasm` namespace, bringing three outlier packages back in line with the documentation conventions used by the rest of the namespace. All changes are documentation-only; no source behavior, public signatures, or test expectations are affected.

### Namespace summary

-   **Members analyzed:** 33 non-autogenerated packages under `@stdlib/blas/base/wasm`.
-   **Structural features (all with a clear majority, ≥75%):** file tree, `package.json` key set / `scripts` / `stdlib` config, `manifest.json` key set, README section list and ordering, and `test/` / `benchmark/` / `examples/` file naming were byte-uniform across all 33 packages.
-   **Semantic features with a clear majority:** `main.js` JSDoc shape (all packages document `main`, `ndarray`, and `Module` with examples), return kind (all export a `Routine`), and error construction (100% use `format` — a single, identical `TypeError` guard on the WebAssembly memory instance).
-   **Features excluded for having no clear majority:** public signature and `require` dependency sets, which legitimately vary per BLAS routine (single vs. double precision, real vs. complex, presence of a scalar argument, number of stride/offset arguments). These are correct-by-design differences, not drift.

Only three deviations from the namespace majority survived validation, all in package documentation:

### `blas/base/wasm/scasum`

The `lib/main.js` JSDoc summary read "WebAssembly module compute the sum of the absolute values...", dropping the word "to". 32 of 33 packages (97%) use the form "WebAssembly module to <verb>...", and `scasum`'s own `lib/index.js` summary already reads "WebAssembly routine to compute...". Inserted the missing "to" to restore the sibling pattern; the described operation is unchanged.

### `blas/base/wasm/dswap`

The README described the operation on "double-precision floating point vectors" (unhyphenated) in all five occurrences. The hyphenated compound modifier "floating-point" is used in 12 of the 14 sibling READMEs that mention the term, and in `dswap`'s own `lib/main.js` JSDoc. Hyphenated all five occurrences to match; `dswap` and `sswap` were the only two READMEs in the namespace using the unhyphenated form.

### `blas/base/wasm/sswap`

Identical to `dswap`: the README used "single-precision floating point vectors" (unhyphenated) in all five occurrences, contradicting the namespace majority and `sswap`'s own `lib/main.js` JSDoc. Hyphenated all five occurrences to "floating-point".

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

The same unhyphenated "floating point" wording also appears in `docs/repl.txt` and `docs/types/index.d.ts` for `dswap` and `sswap`. Those files were intentionally left untouched here (declaration files are part of the public API and REPL fixtures are treated as generator-adjacent); a maintainer may prefer to normalize them in a follow-up.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** Structural features were extracted deterministically across all 33 packages. Semantic features were cross-checked both deterministically (error-construction, JSDoc tag structure, require sets, copyright headers) and via parallel review across three lenses (documentation, source/validation, metadata). Each surviving outlier was then independently reviewed by three validators — semantic review (intentional vs. unintentional drift), cross-reference (whether any test or example relies on the wording, and whether a documented API contract would break), and structural review (whether the majority form is what should actually be applied). All three validators returned `confirmed-drift` for all three outliers.

**Deliberately excluded:** per-routine signature and dependency differences (correct-by-design, no clear majority); the `docs/repl.txt` and `docs/types/index.d.ts` occurrences of the same hyphenation (out of scope per the above); and copyright-year differences across packages (these reflect authoring date, not drift). The structural analysis found no missing files or fields to add — the namespace is otherwise uniform.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was produced by Claude Code running an automated cross-package documentation-drift detection routine over the `blas/base/wasm` namespace. Claude performed the structural and semantic feature extraction, computed per-feature majority patterns, identified and validated the outliers, applied the documentation fixes, and drafted this description. All changes are documentation-only and were reviewed for behavior preservation.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaxXUgKAgsgZ1cySp219yb)_