### PR TITLE
chore: clean-up

### DIFF
--- a/lib/node_modules/@stdlib/array/base/logspace/README.md
+++ b/lib/node_modules/@stdlib/array/base/logspace/README.md
@@ -47,7 +47,7 @@ var arr = logspace( 0, 2, 6 );
 
 ## Notes
 
--   The output `array` includes the values `10^a` and `10^b`. **Beware** of floating point errors, including for the first and last `array` elements.
+-   The output `array` includes the values `10^a` and `10^b`. **Beware** of floating-point errors, including for the first and last `array` elements.
 
 </section>
 

--- a/lib/node_modules/@stdlib/array/logspace/README.md
+++ b/lib/node_modules/@stdlib/array/logspace/README.md
@@ -47,7 +47,7 @@ var arr = logspace( 0, 2, 6 );
 
 ## Notes
 
--   The output `array` includes the values `10^a` and `10^b`. **Beware** of floating point errors, including for the first and last `array` elements.
+-   The output `array` includes the values `10^a` and `10^b`. **Beware** of floating-point errors, including for the first and last `array` elements.
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/base/caxpy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/caxpy/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( N, alpha, x, strideX, y, strideY )
     Scales a single-precision complex floating-point vector by a single-
-    precision complex floating point constant and adds the result to a single-
+    precision complex floating-point constant and adds the result to a single-
     precision complex floating-point vector.
 
     The `N` and stride parameters determine how values from `x` are scaled by

--- a/lib/node_modules/@stdlib/blas/base/wasm/dswap/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dswap/docs/repl.txt
@@ -440,7 +440,7 @@
 
 
 {{alias}}.Module.prototype.main( N, xp, sx, yp, sy )
-    Interchanges two double-precision floating point vectors.
+    Interchanges two double-precision floating-point vectors.
 
     Parameters
     ----------
@@ -489,7 +489,7 @@
 
 
 {{alias}}.Module.prototype.ndarray( N, xp, sx, ox, yp, sy, oy )
-    Interchanges two double-precision floating point vectors using alternative
+    Interchanges two double-precision floating-point vectors using alternative
     indexing semantics.
 
     Parameters

