### PR TITLE
docs: add missing usage notes sections and MGF link

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/cdf/README.md
@@ -134,6 +134,16 @@ y = mycdf( 0.3 );
 
 <!-- /.usage -->
 
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
 <section class="examples">
 
 ## Examples

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/mgf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Moment-Generating Function
 
-> [Beta][beta-distribution] distribution moment-generating function (MGF).
+> [Beta][beta-distribution] distribution [moment-generating function][mgf] (MGF).
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/quantile/README.md
@@ -126,6 +126,16 @@ y = myquantile( 0.4 );
 
 <!-- /.usage -->
 
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
 <section class="examples">
 
 ## Examples


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request normalizes three README documentation inconsistencies in the `stats/base/dists/beta` namespace against the conventions used by the majority of sibling packages. All changes are documentation-only and render no observable output difference.

### Namespace summary

-   **Members analyzed:** 15 (`cdf, ctor, entropy, kurtosis, logcdf, logpdf, mean, median, mgf, mode, pdf, quantile, skewness, stdev, variance`); 0 autogenerated.
-   **Features analyzed:** structural (file tree, `package.json` key/script sets, README section structure and blockquote-link convention, `manifest.json` shape, test/benchmark/example naming) and semantic (public signature, return kind, validation prologue in `lib/main.js` and `lib/factory.js`, error construction, JSDoc shape, dependencies).
-   **Features with a clear majority (≥75%):** core file set and `package.json` key set (15/15); validation prologues (consistent by arity — grouped `isnan` checks for three-argument functions, interleaved for two-argument properties); JSDoc `@param`/`@returns`/`@example` shape; JavaScript-side `<section class="notes">` placeholder (12/15); blockquote metric-term reference link (11/14 applicable).
-   **Features without a clear majority (excluded):** the `Notes` content section (2/15, `logcdf`/`logpdf`); secondary `test/test.<name>.js` naming; the native-binding split (`gypfile`, C API files — 11/15, excluded as incremental per-package work); language-specific benchmark and fixture files (SciPy/Julia).

### `cdf`

The JavaScript-side usage documentation ran straight from the usage section into the examples section, omitting the empty `<section class="notes">` placeholder carried by 12 of 15 (80%) packages in the namespace. This package's own C API section already contains the placeholder, so the JavaScript-side omission is template drift, not intent. Added the placeholder; it renders nothing.

### `quantile`

Same omission — no notes section on the JavaScript side against the 80% namespace majority. Added the empty `<section class="notes">` placeholder to match. Documentation output is unchanged.

### `mgf`

The introductory blockquote left "moment-generating function" as plain text while the README body links `[moment-generating function][mgf]` four times and defines the `[mgf]` reference. Wrapped the blockquote term in the existing reference link, matching both the in-file usage and the 11 of 14 (79%) applicable siblings that link the metric term in the blockquote.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Validation

-   **Structural extraction** (filesystem and string comparison) and **semantic extraction** (per-package reading of `lib/main.js`, `lib/factory.js`, `lib/index.js`, JSDoc, and READMEs) were run across all 15 members.
-   **Three-agent drift validation** (semantic-review, cross-reference, structural-review) was run on each candidate; all three returned `confirmed-drift` for the three corrections in this PR. No test or example depends on the edited README content.
-   **Deliberately excluded:** `beta/pdf` and `beta/logpdf` blockquote-link fixes (already proposed in open PR #13410); the `beta/pdf` notes-section placeholder (real drift, but excluded to avoid editing `pdf/README.md` concurrently with #13410); `beta/logcdf` (open PR #13649 in flight; not an outlier here regardless); native-binding and language-specific fixture differences (incremental / ecosystem-level, not drift); and all features lacking a clear ≥75% majority.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [x] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This pull request was authored by Claude Code as an automated cross-package drift-detection run over the `stats/base/dists/beta` namespace. Candidate corrections were extracted programmatically from structural and semantic feature comparisons, independently validated by parallel reviewer agents (semantic, cross-reference, and structural review), and confined to documentation. A maintainer should audit and promote out of draft.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_018oe7WVLAzwRF6XMo3G5Yo4)_