### PR TITLE
test: migrate `stats/base/dists/levy/logpdf` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.factory.js
@@ -158,7 +158,7 @@ tape( 'the created function evaluates the logpdf for `x` given positive `mu`', f
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( mu[i], c[i] );
 		y = logpdf( x[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
@@ -181,7 +181,7 @@ tape( 'the created function evaluates the logpdf for `x` given negative `mu`', f
 	for ( i = 0; i < x.length; i++ ) {
 		logpdf = factory( mu[i], c[i] );
 		y = logpdf( x[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.factory.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -145,8 +145,6 @@ tape( 'if provided a nonpositive `c`, the created function always returns `NaN`'
 tape( 'the created function evaluates the logpdf for `x` given positive `mu`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var x;
@@ -161,13 +159,7 @@ tape( 'the created function evaluates the logpdf for `x` given positive `mu`', f
 		logpdf = factory( mu[i], c[i] );
 		y = logpdf( x[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -176,8 +168,6 @@ tape( 'the created function evaluates the logpdf for `x` given positive `mu`', f
 tape( 'the created function evaluates the logpdf for `x` given negative `mu`', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var x;
@@ -192,13 +182,7 @@ tape( 'the created function evaluates the logpdf for `x` given negative `mu`', f
 		logpdf = factory( mu[i], c[i] );
 		y = logpdf( x[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -207,8 +191,6 @@ tape( 'the created function evaluates the logpdf for `x` given negative `mu`', f
 tape( 'the created function evaluates the logpdf for `x` given large variance ( = large `c`)', function test( t ) {
 	var expected;
 	var logpdf;
-	var delta;
-	var tol;
 	var mu;
 	var c;
 	var x;
@@ -223,13 +205,7 @@ tape( 'the created function evaluates the logpdf for `x` given large variance ( 
 		logpdf = factory( mu[i], c[i] );
 		y = logpdf( x[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.logpdf.js
@@ -116,7 +116,7 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', function 
 	c = positiveMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
@@ -137,7 +137,7 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', function 
 	c = negativeMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
-		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
+		if ( expected[i] !== null && !( expected[i] === 0.0 && y < EPS ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.logpdf.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -104,8 +104,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', function test
 
 tape( 'the function evaluates the logpdf for `x` given positive `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -119,13 +117,7 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', function 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -133,8 +125,6 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', function 
 
 tape( 'the function evaluates the logpdf for `x` given negative `mu`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -148,13 +138,7 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', function 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null && !(expected[i] === 0.0 && y < EPS ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -162,8 +146,6 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', function 
 
 tape( 'the function evaluates the logpdf for `x` given large variance ( = large `c` )', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -177,13 +159,7 @@ tape( 'the function evaluates the logpdf for `x` given large variance ( = large 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.native.js
@@ -115,7 +115,7 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, fun
 	c = positiveMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
-		if ( expected[i] !== null && !(expected[i] === NINF && y === NINF ) ) {
+		if ( expected[i] !== null && !( expected[i] === NINF && y === NINF ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
@@ -136,7 +136,7 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, fun
 	c = negativeMean.c;
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
-		if ( expected[i] !== null && !(expected[i] === NINF && y === NINF ) ) {
+		if ( expected[i] !== null && !( expected[i] === NINF && y === NINF ) ) {
 			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/levy/logpdf/test/test.native.js
@@ -23,11 +23,10 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -104,8 +103,6 @@ tape( 'if provided a nonpositive `c`, the function returns `NaN`', opts, functio
 
 tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -119,13 +116,7 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, fun
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null && !(expected[i] === NINF && y === NINF ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -133,8 +124,6 @@ tape( 'the function evaluates the logpdf for `x` given positive `mu`', opts, fun
 
 tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -148,13 +137,7 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, fun
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null && !(expected[i] === NINF && y === NINF ) ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 3.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();
@@ -162,8 +145,6 @@ tape( 'the function evaluates the logpdf for `x` given negative `mu`', opts, fun
 
 tape( 'the function evaluates the logpdf for `x` given large variance ( = large `c` )', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var mu;
 	var x;
 	var c;
@@ -177,13 +158,7 @@ tape( 'the function evaluates the logpdf for `x` given large variance ( = large 
 	for ( i = 0; i < x.length; i++ ) {
 		y = logpdf( x[i], mu[i], c[i] );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'x: '+x[i]+', mu: '+mu[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. mu: '+mu[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the fixture-based value tests for `stats/base/dists/levy/logpdf` from relative-tolerance (`delta`/`tol`) comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per the tracking issue #11352.
-   updates `test/test.logpdf.js`, `test/test.factory.js`, and `test/test.native.js`.
-   the tightest ULP bound was determined agentically by running the full fixture suite; the measured minimum required bound was **0 ULP** (i.e., exact bit-for-bit agreement) across all three fixture sets (`positive_mean`, `negative_mean`, `large_variance`) in every test body, matching the precedent set in already-converted, same-family packages such as `stats/base/dists/uniform/logpdf`.
-   pre-existing edge-case skip guards (e.g., `expected[i] === 0.0 && y < EPS` in the JS tests, `expected[i] === NINF && y === NINF` in the native tests) were left untouched, since they guard against known JS-vs-C divergence at specific fixture points rather than being part of the tolerance idiom being migrated.
-   the now-unused `abs` (and, where applicable, `EPS`) requires were removed accordingly.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Full fixture suite (`test.js`, `test.logpdf.js`, `test.factory.js`) run twice at the final ULP bound to confirm determinism; all assertions passed both times. `test.native.js` is skipped locally (no built native addon in this environment) but was updated to mirror the same idiom.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, run as an automated, scheduled task on behalf of the repository maintainer (@Planeshifter) to work through the ULP migration tracking issue (#11352) package by package, following the pattern established by prior merged PRs against this same issue.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_0175BsFzQa9Lnt6kD4MCH4nH)_