### PR TITLE
test: migrate `stats/base/dists/bernoulli/skewness` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/skewness/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/skewness/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
 
@@ -80,8 +79,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function returns the skewness of a Bernoulli distribution', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -90,13 +87,7 @@ tape( 'the function returns the skewness of a Bernoulli distribution', function 
 	p = data.p;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/skewness/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/skewness/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -89,8 +88,6 @@ tape( 'if provided a success probability `p` outside of `[0,1]`, the function re
 
 tape( 'the function returns the skewness of a Bernoulli distribution', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var i;
 	var p;
 	var y;
@@ -99,13 +96,7 @@ tape( 'the function returns the skewness of a Bernoulli distribution', opts, fun
 	p = data.p;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = skewness( p[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'p: '+p[i]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. p: '+p[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/bernoulli/skewness` from relative tolerance testing (`delta = abs( y - expected[i] )`, `tol = 1.0 * EPS * abs( expected[i] )`, `t.ok( delta <= tol, ... )`) to ULP difference testing using [`@stdlib/assert/is-almost-same-value`][is-almost-same-value].
-   updates both `test/test.js` and `test/test.native.js`, which mirror one another.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` imports from both test files (`EPS` is not used anywhere else in these files).

The ULP bounds were tightened to the measured minimum which passes over the full fixture set, for both the JavaScript and the C implementations:

| Fixture file | Test case | ULP bound | Measured maximum ULP difference |
| --- | --- | --- | --- |
| `fixtures/julia/data.json` | the function returns the skewness of a Bernoulli distribution | `0` | 0 (JS and native) |

Notes on how the bound was determined:

-   The bound is the minimum non-negative integer for which every fixture value passes. Starting from `64`, the bound was lowered stepwise (`64`, `16`, `4`, `2`, `1`, `0`), with the full suite run at each step; all 1000 fixture values are bit-for-bit exact against the Julia reference values, for both implementations, so `0` is both the measured maximum and the tightest possible bound. The measurement was also performed directly, by computing the ULP difference for each fixture value via `@stdlib/number/float64/base/assert/is-almost-same-value`.
-   This is expected: the skewness of a Bernoulli distribution is `( 1 - 2p ) / sqrt( p * ( 1 - p ) )`, and both the JavaScript and C implementations evaluate exactly that expression in the same order. `2 * p` is exact, `sqrt` is correctly rounded under IEEE 754, and the division is a single correctly rounded operation, so there is no room for the two implementations to diverge, and no opportunity for FMA contraction to change a result.
-   Because the results are exact, the old `y === expected[i]` fast path was taken for every fixture value and the tolerance branch was never exercised.
-   The JavaScript and C implementations agree exactly, so `test.js` and `test.native.js` use identical bounds.
-   The native add-on was compiled locally, so `test/test.native.js` was exercised against the actual C implementation rather than skipped. Both test files were run twice at the final bound, with identical results (1009 assertions each, all passing, per run).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

Given that every fixture value is bit-for-bit exact, a bound of `0` is equivalent to a strict equality check. Reviewers may prefer plain `t.strictEqual( y, expected[ i ], ... )` here instead; `isAlmostSameValue( ..., 0 )` was chosen for consistency with the other converted packages, which already use a `0` bound in many places.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   Only the two test files are modified; no source, documentation, benchmark, or fixture files are touched.
-   Linting is clean via ESLint using `etc/eslint/.eslintrc.tests.js` (verified against a deliberately introduced violation to confirm the configuration was actually applied).
-   `make install-node-modules` could not complete in this environment: a transitive dependency requires `es-object-atoms@^1.1.2`, which is newer than the `min-release-age = 90` threshold configured in the repository `.npmrc`, so the registry resolution fails. Rather than weakening that setting, the required test tooling (`tape`, ESLint 8.57 and the repository's remark/ESLint plugins, `node-gyp`) was installed separately, and the tests and linter were run directly against the package. Nothing outside `node_modules` was affected.
-   The `editorconfig` pre-commit hook could not run in this environment, as it downloads its binary from a GitHub repository that this session cannot reach. The two files were instead checked manually against `.editorconfig` (LF endings, tab indentation, final newline, UTF-8); the diff introduces no new violations.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running as an unattended scheduled task. The test migration follows the idiom established by previously merged conversions, and the ULP bound was measured empirically against both the JavaScript and compiled C implementations rather than guessed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[is-almost-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-same-value

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1Fsx8FyCM2U9HpHWjDvY1)_