### PR TITLE
test: migrate `math/base/special/fast/hypot` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fast/hypot/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/hypot/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var hypot = require( './../lib' );
 
 
@@ -42,8 +41,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the hypotenuse', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var h;
 	var x;
 	var y;
@@ -55,13 +52,7 @@ tape( 'the function computes the hypotenuse', function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		h = hypot( x[ i ], y[ i ] );
-		if ( h === expected[ i ] ) {
-			t.ok( true, 'x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'.' );
-		} else {
-			delta = abs( h - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( h, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/fast/hypot/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/hypot/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var abs = require( '@stdlib/math/base/special/abs' );
 
 
 // VARIABLES //
@@ -51,8 +50,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the hypotenuse', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var h;
 	var x;
 	var y;
@@ -64,13 +61,7 @@ tape( 'the function computes the hypotenuse', opts, function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		h = hypot( x[ i ], y[ i ] );
-		if ( h === expected[ i ] ) {
-			t.ok( true, 'x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'.' );
-		} else {
-			delta = abs( h - expected[ i ] );
-			tol = 1.4 * EPS * abs( expected[ i ] );
-			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( h, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/fast/hypot` from relative tolerance assertions to ULP difference assertions, per #11352.
-   replaces the `delta`/`tol` comparison (`tol = 1.4 * EPS * abs( expected[ i ] )`) in `test/test.js` and `test/test.native.js` with `t.strictEqual( isAlmostSameValue( h, expected[ i ], 1 ), true, 'returns expected value' );`.
-   adds the `@stdlib/assert/is-almost-same-value` require and drops the now-unused `@stdlib/constants/float64/eps` and `@stdlib/math/base/special/abs` requires.

Only the two test files are changed; no implementation, fixture, or documentation changes are included.

**ULP bound:** `1` in both `test/test.js` and `test/test.native.js`.

The bound was measured, not guessed. Iterating downward over the full 2003-value Julia fixture set, the maximum observed ULP difference is `1` for both the JavaScript and native implementations (worst case at index 3: `x = -288.6569990349477`, `y = 45.66311946727046`), so `1` is the minimum value that passes. `0` fails: 243 of the 2003 native results and a comparable share of the JavaScript results are not bit-exact against the fixtures. Both implementations compute `sqrt( (x*x) + (y*y) )`, and the native addon was built locally so `test/test.native.js` actually executed rather than being skipped; the two suites were each run twice at the final bound with identical results, so no FMA-contraction or architecture-dependent variation was observed.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Verification performed:

-   `make test TESTS_FILTER=".*/math/base/special/fast/hypot/.*"` — 2010 passing, run twice.
-   `test/test.native.js` executed directly against a locally built addon — 2010 passing, run twice.
-   ESLint clean against `etc/eslint/.eslintrc.tests.js`.

Note: the `lint-editorconfig` pre-commit hook could not run in this environment because it downloads its checker binary from a GitHub repository that is out of scope for this session. The two changed files were verified manually against `.editorconfig` (LF endings, UTF-8, tab indentation, no trailing whitespace, final newline present).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code running as an unattended scheduled task. Claude Code selected the package, studied previously merged ULP migrations to match the established idiom, applied the test edits, and determined the ULP bound empirically by scanning the fixture set and re-running the suites.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDmD2mFbTpzyj16ndGHjGK)_