### PR TITLE
test: migrate `stats/base/dists/negative-binomial/cdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/cdf/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/cdf/test/test.cdf.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
 
@@ -113,8 +112,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function evaluates the cdf for `x` given large `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var r;
 	var p;
@@ -127,21 +124,13 @@ tape( 'the function evaluates the cdf for `x` given large `r` and `p`', function
 	p = highHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 63 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given large `r` and small `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var r;
 	var p;
@@ -154,21 +143,13 @@ tape( 'the function evaluates the cdf for `x` given large `r` and small `p`', fu
 	p = highSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 320.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 441 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given small `r` and large `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var r;
 	var p;
@@ -181,21 +162,13 @@ tape( 'the function evaluates the cdf for `x` given small `r` and large `p`', fu
 	p = smallHigh.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 9 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function evaluates the cdf for `x` given small `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var r;
 	var p;
@@ -208,13 +181,7 @@ tape( 'the function evaluates the cdf for `x` given small `r` and `p`', function
 	p = smallSmall.p;
 	for ( i = 0; i < x.length; i++ ) {
 		y = cdf( x[i], r[i], p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 89 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/cdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/cdf/test/test.factory.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -161,9 +160,7 @@ tape( 'if provided a success probability `p` outside `[0,1]`, the created functi
 
 tape( 'the created function evaluates the cdf for `x` given large `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -177,22 +174,14 @@ tape( 'the created function evaluates the cdf for `x` given large `r` and `p`', 
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( r[i], p[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 60.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 63 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given large `r` and small `p`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var i;
 	var p;
 	var r;
@@ -206,22 +195,14 @@ tape( 'the created function evaluates the cdf for `x` given large `r` and small 
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( r[i], p[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 320.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 441 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given small `r` and large `p`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -235,22 +216,14 @@ tape( 'the created function evaluates the cdf for `x` given small `r` and large 
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( r[i], p[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 10.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 9 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the created function evaluates the cdf for `x` given small `r` and `p`', function test( t ) {
 	var expected;
-	var delta;
 	var cdf;
-	var tol;
 	var i;
 	var r;
 	var p;
@@ -264,13 +237,7 @@ tape( 'the created function evaluates the cdf for `x` given small `r` and `p`', 
 	for ( i = 0; i < x.length; i++ ) {
 		cdf = factory( r[i], p[i] );
 		y = cdf( x[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'x: '+x[i]+', r: '+r[i]+', p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 80.0 * EPS * abs( expected[i] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. r: '+r[i]+'. p: '+p[i]+'. y: '+y+'. Expected: '+expected[i]+'. tol: '+tol+'. delta: '+delta+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[i], 89 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   Migrates the test suite for `stats/base/dists/negative-binomial/cdf` from relative-tolerance-based assertions to ULP (units in the last place) difference-based assertions, using `@stdlib/assert/is-almost-same-value`.
-   Replaces the `delta`/`tol`/`EPS`-based comparisons in `test/test.cdf.js` and `test/test.factory.js` with `t.strictEqual( isAlmostSameValue( actual, expected[ i ], N ), true, 'returns expected value' )`, using the minimum ULP tolerance `N` required for each fixture group to pass:
    -   large `r`, large `p` (`high_high` fixtures): `63`
    -   large `r`, small `p` (`high_small` fixtures): `441`
    -   small `r`, large `p` (`small_high` fixtures): `9`
    -   small `r`, small `p` (`small_small` fixtures): `89`
-   These minimums were determined by measuring the actual ULP difference between computed and expected values across the full fixture set (1000 cases per group) and running the suite twice to confirm the results are deterministic.
-   No behavioral or non-test changes are included; `test/test.js` did not contain tolerance-based assertions and was left unchanged.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, run as an unattended scheduled task by the repository maintainer. It discovered the candidate package, studied prior-art conversions for the exact idiom, measured minimum ULP bounds directly from the fixtures, and ran the test suite (including eslint) to verify before opening this PR.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUnxUsZ4Gz5R5QcFGfjK2r)_