--- a/lib/node_modules/@stdlib/blas/base/wasm/dswap/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/wasm/dswap/docs/types/index.d.ts
@@ -146,7 +146,7 @@ interface ModuleConstructor {
 */
 interface Module extends ModuleWrapper {
 	/**
-	* Interchanges two double-precision floating point vectors.
+	* Interchanges two double-precision floating-point vectors.
 	*
 	* @param N - number of indexed elements
 	* @param xptr - first input array pointer (i.e., byte offset)
@@ -207,7 +207,7 @@ interface Module extends ModuleWrapper {
 	main( N: number, xptr: number, strideX: number, yptr: number, strideY: number ): number;
 
 	/**
-	* Interchanges two double-precision floating point vectors using alternative indexing semantics.
+	* Interchanges two double-precision floating-point vectors using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param xptr - first input array pointer (i.e., byte offset)
@@ -275,7 +275,7 @@ interface Module extends ModuleWrapper {
 */
 interface Routine extends ModuleWrapper {
 	/**
-	* Interchanges two double-precision floating point vectors.
+	* Interchanges two double-precision floating-point vectors.
 	*
 	* @param N - number of indexed elements
 	* @param x - first input array
@@ -297,7 +297,7 @@ interface Routine extends ModuleWrapper {
 	main( N: number, x: Float64Array, strideX: number, y: Float64Array, strideY: number ): Float64Array;
 
 	/**
-	* Interchanges two double-precision floating point vectors using alternative indexing semantics.
+	* Interchanges two double-precision floating-point vectors using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param x - first input array
@@ -379,7 +379,7 @@ interface Routine extends ModuleWrapper {
 }
 
 /**
-* Interchanges two double-precision floating point vectors.
+* Interchanges two double-precision floating-point vectors.
 *
 * @param N - number of indexed elements
 * @param x - first input array

--- a/lib/node_modules/@stdlib/blas/base/wasm/sswap/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sswap/docs/repl.txt
@@ -440,7 +440,7 @@
 
 
 {{alias}}.Module.prototype.main( N, xp, sx, yp, sy )
-    Interchanges two single-precision floating point vectors.
+    Interchanges two single-precision floating-point vectors.
 
     Parameters
     ----------
@@ -489,7 +489,7 @@
 
 
 {{alias}}.Module.prototype.ndarray( N, xp, sx, ox, yp, sy, oy )
-    Interchanges two single-precision floating point vectors using alternative
+    Interchanges two single-precision floating-point vectors using alternative
     indexing semantics.
 
     Parameters

--- a/lib/node_modules/@stdlib/blas/base/wasm/sswap/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/wasm/sswap/docs/types/index.d.ts
@@ -146,7 +146,7 @@ interface ModuleConstructor {
 */
 interface Module extends ModuleWrapper {
 	/**
-	* Interchanges two single-precision floating point vectors.
+	* Interchanges two single-precision floating-point vectors.
 	*
 	* @param N - number of indexed elements
 	* @param xptr - first input array pointer (i.e., byte offset)
@@ -207,7 +207,7 @@ interface Module extends ModuleWrapper {
 	main( N: number, xptr: number, strideX: number, yptr: number, strideY: number ): number;
 
 	/**
-	* Interchanges two single-precision floating point vectors using alternative indexing semantics.
+	* Interchanges two single-precision floating-point vectors using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param xptr - first input array pointer (i.e., byte offset)
@@ -275,7 +275,7 @@ interface Module extends ModuleWrapper {
 */
 interface Routine extends ModuleWrapper {
 	/**
-	* Interchanges two single-precision floating point vectors.
+	* Interchanges two single-precision floating-point vectors.
 	*
 	* @param N - number of indexed elements
 	* @param x - first input array
@@ -297,7 +297,7 @@ interface Routine extends ModuleWrapper {
 	main( N: number, x: Float32Array, strideX: number, y: Float32Array, strideY: number ): Float32Array;
 
 	/**
-	* Interchanges two single-precision floating point vectors using alternative indexing semantics.
+	* Interchanges two single-precision floating-point vectors using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param x - first input array
@@ -379,7 +379,7 @@ interface Routine extends ModuleWrapper {
 }
 
 /**
-* Interchanges two single-precision floating point vectors.
+* Interchanges two single-precision floating-point vectors.
 *
 * @param N - number of indexed elements
 * @param x - first input array

--- a/lib/node_modules/@stdlib/blas/base/zaxpy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/zaxpy/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( N, alpha, x, strideX, y, strideY )
     Scales a double-precision complex floating-point vector by a double-
-    precision complex floating point constant and adds the result to a double-
+    precision complex floating-point constant and adds the result to a double-
     precision complex floating-point vector.
 
     The `N` and stride parameters determine how values from `x` are scaled by

--- a/lib/node_modules/@stdlib/math/base/special/ahavercosf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ahavercosf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # ahavercosf
 
-> Compute the [inverse half-value versed cosine][archavercosine] of a single-precision floating point number.
+> Compute the [inverse half-value versed cosine][archavercosine] of a single-precision floating-point number.
 
 <section class="intro">
 
@@ -53,7 +53,7 @@ var ahavercosf = require( '@stdlib/math/base/special/ahavercosf' );
 
 #### ahavercosf( x )
 
-Computes the [inverse half-value versed cosine][archavercosine] of a single-precision floating point number (in radians).
+Computes the [inverse half-value versed cosine][archavercosine] of a single-precision floating-point number (in radians).
 
 ```javascript
 var v = ahavercosf( 0.0 );

--- a/lib/node_modules/@stdlib/math/base/special/ahavercosf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/ahavercosf/lib/main.js
@@ -28,7 +28,7 @@ var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 // MAIN //
 
 /**
-* Computes the inverse half-value versed cosine of a single-precision floating point number.
+* Computes the inverse half-value versed cosine of a single-precision floating-point number.
 *
 * @param {number} x - input value
 * @returns {number} inverse half-value versed cosine

--- a/lib/node_modules/@stdlib/math/base/special/ahavercosf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/ahavercosf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/math/base/special/ahavercosf",
   "version": "0.0.0",
-  "description": "Compute the inverse half-value versed cosine for a single-precision floating point number.",
+  "description": "Compute the inverse half-value versed cosine for a single-precision floating-point number.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/math/base/special/floor2f/include/stdlib/math/base/special/floor2f.h
+++ b/lib/node_modules/@stdlib/math/base/special/floor2f/include/stdlib/math/base/special/floor2f.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Rounds a single-precision floating point number to the nearest power of two toward negative infinity.
+* Rounds a single-precision floating-point number to the nearest power of two toward negative infinity.
 */
 float stdlib_base_floor2f( const float x );
 

--- a/lib/node_modules/@stdlib/math/base/special/floor2f/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/floor2f/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Round a single-precision floating point number to the nearest power of two toward negative infinity.
+* Round a single-precision floating-point number to the nearest power of two toward negative infinity.
 *
 * @module @stdlib/math/base/special/floor2f
 *

--- a/lib/node_modules/@stdlib/math/base/special/floor2f/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/floor2f/lib/main.js
@@ -42,7 +42,7 @@ var ONE = f32( 1.0 );
 // MAIN //
 
 /**
-* Rounds a single-precision floating point number to the nearest power of two toward negative infinity.
+* Rounds a single-precision floating-point number to the nearest power of two toward negative infinity.
 *
 * @param {number} x - input value
 * @returns {number} rounded value

--- a/lib/node_modules/@stdlib/math/base/special/floor2f/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/floor2f/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Rounds a single-precision floating point number to the nearest power of two toward negative infinity.
+* Rounds a single-precision floating-point number to the nearest power of two toward negative infinity.
 *
 * @private
 * @param {number} x - input value

--- a/lib/node_modules/@stdlib/math/base/special/floor2f/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/floor2f/src/main.c
@@ -32,7 +32,7 @@
 extern float log2f( const float x );
 
 /**
-* Rounds a single-precision floating point number to the nearest power of two toward negative infinity.
+* Rounds a single-precision floating-point number to the nearest power of two toward negative infinity.
 *
 * @param x    input value
 * @return     rounded value

--- a/lib/node_modules/@stdlib/types/index.d.ts
+++ b/lib/node_modules/@stdlib/types/index.d.ts
@@ -1100,7 +1100,7 @@ declare module '@stdlib/types/array' {
 	};
 
 	/**
-	* Mapping of real floating point data types and the "generic" data type to array constructors.
+	* Mapping of real floating-point data types and the "generic" data type to array constructors.
 	*/
 	type RealFloatingPointAndGenericDataTypeMap<T> = Remap<RealFloatingPointDataTypeMap & { 'generic': Array<T> }>;
 
@@ -1114,7 +1114,7 @@ declare module '@stdlib/types/array' {
 	};
 
 	/**
-	* Mapping of complex floating point data types and the "generic" data type to array constructors.
+	* Mapping of complex floating-point data types and the "generic" data type to array constructors.
 	*/
 	type ComplexFloatingPointAndGenericDataTypeMap<T> = Remap<ComplexFloatingPointDataTypeMap & { 'generic': Array<T> }>;
 
@@ -1124,7 +1124,7 @@ declare module '@stdlib/types/array' {
 	type FloatingPointDataTypeMap = Remap<RealFloatingPointDataTypeMap & ComplexFloatingPointDataTypeMap>;
 
 	/**
-	* Mapping for floating point (real or complex) data types and the "generic" data type to array constructors.
+	* Mapping for floating-point (real or complex) data types and the "generic" data type to array constructors.
 	*/
 	type FloatingPointAndGenericDataTypeMap<T> = Remap<FloatingPointDataTypeMap & { 'generic': Array<T> }>;
 
@@ -5212,7 +5212,7 @@ declare module '@stdlib/types/ndarray' {
 	};
 
 	/**
-	* Mapping of real floating point data types and the "generic" data type to ndarray constructors.
+	* Mapping of real floating-point data types and the "generic" data type to ndarray constructors.
 	*/
 	type RealFloatingPointAndGenericDataTypeMap<T> = Remap<RealFloatingPointDataTypeMap & { 'generic': genericndarray<T> }>;
 
@@ -5226,7 +5226,7 @@ declare module '@stdlib/types/ndarray' {
 	};
 
 	/**
-	* Mapping of complex floating point data types and the "generic" data type to ndarray constructors.
+	* Mapping of complex floating-point data types and the "generic" data type to ndarray constructors.
 	*/
 	type ComplexFloatingPointAndGenericDataTypeMap<T> = Remap<ComplexFloatingPointDataTypeMap & { 'generic': genericndarray<T> }>;
 
@@ -5236,7 +5236,7 @@ declare module '@stdlib/types/ndarray' {
 	type FloatingPointDataTypeMap = Remap<RealFloatingPointDataTypeMap & ComplexFloatingPointDataTypeMap>;
 
 	/**
-	* Mapping for floating point (real or complex) data types and the "generic" data type to ndarray constructors.
+	* Mapping for floating-point (real or complex) data types and the "generic" data type to ndarray constructors.
 	*/
 	type FloatingPointAndGenericDataTypeMap<T> = Remap<FloatingPointDataTypeMap & { 'generic': genericndarray<T> }>;
 

--- a/lib/node_modules/@stdlib/utils/async/do-until/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/async/do-until/lib/main.js
@@ -91,9 +91,9 @@ function doUntilAsync( fcn, predicate, done, thisArg ) {
 
 		// Cache the most recent results...
 		if ( arguments.length > 1 ) {
-			args = new Array( arguments.length-1 );
+			args = [];
 			for ( i = 1; i < arguments.length; i++ ) {
-				args[ i-1 ] = arguments[ i ];
+				args.push( arguments[ i ] );
 			}
 		}
 		// Run the test condition:

--- a/lib/node_modules/@stdlib/utils/open-url/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/open-url/lib/main.js
@@ -70,9 +70,9 @@ function openURL( url ) {
 	if ( !isURI( url ) ) {
 		throw new TypeError( format( 'invalid argument. Must provide a valid URI. Value: `%s`.', url ) );
 	}
-	args = new Array( ARGS.length );
+	args = [];
 	for ( i = 0; i < ARGS.length; i++ ) {
-		args[ i ] = ARGS[ i ];
+		args.push( ARGS[ i ] );
 	}
 	if ( IS_WINDOWS ) {
 		// `&` characters must be escaped when passed to `start`:

--- a/lib/node_modules/@stdlib/utils/papply-right/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/papply-right/lib/main.js
@@ -55,9 +55,9 @@ function papplyRight( fcn ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
 	}
 	len = arguments.length - 1;
-	pargs = new Array( len );
+	pargs = [];
 	for ( i = 1; i < arguments.length; i++ ) {
-		pargs[ i-1 ] = arguments[ i ];
+		pargs.push( arguments[ i ] );
 	}
 	return pappliedRight;
 
@@ -73,12 +73,12 @@ function papplyRight( fcn ) {
 		var args;
 		var j;
 		nargs = arguments.length;
-		args = new Array( len+nargs );
-		for ( j = 0; j < args.length; j++ ) {
+		args = [];
+		for ( j = 0; j < len+nargs; j++ ) {
 			if ( j >= nargs ) {
-				args[ j ] = pargs[ j-nargs ];
+				args.push( pargs[ j-nargs ] );
 			} else {
-				args[ j ] = arguments[ j ];
+				args.push( arguments[ j ] );
 			}
 		}
 		return fcn.apply( null, args );

--- a/lib/node_modules/@stdlib/utils/papply/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/papply/lib/main.js
@@ -50,9 +50,9 @@ function papply( fcn ) {
 	if ( !isFunction( fcn ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
 	}
-	pargs = new Array( arguments.length-1 );
+	pargs = [];
 	for ( i = 1; i < arguments.length; i++ ) {
-		pargs[ i-1 ] = arguments[ i ];
+		pargs.push( arguments[ i ] );
 	}
 	return papplied;
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request propagates fixes merged to `develop` between 2026-08-17 and 2026-08-18 (`0acfa70d8..600a127f0`) to sibling packages with the same underlying defects.

### `floating point` → `floating-point` (source: 600a127f0)

This PR extends the fix from 600a127f0 to the sibling doc surfaces that commit missed. Same defect, same treatment: unhyphenated `floating point` used attributively becomes `floating-point` — 33 lines, 17 files, prose only.

-   `blas/base/wasm/dswap`, `blas/base/wasm/sswap` — `docs/repl.txt`, `docs/types/index.d.ts`
-   `blas/base/caxpy`, `blas/base/zaxpy` — `docs/repl.txt`
-   `math/base/special/ahavercosf` — README, JSDoc, `package.json` description
-   `math/base/special/floor2f` — header, JSDoc, C source
-   `array/base/logspace`, `array/logspace` — READMEs
-   `types` — `index.d.ts`

Occurrences inside FDLIBM-ported algorithm notes and printf conversion-specifier terminology are untouched — those are quoted/attributed source text, not stdlib prose.

### `stdlib/no-new-array` lint errors (source: 6a94f9319)

Fixes the same `stdlib/no-new-array` violation pattern in the remaining single-site packages, following commit 6a94f9319 (#14286): `new Array( n )` preallocation plus indexed fill replaced with an array literal and `push`. Loop bounds that referenced the preallocated array's length are rewritten to invariant expressions; element order and semantics are unchanged. Applies to:

-   `utils/papply`
-   `utils/papply-right`
-   `utils/async/do-until`
-   `utils/open-url`

`utils/compose`, `utils/function-sequence`, and `utils/async/compose` are excluded: each has a second `new Array` site of a different shape, and fixing only the matching site would leave the rule still failing there. Those require a separate PR.

## Related Issues

> Does this pull request have any related issues?

No related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Two additional sites were fixed and subsequently excluded after CI surfaced pre-existing failures unrelated to the changes themselves:

-   `string/format` (README hyphenation): the README has four pre-existing doctest mismatches in unrelated example blocks (lines 93–125, 162–178, 213–230), so any edit to the file fails the changed-examples check. The hyphenation fix should land together with corrections to those examples.
-   `utils/merge` (`stdlib/no-new-array` fix): touching `utils/merge` runs the test suites of its `_tools/github/*` dependents, and `_tools/github/rank-followers/test/test.cli.js` has pre-existing failures — the tests assert `opts.format`/`opts.delimiter`, which `bin/cli` never sets (the format fixture also passes `--format=json` while the test expects `'csv'`). The `utils/merge` fix should land once those dependent tests are corrected.

Validation performed before applying changes:

-   Candidate sites enumerated via pattern search over the affected namespaces; occurrences in FDLIBM-ported comments, printf terminology, noun-phrase usage ("in floating point"), bot-regenerated namespace TOCs, and dataset contents were excluded.
-   Two independent validation passes confirmed each site in full file context; an adaptation pass produced per-site patches; a style-consistency pass verified conformance with surrounding package conventions (e.g., the uncached-loop-bound idiom in `utils/push`).
-   Sites flagged as requiring human judgment were dropped: `string/format` README example strings, `utils/compose`, `utils/function-sequence`, `utils/async/compose` (second `new Array` site of a different shape), `utils/reverse-arguments` (reverse-order fill), `utils/pluck`/`utils/deep-pluck` (conditional aliasing).
-   All modified JavaScript passes `node --check`; patched `utils` functions were smoke-tested for behavior preservation (`papply`, `papply-right`, `async/do-until`).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code as part of an automated fix-propagation routine: recent fixes on `develop` were pattern-matched against sibling packages, and each candidate site was validated by independent review passes before the equivalent fix was applied.

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B1i21KTYKBJ3n5E3mSFp3