### PR TITLE
chore: add keywords

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/find-index/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/find-index/package.json
@@ -50,6 +50,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "blas",
     "find",
     "index",

--- a/lib/node_modules/@stdlib/blas/ext/find-last-index/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/find-last-index/package.json
@@ -50,6 +50,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "blas",
     "find",
     "index",

--- a/lib/node_modules/@stdlib/blas/ext/index-of/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/index-of/package.json
@@ -50,6 +50,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "blas",
     "find",
     "index",

--- a/lib/node_modules/@stdlib/blas/ext/last-index-of/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/last-index-of/package.json
@@ -50,6 +50,9 @@
   ],
   "keywords": [
     "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
     "blas",
     "find",
     "findlast",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds the namespace-standard `stdmath`, `mathematics`, and `math` keywords to the four `blas/ext` search packages that omit them, bringing their `package.json` keyword sets in line with their siblings and their generic base analogs.

### Namespace summary

-   **Namespace:** `@stdlib/blas/ext`
-   **Members analyzed:** 19 (18 function packages plus the `base` namespace aggregator).
-   **Structural features extracted:** file tree, `package.json` shape (`scripts`/`stdlib`/`manifest` key sets), README section order, test/benchmark/example file naming, and keyword sets.
-   **Semantic features extracted (per package):** public signature, return kind, validation prologue, error construction, JSDoc shape, and dependencies.
-   **Feature with a clear majority and a correctable outlier set:** `package.json` `keywords` — the set {`stdmath`, `mathematics`, `math`} is carried by 15/19 members (79%), including every non-search operation (`join`, `circshift`, `copy-within`, `one-to`, `zero-to`, `unitspace`, ...) and the `base` aggregator.
-   **Features excluded for lacking a clear majority:** the `assign` API variant (13/18 function packages, 72%), stats keywords (8/18), and the per-function signature/validation shapes (the operations are semantically heterogeneous). Error construction is already uniformly `format` across the namespace, so there is no drift to normalize.

### Per outlier package

#### `blas/ext/find-index`

Carried the typed-kernel keyword template (`stdlib`, `blas`, `find`, ...) rather than the template of its true structural analog, the generic `blas/ext/base/gfind-index`. Added `stdmath`, `mathematics`, and `math` immediately after `stdlib`, matching the ordering used by every sibling that carries them. Conformance: 15/19 (79%).

#### `blas/ext/find-last-index`

Same typed-template copy-drift; the generic analog `blas/ext/base/gfind-last-index` carries the three keywords, as do all non-search siblings. Added the keywords in sibling-consistent order. Conformance: 15/19 (79%).

#### `blas/ext/index-of`

Keyword set mirrored the typed `dindex-of`/`sindex-of` kernels, which drop the broad math-category tags in favor of dtype tags; the generic analog `blas/ext/base/gindex-of` retains them. Added `stdmath`, `mathematics`, and `math`. Conformance: 15/19 (79%).

#### `blas/ext/last-index-of`

Longest deviating keyword array in the group, but math tags were absent for the same reason; `blas/ext/base/glast-index-of` carries them. Added the keywords after `stdlib`. Conformance: 15/19 (79%).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

Structural features were extracted from the filesystem and from `package.json`/README strings; semantic features (public signature, return kind, validation prologue, error construction, JSDoc shape, dependencies) were extracted per package. The single surviving drift finding — the missing math keywords on the four generic search packages — was confirmed by a three-agent validation panel (semantic review, cross-reference against tests/examples/docs, and structural review); all three returned `confirmed-drift` for all four packages. Cross-referencing found no test, example, REPL doc, TypeScript test, or documented API contract that relies on the current keyword sets, and the change is metadata-only: no observable behavior, signature, or test expectation changes.

Deliberately excluded from this PR:

-   The `base` namespace aggregator — a different kind of package that legitimately omits the `Notes` README section and the `__stdlib__` marker.
-   The `assign`-variant files — present in only 13/18 function packages, reflecting an intentional API distinction (not every operation exposes an in-place output variant) rather than drift.
-   The absence of `lib/base.js` in `sum`, `to-sorted`, and `to-sortedhp` — correcting it is a refactor that would cascade into logic and tests, which is out of scope for a drift correction.
-   All per-function signature and validation-prologue differences — the operations are heterogeneous (search vs. reduction vs. sequence construction), so no namespace-wide majority exists.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was authored end-to-end by Claude Code as part of a scheduled cross-package API drift-detection routine over `@stdlib/blas/ext`. Structural and semantic features were extracted from all 19 namespace members, a majority vote (≥75%) surfaced the missing math keywords on the four generic search packages, and a three-agent validation panel confirmed the drift before the metadata-only fix was applied. Pending human audit (draft).

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTHkxoKuGw8xbCy7je6aKy)_