### PR TITLE
test: migrate `stats/base/dists/frechet/entropy` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/entropy/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/entropy/test/test.js
@@ -21,11 +21,10 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
 
@@ -97,8 +96,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', function test
 tape( 'the function returns the differential entropy of a Fréchet distribution', function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -109,13 +106,7 @@ tape( 'the function returns the differential entropy of a Fréchet distribution'
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = entropy( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/entropy/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/entropy/test/test.native.js
@@ -22,12 +22,11 @@
 
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 
 
 // FIXTURES //
@@ -112,8 +111,6 @@ tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, functio
 tape( 'the function returns the differential entropy of a Fréchet distribution', opts, function test( t ) {
 	var expected;
 	var alpha;
-	var delta;
-	var tol;
 	var s;
 	var y;
 	var i;
@@ -124,13 +121,7 @@ tape( 'the function returns the differential entropy of a Fréchet distribution'
 	for ( i = 0; i < alpha.length; i++ ) {
 		y = entropy( alpha[i], s[i], 0.0 );
 		if ( expected[i] !== null ) {
-			if ( y === expected[i] ) {
-				t.strictEqual( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
-			} else {
-				delta = abs( y - expected[ i ] );
-				tol = 2.0 * EPS * abs( expected[ i ] );
-				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
-			}
+			t.strictEqual( isAlmostSameValue( y, expected[ i ], 0 ), true, 'returns expected value' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves a part of #11352.

## Description

> What is the purpose of this pull request?

This pull request:

-   migrates `stats/base/dists/frechet/entropy` test fixtures from the old computed EPS-based tolerance idiom (`delta`/`tol`/`abs( delta ) <= tol`) to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   applies the change to both `test/test.js` and `test/test.native.js`.
-   the minimum ULP bound was determined empirically by running both the JavaScript and native (compiled C add-on) implementations against the full fixture set: both implementations return bit-exact matches for every fixture value, so the tightest passing bound is `0` ULPs. Verified deterministic by running each suite twice.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was generated by an automated Claude Code routine that discovers packages still using the old EPS-tolerance test idiom, converts them to `isAlmostSameValue`-based ULP assertions mirroring prior art from already-merged conversions in the same package family, and empirically determines the tightest passing ULP bound.

* * *

@stdlib-js/reviewers

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5h9Hy7MsG17gB94hedX7h)_