### PR TITLE
test: migrate `stats/base/dists/planck/stdev` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/stdev/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/stdev/test/test.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
 
@@ -60,8 +59,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function returns the standard deviation of a Planck distribution', function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -69,13 +66,7 @@ tape( 'the function returns the standard deviation of a Planck distribution', fu
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/stdev/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/stdev/test/test.native.js
@@ -22,10 +22,9 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -69,8 +68,6 @@ tape( 'if provided a shape parameter `lambda` which is nonpositive, the function
 tape( 'the function returns the standard deviation of a Planck distribution', opts, function test( t ) {
 	var expected;
 	var lambda;
-	var delta;
-	var tol;
 	var i;
 	var y;
 
@@ -78,13 +75,7 @@ tape( 'the function returns the standard deviation of a Planck distribution', op
 	lambda = data.lambda;
 	for ( i = 0; i < expected.length; i++ ) {
 		y = stdev( lambda[i] );
-		if ( y === expected[i] ) {
-			t.strictEqual( y, expected[i], 'lambda: '+lambda[ i ]+', y: '+y+', expected: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = 1.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. lambda: '+lambda[ i ]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-		}
+		t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `stats/base/dists/planck/stdev` from EPS-scaled relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from `test/test.js` and `test/test.native.js`.

Details:

-   **Package converted:** `stats/base/dists/planck/stdev` (`test/test.js` and `test/test.native.js`).
-   **Final ULP constant:** `1` in both `test/test.js` and `test/test.native.js`.
-   **Measured minimum:** starting from a loose bound and tightening, `1` is the smallest integer bound under which the full 1000-value fixture set passes for both the JavaScript and C implementations. At `0`, 273 of the 1000 fixture assertions fail in each file (727 fixture values are bit-for-bit exact), so the bound cannot be tightened further.
-   **Determinism:** the suite was run twice at the final bound, with the native add-on compiled locally so `test/test.native.js` actually executed rather than being skipped. Both runs: 1005 assertions, 1005 passing, in each of the two test files.
-   Linting is clean for both files under `etc/eslint/.eslintrc.tests.js`, and the only changed files are the two test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The conversion mirrors the idiom already used in the same family (e.g., `stats/base/dists/halfnormal/stdev`): the fixture loop drops the exact-vs-tolerance branch entirely in favor of a single `t.strictEqual( isAlmostSameValue( y, expected[ i ], 1 ), true, 'returns expected value' );` assertion.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running unattended as a scheduled task, which selected the package, mirrored the conversion idiom from previously merged conversions, and empirically determined and verified the minimum ULP bound.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKbR3GmRrGfST5h1G2dcZe)_