### PR TITLE
test: migrate `math/base/special/factorial2f` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/factorial2f/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2f/test/test.js
@@ -22,11 +22,10 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var factorial2f = require( './../lib' );
 
 
@@ -76,8 +75,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 
 tape( 'the function evaluates the double factorial', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -87,15 +84,9 @@ tape( 'the function evaluates the double factorial', function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = factorial2f( x[ i ] );
-		if ( v === expected[ i ] ) {
-			t.strictEqual( v, expected[ i ], 'returns expected value' );
-		} else {
-			delta = absf( v - expected[i] );
 
-			// NOTE: We use approximate equality because expected values from SciPy are computed using gamma function approximations instead of iterative single-precision computation.
-			tol = 2.4 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+v+'. e: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		// NOTE: We use approximate equality because expected values from SciPy are computed using gamma function approximations instead of iterative single-precision computation.
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/factorial2f/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2f/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
+var isAlmostSameValue = require( '@stdlib/number/float32/base/assert/is-almost-same-value' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -85,8 +84,6 @@ tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) 
 
 tape( 'the function evaluates the double factorial', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 	var i;
@@ -96,15 +93,9 @@ tape( 'the function evaluates the double factorial', opts, function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		v = factorial2f( x[ i ] );
-		if ( v === expected[ i ] ) {
-			t.strictEqual( v, expected[ i ], 'returns expected value' );
-		} else {
-			delta = absf( v - expected[i] );
 
-			// NOTE: We use approximate equality because expected values from SciPy are computed using gamma function approximations instead of iterative single-precision computation.
-			tol = 2.4 * EPS * absf( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. v: '+v+'. e: '+expected[i]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		// NOTE: We use approximate equality because expected values from SciPy are computed using gamma function approximations instead of iterative single-precision computation.
+		t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suites for `math/base/special/factorial2f` from relative tolerance assertions to ULP difference assertions, as described in #11352.
-   replaces the `delta`/`tol` computation (previously `2.4 * EPS * absf( expected[i] )`) and the associated `t.ok( delta <= tol, ... )` / exact-equality branch with a single `t.strictEqual( isAlmostSameValue( v, expected[ i ], 3 ), true, 'returns expected value' )` assertion.
-   adds a require for `@stdlib/number/float32/base/assert/is-almost-same-value` (the single-precision variant, as `factorial2f` operates on single-precision values) and removes the now unused `@stdlib/math/base/special/absf` and `@stdlib/constants/float32/eps` requires.

The same change is applied to both `test/test.js` and `test/test.native.js`.

**ULP bound:** `3` ULP, for the "the function evaluates the double factorial" test in both `test/test.js` and `test/test.native.js`. This is the measured minimum over the full fixture set (56 values, `test/fixtures/python/data.json`); the observed ULP difference distribution is `{0: 32, 1: 20, 2: 2, 3: 2}`, with the maximum occurring at `x = 47`. Lowering the bound to `2` causes 2 test cases to fail, so `3` is the tightest bound which passes. The suite was run twice at the final bound to confirm the result is deterministic.

Only the two test files are changed; no source, documentation, or fixture files were touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   `test/test.native.js` is skipped locally, as the native add-on was not built in this environment. The ULP bound in `test/test.native.js` mirrors the bound measured for the JavaScript implementation, consistent with prior conversions in this family (e.g., `math/base/special/cphasef`, `math/base/special/gammaln`).
-   The existing `NOTE` explaining why approximate equality is used for these fixtures (SciPy computes the expected values via gamma function approximations rather than iterative single-precision computation) has been retained, as it remains applicable.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code, running as an automated task. The ULP bound was determined empirically by measuring the ULP difference across the full fixture set and verifying that the next lower bound fails.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_015Vv5dR7LHabJ4jhtD9ybGb)_