### PR TITLE
test: migrate `math/base/special/rempio2` to ULP-based assertions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rempio2/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/test/test.js
@@ -27,11 +27,10 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PIO2 = require( '@stdlib/constants/float64/half-pi' );
 var PIO4 = require( '@stdlib/constants/float64/fourth-pi' );
 var rempio2 = require( './../lib' );
@@ -70,8 +69,6 @@ tape( 'the function returns `0` and sets the elements of `y` to `NaN` if provide
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (positive)', function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -88,16 +85,12 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x );
-		tol = EPS * abs( x );
-		t.strictEqual( delta <= tol, true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( z, x, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (tiny positive)', function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -114,16 +107,12 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x );
-		tol = EPS * abs( x );
-		t.strictEqual( delta <= tol, true, 'returns expected value' );
+		t.strictEqual( z, x, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (negative)', function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -140,16 +129,12 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x );
-		tol = EPS * abs( x );
-		t.strictEqual( delta <= tol, true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( z, x, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (tiny negative)', function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -166,16 +151,12 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x );
-		tol = EPS * abs( x );
-		t.strictEqual( delta <= tol, true, 'returns expected value' );
+		t.strictEqual( z, x, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (multiples of π/4)', function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -192,9 +173,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x[i] );
-		tol = EPS * abs( x[i] );
-		t.strictEqual( delta <= tol, true, 'returns expected value' );
+		t.strictEqual( isAlmostSameValue( z, x[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/rempio2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/test/test.native.js
@@ -28,11 +28,10 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrspace = require( '@stdlib/array/base/incrspace' );
 var linspace = require( '@stdlib/array/base/linspace' );
 var randu = require( '@stdlib/random/base/randu' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var isAlmostSameValue = require( '@stdlib/assert/is-almost-same-value' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PIO2 = require( '@stdlib/constants/float64/half-pi' );
 var PIO4 = require( '@stdlib/constants/float64/fourth-pi' );
 var Float64Array = require( '@stdlib/array/float64' );
@@ -80,8 +79,6 @@ tape( 'the function returns `0` and sets the elements of `y` to `NaN` if provide
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (positive)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -98,16 +95,12 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x );
-		tol = EPS * abs( x );
-		t.strictEqual( delta <= tol, true, 'can recover input value' );
+		t.strictEqual( isAlmostSameValue( z, x, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (tiny positive)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -124,16 +117,12 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x );
-		tol = EPS * abs( x );
-		t.strictEqual( delta <= tol, true, 'can recover input value' );
+		t.strictEqual( z, x, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (negative)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -150,16 +139,12 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x );
-		tol = EPS * abs( x );
-		t.strictEqual( delta <= tol, true, 'can recover input value' );
+		t.strictEqual( isAlmostSameValue( z, x, 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (tiny negative)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -176,16 +161,12 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x );
-		tol = EPS * abs( x );
-		t.strictEqual( delta <= tol, true, 'can recover input value' );
+		t.strictEqual( z, x, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (multiples of π/4)', opts, function test( t ) {
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var z;
@@ -202,9 +183,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 		t.strictEqual( isNumber( y[1] ), true, 'returns expected value' );
 
 		z = ( PIO2*n ) + ( y[0]+y[1] );
-		delta = abs( z - x[i] );
-		tol = EPS * abs( x[i] );
-		t.strictEqual( delta <= tol, true, 'can recover input value' );
+		t.strictEqual( isAlmostSameValue( z, x[ i ], 1 ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   migrates the tests for `math/base/special/rempio2` from EPS-scaled relative tolerance comparisons to ULP-based assertions using `@stdlib/assert/is-almost-same-value`, per #11352.
-   removes the now unused `@stdlib/math/base/special/abs` and `@stdlib/constants/float64/eps` requires from `test/test.js` and `test/test.native.js`.

Details:

-   **Package converted:** `math/base/special/rempio2` (`test/test.js` and `test/test.native.js`; these are the only test files in the package).
-   **Final ULP bounds,** identical across both test files:

    | test | previous tolerance | final bound |
    | ---- | ------------------ | ----------- |
    | reconstruction, positive (`randu()*100`) | `EPS * abs( x )` | `1` ULP |
    | reconstruction, tiny positive (`randu()*1.0e-100`) | `EPS * abs( x )` | exact |
    | reconstruction, negative (`-100 * randu()`) | `EPS * abs( x )` | `1` ULP |
    | reconstruction, tiny negative (`-1.0e-100 * randu()`) | `EPS * abs( x )` | exact |
    | reconstruction, multiples of `π/4` | `EPS * abs( x )` | `1` ULP |

-   **Measured minimum:** `1` ULP is the smallest integer bound under which the positive and negative reconstruction loops pass. Instrumenting `ulpdiff( ( PIO2*n ) + ( y[0]+y[1] ), x )` directly over 1.2M random samples per range gives a maximum observed difference of exactly `1` ULP for the `±[0,100)` ranges and `0` for both tiny ranges and for all 20 multiples of `π/4`. Lowering the bound to `0` produces 88–97 failing assertions per run.
-   For the two tiny ranges, `|x| < 2^-27`, so the function returns `n = 0` with `y[0] = x` and `y[1] = 0` and reconstruction is bit-for-bit exact; those assertions therefore use exact equality, matching the float32 counterpart `math/base/special/rempio2f`. Exact equality (rather than a `0` ULP bound) is used deliberately, because `randu()` is documented as returning on the interval `[0,1)` and so `x` may be `-0`, which `isAlmostSameValue( z, x, 0 )` would reject.
-   The multiples-of-`π/4` loop measures `0` ULP here, but is kept at `1` ULP to match the other reconstruction loops and `rempio2f`, and to leave headroom for compiler-dependent contraction in the C implementation on platforms other than the one measured.
-   **Determinism:** the native add-on was compiled locally so that `test/test.native.js` actually executed rather than being skipped, and the suite was then run four times at the final bounds. Every run: 83291 assertions in `test/test.js` and 83291 in `test/test.native.js`, all passing.
-   Linting is clean for both files under `etc/eslint/.eslintrc.tests.js`, and the only changed files are the two test files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #11352

## Questions

> Any questions for reviewers of this pull request?

The assertion messages in `test/test.native.js` were `'can recover input value'` rather than `'returns expected value'`; they have been normalized to `'returns expected value'` to match the idiom in #11352 and in `rempio2f`. Happy to restore the original wording if reviewers would prefer to keep it.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The conversion mirrors the float32 counterpart in the same family, `math/base/special/rempio2f`, which has the same test structure and already uses `t.strictEqual( isAlmostSameValue( z, x, 1 ), true, 'returns expected value' );` for the reconstruction loops and exact equality for the tiny ranges.

The `for large/huge positive/negative input values` tests contain no tolerance math and are unchanged.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

This PR was authored by Claude Code, running unattended as a scheduled task, which selected the package, mirrored the conversion idiom from previously merged conversions, and empirically determined and verified the minimum ULP bounds.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

---
_Generated by [Claude Code](https://claude.ai/code/session_0126JBJYGMzjhQq8VHZUyEaa)_