### PR TITLE
test: migrate `stats/base/dists/geometric/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/stdev/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -68,8 +67,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function returns the standard deviation of a geometric distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -78,13 +75,7 @@ tape( 'the function returns the standard deviation of a geometric distribution',
 	p = data.p;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/stdev/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // VARIABLES //
@@ -77,8 +76,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function returns the standard deviation of a geometric distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -87,13 +84,7 @@ tape( 'the function returns the standard deviation of a geometric distribution',
 	p = data.p;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the test suites for `stats/base/dists/geometric/stdev` from relative tolerance assertions to ULP difference assertions, as described in #11352.
-   replaces the `delta`/`tol` computation (previously `1.0 * EPS * abs( expected[ i ] )`) and the associated `t.ok( delta <= tol, ... )` / exact-equality branch with a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' )` assertion.
-   adds a require for `@stdlib/assert/is-almost-same-value` and removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires.

The same change is applied to both `test/test.js` and `test/test.native.js`.

**ULP bound:** `1` ULP, for the "the function returns the standard deviation of a geometric distribution" test in both `test/test.js` and `test/test.native.js`. This is the measured minimum over the full fixture set (1000 values, `test/fixtures/python/data.json`); the observed ULP difference distribution is `{0: 717, 1: 283}`. Lowering the bound to `0` causes 283 test cases to fail, so `1` is the tightest bound which passes. The suite was run twice at the final bound to confirm the result is deterministic.

Only the two test files are changed; no source, documentation, or fixture files were touched.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   `test/test.native.js` is skipped locally, as the native add-on was not built in this environment. The ULP bound in `test/test.native.js` mirrors the bound measured for the JavaScript implementation, consistent with prior conversions in this family (e.g., `stats/base/dists/negative-binomial/cdf`, `stats/base/dists/frechet/mode`). As an additional check, the C implementation (`sqrt( 1.0-p ) / p`, per `src/main.c`) was compiled standalone and evaluated over the full fixture set; its results are bitwise identical to the JavaScript implementation for all 1000 fixture values, so the same bound applies.
-   The `if ( y === expected[i] )` exact-equality fast path was removed, as `isAlmostSameValue` already returns `true` for exactly equal values.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

This PR was authored by Claude Code, running as an automated task. The ULP bound was determined empirically by measuring the ULP difference across the full fixture set and verifying that the next lower bound fails.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6bKpmr2wWQ3vQzCNgtMHm)_