### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/strategy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/strategy/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( x )
-    Returns an object for reshaping an ndarray as a one-dimensional strided
-    array view.
+    Returns an object containing methods for reshaping an ndarray as a
+    one-dimensional strided array view.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/strategy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/strategy/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( x )
-    Returns an object containing methods for reshaping an ndarray as a
-    one-dimensional strided array view.
+    Returns an object containing methods for reshaping an ndarray as a one-
+    dimensional strided array view.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/unblocked/lib/4d.js
+++ b/lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/unblocked/lib/4d.js
@@ -199,7 +199,7 @@ function kernel( fcn, arrays, views, shape, stridesX, stridesY, strategyX, strat
 			dv0.push( sv[3] );
 			dv1.push( sv[2] - ( S0*sv[3] ) );
 			dv2.push( sv[1] - ( S1*sv[2] ) );
-			dv3.push( sv[0] - ( S2*sv[1]) );
+			dv3.push( sv[0] - ( S2*sv[1] ) );
 		}
 	} else { // order === 'column-major'
 		// For column-major ndarrays, the first dimensions have the fastest changing indices...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Follow-up fixes for commits merged to `develop` between 2026-08-17 15:10 (-0700) (`0acfa70d8`) and 2026-08-18 04:03 (-0700) (`600a127f0`).

This pull request:

-   `ndarray/base/kernels/generic/unary-strided1d/strategy`: Restore "containing methods" dropped from repl.txt in eb271061 so the REPL help text matches README.md, lib/index.js, lib/main.js, and package.json in `lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/strategy/docs/repl.txt`.
-   `ndarray/base/kernels/generic/unary-strided1d/unblocked`: Fix formatting inconsistency introduced in 2359f618: `lib/node_modules/@stdlib/ndarray/base/kernels/generic/unary-strided1d/unblocked/lib/4d.js:202` had `( S2*sv[1])`, missing the closing-paren space present everywhere else in the file (e.g., line 230) and across the 0d–10d kernels. Pad it to `( S2*sv[1] )` for consistency.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Validation.** All 25 commits merged to `develop` in the window were reviewed by four independent passes: two style-compliance audits against `docs/style-guides` and established reference packages (`unary-strided1d/blocked`, `stats/base/ndarray/dnanmin`, already-migrated ULP test files), and two bug scans covering the new `unary-strided1d` kernel packages (dispatch bounds, per-dimension stride/offset arithmetic), the `dnanmax` C addon (NAPI argument handling, memory management, compile check), the ULP test migrations (assertion targets, leftover requires), and the docs/bot commits. Deliberately excluded: anything requiring interpretation or changes outside the window's diff — notably, the `dnanmax` C example's `NaN` placement at a buffer index the strided view never visits was left alone, since the file byte-for-byte matches the established `dnanmin` reference.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code as part of an automated review of commits merged to `develop` in the last 24 hours; findings were cross-validated by multiple independent review passes before inclusion.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtNcAgnF5HjEo3yHbDT6EY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtNcAgnF5HjEo3yHbDT6EY)_